### PR TITLE
fix(pools): grise et bloque les matchs des tireurs abandonnés

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -617,13 +617,17 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                       pool={pool}
                       weapon={competition.weapon}
                       maxScore={poolMaxScore}
-                      onScoreUpdate={(matchIndex, scoreA, scoreB) =>
-                        updateScore(poolIndex, matchIndex, scoreA, scoreB)
+                      onScoreUpdate={(matchIndex, scoreA, scoreB, winner, specialStatus) =>
+                        updateScore(poolIndex, matchIndex, scoreA, scoreB, winner, specialStatus)
                       }
                       onFencerStatusChange={(fencerId, status) => {
-                        // Si abandon ou forfait, mettre à jour tous les matchs du tireur
-                        if (status === 'abandon' || status === 'forfait') {
-                          handleFencerForfeit(fencerId);
+                        // Si abandon, forfait ou exclusion, mettre à jour tous les matchs du tireur
+                        if (
+                          status === 'abandon' ||
+                          status === 'forfait' ||
+                          status === 'exclusion'
+                        ) {
+                          handleFencerForfeit(fencerId, status);
                         }
                       }}
                     />

--- a/src/renderer/components/OptimizedPoolGrid.tsx
+++ b/src/renderer/components/OptimizedPoolGrid.tsx
@@ -48,7 +48,15 @@ const GridCell = memo(
       );
     }
 
-    if (isFencerAbandoned(rowFencer) || isFencerAbandoned(colFencer)) {
+    const isMatchForfait =
+      match?.scoreA?.isForfait === true ||
+      match?.scoreB?.isForfait === true ||
+      match?.scoreA?.isAbstention === true ||
+      match?.scoreB?.isAbstention === true ||
+      match?.scoreA?.isExclusion === true ||
+      match?.scoreB?.isExclusion === true;
+
+    if (isFencerAbandoned(rowFencer) || isFencerAbandoned(colFencer) || isMatchForfait) {
       return (
         <td
           style={{

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -5,7 +5,7 @@
  */
 
 import { useState, useCallback } from 'react';
-import { Pool, Fencer, Match, MatchStatus, Weapon, PoolRanking } from '../../shared/types';
+import { Pool, Fencer, Match, MatchStatus, FencerStatus, Weapon, PoolRanking } from '../../shared/types';
 import { useToast } from '../components/Toast';
 import {
   distributeFencersToPoolsSerpentine,
@@ -244,15 +244,28 @@ export const usePoolManagement = ({
     };
   }, [pools]);
 
-  // Gérer le forfait/abandon d'un tireur sur tous ses matchs
-  // Les matchs sont marqués comme non disputés (grisés) sans modifier les scores des adversaires
+  // Gérer le forfait/abandon/exclusion d'un tireur sur tous ses matchs non encore disputés
+  // Met à jour le statut du tireur et grise ses matchs restants dans la grille
   const handleFencerForfeit = useCallback(
-    (fencerId: string) => {
+    (fencerId: string, status: 'abandon' | 'forfait' | 'exclusion') => {
+      const newFencerStatus =
+        status === 'abandon'
+          ? FencerStatus.ABANDONED
+          : status === 'forfait'
+            ? FencerStatus.FORFAIT
+            : FencerStatus.EXCLUDED;
+
       setPools(prevPools => {
         const updatedPools = [...prevPools];
         let modifiedCount = 0;
 
         updatedPools.forEach(pool => {
+          // Mettre à jour le statut du tireur dans la liste des tireurs de la poule
+          const poolFencer = pool.fencers.find(f => f.id === fencerId);
+          if (poolFencer) {
+            poolFencer.status = newFencerStatus;
+          }
+
           pool.matches.forEach(match => {
             // Vérifier si le tireur est dans ce match
             const isFencerA = match.fencerA?.id === fencerId;
@@ -260,33 +273,41 @@ export const usePoolManagement = ({
 
             if (!isFencerA && !isFencerB) return;
 
-            // Marquer le match comme "non disputé" à cause du forfait/abandon
-            // Les scores de l'adversaire restent null (non modifiés)
-            if (isFencerA) {
+            // Ne pas écraser les matchs déjà disputés avec de vrais scores
+            const isAlreadyPlayed =
+              match.status === MatchStatus.FINISHED &&
+              !match.scoreA?.isForfait &&
+              !match.scoreB?.isForfait;
+            if (isAlreadyPlayed) return;
+
+            // Mettre à jour le statut du tireur dans les références du match
+            if (isFencerA && match.fencerA) {
+              match.fencerA.status = newFencerStatus;
               match.scoreA = {
                 value: 0,
                 isVictory: false,
-                isAbstention: false,
-                isExclusion: false,
-                isForfait: true,
+                isAbstention: status === 'abandon',
+                isExclusion: status === 'exclusion',
+                isForfait: status === 'forfait',
               };
-            } else {
+            } else if (isFencerB && match.fencerB) {
+              match.fencerB.status = newFencerStatus;
               match.scoreB = {
                 value: 0,
                 isVictory: false,
-                isAbstention: false,
-                isExclusion: false,
-                isForfait: true,
+                isAbstention: status === 'abandon',
+                isExclusion: status === 'exclusion',
+                isForfait: status === 'forfait',
               };
             }
 
-            // Marquer le match comme terminé mais avec forfait
+            // Marquer le match comme terminé (non disputé)
             match.status = MatchStatus.FINISHED;
             match.updatedAt = new Date();
             modifiedCount++;
           });
 
-          // Recalculer le classement de la pou00le
+          // Recalculer le classement de la poule
           if (modifiedCount > 0) {
             pool.ranking = computePoolRanking(pool);
             pool.updatedAt = new Date();
@@ -298,7 +319,7 @@ export const usePoolManagement = ({
           const newOverallRanking = computeOverallRanking(updatedPools);
           setOverallRanking(newOverallRanking);
           showToast(
-            `${modifiedCount} match(s) marqué(s) comme non disputés (forfait/abandon)`,
+            `${modifiedCount} match(s) marqué(s) comme non disputés (${status})`,
             'success'
           );
         }


### PR DESCRIPTION
## Problème

Lors de l'abandon d'un combattant, ses matchs restants n'étaient pas grisés et restaient éditables. Les scores affichaient 0 pour le tireur et le score max (ex: 21 en laser sabre) pour l'adversaire.

## Cause racine

`handleFencerForfeit` mettait à jour les scores des matchs (`isForfait: true`) mais **ne mettait jamais à jour `pool.fencers[i].status`**. Or `OptimizedPoolGrid` se base uniquement sur `fencer.status === 'A'|'F'|'E'` pour griser les cellules.

## Corrections

### `usePoolManagement.ts`
- Mise à jour de `pool.fencers[i].status` vers `FencerStatus.ABANDONED/FORFAIT/EXCLUDED`
- Propagation du statut dans `match.fencerA/fencerB`
- Les matchs déjà disputés (FINISHED, sans flag forfait) ne sont plus écrasés
- Le type de statut (`abandon`/`forfait`/`exclusion`) est utilisé pour les flags `isAbstention`/`isForfait`/`isExclusion`

### `CompetitionView.tsx`
- Transmission complète des paramètres `winnerOverride` et `specialStatus` dans `onScoreUpdate`
- Passage du `status` à `handleFencerForfeit` (abandon vs forfait vs exclusion)
- Gestion de `exclusion` en plus de `abandon` et `forfait`

### `OptimizedPoolGrid.tsx`
- Défense en profondeur : vérification de `isMatchForfait` (`isForfait/isAbstention/isExclusion` sur les scores) en plus du statut du tireur

## Test

1. Créer une poule, saisir quelques scores
2. Sur un match, cliquer « Abandon »
3. ✅ Les matchs restants du tireur doivent être grisés et non cliquables
4. ✅ Les matchs déjà joués conservent leurs vrais scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)