### PR TITLE
fix(tableau): ajoute le tableau de 64 et corrige la gestion jusqu'à 1…

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -107,16 +107,15 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   }, [ranking.length, thirdPlaceMatch, maxScore, matches.length]); // Dépend du nombre de tireurs, match pour la 3ème place et score max
 
   const getTableauSize = (fencerCount: number): number => {
-    const effectiveCount = Math.ceil(fencerCount / 2);
     const sizes = [4, 8, 16, 32, 64, 128, 256];
     for (const size of sizes) {
-      if (effectiveCount <= size) return size;
+      if (fencerCount <= size) return size;
     }
     return 256;
   };
 
   const generateTableau = () => {
-    const qualifiedFencers = ranking.slice(0, Math.min(ranking.length, 64));
+    const qualifiedFencers = ranking;
     const size = getTableauSize(qualifiedFencers.length);
     setTableauSize(size);
 
@@ -201,6 +200,16 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         1, 64, 33, 32, 17, 48, 49, 16, 9, 56, 41, 24, 25, 40, 57, 8, 5, 60, 37, 28, 21, 44, 53, 12,
         13, 52, 45, 20, 29, 36, 61, 4, 3, 62, 35, 30, 19, 46, 51, 14, 11, 54, 43, 22, 27, 38, 59, 6,
         7, 58, 39, 26, 23, 42, 55, 10, 15, 50, 47, 18, 31, 34, 63, 2,
+      ];
+    }
+    if (size === 128) {
+      return [
+        1, 128, 65, 64, 33, 96, 97, 32, 17, 112, 81, 48, 49, 80, 113, 16, 9, 120, 73, 56, 41, 88,
+        105, 24, 25, 104, 89, 40, 57, 72, 121, 8, 5, 124, 69, 60, 37, 92, 101, 28, 21, 108, 85, 44,
+        53, 76, 117, 12, 13, 116, 77, 52, 45, 84, 109, 20, 29, 100, 93, 36, 61, 68, 125, 4, 3, 126,
+        67, 62, 35, 94, 99, 30, 19, 110, 83, 46, 51, 78, 115, 14, 11, 118, 75, 54, 43, 86, 107, 22,
+        27, 102, 91, 38, 59, 70, 123, 6, 7, 122, 71, 58, 39, 90, 103, 26, 23, 106, 87, 42, 55, 74,
+        119, 10, 15, 114, 79, 50, 47, 82, 111, 18, 31, 98, 95, 34, 63, 66, 127, 2,
       ];
     }
     return Array.from({ length: size }, (_, i) => i + 1);
@@ -631,7 +640,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     // Issue #61: Les éliminés en quarts se retrouvaient en bas du classement
     // Issue #60: Les tireurs éliminés à chaque tour ont des rangs distincts
     // Issue #59: Départage par somme des points Quest (poules + tableau)
-    const rounds = [4, 8, 16, 32, 64].filter(r => r <= tableauSize);
+    const rounds = [4, 8, 16, 32, 64, 128].filter(r => r <= tableauSize);
     let currentRank = thirdPlaceMatch?.winner ? 5 : 3;
 
     // DEBUG: console.log('Rounds à traiter:', rounds, 'currentRank de départ:', currentRank);


### PR DESCRIPTION
…28 tireurs

- getTableauSize : supprime la division par 2 erronée qui décalait d'un cran
  la sélection (ex : 33–64 tireurs → taille 32 au lieu de 64)
- generateTableau : supprime la limite arbitraire à 64 qualifiés
- generateFIESeeding : ajoute le placement FIE standard pour un tableau de 128
- Boucle classement : ajoute le tour 128 pour classer les perdants du 1er tour

Avec 90 tireurs : tableau de 128, 38 exempts (seeds 1–38), 52 matchs au 1er tour.

https://claude.ai/code/session_01PpDcLLT3A5HkxzDGgRMac2