### PR TITLE
Fix: TypeScript TS2339 error on scoreA/scoreB in remoteScoreServer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.1-build.285",
+  "version": "1.0.2-build.434",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.1-build.285",
+      "version": "1.0.2-build.434",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -742,8 +742,8 @@ export class RemoteScoreServer {
           const m = data.match;
           this.assignMatchToArena(data.arenaId, {
             ...m,
-            scoreA: typeof m.scoreA === 'object' ? (m.scoreA?.value ?? 0) : (m.scoreA ?? 0),
-            scoreB: typeof m.scoreB === 'object' ? (m.scoreB?.value ?? 0) : (m.scoreB ?? 0),
+            scoreA: typeof (m.scoreA as unknown) === 'object' ? ((m.scoreA as unknown as { value?: number })?.value ?? 0) : (m.scoreA ?? 0),
+            scoreB: typeof (m.scoreB as unknown) === 'object' ? ((m.scoreB as unknown as { value?: number })?.value ?? 0) : (m.scoreB ?? 0),
           });
           // Réinitialiser les cartons
           this.arenaCards.set(data.arenaId, { cardsA: [], cardsB: [] });


### PR DESCRIPTION
Cast to unknown before typeof check to allow runtime Score-object guard
while satisfying TypeScript strict typing on ArenaMatch (scoreA: number).

https://claude.ai/code/session_0198AwH91UKY9ucUzJMsL6Ky