### PR TITLE
fix(pools): corrige la distribution serpentine des poules (#65)

### DIFF
--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -378,13 +378,13 @@ export function distributeFencersToPoolsSerpentine(
     // Avancer dans la serpentine
     poolIndex += direction;
     if (poolIndex >= poolCount) {
-      // On arrive à la fin, on repart en arrière
+      // On arrive à la fin, on repart en arrière (la dernière poule est visitée deux fois)
       direction = -1;
-      poolIndex = poolCount - 2;
+      poolIndex = poolCount - 1;
     } else if (poolIndex < 0) {
-      // On arrive au début, on repart en avant
+      // On arrive au début, on repart en avant (la première poule est visitée deux fois)
       direction = 1;
-      poolIndex = 1;
+      poolIndex = 0;
     }
   }
 
@@ -568,10 +568,12 @@ function rebalancePools(
     rebalanced = false;
     iterations++;
 
-    // Trouver les poules surchargées et sous-chargées
+    // Trouver les poules sources (> idealSize) et sous-chargées (< idealSize)
+    // On utilise idealSize comme seuil source (pas maxSize) pour corriger les cas où
+    // toutes les poules sont à maxSize mais certaines restent sous idealSize
     const overloaded = pools
       .map((pool, idx) => ({ idx, pool, size: pool.length }))
-      .filter(p => p.size > maxSize)
+      .filter(p => p.size > idealSize)
       .sort((a, b) => b.size - a.size);
 
     const underloaded = pools
@@ -584,7 +586,7 @@ function rebalancePools(
     // Déplacer des tireurs des poules surchargées vers les sous-chargées
     for (const source of overloaded) {
       for (const target of underloaded) {
-        if (source.size <= maxSize || target.size >= idealSize) continue;
+        if (source.size <= idealSize || target.size >= idealSize) continue;
 
         // Chercher un tireur à déplacer qui ne crée pas de conflit
         for (let i = source.pool.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Problème

Avec 58 tireurs et 8 poules, l'application générait **6 poules de 8 + 2 poules de 5** au lieu des **6 poules de 7 + 2 poules de 8** attendues.

Closes #65

## Cause

Deux bugs dans `src/shared/utils/poolCalculations.ts` introduits dans le commit `8cd8460` :

### Bug 1 — Serpentine : bornes incorrectes

```typescript
// Avant (FAUX)
poolIndex = poolCount - 2;  // saute la dernière poule
poolIndex = 1;              // saute la première poule
```

La séquence produite était `0,1,2,3,4,5,6,7,6,5,4,3,2,1,0,1,...` (cycle de 14) : les poules aux extrémités étaient visitées deux fois moins souvent que les poules centrales.

### Bug 2 — `rebalancePools` : seuil source trop restrictif

Le rééquilibrage ne prenait des tireurs que dans les poules `> maxSize`. Après la mauvaise serpentine, si toutes les poules excédentaires étaient exactement à `maxSize`, la boucle sortait immédiatement sans corriger les poules déficitaires.

## Fix

**Serpentine :** `poolCount - 2` → `poolCount - 1` et `1` → `0`
→ Séquence FIE correcte : `0,1,...,N-1,N-1,...,0,0,1,...` (cycle de 16, chaque poule visitée deux fois)

**`rebalancePools` :** seuil source `> maxSize` → `> idealSize`
→ Permet de rééquilibrer même quand les poules excédentaires sont exactement à `idealSize + 1`

## Test

- 58 tireurs, 8 poules → **6×7 + 2×8** ✓
- 40 tireurs, 5 poules → **5×8** ✓
- 13 tireurs, 2 poules → **1×6 + 1×7** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)