### PR TITLE
Improve release management and update download flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,12 +198,20 @@ jobs:
       - name: List downloaded files
         run: find builds -type f
 
-      - name: Delete existing release
+      - name: Delete all existing releases
         run: |
-          curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/tags/latest" || true
-          curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/latest" || true
+          # Supprimer toutes les releases pour ne conserver que la nouvelle
+          tags=$(gh release list --repo "${{ github.repository }}" --json tagName -q '.[].tagName' 2>/dev/null || true)
+          if [ -n "$tags" ]; then
+            echo "$tags" | while read -r tag; do
+              echo "Suppression de la release: $tag"
+              gh release delete "$tag" --repo "${{ github.repository }}" --yes --cleanup-tag 2>/dev/null || true
+            done
+          fi
+          # Nettoyer le tag 'latest' orphelin s'il reste
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/latest" 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/src/main/autoUpdater.ts
+++ b/src/main/autoUpdater.ts
@@ -423,13 +423,13 @@ export class AutoUpdater {
       if (this.updateInfo!.latestVersion && this.updateInfo!.latestBuild) {
         downloadUrl = `https://github.com/klinnex/bellepoule-modern/releases/tag/v${this.updateInfo!.latestVersion}-build.${this.updateInfo!.latestBuild}`;
       } else {
-        downloadUrl = 'https://github.com/klinnex/bellepoule-modern/releases';
+        downloadUrl = 'https://github.com/klinnex/bellepoule-modern/releases/latest';
       }
-      
+
       if (asset) {
         // Ouvrir la page de la release spécifique
         shell.openExternal(downloadUrl);
-        
+
         dialog.showMessageBox(this.mainWindow!, {
           type: 'info',
           title: '📥 Téléchargement',
@@ -442,7 +442,7 @@ export class AutoUpdater {
       }
     } catch (error) {
       console.error('Download failed:', error);
-      shell.openExternal('https://github.com/klinnex/bellepoule-modern/releases');
+      shell.openExternal('https://github.com/klinnex/bellepoule-modern/releases/latest');
     }
   }
 


### PR DESCRIPTION
## Summary
This PR improves the release management workflow and enhances the auto-updater's download experience by implementing a more robust release cleanup strategy and directing users to the latest release.

## Key Changes

- **Enhanced release deletion workflow** (.github/workflows/build.yml)
  - Replaced individual curl requests with GitHub CLI (`gh`) commands for better reliability
  - Implemented batch deletion of all existing releases instead of just the "latest" tag
  - Added proper cleanup of orphaned "latest" tag references
  - Improved error handling and logging with descriptive messages in French
  - Uses `GH_TOKEN` environment variable for cleaner authentication

- **Updated download URLs** (src/main/autoUpdater.ts)
  - Changed fallback download URL from `/releases` to `/releases/latest` for direct access to the most recent release
  - Applied the same improvement to the error fallback URL
  - Cleaned up trailing whitespace

## Implementation Details

The release deletion now uses a more comprehensive approach:
- Fetches all release tags using `gh release list`
- Iterates through each tag and deletes it with `--cleanup-tag` flag to remove associated git refs
- Falls back to direct API call for any orphaned "latest" tag

This ensures a clean slate for each new release while maintaining better visibility into the deletion process through console output.

https://claude.ai/code/session_01TzPG2b1ZbMC6n9eg9nHZHA