### PR TITLE
feat: file d'attente par arène pour le tableau d'élimination directe

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -33,6 +33,7 @@ export class RemoteScoreServer {
   private sessionWeapon: string | null = null; // Type d'arme de la compétition (L = Laser)
   private sessionMatches: any[] = []; // Matches passés depuis le renderer
   private arenaNextMatchIndex: Map<string, number> = new Map(); // Index du prochain match par arène
+  private arenaMatchQueue: Map<string, ArenaMatch[]> = new Map(); // File d'attente DE par arène
 
   // Stocker le contenu des fichiers HTML en mémoire pour éviter les problèmes de chemin
   private htmlFiles: Map<string, string> = new Map();
@@ -946,6 +947,7 @@ export class RemoteScoreServer {
         },
       };
       this.arenas.set(arena.id, arena);
+      this.arenaMatchQueue.set(arena.id, []);
       console.log(`[RemoteScoreServer] Arène ${i} créée ✓`);
     }
     console.log(`[RemoteScoreServer] ${arenaCount} arènes initialisées avec succès ✓`);
@@ -1232,7 +1234,17 @@ export class RemoteScoreServer {
       );
     }
 
-    // Pas de match suivant dans le même pool - marquer l'arène comme vide
+    // Vérifier la file d'attente DE avant de marquer l'arène comme vide
+    const deQueue = this.arenaMatchQueue.get(arenaId) || [];
+    if (deQueue.length > 0) {
+      const nextDeMatch = deQueue[0];
+      this.arenaMatchQueue.set(arenaId, deQueue.slice(1));
+      console.log(`[RemoteScoreServer] Match DE suivant ${nextDeMatch.id} chargé depuis la file sur arène ${arenaId}`);
+      this.assignMatchToArena(arenaId, nextDeMatch);
+      return;
+    }
+
+    // Plus aucun match - marquer l'arène comme vide
     arena.currentMatch = null;
     arena.status = 'idle';
     arena.startTime = null;
@@ -1420,6 +1432,48 @@ export class RemoteScoreServer {
       );
 
       poolIndex++;
+    }
+
+    // Distribuer les matchs d'élimination directe (sans poolId) dans les files par arène
+    const deMatches = allMatches
+      .filter(m => !m.poolId && (m.round !== undefined || m.isTableau))
+      .sort((a: any, b: any) => (a.round || 0) - (b.round || 0));
+
+    if (deMatches.length > 0) {
+      console.log(`[RemoteScoreServer] ${deMatches.length} matchs DE à distribuer sur ${strips} arènes`);
+      let rrIndex = 0;
+      const queuesByArena = new Map<string, ArenaMatch[]>();
+      for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
+
+      for (const match of deMatches) {
+        const targetArenaId = match.arena
+          ? `arena${match.arena}`
+          : `arena${(rrIndex % strips) + 1}`;
+        if (!queuesByArena.has(targetArenaId)) {
+          // arène hors plage → round-robin sur arènes disponibles
+          const fallbackId = `arena${(rrIndex % strips) + 1}`;
+          queuesByArena.get(fallbackId)!.push({ id: match.id, fencerA: match.fencerA, fencerB: match.fencerB, scoreA: 0, scoreB: 0, status: 'not_started', startTime: null, endTime: null });
+        } else {
+          queuesByArena.get(targetArenaId)!.push({ id: match.id, fencerA: match.fencerA, fencerB: match.fencerB, scoreA: 0, scoreB: 0, status: 'not_started', startTime: null, endTime: null });
+        }
+        rrIndex++;
+      }
+
+      for (const [arenaId, queue] of queuesByArena) {
+        const arena = this.arenas.get(arenaId);
+        if (!arena) continue;
+        if (!arena.currentMatch && queue.length > 0) {
+          // Arène libre → charger le premier match directement
+          this.assignMatchToArena(arenaId, queue[0]);
+          this.arenaMatchQueue.set(arenaId, queue.slice(1));
+          console.log(`[RemoteScoreServer] Match DE ${queue[0].id} chargé sur arène ${arenaId}, ${queue.length - 1} en file`);
+        } else {
+          // Arène occupée (match de poule en cours) → tout en file
+          const existing = this.arenaMatchQueue.get(arenaId) || [];
+          this.arenaMatchQueue.set(arenaId, [...existing, ...queue]);
+          console.log(`[RemoteScoreServer] ${queue.length} matchs DE mis en file sur arène ${arenaId}`);
+        }
+      }
     }
 
     // Créer la session - utiliser allMatches au lieu de pendingMatches

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -62,6 +62,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     content: string;
   } | null>(null);
   const [isRemoteActive, setIsRemoteActive] = useState(false);
+  const [remoteArenaCount, setRemoteArenaCount] = useState<number>(1);
   const [showThirdPlaceDialog, setShowThirdPlaceDialog] = useState(false);
   const [tableauMatches, setTableauMatches] = useState<TableauMatch[]>([]);
   const [finalResults, setFinalResults] = useState<FinalResult[]>([]);
@@ -114,6 +115,11 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     competition,
     showToast,
   });
