### PR TITLE
Mort subite Sabre Laser : affichage MORT SUBITE + 30 s de prolongation

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -281,7 +281,7 @@ export class RemoteScoreServer {
       if (!this.session) {
         return res.status(404).json({ error: 'Aucune session active' });
       }
-      res.json(this.session);
+      res.json({ ...this.session, weapon: this.sessionWeapon });
     });
 
     this.app.post('/api/session/start', async (req, res) => {
@@ -803,6 +803,7 @@ export class RemoteScoreServer {
           match: arena.currentMatch,
           time: data.time,
           timerStatus: data.timerStatus,
+          suddenDeath: data.suddenDeath ?? false,
           status: arena.status,
         });
         break;

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -359,6 +359,25 @@
         }
       }
 
+      .sudden-death-banner {
+        margin-top: 1rem;
+        padding: 0.75rem 2rem;
+        background: linear-gradient(135deg, #dc2626, #ef4444);
+        color: #fff;
+        font-size: 3rem;
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.2em;
+        border-radius: 0.75rem;
+        text-align: center;
+        animation: timer-pulse 0.8s infinite;
+        display: none;
+      }
+
+      .sudden-death-banner.active {
+        display: block;
+      }
+
       .timer-label {
         font-size: 1.1rem;
         color: #6b7280;
@@ -480,6 +499,7 @@
         <!-- Chronomètre -->
         <div class="timer-section">
           <div class="timer-display" id="timer-display">03:00</div>
+          <div class="sudden-death-banner" id="sudden-death-banner">⚡ MORT SUBITE</div>
           <div class="timer-label">Temps restant</div>
         </div>
       </div>
@@ -496,6 +516,7 @@
           this.matchStatus = 'idle';
           this.cardsA = [];
           this.cardsB = [];
+          this.isSuddenDeath = false;
           this.inversionEnabled = localStorage.getItem('inversionEnabled') === 'true';
 
           this.init();
@@ -603,6 +624,12 @@
             this.updateTimerDisplay(data.timerStatus);
           }
 
+          // Mise à jour mort subite
+          if (data.suddenDeath !== undefined) {
+            this.isSuddenDeath = data.suddenDeath;
+            this.updateSuddenDeathBanner();
+          }
+
           // Afficher/masquer selon le statut
           this.updateVisibility();
         }
@@ -690,6 +717,16 @@
           }
         }
 
+        updateSuddenDeathBanner() {
+          const banner = document.getElementById('sudden-death-banner');
+          if (!banner) return;
+          if (this.isSuddenDeath) {
+            banner.classList.add('active');
+          } else {
+            banner.classList.remove('active');
+          }
+        }
+
         updateVisibility() {
           const waitingScreen = document.getElementById('waiting-screen');
           const matchDisplay = document.getElementById('match-display');
@@ -697,6 +734,8 @@
           if (this.matchStatus === 'idle' || this.matchStatus === 'not_started') {
             waitingScreen.classList.remove('hidden');
             matchDisplay.classList.remove('active');
+            this.isSuddenDeath = false;
+            this.updateSuddenDeathBanner();
           } else {
             waitingScreen.classList.add('hidden');
             matchDisplay.classList.add('active');

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -742,6 +742,7 @@
         <!-- Chronomètre -->
         <div class="timer-section">
           <div class="timer-display" id="timer-display">03:00</div>
+          <div id="sudden-death-label" style="display:none; color:#ef4444; font-weight:900; font-size:1.5rem; text-align:center; margin-top:0.5rem; letter-spacing:0.1em; animation: pulse-timer 0.8s infinite;">⚡ MORT SUBITE</div>
           <div class="timer-hint">Tapez pour démarrer/pause - Appui long pour reset</div>
         </div>
 
@@ -817,6 +818,8 @@
           this.timerInterval = null;
           this.timerRunning = false;
           this.longPressTimer = null;
+          this.isLaserSabre = false;
+          this.isSuddenDeath = false;
 
           this.init();
         }
@@ -838,6 +841,11 @@
           this.setupTimerInteractions();
           this.setupLongPressInteractions();
           this.showNextMatchesScreen();
+          // Détecter l'arme de la compétition pour la mort subite Laser Sabre
+          fetch('/api/session')
+            .then(r => (r.ok ? r.json() : null))
+            .then(s => { if (s) this.isLaserSabre = s.weapon === 'L'; })
+            .catch(() => {});
         }
 
         setupLongPressInteractions() {
@@ -1108,6 +1116,7 @@
           this.cardsB = [];
           this.matchStatus = match.status;
           this.timerSeconds = 180;
+          this.isSuddenDeath = false;
           this.stopTimer();
 
           // Charger les infos du match
@@ -1305,7 +1314,11 @@
 
               if (this.timerSeconds === 0) {
                 this.stopTimer();
-                this.showNotification('⏰ Temps écoulé !');
+                if (this.isLaserSabre && this.scoreA === this.scoreB && !this.isSuddenDeath) {
+                  this.triggerSuddenDeath();
+                } else {
+                  this.showNotification('⏰ Temps écoulé !');
+                }
               }
             }
           }, 1000);
