### PR TITLE
fix: bouton export CSV du classement non fonctionnel

### DIFF
--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -121,6 +121,18 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   const handleExport = (format: 'csv' | 'xml' | 'pdf') => {
     if (onExport) {
       onExport(format);
+    } else if (format === 'csv') {
+      const content = generateCSV();
+      const blob = new Blob(['\uFEFF' + content], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'classement.csv';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      showToast('Export CSV réussi', 'success');
     } else {
       showToast(`Export ${format.toUpperCase()} non implémenté`, 'warning');
     }


### PR DESCRIPTION
Le handler handleExport appelait onExport (prop optionnel) jamais transmis
par CompetitionView, tombant toujours dans le toast "non implémenté".
generateCSV() était défini mais jamais invoqué.

Correction : en l'absence de prop onExport, téléchargement direct via
generateCSV() + Blob URL (BOM UTF-8 pour compatibilité Excel).

https://claude.ai/code/session_0184BqRM6mxAvjbWDDMrd5Mr