### PR TITLE
Fix: add suddenDeath?: boolean to handleArenaControl data type

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -701,6 +701,7 @@ export class RemoteScoreServer {
       cardType?: 'white' | 'yellow' | 'red';
       cardsA?: string[];
       cardsB?: string[];
+      suddenDeath?: boolean;
     }
   ): void {
     const arena = this.getArena(data.arenaId);


### PR DESCRIPTION
Property 'suddenDeath' was accessed at line 806 but missing from the
inline parameter type, causing TypeScript compilation errors on all platforms.

https://claude.ai/code/session_01RjFzvjo2WdRo8wpL8eKRWG