### PR TITLE
fix: matchs d'élimination directe absents des arènes distantes

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1336,7 +1336,7 @@ export class RemoteScoreServer {
     if (matchesFromRenderer && matchesFromRenderer.length > 0) {
       console.log(`[RemoteScoreServer] ${matchesFromRenderer.length} matchs reçus du renderer`);
       allMatches = matchesFromRenderer.filter(
-        m => m.status === 'not_started' || m.status === 'in_progress'
+        m => m.isTableau || m.status === 'not_started' || m.status === 'in_progress'
       );
       console.log(`[RemoteScoreServer] ${allMatches.length} matchs en attente après filtrage`);
     } else {
@@ -1363,6 +1363,7 @@ export class RemoteScoreServer {
     // Grouper les matches par pool
     const matchesByPool = new Map<string, any[]>();
     for (const match of allMatches) {
+      if (match.isTableau) continue; // Les matchs DE sont traités séparément plus bas
       const poolId = match.poolId || match.pool?.id || `pool-${match.poolNumber || match.number}`;
       if (!matchesByPool.has(poolId)) {
         matchesByPool.set(poolId, []);


### PR DESCRIPTION
- Les matchs DE (TableauMatch) n'ont pas de champ `status`, ce qui les
  faisait exclure du filtre `not_started | in_progress` → aucun match
  DE n'apparaissait sur les affichages distants ni l'interface arbitre.
  Fix : conserver les matchs marqués `isTableau` indépendamment du statut.

- Les matchs DE sans poolId recevaient la clé synthétique "pool-undefined"
  dans le groupement par pool, ce qui les faisait traiter une première
  fois comme une poule (assignation arène incorrecte) puis une seconde
  fois dans la boucle DE.
  Fix : skip explicite des matchs isTableau dans le groupement par pool.

https://claude.ai/code/session_015v7RfKbBieCZQaAYJzaSQw