### PR TITLE
feat: afficher les prochains matchs de l'arène après saisie du score

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -628,6 +628,71 @@
         background: #ef4444;
       }
 
+      /* Écran prochains matchs */
+      .next-matches-screen {
+        display: none;
+        background: rgba(0, 0, 0, 0.4);
+        border-radius: 1rem;
+        padding: 1.5rem 1rem;
+        margin-bottom: 1rem;
+      }
+
+      .next-matches-screen.visible {
+        display: block;
+      }
+
+      .next-matches-screen h2 {
+        font-size: 1.2rem;
+        font-weight: 700;
+        margin-bottom: 1.25rem;
+        text-align: center;
+        opacity: 0.95;
+      }
+
+      .next-match-card {
+        background: rgba(255, 255, 255, 0.12);
+        border: 2px solid rgba(255, 255, 255, 0.2);
+        border-radius: 0.75rem;
+        padding: 1.25rem 1rem;
+        margin-bottom: 0.75rem;
+        cursor: pointer;
+        transition: all 0.2s;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .next-match-card:hover,
+      .next-match-card:active {
+        background: rgba(255, 255, 255, 0.22);
+        border-color: #22c55e;
+        transform: translateY(-1px);
+      }
+
+      .next-match-card-names {
+        font-size: 1.05rem;
+        font-weight: 700;
+      }
+
+      .next-match-card-sub {
+        font-size: 0.78rem;
+        opacity: 0.65;
+        margin-top: 0.2rem;
+      }
+
+      .next-match-card-arrow {
+        font-size: 1.5rem;
+        opacity: 0.6;
+        flex-shrink: 0;
+      }
+
+      .next-matches-empty {
+        text-align: center;
+        opacity: 0.65;
+        padding: 2rem 1rem;
+        font-size: 0.95rem;
+      }
+
       /* Responsive */
       @media (min-width: 768px) {
         .main-container {
@@ -818,6 +883,14 @@
           </button>
         </div>
       </div>
+
+      <!-- Écran prochains matchs -->
+      <div class="next-matches-screen" id="next-matches-screen">
+        <h2>⏭️ Prochains matchs — Arène <span id="next-arena-number">1</span></h2>
+        <div id="next-matches-list">
+          <div class="next-matches-empty">Chargement...</div>
+        </div>
+      </div>
     </div>
 
     <!-- Modal de confirmation -->
@@ -879,6 +952,7 @@
 
         init() {
           document.getElementById('arena-number').textContent = this.arenaNumber;
+          document.getElementById('next-arena-number').textContent = this.arenaNumber;
           this.setupSocketListeners();
           this.setupTimerInteractions();
           this.setupLongPressInteractions();
@@ -1207,6 +1281,10 @@
         selectMatch(matchId) {
           const match = this.matches.find(m => m.id === matchId);
           if (!match || match.status === 'finished') return;
+
+          // Masquer le sélecteur et l'écran des prochains matchs
+          document.getElementById('match-selector').style.display = 'none';
+          this.hideNextMatchesScreen();
 
           this.currentMatch = match;
           this.scoreA = match.scoreA?.value || 0;
@@ -1559,7 +1637,7 @@
 
             this.showNotification('✅ Match terminé et enregistré !');
 
-            // Réinitialiser pour le prochain match
+            // Afficher l'écran des prochains matchs
             setTimeout(() => {
               this.currentMatch = null;
               this.scoreA = 0;
@@ -1570,7 +1648,7 @@
               this.timerSeconds = 180;
               this.updateTimerDisplay();
               document.getElementById('active-match').classList.remove('visible');
-              this.renderMatchesList();
+              this.showNextMatchesScreen();
             }, 2000);
           } catch (error) {
             console.error('Erreur fin de match:', error);
@@ -1677,7 +1755,15 @@
               this.matches.push(newMatch);
             }
 
-            // Afficher automatiquement le prochain match
+            // Si l'écran des prochains matchs est visible, rafraîchir la liste sans auto-sélectionner
+            const nextScreen = document.getElementById('next-matches-screen');
+            if (nextScreen && nextScreen.classList.contains('visible')) {
+              this.loadNextMatches();
+              this.showNotification('⏭️ Match suivant disponible !');
+              return;
+            }
+
+            // Afficher automatiquement le prochain match (comportement hors écran next-matches)
             this.currentMatch = newMatch;
             this.scoreA = 0;
             this.scoreB = 0;
@@ -1705,6 +1791,70 @@
             document.getElementById('active-match').classList.add('visible');
             this.showNotification('⏭️ Match suivant prêt !');
           }
+        }
+
+        showNextMatchesScreen() {
+          document.getElementById('match-selector').style.display = 'none';
+          document.getElementById('next-matches-screen').classList.add('visible');
+          this.loadNextMatches();
+        }
+
+        hideNextMatchesScreen() {
+          document.getElementById('next-matches-screen').classList.remove('visible');
+        }
+
+        async loadNextMatches() {
+          const container = document.getElementById('next-matches-list');
+          container.innerHTML = '<div class="next-matches-empty">Chargement...</div>';
+          try {
+            const response = await fetch(`/api/arenas/${this.arenaId}/matches`);
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            const data = await response.json();
+            const pending = (data.matches || []).filter(
+              m => m.status === 'not_started' || m.status === 'in_progress'
+            );
+            // Fusionner dans this.matches pour que selectMatch() fonctionne
+            for (const m of pending) {
+              if (!this.matches.find(existing => existing.id === m.id)) {
+                this.matches.push(m);
+              }
+            }
+            this.renderNextMatchesList(pending);
+          } catch (error) {
+            console.error('Erreur chargement prochains matchs:', error);
+            container.innerHTML = '<div class="next-matches-empty">Erreur de connexion</div>';
+          }
+        }
+
+        renderNextMatchesList(matches) {
+          const container = document.getElementById('next-matches-list');
+          if (matches.length === 0) {
+            container.innerHTML =
+              '<div class="next-matches-empty">✅ Tous les matchs de cette arène sont terminés</div>';
+            return;
+          }
+          container.innerHTML = matches
+            .map(
+              match => `
+              <div class="next-match-card" onclick="refereeApp.selectMatchFromNextScreen('${match.id}')">
+                <div>
+                  <div class="next-match-card-names">
+                    ${match.fencerA?.lastName || '?'} <span style="opacity:0.6;font-weight:400">vs</span> ${match.fencerB?.lastName || '?'}
+                  </div>
+                  <div class="next-match-card-sub">
+                    ${[match.fencerA?.club, match.fencerB?.club].filter(Boolean).join(' · ') || ''}
+                  </div>
+                </div>
+                <div class="next-match-card-arrow">›</div>
+              </div>
+            `
+            )
+            .join('');
+        }
+
+        selectMatchFromNextScreen(matchId) {
+          this.hideNextMatchesScreen();
+          this.selectMatch(matchId);
         }
 
         showNotification(message, isError = false) {


### PR DESCRIPTION
Après confirmation d'un match terminé, l'arbitre est redirigé vers un
écran dédié listant uniquement les matchs en attente (not_started /
in_progress) de son arène. Un clic sur un match ouvre directement
l'interface de saisie des scores, sans afficher les matchs passés.

- Ajout du panneau #next-matches-screen avec CSS et HTML
- Méthodes : showNextMatchesScreen, loadNextMatches,
  renderNextMatchesList, selectMatchFromNextScreen
- confirmFinish() appelle showNextMatchesScreen() après 2s
- selectMatch() masque le sélecteur de poule et l'écran next-matches
- handleArenaUpdate() rafraîchit la liste si l'écran est visible
  (sans auto-sélection)

https://claude.ai/code/session_01S7efhyP2Y9M9dqDz7SppoP