### PR TITLE
feat: demander confirmation arbitre avant fin de match Laser Sabre

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1087,11 +1087,11 @@ export class RemoteScoreServer {
 
     if (scoreReached15A || scoreReached15B) {
       console.log(
-        `[RemoteScoreServer] Score de ${SCORE_LIMIT_LASER} atteint en Laser Sabre - Arrêt automatique du match`
+        `[RemoteScoreServer] Score de ${SCORE_LIMIT_LASER} atteint en Laser Sabre - Signal score_limit_reached envoyé à l'arbitre`
       );
 
-      // Terminer le match
-      this.finishArenaMatch(arenaId);
+      // Signaler la tablette arbitre pour afficher la fenêtre de confirmation
+      this.io.emit(`arena:${arenaId}:score_limit_reached`, { scoreA, scoreB });
     }
   }
 

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1101,6 +1101,10 @@
           this.socket.on(`arena:${this.arenaId}:update`, data => {
             this.handleArenaUpdate(data);
           });
+
+          this.socket.on(`arena:${this.arenaId}:score_limit_reached`, () => {
+            this.showFinishModal();
+          });
         }
 
         setupTimerInteractions() {


### PR DESCRIPTION
Au lieu d'arrêter automatiquement le match quand le score 15 est atteint,
le serveur émet maintenant un événement `score_limit_reached` vers la
tablette arbitre, qui affiche une modale de confirmation avant de
terminer le match.

https://claude.ai/code/session_01YQC1p1HfWf4M6dQe32LZCk