### PR TITLE
fix: espacement entre les matchs de la première colonne du tableau d'élimination

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -56,7 +56,7 @@ interface TableauViewProps {
 }
 
 const BASE_MATCH_HEIGHT = 80;
-const SLOT_HEIGHT = BASE_MATCH_HEIGHT + 8; // hauteur d'un créneau dans la première colonne
+const SLOT_HEIGHT = BASE_MATCH_HEIGHT + 16; // hauteur d'un créneau dans la première colonne
 
 const TableauViewComponent: React.FC<TableauViewProps> = ({
   ranking,


### PR DESCRIPTION
Augmente le gap vertical de 8px à 16px (SLOT_HEIGHT = BASE_MATCH_HEIGHT + 16)
pour une meilleure lisibilité des matchs dans la première colonne.

https://claude.ai/code/session_018P43ybCQvYoBTgsfmzDtLS