+
+  // Synchroniser le nombre d'arènes avec le nombre de poules
+  useEffect(() => {
+    if (pools.length > 0) setRemoteArenaCount(pools.length);
+  }, [pools.length]);
 
   // Session state persistence
   const { isLoaded, restoredState } = useCompetitionSession({
@@ -710,6 +716,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onMatchesChange={setTableauMatches}
             maxScore={tableMaxScore === 0 ? 999 : tableMaxScore}
             thirdPlaceMatch={thirdPlaceMatch}
+            arenaCount={remoteArenaCount}
             onComplete={results => {
               setFinalResults(results);
               setCurrentPhase('results');
@@ -729,6 +736,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
           <RemoteScoreManager
             competition={competition}
             pools={pools}
+            tableauMatches={tableauMatches}
+            onArenaCountChange={setRemoteArenaCount}
             onStartRemote={() => setIsRemoteActive(true)}
             onStopRemote={() => setIsRemoteActive(false)}
             isRemoteActive={isRemoteActive}

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -6,11 +6,14 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { Competition, Pool } from '../../shared/types';
+import { TableauMatch } from './TableauView';
 import { useToast } from './Toast';
 
 interface RemoteScoreManagerProps {
   competition: Competition;
   pools: Pool[];
+  tableauMatches?: TableauMatch[];
+  onArenaCountChange?: (count: number) => void;
   onStartRemote: () => void;
   onStopRemote: () => void;
   isRemoteActive?: boolean;
@@ -31,6 +34,8 @@ interface RemoteSession {
 const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   competition,
   pools,
+  tableauMatches,
+  onArenaCountChange,
   onStartRemote,
   onStopRemote,
   isRemoteActive = false,
@@ -87,8 +92,18 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
 
   const startSession = async (baseUrl: string, count: number) => {
     try {
-      const allMatches = pools.flatMap(pool => pool.matches || []);
-      console.log('[RemoteScoreManager] Passing matches to server:', allMatches.length);
+      const poolMatches = pools.flatMap(pool => pool.matches || []);
+      const deMatches = (tableauMatches || [])
+        .filter(m => m.status !== 'finished' && m.fencerA && m.fencerB)
+        .map(m => ({ ...m, isTableau: true }));
+      const allMatches = [...poolMatches, ...deMatches];
+      console.log(
+        '[RemoteScoreManager] Passing matches to server:',
+        poolMatches.length,
+        'pool +',
+        deMatches.length,
+        'DE'
+      );
       const result = await window.electronAPI.remote.startSession(
         competition.id,
         count,
@@ -96,6 +111,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       );
       if (result.success && result.session) {
         setSession(result.session);
+        onArenaCountChange?.(count);
         showToast('Saisie distante démarrée', 'success');
       } else {
         showToast(`Erreur session: ${result.error}`, 'error');
@@ -113,6 +129,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       if (result.success && result.session) {
         setSession(result.session);
         setStripCount(newCount);
+        onArenaCountChange?.(newCount);
       } else {
         showToast(`Erreur: ${result.error}`, 'error');
       }

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -1538,9 +1538,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                   -
                 </button>
                 {Array.from({ length: arenaCount }, (_, i) => i + 1).map(arenaNum => {
-                  const isAssigned = matches.some(
-                    m => m.arena === arenaNum && m.id !== selectedMatchForArena
-                  );
+                  const queueCount = matches.filter(
+                    m => m.arena === arenaNum && m.id !== selectedMatchForArena && m.status !== 'finished'
+                  ).length;
                   return (
                     <button
                       key={arenaNum}
@@ -1553,13 +1553,14 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                         setShowArenaModal(false);
                         setSelectedMatchForArena(null);
                       }}
-                      disabled={isAssigned}
-                      style={{
-                        padding: '0.75rem',
-                        opacity: isAssigned ? 0.5 : 1,
-                      }}
+                      style={{ padding: '0.75rem', position: 'relative' }}
                     >
                       Piste {arenaNum}
+                      {queueCount > 0 && (
+                        <span style={{ fontSize: '0.7rem', marginLeft: '0.3rem', color: '#6b7280' }}>
+                          (+{queueCount})
+                        </span>
+                      )}
                     </button>
                   );
                 })}

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -109,7 +109,7 @@ export interface ArenaSettings {
 
 export interface ArenaMatch {
   id: string;
-  poolId: string;
+  poolId?: string; // absent pour les matchs d'élimination directe
   fencerA: Fencer;
   fencerB: Fencer;
   scoreA: number;


### PR DESCRIPTION
- TableauView reçoit arenaCount depuis RemoteScoreManager via CompetitionView
  au lieu d'une valeur codée en dur (4)
- RemoteScoreManager transmet les matchs DE au serveur lors du démarrage
  de session et notifie CompetitionView des changements de nombre de pistes
- remoteScoreServer distribue les matchs DE dans des files par arène
  (par assignation explicite ou round-robin) et les charge automatiquement
  quand une arène se libère
- TableauView : l'assignation multi-piste est maintenant autorisée avec
  badge indiquant le nombre de matchs déjà en file par piste

https://claude.ai/code/session_0179KQ5mzfvc6J3ZTmnRQ1Vu