### PR TITLE
Ajout export PDF feuilles de match sur le tableau d'élimination directe

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -9,6 +9,10 @@ import { Fencer, PoolRanking } from '../../shared/types';
 import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
 import Bracket from './Bracket';
+import {
+  exportTableauToPDF,
+  MAX_MATCHES_PER_PAGE_TABLEAU,
+} from '../../shared/utils/pdfExport';
 
 interface BracketMatch {
   id: string;
@@ -81,6 +85,8 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const [showArenaModal, setShowArenaModal] = useState(false);
   const [selectedMatchForArena, setSelectedMatchForArena] = useState<string | null>(null);
   const [pyramidViewMode, setPyramidViewMode] = useState<boolean>(false);
+  const [showPdfModal, setShowPdfModal] = useState(false);
+  const [pdfMatchesPerPage, setPdfMatchesPerPage] = useState<number>(MAX_MATCHES_PER_PAGE_TABLEAU);
   const isUnlimitedScore = maxScore === 999;
 
   const { modalRef } = useModalResize({
@@ -483,6 +489,17 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     setVictoryA(false);
     setVictoryB(false);
     setShowScoreModal(true);
+  };
+
+  const handleExportPDF = async () => {
+    const perPage = Math.max(1, Math.min(pdfMatchesPerPage, MAX_MATCHES_PER_PAGE_TABLEAU));
+    const title = `Tableau de ${tableauSize}`;
+    try {
+      await exportTableauToPDF(matches, perPage, title);
+      setShowPdfModal(false);
+    } catch (e) {
+      showToast((e as Error).message, 'error');
+    }
   };
 
   const handleSpecialStatus = (status: 'abandon' | 'forfait' | 'exclusion') => {
@@ -1131,6 +1148,25 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
           >
             {pyramidViewMode ? '🔲 Tableau' : '🔺 Pyramide'}
           </button>
+          <button
+            onClick={() => setShowPdfModal(true)}
+            style={{
+              background: '#10b981',
+              color: 'white',
+              border: 'none',
+              padding: '0.5rem 0.75rem',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontSize: '0.875rem',
+              fontWeight: '500',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem',
+            }}
+            title="Exporter les feuilles de match en PDF"
+          >
+            📄 Export PDF
+          </button>
           {champion && (
             <div
               style={{
@@ -1506,6 +1542,75 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
 
         return scoreModal;
       })()}
+
+      {showPdfModal && (
+        <div className="modal-overlay" onClick={() => setShowPdfModal(false)}>
+          <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '400px' }}>
+            <div className="modal-header">
+              <h3 className="modal-title">Export PDF – Feuilles de match</h3>
+              <button className="btn-close" onClick={() => setShowPdfModal(false)}>
+                &times;
+              </button>
+            </div>
+            <div className="modal-body" style={{ padding: '1.5rem' }}>
+              <p style={{ marginBottom: '1rem', color: '#6b7280', fontSize: '0.875rem' }}>
+                Chaque fiche contient le nom complet des combattants, une case score et une case
+                signature.
+              </p>
+              <label style={{ display: 'block', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Matchs par feuille A4{' '}
+                <span style={{ fontWeight: '400', color: '#6b7280' }}>
+                  (max {MAX_MATCHES_PER_PAGE_TABLEAU})
+                </span>
+              </label>
+              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                {Array.from({ length: MAX_MATCHES_PER_PAGE_TABLEAU }, (_, i) => i + 1).map(n => (
+                  <button
+                    key={n}
+                    onClick={() => setPdfMatchesPerPage(n)}
+                    style={{
+                      flex: 1,
+                      padding: '0.6rem',
+                      background: pdfMatchesPerPage === n ? '#10b981' : '#e5e7eb',
+                      color: pdfMatchesPerPage === n ? 'white' : '#374151',
+                      border: 'none',
+                      borderRadius: '6px',
+                      cursor: 'pointer',
+                      fontWeight: '600',
+                      fontSize: '1rem',
+                    }}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+              <p style={{ marginTop: '0.75rem', fontSize: '0.8rem', color: '#9ca3af' }}>
+                {matches.filter(m => !m.isBye && m.fencerA && m.fencerB).length} matchs →{' '}
+                {Math.ceil(
+                  matches.filter(m => !m.isBye && m.fencerA && m.fencerB).length / pdfMatchesPerPage
+                )}{' '}
+                feuille
+                {Math.ceil(
+                  matches.filter(m => !m.isBye && m.fencerA && m.fencerB).length / pdfMatchesPerPage
+                ) > 1
+                  ? 's'
+                  : ''}
+              </p>
+            </div>
+            <div
+              className="modal-footer"
+              style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}
+            >
+              <button className="btn btn-secondary" onClick={() => setShowPdfModal(false)}>
+                Annuler
+              </button>
+              <button className="btn btn-primary" onClick={handleExportPDF}>
+                Générer PDF
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {showArenaModal && selectedMatchForArena && (
         <div className="modal-overlay" onClick={() => setShowArenaModal(false)}>

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -358,3 +358,168 @@ export async function exportMultiplePoolsToPDF(
 
 // Alias pour compatibilité
 export const exportOptimizedPoolToPDF = exportPoolToPDF;
+
+// ─── Export Tableau Élimination Directe ──────────────────────────────────────
+
+export interface TableauMatchForPDF {
+  id: string;
+  round: number;
+  position: number;
+  fencerA: { firstName?: string; lastName: string } | null;
+  fencerB: { firstName?: string; lastName: string } | null;
+  scoreA: number | null;
+  scoreB: number | null;
+  winner: { id: string } | null;
+  isBye: boolean;
+}
+
+/** Nombre maximum de matchs par feuille A4 (marges 8mm, carte ~52mm/match) */
+export const MAX_MATCHES_PER_PAGE_TABLEAU = 5;
+
+function getTableauRoundName(round: number): string {
+  if (round === 2) return 'Finale';
+  if (round === 3) return 'Petite finale';
+  if (round === 4) return 'Demi-finales';
+  if (round === 8) return 'Quarts de finale';
+  if (round === 16) return 'Tableau de 16';
+  if (round === 32) return 'Tableau de 32';
+  if (round === 64) return 'Tableau de 64';
+  if (round === 128) return 'Tableau de 128';
+  return `Tableau de ${round}`;
+}
+
+function generateTableauHTML(
+  matches: TableauMatchForPDF[],
+  matchesPerPage: number,
+  title: string
+): string {
+  const realMatches = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
+  const sorted = [...realMatches].sort((a, b) => b.round - a.round || a.position - b.position);
+
+  const pages: TableauMatchForPDF[][] = [];
+  for (let i = 0; i < sorted.length; i += matchesPerPage) {
+    pages.push(sorted.slice(i, i + matchesPerPage));
+  }
+
+  const pagesHTML = pages
+    .map((pageMatches, pageIdx) => {
+      const isLast = pageIdx === pages.length - 1;
+      const cards = pageMatches
+        .map((match, matchIdx) => {
+          const roundName = getTableauRoundName(match.round);
+          const f = match.fencerA!;
+          const g = match.fencerB!;
+          const nameA = `${f.lastName} ${f.firstName || ''}`.trim();
+          const nameB = `${g.lastName} ${g.firstName || ''}`.trim();
+          const num = pageIdx * matchesPerPage + matchIdx + 1;
+          return `
+<div class="match-card">
+  <div class="match-header">
+    <span class="match-round">${roundName}</span>
+    <span class="match-num">Match ${num}</span>
+  </div>
+  <table class="match-table">
+    <colgroup>
+      <col class="col-name">
+      <col class="col-score">
+      <col class="col-sig">
+    </colgroup>
+    <thead><tr>
+      <th>Tireur</th>
+      <th>Score</th>
+      <th>Signature</th>
+    </tr></thead>
+    <tbody>
+      <tr><td class="fencer-name">${nameA}</td><td class="score-box"></td><td class="sig-box"></td></tr>
+      <tr><td class="fencer-name">${nameB}</td><td class="score-box"></td><td class="sig-box"></td></tr>
+    </tbody>
+  </table>
+</div>`;
+        })
+        .join('');
+      return `<div class="page${isLast ? '' : ' page-break'}">${cards}</div>`;
+    })
+    .join('');
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>${title}</title>
+  <style>
+    @page { size: A4 portrait; margin: 8mm; }
+    @media print {
+      body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      .no-print { display: none; }
+      .page-break { page-break-after: always; }
+    }
+    * { box-sizing: border-box; }
+    body { font-family: 'Segoe UI', Arial, sans-serif; font-size: 10pt; margin: 0; padding: 10px; color: #333; }
+    h1 { text-align: center; font-size: 16pt; margin: 0 0 6mm 0; color: #1a365d; }
+    .page { padding-top: 0; }
+    .page-break { page-break-after: always; }
+    .match-card { border: 2px solid #2d3748; border-radius: 4px; margin-bottom: 7mm; overflow: hidden; }
+    .match-header {
+      background: #2d3748; color: white; padding: 2.5mm 4mm;
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    .match-round { font-weight: 700; font-size: 11pt; }
+    .match-num { font-size: 9pt; opacity: 0.75; }
+    .match-table { width: 100%; border-collapse: collapse; }
+    col.col-name  { width: 55%; }
+    col.col-score { width: 15%; }
+    col.col-sig   { width: 30%; }
+    .match-table thead th {
+      background: #edf2f7; font-size: 8pt; font-weight: 600;
+      padding: 1.5mm 3mm; border-bottom: 1px solid #cbd5e0;
+      text-align: left; color: #4a5568;
+    }
+    .match-table thead th:nth-child(2) { text-align: center; }
+    .match-table tbody tr:first-child td { border-bottom: 1px solid #e2e8f0; }
+    .fencer-name { padding: 3mm 3mm; font-size: 12pt; font-weight: 600; vertical-align: middle; }
+    .score-box {
+      border-left: 1px solid #cbd5e0; border-right: 1px solid #cbd5e0;
+      height: 18mm; vertical-align: middle; text-align: center;
+    }
+    .sig-box { height: 18mm; }
+    .print-btn {
+      position: fixed; top: 10px; right: 10px;
+      padding: 8px 16px; background: #3182ce; color: white;
+      border: none; border-radius: 4px; cursor: pointer; font-size: 12pt;
+    }
+    .print-btn:hover { background: #2c5282; }
+  </style>
+</head>
+<body>
+  <button class="print-btn no-print" onclick="window.print()">🖨️ Imprimer / PDF</button>
+  <h1>${title}</h1>
+  ${pagesHTML}
+</body>
+</html>`;
+}
+
+/**
+ * Exporte le tableau d'élimination directe en feuilles d'arbitrage imprimables.
+ * Chaque fiche contient : noms des combattants, case score, case signature.
+ */
+export async function exportTableauToPDF(
+  matches: TableauMatchForPDF[],
+  matchesPerPage: number,
+  title: string = 'Tableau Élimination Directe'
+): Promise<void> {
+  const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
+  if (real.length === 0) {
+    throw new Error('Aucun match à exporter (tous sont des exempts ou sans tireurs assignés)');
+  }
+
+  const html = generateTableauHTML(matches, matchesPerPage, title);
+  const printWindow = window.open('', '_blank', 'width=900,height=700');
+  if (printWindow) {
+    printWindow.document.write(html);
+    printWindow.document.close();
+  } else {
+    throw new Error(
+      "Impossible d'ouvrir la fenêtre d'impression. Vérifiez que les popups sont autorisés."
+    );
+  }
+}


### PR DESCRIPTION
- Nouveau bouton "📄 Export PDF" dans la barre d'outils du tableau
- Modal pour choisir le nombre de matchs par feuille A4 (1 à 5)
- Calcul automatique du nombre de feuilles nécessaires affiché en temps réel
- Chaque fiche contient : tour/round, nom prénom des deux combattants,
  case score et case signature pour chacun
- Les matchs bye (exempts) sont filtrés ; tri par tour puis position
- Fonction exportTableauToPDF + constante MAX_MATCHES_PER_PAGE_TABLEAU
  ajoutées dans pdfExport.ts (même pattern print navigateur que les poules)

https://claude.ai/code/session_015Fwf3G8erxWWwf9fW3Qrw6