### PR TITLE
Fix: score affiché [object Object] lors du changement de match

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -739,7 +739,12 @@ export class RemoteScoreServer {
       case 'select_match':
         // Sélection d'un match par l'arbitre
         if (data.match) {
-          this.assignMatchToArena(data.arenaId, data.match);
+          const m = data.match;
+          this.assignMatchToArena(data.arenaId, {
+            ...m,
+            scoreA: typeof m.scoreA === 'object' ? (m.scoreA?.value ?? 0) : (m.scoreA ?? 0),
+            scoreB: typeof m.scoreB === 'object' ? (m.scoreB?.value ?? 0) : (m.scoreB ?? 0),
+          });
           // Réinitialiser les cartons
           this.arenaCards.set(data.arenaId, { cardsA: [], cardsB: [] });
         }

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -653,8 +653,12 @@
             `${fencerB.lastName || ''} ${fencerB.firstName || ''}`.trim() || '-';
           document.getElementById('fencer-b-club').textContent = fencerB.club || '';
 
-          document.getElementById('score-a').textContent = this.currentMatch.scoreA || 0;
-          document.getElementById('score-b').textContent = this.currentMatch.scoreB || 0;
+          const sA = this.currentMatch.scoreA;
+          const sB = this.currentMatch.scoreB;
+          document.getElementById('score-a').textContent =
+            (typeof sA === 'object' ? (sA?.value ?? 0) : sA) ?? 0;
+          document.getElementById('score-b').textContent =
+            (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
         }
 
         updateCardsDisplay() {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1132,7 +1132,11 @@
           this.socket.emit('arena_control', {
             arenaId: this.arenaId,
             action: 'select_match',
-            match: match,
+            match: {
+              ...match,
+              scoreA: this.scoreA,
+              scoreB: this.scoreB,
+            },
           });
         }
 


### PR DESCRIPTION
- referee.html : envoi des scores normalisés (this.scoreA/this.scoreB) dans
  l'événement select_match au lieu du match brut (scoreA pouvait être un objet)
- arena.html : extraction de .value si scoreA/scoreB est un objet Score dans
  updateMatchDisplay()
- remoteScoreServer.ts : normalisation défensive des scores dans le handler
  select_match avant assignMatchToArena()

https://claude.ai/code/session_01KChw3xPhUMTprZQ18rsfGP