@@ -1327,10 +1340,20 @@
 
         resetTimer() {
           this.stopTimer();
+          this.isSuddenDeath = false;
           this.timerSeconds = 180;
           this.updateTimerDisplay();
           this.broadcastTimerUpdate();
           this.showNotification('🔄 Chronomètre réinitialisé');
+        }
+
+        triggerSuddenDeath() {
+          this.isSuddenDeath = true;
+          this.timerSeconds = 30;
+          this.updateTimerDisplay();
+          this.broadcastTimerUpdate();
+          this.showNotification('⚡ MORT SUBITE – 30 secondes !');
+          this.startTimer();
         }
 
         updateTimerDisplay() {
@@ -1354,6 +1377,10 @@
           } else if (this.timerSeconds <= 30) {
             timerEl.classList.add('warning');
           }
+
+          // Affichage mort subite
+          const sdLabel = document.getElementById('sudden-death-label');
+          if (sdLabel) sdLabel.style.display = this.isSuddenDeath ? 'block' : 'none';
         }
 
         broadcastTimerUpdate() {
@@ -1362,6 +1389,7 @@
             action: this.timerRunning ? 'update_timer' : 'pause_timer',
             time: this.timerSeconds,
             timerStatus: this.timerRunning ? 'running' : 'paused',
+            suddenDeath: this.isSuddenDeath,
           });
         }
 
@@ -1462,6 +1490,7 @@
               this.cardsB = [];
               this.matchStatus = 'not_started';
               this.timerSeconds = 180;
+              this.isSuddenDeath = false;
               this.updateTimerDisplay();
               document.getElementById('active-match').classList.remove('visible');
               this.showNextMatchesScreen();

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -47,6 +47,7 @@ export interface RemoteSession {
   activeMatches: RemoteMatch[];
   isRunning: boolean;
   startTime?: Date;
+  weapon?: string;
 }
 
 export interface WebSocketMessage {
@@ -132,6 +133,7 @@ export interface ArenaUpdate {
   timerStatus?: 'running' | 'paused' | 'reset';
   cardsA?: string[];
   cardsB?: string[];
+  suddenDeath?: boolean;
 }
 
 export interface RefereeControl {


### PR DESCRIPTION
En cas d'égalité à la fin des 3 minutes réglementaires d'un match
Sabre Laser, déclenche automatiquement une prolongation de 30 secondes
en mort subite.

- RemoteSession.weapon et ArenaUpdate.suddenDeath ajoutés aux types
- /api/session expose le type d'arme de la compétition
- referee.html détecte l'arme, déclenche triggerSuddenDeath() à 0 s si
  Laser + égalité, propage le flag suddenDeath dans chaque mise à jour
- arena.html affiche une bannière rouge clignotante « ⚡ MORT SUBITE »

https://claude.ai/code/session_012LAhwhxd2cQRMAFoKZj6UW