### PR TITLE
fix: corriger l'assignation d'arène et le score distant en élimination directe

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1098,6 +1098,7 @@ export class RemoteScoreServer {
         scoreA: finishedMatch.scoreA,
         scoreB: finishedMatch.scoreB,
         poolId: finishedMatch.poolId,
+        isTableau: finishedMatch.isTableau ?? false,
       });
       console.log(
         `[RemoteScoreServer] Émission match:finished pour ${finishedMatch.id}: ${finishedMatch.scoreA}-${finishedMatch.scoreB}`
@@ -1433,9 +1434,9 @@ export class RemoteScoreServer {
         if (!queuesByArena.has(targetArenaId)) {
           // arène hors plage → round-robin sur arènes disponibles
           const fallbackId = `arena${(rrIndex % strips) + 1}`;
-          queuesByArena.get(fallbackId)!.push({ id: match.id, fencerA: match.fencerA, fencerB: match.fencerB, scoreA: 0, scoreB: 0, status: 'not_started', startTime: null, endTime: null });
+          queuesByArena.get(fallbackId)!.push({ id: match.id, fencerA: match.fencerA, fencerB: match.fencerB, scoreA: 0, scoreB: 0, status: 'not_started', startTime: null, endTime: null, isTableau: true });
         } else {
-          queuesByArena.get(targetArenaId)!.push({ id: match.id, fencerA: match.fencerA, fencerB: match.fencerB, scoreA: 0, scoreB: 0, status: 'not_started', startTime: null, endTime: null });
+          queuesByArena.get(targetArenaId)!.push({ id: match.id, fencerA: match.fencerA, fencerB: match.fencerB, scoreA: 0, scoreB: 0, status: 'not_started', startTime: null, endTime: null, isTableau: true });
         }
         rrIndex++;
       }
@@ -1478,6 +1479,9 @@ export class RemoteScoreServer {
 
   public stopSession(): void {
     this.session = null;
+    this.sessionMatches = [];
+    this.arenaMatchQueue.clear();
+    this.arenaNextMatchIndex.clear();
   }
 
   public updateStripCount(newCount: number): RemoteSession | null {

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -8,7 +8,7 @@ import { Competition, Fencer, FencerStatus, MatchStatus, Weapon } from '../../sh
 import { RankingImportResult } from '../../shared/utils/fileParser';
 import FencerList from './FencerList';
 import PoolView from './PoolView';
-import TableauView, { TableauMatch, FinalResult } from './TableauView';
+import TableauView, { TableauMatch, FinalResult, propagateWinners } from './TableauView';
 import PoolRankingView from './PoolRankingView';
 import ResultsView from './ResultsView';
 import AddFencerModal from './AddFencerModal';
@@ -179,10 +179,24 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   useEffect(() => {
     if (!window.electronAPI?.onRemoteMatchFinished) return;
 
-    const handleMatchFinished = (data: { matchId: string; scoreA: number; scoreB: number }) => {
+    const handleMatchFinished = (data: { matchId: string; scoreA: number; scoreB: number; isTableau?: boolean }) => {
       const { matchId, scoreA, scoreB } = data;
       console.log(`[CompetitionView] Match terminé reçu: ${matchId} - Score: ${scoreA}-${scoreB}`);
       updateMatchFromRemote(matchId, scoreA, scoreB, MatchStatus.FINISHED);
+
+      // Mise à jour du tableau d'élimination directe si c'est un match DE
+      setTableauMatches(prev => {
+        const idx = prev.findIndex(m => m.id === matchId);
+        if (idx === -1) return prev;
+        const match = prev[idx];
+        const winner = scoreA > scoreB ? match.fencerA : scoreB > scoreA ? match.fencerB : null;
+        const updated = prev.map((m, i) =>
+          i === idx ? { ...m, scoreA, scoreB, winner } : m
+        );
+        const size = prev.length > 0 ? Math.max(...prev.map(m => m.round)) : 0;
+        propagateWinners(updated, size);
+        return [...updated];
+      });
     };
 
     window.electronAPI.onRemoteMatchFinished(handleMatchFinished);

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -62,6 +62,89 @@ interface TableauViewProps {
 const BASE_MATCH_HEIGHT = 100;
 const SLOT_HEIGHT = BASE_MATCH_HEIGHT + 50; // hauteur d'un créneau dans la première colonne
 
+export function propagateWinners(matchList: TableauMatch[], size: number): void {
+  let currentRound = size;
+
+  while (currentRound > 2) {
+    const nextRound = currentRound / 2;
+    const currentMatches = matchList.filter(m => m.round === currentRound);
+    const nextMatches = matchList.filter(m => m.round === nextRound);
+
+    // Première passe : propager tous les gagnants (y compris les exempts)
+    currentMatches.forEach((match, idx) => {
+      if (match.winner) {
+        const nextMatchIdx = Math.floor(idx / 2);
+        const nextMatch = nextMatches[nextMatchIdx];
+        if (nextMatch) {
+          if (idx % 2 === 0) {
+            nextMatch.fencerA = match.winner;
+          } else {
+            nextMatch.fencerB = match.winner;
+          }
+        }
+      }
+    });
+
+    // Deuxième passe : vérifier les exempts au tour suivant
+    nextMatches.forEach((nextMatch, nextIdx) => {
+      // Ne pas modifier les matchs déjà joués
+      if (nextMatch.scoreA !== null && nextMatch.scoreB !== null) return;
+
+      const feederA = currentMatches[nextIdx * 2];
+      const feederB = currentMatches[nextIdx * 2 + 1];
+
+      // Vérifier si les deux matchs sources sont résolus
+      const feederAResolved =
+        !feederA ||
+        feederA.winner !== null ||
+        (feederA.isBye && !feederA.fencerA && !feederA.fencerB);
+      const feederBResolved =
+        !feederB ||
+        feederB.winner !== null ||
+        (feederB.isBye && !feederB.fencerA && !feederB.fencerB);
+
+      if (feederAResolved && feederBResolved) {
+        if (nextMatch.fencerA && !nextMatch.fencerB) {
+          nextMatch.winner = nextMatch.fencerA;
+          nextMatch.isBye = true;
+        } else if (!nextMatch.fencerA && nextMatch.fencerB) {
+          nextMatch.winner = nextMatch.fencerB;
+          nextMatch.isBye = true;
+        } else if (nextMatch.fencerA && nextMatch.fencerB) {
+          nextMatch.isBye = false;
+          nextMatch.winner = null;
+        }
+      }
+    });
+
+    currentRound = nextRound;
+  }
+
+  // Gérer le match de 3ème place si présent dans matchList
+  const thirdPlaceMatchEntry = matchList.find(m => m.round === 3);
+  if (thirdPlaceMatchEntry && size >= 4) {
+    const semiFinalMatches = matchList.filter(m => m.round === 4);
+
+    if (semiFinalMatches.length === 2) {
+      // Assigner les perdants des demi-finales au match de 3ème place
+      const losers: Fencer[] = [];
+
+      semiFinalMatches.forEach(semiFinal => {
+        if (semiFinal.winner) {
+          const loser =
+            semiFinal.fencerA?.id === semiFinal.winner.id ? semiFinal.fencerB : semiFinal.fencerA;
+          if (loser) losers.push(loser);
+        }
+      });
+
+      if (losers.length === 2) {
+        thirdPlaceMatchEntry.fencerA = losers[0];
+        thirdPlaceMatchEntry.fencerB = losers[1];
+      }
+    }
+  }
+}
+
 const TableauViewComponent: React.FC<TableauViewProps> = ({
   ranking,
   matches,
@@ -219,92 +302,6 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
       ];
     }
     return Array.from({ length: size }, (_, i) => i + 1);
-  };
-
-  const propagateWinners = (matchList: TableauMatch[], size: number) => {
-    let currentRound = size;
-
-    while (currentRound > 2) {
-      const nextRound = currentRound / 2;
-      const currentMatches = matchList.filter(m => m.round === currentRound);
-      const nextMatches = matchList.filter(m => m.round === nextRound);
-
-      // Première passe : propager tous les gagnants (y compris les exempts)
-      currentMatches.forEach((match, idx) => {
-        if (match.winner) {
-          const nextMatchIdx = Math.floor(idx / 2);
-          const nextMatch = nextMatches[nextMatchIdx];
-          if (nextMatch) {
-            if (idx % 2 === 0) {
-              nextMatch.fencerA = match.winner;
-            } else {
-              nextMatch.fencerB = match.winner;
-            }
-          }
-        }
-      });
-
-      // Deuxième passe : vérifier les exempts au tour suivant
-      nextMatches.forEach((nextMatch, nextIdx) => {
-        // Ne pas modifier les matchs déjà joués
-        if (nextMatch.scoreA !== null && nextMatch.scoreB !== null) return;
-
-        const feederA = currentMatches[nextIdx * 2];
-        const feederB = currentMatches[nextIdx * 2 + 1];
-
-        // Vérifier si les deux matchs sources sont résolus
-        const feederAResolved =
-          !feederA ||
-          feederA.winner !== null ||
-          (feederA.isBye && !feederA.fencerA && !feederA.fencerB);
-        const feederBResolved =
-          !feederB ||
-          feederB.winner !== null ||
-          (feederB.isBye && !feederB.fencerA && !feederB.fencerB);
-
-        if (feederAResolved && feederBResolved) {
-          if (nextMatch.fencerA && !nextMatch.fencerB) {
-            nextMatch.winner = nextMatch.fencerA;
-            nextMatch.isBye = true;
-          } else if (!nextMatch.fencerA && nextMatch.fencerB) {
-            nextMatch.winner = nextMatch.fencerB;
-            nextMatch.isBye = true;
-          } else if (nextMatch.fencerA && nextMatch.fencerB) {
-            nextMatch.isBye = false;
-            nextMatch.winner = null;
-          }
-        }
-      });
-
-      currentRound = nextRound;
-    }
-
-    // Gérer le match de 3ème place si présent dans matchList
-    const thirdPlaceMatchEntry = matchList.find(m => m.round === 3);
-    if (thirdPlaceMatchEntry && size >= 4) {
-      const semiFinalMatches = matchList.filter(m => m.round === 4);
-
-      if (semiFinalMatches.length === 2) {
-        // Assigner les perdants des demi-finales au match de 3ème place
-        const losers: Fencer[] = [];
-
-        semiFinalMatches.forEach(semiFinal => {
-          if (semiFinal.winner) {
-            const loser =
-              semiFinal.fencerA?.id === semiFinal.winner.id ? semiFinal.fencerB : semiFinal.fencerA;
-            if (loser) losers.push(loser);
-          }
-        });
-
-        // DEBUG: console.log('Propagation 3ème place:', losers.map(l => l?.lastName));
-
-        if (losers.length === 2) {
-          thirdPlaceMatchEntry.fencerA = losers[0];
-          thirdPlaceMatchEntry.fencerB = losers[1];
-          // DEBUG: console.log('Assigné à la petite finale:', losers[0]?.lastName, 'vs', losers[1]?.lastName);
-        }
-      }
-    }
   };
 
   const getRoundName = (round: number): string => {

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -110,6 +110,7 @@ export interface ArenaSettings {
 export interface ArenaMatch {
   id: string;
   poolId?: string; // absent pour les matchs d'élimination directe
+  isTableau?: boolean; // true pour les matchs DE (élimination directe)
   fencerA: Fencer;
   fencerB: Fencer;
   scoreA: number;


### PR DESCRIPTION
Bug 1 - Arène : stopSession() ne purgait pas arenaMatchQueue, sessionMatches
et arenaNextMatchIndex. Les entrées stales de la session précédente étaient
réutilisées au redémarrage, causant des doublons dans les files d'arène.

Bug 2 - Score : handleMatchFinished dans CompetitionView appelait uniquement
updateMatchFromRemote qui ne cherche que dans les poules. Les matchs DE
(sans poolId) n'étaient jamais mis à jour dans tableauMatches.

Corrections :
- stopSession() purge maintenant sessionMatches, arenaMatchQueue et arenaNextMatchIndex
- ArenaMatch.isTableau ajouté pour distinguer les matchs DE
- Les ArenaMatch DE sont construits avec isTableau: true dans startSession
- L'événement match:finished inclut désormais isTableau
- propagateWinners extrait comme export nommé de TableauView (était local)
- handleMatchFinished met à jour tableauMatches + propage le vainqueur au tour suivant

https://claude.ai/code/session_01XiqD1UXwSvogJJqyjWi7qS