### PR TITLE
fix: mise à jour du score de poule lors de la fin d'un match distant

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -165,22 +165,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   }, [loadFencers]);
 
   // Écouter les mises à jour des matches distants
+  // Note: pas de garde sur currentPhase car la phase 'remote' affiche le panel de saisie distante
+  // mais les mises à jour doivent quand même être appliquées aux pools
   useEffect(() => {
-    if (!window.electronAPI?.onRemoteMatchFinished || currentPhase !== 'pools') return;
+    if (!window.electronAPI?.onRemoteMatchFinished) return;
 
     const handleMatchFinished = (data: { matchId: string; scoreA: number; scoreB: number }) => {
       const { matchId, scoreA, scoreB } = data;
       console.log(`[CompetitionView] Match terminé reçu: ${matchId} - Score: ${scoreA}-${scoreB}`);
-
-      // Trouver le match dans les pools et le mettre à jour
-      for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
-        const matchIdx = pools[poolIdx].matches.findIndex(m => m.id === matchId);
-        if (matchIdx !== -1) {
-          updateMatchFromRemote(matchId, scoreA, scoreB, MatchStatus.FINISHED);
-          console.log(`[CompetitionView] Match ${matchId} mis à jour dans pool ${poolIdx}`);
-          break;
-        }
-      }
+      updateMatchFromRemote(matchId, scoreA, scoreB, MatchStatus.FINISHED);
     };
 
     window.electronAPI.onRemoteMatchFinished(handleMatchFinished);
@@ -188,7 +181,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     return () => {
       window.electronAPI.removeAllListeners?.('match:finished');
     };
-  }, [currentPhase, pools, updateMatchFromRemote]);
+  }, [updateMatchFromRemote]);
 
   // Menu events
   useMenuEvents({


### PR DESCRIPTION
Le listener `match:finished` était conditionné à `currentPhase === 'pools'`, mais quand l'utilisateur ouvre le panel "Saisie distante", la phase passe à 'remote' — le listener n'était donc jamais enregistré et le tableau de poule n'était jamais mis à jour.

Corrections :
- Suppression du garde `currentPhase !== 'pools'` sur l'effet
- Suppression de la recherche redondante dans `pools` (déjà faite en interne par `updateMatchFromRemote` via `setPools(prevPools => ...)`)
- `pools` retiré des dépendances de l'effet (plus utilisé dans le handler)

https://claude.ai/code/session_01AyGZ9G44ziJF1NBSW51vtP