### PR TITLE
fix: corriger erreurs TypeScript TS2339 bloquant le CI (remoteScoreSe…

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -740,10 +740,12 @@ export class RemoteScoreServer {
         // Sélection d'un match par l'arbitre
         if (data.match) {
           const m = data.match;
+          const rawA = m.scoreA as unknown;
+          const rawB = m.scoreB as unknown;
           this.assignMatchToArena(data.arenaId, {
             ...m,
-            scoreA: typeof m.scoreA === 'object' ? (m.scoreA?.value ?? 0) : (m.scoreA ?? 0),
-            scoreB: typeof m.scoreB === 'object' ? (m.scoreB?.value ?? 0) : (m.scoreB ?? 0),
+            scoreA: rawA !== null && typeof rawA === 'object' ? ((rawA as { value?: number }).value ?? 0) : ((rawA as number) ?? 0),
+            scoreB: rawB !== null && typeof rawB === 'object' ? ((rawB as { value?: number }).value ?? 0) : ((rawB as number) ?? 0),
           });
           // Réinitialiser les cartons
           this.arenaCards.set(data.arenaId, { cardsA: [], cardsB: [] });


### PR DESCRIPTION
…rver)

`m.scoreA` est typé `number` dans `ArenaMatch`, donc `typeof m.scoreA === 'object'` narrow vers `never` et `.value` produisait TS2339 Property 'value' does not exist on type 'never'.

Fix : cast en `unknown` avant le typeof pour permettre la vérification runtime sans conflit avec le type statique.

https://claude.ai/code/session_01LhaNHyGk9hk9cQ5i9dRqJt