### PR TITLE
Fix alignement tableau d'élimination : correction formule de position verticale

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -876,7 +876,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     // k = nombre de créneaux de la première colonne couverts par ce match
     const k = baseRound / matchRound;
     // Centre ce match verticalement dans ses k créneaux
-    return Math.max(0, (matchPosition - 0.5) * k * SLOT_HEIGHT - BASE_MATCH_HEIGHT / 2);
+    return (matchPosition + 0.5) * k * SLOT_HEIGHT - BASE_MATCH_HEIGHT / 2;
   };
 
   const getMatchPosition = (match: TableauMatch): number => {


### PR DESCRIPTION
Les positions de match sont 0-indexées mais la formule utilisait (matchPosition - 0.5)
qui suppose une indexation à partir de 1. Cela causait un Math.max(0,...) qui clampait
les premiers matchs de chaque tour à 0, produisant des chevauchements.

Correction : (matchPosition - 0.5) → (matchPosition + 0.5)

https://claude.ai/code/session_01MWw4EEBq6Y1vbQx6CtLQ8n