### PR TITLE
Optimise interface arbitre mobile : supprime badge statut redondant

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -149,7 +149,7 @@
       .active-match {
         background: rgba(255, 255, 255, 0.95);
         border-radius: 1rem;
-        padding: 1rem;
+        padding: 0.75rem;
         color: #1f2937;
         margin-bottom: 1rem;
         display: none;
@@ -159,45 +159,18 @@
         display: block;
       }
 
-      .match-header {
-        text-align: center;
-        margin-bottom: 1rem;
-      }
-
-      .match-status-badge {
-        display: inline-block;
-        padding: 0.25rem 0.75rem;
-        border-radius: 1rem;
-        font-size: 0.75rem;
-        font-weight: 600;
-        text-transform: uppercase;
-      }
-
-      .status-waiting {
-        background: #6b7280;
-        color: white;
-      }
-      .status-progress {
-        background: #3b82f6;
-        color: white;
-      }
-      .status-finished {
-        background: #10b981;
-        color: white;
-      }
-
       /* Tireurs */
       .fencers-container {
         display: grid;
         grid-template-columns: 1fr auto 1fr;
-        gap: 0.75rem;
+        gap: 0.5rem;
         align-items: center;
-        margin-bottom: 1rem;
+        margin-bottom: 0.75rem;
       }
 
       .fencer-box {
         background: #f3f4f6;
-        padding: 1rem;
+        padding: 0.6rem;
         border-radius: 0.75rem;
         text-align: center;
         border: 3px solid transparent;
@@ -214,33 +187,16 @@
         background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
       }
 
-      .fencer-color {
-        width: 24px;
-        height: 24px;
-        border-radius: 50%;
-        margin: 0 auto 0.5rem;
-      }
-
-      .fencer-color.red {
-        background: linear-gradient(135deg, #ef4444, #dc2626);
-        box-shadow: 0 2px 8px rgba(239, 68, 68, 0.4);
-      }
-
-      .fencer-color.green {
-        background: linear-gradient(135deg, #22c55e, #16a34a);
-        box-shadow: 0 2px 8px rgba(34, 197, 94, 0.4);
-      }
-
       .fencer-name {
         font-weight: 700;
         font-size: 1rem;
-        margin-bottom: 0.25rem;
+        margin-bottom: 0.2rem;
       }
 
       .fencer-club {
-        font-size: 0.75rem;
+        font-size: 0.7rem;
         color: #6b7280;
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.5rem;
       }
 
       /* Cartons */
@@ -286,7 +242,7 @@
       .score-display {
         font-size: 3rem;
         font-weight: 800;
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.5rem;
       }
 
       .score-display.red-score {
@@ -307,12 +263,12 @@
       /* Boutons de score */
       .score-buttons {
         display: grid;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(3, 1fr);
         gap: 0.35rem;
       }
 
       .score-btn {
-        padding: 0.6rem 0.3rem;
+        padding: 0.75rem 0.3rem;
         border: none;
         border-radius: 0.5rem;
         font-size: 1rem;
@@ -410,9 +366,9 @@
       .timer-section {
         background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
         border-radius: 1rem;
-        padding: 1.5rem 1rem;
+        padding: 0.75rem 1rem;
         text-align: center;
-        margin-bottom: 1rem;
+        margin-bottom: 0.75rem;
         box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
       }
 
@@ -740,14 +696,9 @@
 
       <!-- Match actif -->
       <div class="active-match" id="active-match">
-        <div class="match-header">
-          <span class="match-status-badge status-waiting" id="match-status">En attente</span>
-        </div>
-
         <div class="fencers-container">
           <!-- Tireur A (Rouge) -->
           <div class="fencer-box red-side" id="fencer-a-box">
-            <div class="fencer-color red"></div>
             <div class="fencer-name" id="fencer-a-name">-</div>
             <div class="fencer-club" id="fencer-a-club">-</div>
             <div class="cards-display" id="fencer-a-cards"></div>
@@ -808,7 +759,6 @@
 
           <!-- Tireur B (Vert) -->
           <div class="fencer-box green-side" id="fencer-b-box">
-            <div class="fencer-color green"></div>
             <div class="fencer-name" id="fencer-b-name">-</div>
             <div class="fencer-club" id="fencer-b-club">-</div>
             <div class="cards-display" id="fencer-b-cards"></div>
@@ -1676,23 +1626,7 @@
         }
 
         updateMatchStatus() {
-          const badge = document.getElementById('match-status');
-          badge.className = 'match-status-badge';
-
-          switch (this.matchStatus) {
-            case 'not_started':
-              badge.textContent = 'En attente';
-              badge.classList.add('status-waiting');
-              break;
-            case 'in_progress':
-              badge.textContent = 'En cours';
-              badge.classList.add('status-progress');
-              break;
-            case 'finished':
-              badge.textContent = 'Terminé';
-              badge.classList.add('status-finished');
-              break;
-          }
+          // badge supprimé — statut visible via boutons de contrôle et chronomètre
         }
 
         updateControlButtons() {


### PR DESCRIPTION
- Supprime le `match-header` (badge En attente/En cours/Terminé) : les
  noms des tireurs dans les cases de score suffisent à identifier le match
- Supprime les pastilles colorées `fencer-color` : le contour coloré des
  cases (rouge/vert) est déjà suffisant
- Réduit les paddings (active-match, fencer-box, timer-section) pour
  maximiser l'espace utile sur tablette/téléphone
- Corrige la grille score-buttons : 3 colonnes au lieu de 4 (3 boutons)
- Augmente la hauteur des boutons de score (+0.75rem) pour de meilleures
  zones de toucher sur mobile
- Neutralise `updateMatchStatus()` (élément supprimé)

https://claude.ai/code/session_012XArPCm3tqJVxFYryg6AJS