### PR TITLE
Ajoute un espacement entre les cases du tableau d'élimination directe

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -56,7 +56,7 @@ interface TableauViewProps {
 }
 
 const BASE_MATCH_HEIGHT = 80;
-const SLOT_HEIGHT = BASE_MATCH_HEIGHT + 16; // hauteur d'un créneau dans la première colonne
+const SLOT_HEIGHT = BASE_MATCH_HEIGHT + 32; // hauteur d'un créneau dans la première colonne
 
 const TableauViewComponent: React.FC<TableauViewProps> = ({
   ranking,


### PR DESCRIPTION
Augmente SLOT_HEIGHT de +16 à +32 pour donner ~16px de gap entre les
cases de la première colonne (fonctionne pour tous les tableaux : 8/16/32/64/128).

https://claude.ai/code/session_015qHP2u8EzzB3kHNoE8mR33