### PR TITLE
fix: afficher la modal de confirmation sur la tablette arbitre quand le score atteint 15

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1082,13 +1082,13 @@ export class RemoteScoreServer {
     const arena = this.arenas.get(arenaId);
     if (!arena || arena.status === 'finished' || !arena.currentMatch) return;
 
-    // Terminer automatiquement le match si un tireur atteint ou dépasse 15 points
+    // Notifier la tablette arbitre quand un tireur atteint ou dépasse 15 points
     const SCORE_LIMIT = 15;
     if (scoreA >= SCORE_LIMIT || scoreB >= SCORE_LIMIT) {
       console.log(
-        `[RemoteScoreServer] Score limite (${SCORE_LIMIT}) atteint - fin automatique du match pour l'arène ${arenaId}`
+        `[RemoteScoreServer] Score limite (${SCORE_LIMIT}) atteint - notification arbitre pour l'arène ${arenaId}`
       );
-      this.finishArenaMatch(arenaId);
+      this.io.emit(`arena:${arenaId}:score_limit_reached`);
     }
   }
 


### PR DESCRIPTION
Remplace le finish automatique côté serveur par l'émission de l'événement
`arena:${arenaId}:score_limit_reached` que la tablette écoute déjà pour
afficher la modal "🏁 Fin de match". L'arbitre doit confirmer avant
que le match soit enregistré dans les poules.

https://claude.ai/code/session_01ASB4eSZJRojUhrWyR2p5G4