### PR TITLE
feat: statistiques par combattant (touches, cartons, timing)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -201,6 +201,48 @@ export class DatabaseManager {
       )
     `);
 
+    // Table pour les touches (points marqués avec horodatage)
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS match_touches (
+        id TEXT PRIMARY KEY,
+        match_id TEXT NOT NULL,
+        fencer_id TEXT NOT NULL,
+        zone TEXT NOT NULL,
+        points INTEGER NOT NULL,
+        timestamp TEXT NOT NULL,
+        is_valid_in_sudden_death INTEGER DEFAULT 0,
+        is_reversed INTEGER DEFAULT 0,
+        FOREIGN KEY (match_id) REFERENCES matches(id) ON DELETE CASCADE
+      )
+    `);
+
+    // Table pour les cartons (avec horodatage)
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS match_cards (
+        id TEXT PRIMARY KEY,
+        match_id TEXT NOT NULL,
+        fencer_id TEXT NOT NULL,
+        card_type TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        card_group INTEGER NOT NULL DEFAULT 1,
+        timestamp TEXT NOT NULL,
+        points_awarded INTEGER NOT NULL DEFAULT 0,
+        resulting_exclusion INTEGER DEFAULT 0,
+        FOREIGN KEY (match_id) REFERENCES matches(id) ON DELETE CASCADE
+      )
+    `);
+
+    // Colonnes de timing sur les matchs (migration idempotente)
+    try {
+      this.db.run(`ALTER TABLE matches ADD COLUMN start_time TEXT`);
+    } catch { /* colonne déjà présente */ }
+    try {
+      this.db.run(`ALTER TABLE matches ADD COLUMN end_time TEXT`);
+    } catch { /* colonne déjà présente */ }
+    try {
+      this.db.run(`ALTER TABLE matches ADD COLUMN duration INTEGER`);
+    } catch { /* colonne déjà présente */ }
+
     // Création des index pour optimiser les performances
     this.createIndexes();
   }
@@ -241,6 +283,12 @@ export class DatabaseManager {
     // Index pour les associations pool/tireur
     this.db.run(`CREATE INDEX IF NOT EXISTS idx_pool_fencers_pool ON pool_fencers(pool_id)`);
     this.db.run(`CREATE INDEX IF NOT EXISTS idx_pool_fencers_fencer ON pool_fencers(fencer_id)`);
+
+    // Index pour les statistiques par combattant
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_touches_match ON match_touches(match_id)`);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_touches_fencer ON match_touches(fencer_id)`);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_cards_match ON match_cards(match_id)`);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_cards_fencer ON match_cards(fencer_id)`);
   }
 
   // Session State Management
@@ -1172,6 +1220,219 @@ export class DatabaseManager {
     }
 
     this.save();
+  }
+
+  // ─── Statistiques combattants ───────────────────────────────────────────────
+
+  public saveTouch(touch: {
+    id: string;
+    matchId: string;
+    fencerId: string;
+    zone: string;
+    points: number;
+    timestamp: string;
+    isValidInSuddenDeath?: boolean;
+    isReversed?: boolean;
+  }): void {
+    if (!this.db) throw new Error('Database not open');
+    this.db.run(
+      `INSERT OR REPLACE INTO match_touches
+        (id, match_id, fencer_id, zone, points, timestamp, is_valid_in_sudden_death, is_reversed)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        touch.id,
+        touch.matchId,
+        touch.fencerId,
+        touch.zone,
+        touch.points,
+        touch.timestamp,
+        touch.isValidInSuddenDeath ? 1 : 0,
+        touch.isReversed ? 1 : 0,
+      ]
+    );
+    this.save();
+  }
+
+  public saveCard(card: {
+    id: string;
+    matchId: string;
+    fencerId: string;
+    cardType: string;
+    reason: string;
+    cardGroup: number;
+    timestamp: string;
+    pointsAwarded: number;
+    resultingExclusion?: boolean;
+  }): void {
+    if (!this.db) throw new Error('Database not open');
+    this.db.run(
+      `INSERT OR REPLACE INTO match_cards
+        (id, match_id, fencer_id, card_type, reason, card_group, timestamp, points_awarded, resulting_exclusion)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        card.id,
+        card.matchId,
+        card.fencerId,
+        card.cardType,
+        card.reason,
+        card.cardGroup,
+        card.timestamp,
+        card.pointsAwarded,
+        card.resultingExclusion ? 1 : 0,
+      ]
+    );
+    this.save();
+  }
+
+  public updateMatchTiming(
+    matchId: string,
+    startTime: string | null,
+    endTime: string | null,
+    duration: number | null
+  ): void {
+    if (!this.db) throw new Error('Database not open');
+    const now = new Date().toISOString();
+    this.db.run(
+      `UPDATE matches SET start_time = ?, end_time = ?, duration = ?, updated_at = ? WHERE id = ?`,
+      [startTime, endTime, duration, now, matchId]
+    );
+    this.save();
+  }
+
+  public getFencerHistory(fencerId: string): {
+    matches: Array<{
+      matchId: string;
+      number: number;
+      opponentId: string | null;
+      opponentLastName: string | null;
+      opponentFirstName: string | null;
+      scoreA: string | null;
+      scoreB: string | null;
+      side: 'A' | 'B';
+      status: string;
+      startTime: string | null;
+      endTime: string | null;
+      duration: number | null;
+      poolId: string | null;
+      tableId: string | null;
+      round: number | null;
+      touches: Array<{
+        id: string;
+        zone: string;
+        points: number;
+        timestamp: string;
+        isValidInSuddenDeath: boolean;
+        isReversed: boolean;
+      }>;
+      cards: Array<{
+        id: string;
+        cardType: string;
+        reason: string;
+        cardGroup: number;
+        timestamp: string;
+        pointsAwarded: number;
+        resultingExclusion: boolean;
+      }>;
+    }>;
+  } {
+    if (!this.db) throw new Error('Database not open');
+
+    // Récupérer les matchs joués par ce combattant (comme A ou B)
+    const matchRows: any[] = [];
+    const matchStmt = this.db.prepare(`
+      SELECT
+        m.id, m.number, m.fencer_a_id, m.fencer_b_id,
+        m.score_a, m.score_b, m.status,
+        m.start_time, m.end_time, m.duration,
+        m.pool_id, m.table_id, m.round,
+        fa.last_name AS opp_a_last, fa.first_name AS opp_a_first,
+        fb.last_name AS opp_b_last, fb.first_name AS opp_b_first
+      FROM matches m
+      LEFT JOIN fencers fa ON m.fencer_a_id = fa.id
+      LEFT JOIN fencers fb ON m.fencer_b_id = fb.id
+      WHERE (m.fencer_a_id = ? OR m.fencer_b_id = ?)
+        AND m.status = 'finished'
+      ORDER BY m.updated_at ASC
+    `);
+    matchStmt.bind([fencerId, fencerId]);
+    while (matchStmt.step()) {
+      matchRows.push(matchStmt.getAsObject());
+    }
+    matchStmt.free();
+
+    const matches = matchRows.map((row) => {
+      const side: 'A' | 'B' = row.fencer_a_id === fencerId ? 'A' : 'B';
+      const opponentId = side === 'A' ? (row.fencer_b_id as string | null) : (row.fencer_a_id as string | null);
+      const opponentLastName = side === 'A' ? (row.opp_b_last as string | null) : (row.opp_a_last as string | null);
+      const opponentFirstName = side === 'A' ? (row.opp_b_first as string | null) : (row.opp_a_first as string | null);
+
+      // Touches de ce combattant dans ce match
+      const touches: any[] = [];
+      const touchStmt = this.db.prepare(`
+        SELECT id, zone, points, timestamp, is_valid_in_sudden_death, is_reversed
+        FROM match_touches
+        WHERE match_id = ? AND fencer_id = ?
+        ORDER BY timestamp ASC
+      `);
+      touchStmt.bind([row.id as string, fencerId]);
+      while (touchStmt.step()) {
+        const t = touchStmt.getAsObject();
+        touches.push({
+          id: t.id as string,
+          zone: t.zone as string,
+          points: t.points as number,
+          timestamp: t.timestamp as string,
+          isValidInSuddenDeath: t.is_valid_in_sudden_death === 1,
+          isReversed: t.is_reversed === 1,
+        });
+      }
+      touchStmt.free();
+
+      // Cartons de ce combattant dans ce match
+      const cards: any[] = [];
+      const cardStmt = this.db.prepare(`
+        SELECT id, card_type, reason, card_group, timestamp, points_awarded, resulting_exclusion
+        FROM match_cards
+        WHERE match_id = ? AND fencer_id = ?
+        ORDER BY timestamp ASC
+      `);
+      cardStmt.bind([row.id as string, fencerId]);
+      while (cardStmt.step()) {
+        const c = cardStmt.getAsObject();
+        cards.push({
+          id: c.id as string,
+          cardType: c.card_type as string,
+          reason: c.reason as string,
+          cardGroup: c.card_group as number,
+          timestamp: c.timestamp as string,
+          pointsAwarded: c.points_awarded as number,
+          resultingExclusion: c.resulting_exclusion === 1,
+        });
+      }
+      cardStmt.free();
+
+      return {
+        matchId: row.id as string,
+        number: row.number as number,
+        opponentId,
+        opponentLastName,
+        opponentFirstName,
+        scoreA: row.score_a as string | null,
+        scoreB: row.score_b as string | null,
+        side,
+        status: row.status as string,
+        startTime: row.start_time as string | null,
+        endTime: row.end_time as string | null,
+        duration: row.duration as number | null,
+        poolId: row.pool_id as string | null,
+        tableId: row.table_id as string | null,
+        round: row.round as number | null,
+        touches,
+        cards,
+      };
+    });
+
+    return { matches };
   }
 
   // Export/Import

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -579,6 +579,23 @@ ipcMain.handle('db:updatePool', async (_, pool) => {
 //   return db.getPoolFencers(poolId);
 // });
 
+// Statistiques combattants
+ipcMain.handle('db:saveTouch', async (_, touch) => {
+  return db.saveTouch(touch);
+});
+
+ipcMain.handle('db:saveCard', async (_, card) => {
+  return db.saveCard(card);
+});
+
+ipcMain.handle('db:updateMatchTiming', async (_, timing) => {
+  return db.updateMatchTiming(timing.matchId, timing.startTime, timing.endTime, timing.duration);
+});
+
+ipcMain.handle('db:getFencerHistory', async (_, fencerId) => {
+  return db.getFencerHistory(fencerId);
+});
+
 // File handlers
 ipcMain.handle('file:export', async (_, filepath) => {
   db.exportToFile(filepath);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -20,6 +20,9 @@ import type {
   FileSaveResult,
   VersionInfo,
   Pool,
+  MatchTouchData,
+  MatchCardData,
+  MatchTimingData,
 } from '../shared/types/preload';
 
 // Input validation functions
@@ -203,6 +206,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
         throw new Error('Competition ID is required and must be a string');
       }
       return ipcRenderer.invoke('db:clearSessionState', competitionId);
+    },
+
+    // Statistiques combattants
+    saveTouch: (touch: MatchTouchData) => ipcRenderer.invoke('db:saveTouch', touch),
+    saveCard: (card: MatchCardData) => ipcRenderer.invoke('db:saveCard', card),
+    updateMatchTiming: (timing: MatchTimingData) =>
+      ipcRenderer.invoke('db:updateMatchTiming', timing),
+    getFencerHistory: (fencerId: string) => {
+      if (!fencerId || typeof fencerId !== 'string') {
+        throw new Error('Fencer ID is required and must be a string');
+      }
+      return ipcRenderer.invoke('db:getFencerHistory', fencerId);
     },
   },
 

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -101,6 +101,79 @@ export interface MatchUpdateData {
   duration?: number;
 }
 
+// ============================================================================
+// Fighter Statistics Types
+// ============================================================================
+
+export interface MatchTouchData {
+  id: string;
+  matchId: string;
+  fencerId: string;
+  zone: string; // TargetZone: A | B | C
+  points: number;
+  timestamp: string; // ISO 8601
+  isValidInSuddenDeath?: boolean;
+  isReversed?: boolean;
+}
+
+export interface MatchCardData {
+  id: string;
+  matchId: string;
+  fencerId: string;
+  cardType: string; // 'yellow' | 'red' | 'black'
+  reason: string; // CardReason
+  cardGroup: number; // 1–4
+  timestamp: string; // ISO 8601
+  pointsAwarded: number;
+  resultingExclusion?: boolean;
+}
+
+export interface MatchTimingData {
+  matchId: string;
+  startTime: string | null; // ISO 8601
+  endTime: string | null;   // ISO 8601
+  duration: number | null;  // secondes
+}
+
+export interface FencerMatchRecord {
+  matchId: string;
+  number: number;
+  opponentId: string | null;
+  opponentLastName: string | null;
+  opponentFirstName: string | null;
+  scoreA: string | null; // JSON Score
+  scoreB: string | null; // JSON Score
+  side: 'A' | 'B';
+  status: string;
+  startTime: string | null;
+  endTime: string | null;
+  duration: number | null;
+  poolId: string | null;
+  tableId: string | null;
+  round: number | null;
+  touches: Array<{
+    id: string;
+    zone: string;
+    points: number;
+    timestamp: string;
+    isValidInSuddenDeath: boolean;
+    isReversed: boolean;
+  }>;
+  cards: Array<{
+    id: string;
+    cardType: string;
+    reason: string;
+    cardGroup: number;
+    timestamp: string;
+    pointsAwarded: number;
+    resultingExclusion: boolean;
+  }>;
+}
+
+export interface FencerHistory {
+  matches: FencerMatchRecord[];
+}
+
 export interface SessionState {
   currentPhase?: number;
   selectedPool?: string;
@@ -268,6 +341,12 @@ export interface DatabaseAPI {
   saveSessionState: (competitionId: string, state: SessionState) => Promise<void>;
   getSessionState: (competitionId: string) => Promise<SessionState | null>;
   clearSessionState: (competitionId: string) => Promise<void>;
+
+  // Statistiques combattants
+  saveTouch: (touch: MatchTouchData) => Promise<void>;
+  saveCard: (card: MatchCardData) => Promise<void>;
+  updateMatchTiming: (timing: MatchTimingData) => Promise<void>;
+  getFencerHistory: (fencerId: string) => Promise<FencerHistory>;
 }
 
 export interface FileAPI {


### PR DESCRIPTION
Ajoute la persistance en base des événements de match par combattant :

- Tables `match_touches` et `match_cards` avec horodatage (ISO 8601)
- Migration idempotente : colonnes `start_time`, `end_time`, `duration` sur `matches`
- Méthodes DB : `saveTouch`, `saveCard`, `updateMatchTiming`, `getFencerHistory`
- `getFencerHistory(fencerId)` retourne l'historique complet des matchs terminés
  avec les touches (zone, points, timestamp) et cartons (type, raison, groupe, timestamp)
- IPC handlers : `db:saveTouch`, `db:saveCard`, `db:updateMatchTiming`, `db:getFencerHistory`
- Preload : méthodes exposées + types `MatchTouchData`, `MatchCardData`,
  `MatchTimingData`, `FencerMatchRecord`, `FencerHistory`

https://claude.ai/code/session_01RYrtBCMayxTB4jfs2X2y3g