### PR TITLE
fix: cibler uniquement l'arène concernée et éviter les émissions répétées pour score_limit_reached

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1076,19 +1076,22 @@ export class RemoteScoreServer {
     arenaId: string,
     scoreA: number,
     scoreB: number,
-    _previousScoreA: number,
-    _previousScoreB: number
+    previousScoreA: number,
+    previousScoreB: number
   ): void {
     const arena = this.arenas.get(arenaId);
     if (!arena || arena.status === 'finished' || !arena.currentMatch) return;
 
-    // Notifier la tablette arbitre quand un tireur atteint ou dépasse 15 points
+    // Notifier la tablette arbitre uniquement quand un tireur franchit le seuil de 15 points
     const SCORE_LIMIT = 15;
-    if (scoreA >= SCORE_LIMIT || scoreB >= SCORE_LIMIT) {
+    const justCrossed =
+      (scoreA >= SCORE_LIMIT && previousScoreA < SCORE_LIMIT) ||
+      (scoreB >= SCORE_LIMIT && previousScoreB < SCORE_LIMIT);
+    if (justCrossed) {
       console.log(
         `[RemoteScoreServer] Score limite (${SCORE_LIMIT}) atteint - notification arbitre pour l'arène ${arenaId}`
       );
-      this.io.emit(`arena:${arenaId}:score_limit_reached`);
+      this.io.to(`arena:${arenaId}`).emit(`arena:${arenaId}:score_limit_reached`);
     }
   }
 


### PR DESCRIPTION
- `io.emit()` → `io.to('arena:${arenaId}').emit()` : l'événement n'est
  envoyé qu'aux tablettes connectées à l'arène concernée, pas à toutes.
- Utilise previousScoreA/B pour n'émettre que quand le seuil de 15 pts
  est franchi (transition < 15 → ≥ 15), évitant les modales répétées
  sur chaque mise à jour de score ultérieure.

https://claude.ai/code/session_01TXwP9iJ5k6XgydMHumqmkz