### PR TITLE
fix: corriger les échecs GitHub Actions claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -36,9 +36,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            Please review this pull request and provide feedback on:
+            - Code quality and potential bugs
+            - TypeScript/React best practices
+            - Performance concerns
+            - Security issues
+            Post your review as a PR comment.
 


### PR DESCRIPTION
- pull-requests: read → write (403 sans cette permission)
- Supprime plugin_marketplaces/plugins (inputs inexistants dans v1)
- Remplace le prompt plugin par un prompt natif direct

https://claude.ai/code/session_01EAZRU88K7qSW7HLXAoR3ny