### PR TITLE
fix: corriger erreurs TypeScript TableauMatch.status dans builds CI

### DIFF
--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -94,7 +94,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     try {
       const poolMatches = pools.flatMap(pool => pool.matches || []);
       const deMatches = (tableauMatches || [])
-        .filter(m => m.status !== 'finished' && m.fencerA && m.fencerB)
+        .filter(m => m.winner === null && m.fencerA && m.fencerB)
         .map(m => ({ ...m, isTableau: true }));
       const allMatches = [...poolMatches, ...deMatches];
       console.log(

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -1539,7 +1539,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 </button>
                 {Array.from({ length: arenaCount }, (_, i) => i + 1).map(arenaNum => {
                   const queueCount = matches.filter(
-                    m => m.arena === arenaNum && m.id !== selectedMatchForArena && m.status !== 'finished'
+                    m => m.arena === arenaNum && m.id !== selectedMatchForArena && m.winner === null
                   ).length;
                   return (
                     <button


### PR DESCRIPTION
`TableauMatch` n'a pas de champ `status` — le code utilisait
`m.status !== 'finished'` (deux endroits) ce qui bloquait tsc depuis PR #89.
Remplacé par `m.winner === null` qui est l'indicateur de complétion réel.

Fichiers corrigés :
- src/renderer/components/RemoteScoreManager.tsx:97
- src/renderer/components/TableauView.tsx:1542

https://claude.ai/code/session_01Cfc7GX8nLbQB66AWokKaZR