### PR TITLE
fix: mise à jour temps réel des arènes lors de l'assignation de matchs DE

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -713,6 +713,21 @@ ipcMain.handle(
   }
 );
 
+ipcMain.handle(
+  'remote:updateMatchArena',
+  async (_, matchId: string, fromArena: number | null, toArena: number | null) => {
+    try {
+      if (!remoteScoreServer) {
+        return { success: false, error: 'Serveur non démarré' };
+      }
+      remoteScoreServer.updateMatchArena(matchId, fromArena, toArena);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+    }
+  }
+);
+
 ipcMain.handle('remote:stopSession', async () => {
   try {
     if (!remoteScoreServer) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -314,6 +314,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getSession: () => ipcRenderer.invoke('remote:getSession'),
     getArenas: () => ipcRenderer.invoke('remote:getArenas'),
     updateStripCount: (count: number) => ipcRenderer.invoke('remote:updateStripCount', count),
+    updateMatchArena: (matchId: string, fromArena: number | null, toArena: number | null) =>
+      ipcRenderer.invoke('remote:updateMatchArena', matchId, fromArena, toArena),
   },
 
   // Remote event listeners (for real-time updates)

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1000,6 +1000,74 @@ export class RemoteScoreServer {
     console.log(`[RemoteScoreServer] Match assigné avec succès à l'arène ${arenaId}`);
   }
 
+  public updateMatchArena(
+    matchId: string,
+    fromArena: number | null,
+    toArena: number | null
+  ): void {
+    let matchToMove: ArenaMatch | undefined;
+
+    // 1. Retirer le match de l'ancienne arène
+    if (fromArena) {
+      const fromArenaId = `arena${fromArena}`;
+      const fromQueue = this.arenaMatchQueue.get(fromArenaId) || [];
+      const idx = fromQueue.findIndex(m => m.id === matchId);
+      if (idx !== -1) {
+        matchToMove = fromQueue[idx];
+        this.arenaMatchQueue.set(fromArenaId, [
+          ...fromQueue.slice(0, idx),
+          ...fromQueue.slice(idx + 1),
+        ]);
+        const fromArenaObj = this.arenas.get(fromArenaId);
+        this.updateArena(fromArenaId, { status: fromArenaObj?.status ?? 'idle' });
+      }
+      // Si c'est le currentMatch pas encore démarré, on l'enlève aussi
+      const fromArenaObj = this.arenas.get(fromArenaId);
+      if (!matchToMove && fromArenaObj?.currentMatch?.id === matchId &&
+          fromArenaObj.currentMatch.status === 'not_started') {
+        matchToMove = fromArenaObj.currentMatch;
+        (fromArenaObj as any).currentMatch = undefined;
+        fromArenaObj.status = 'idle';
+        this.updateArena(fromArenaId, { status: 'idle', currentMatch: undefined as any });
+      }
+    }
+
+    // Si le match n'est dans aucune arène, le construire depuis sessionMatches
+    if (!matchToMove) {
+      const sm = this.sessionMatches.find((m: any) => m.id === matchId);
+      if (sm) {
+        matchToMove = {
+          id: sm.id,
+          fencerA: sm.fencerA,
+          fencerB: sm.fencerB,
+          scoreA: 0,
+          scoreB: 0,
+          status: 'not_started',
+          startTime: null,
+          endTime: null,
+          isTableau: true,
+        };
+      }
+    }
+
+    if (!matchToMove || !toArena) return;
+
+    // 2. Ajouter à la nouvelle arène
+    const toArenaId = `arena${toArena}`;
+    const toArenaObj = this.arenas.get(toArenaId);
+    if (!toArenaObj) return;
+
+    if (!toArenaObj.currentMatch) {
+      this.assignMatchToArena(toArenaId, matchToMove);
+    } else {
+      const toQueue = this.arenaMatchQueue.get(toArenaId) || [];
+      this.arenaMatchQueue.set(toArenaId, [...toQueue, matchToMove]);
+      this.updateArena(toArenaId, { status: toArenaObj.status });
+    }
+
+    console.log(`[RemoteScoreServer] Match ${matchId} déplacé de arena${fromArena} vers arena${toArena}`);
+  }
+
   public startArenaMatch(arenaId: string): void {
     const arena = this.arenas.get(arenaId);
     if (!arena || !arena.currentMatch) return;

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -761,6 +761,11 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               setFinalResults(results);
               setCurrentPhase('results');
             }}
+            onMatchArenaChange={(matchId, oldArena, newArena) => {
+              if (isRemoteActive) {
+                window.electronAPI.remote.updateMatchArena(matchId, oldArena, newArena);
+              }
+            }}
           />
         )}
 

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -57,6 +57,7 @@ interface TableauViewProps {
   onComplete?: (results: FinalResult[]) => void;
   thirdPlaceMatch?: boolean;
   arenaCount?: number;
+  onMatchArenaChange?: (matchId: string, oldArena: number | null, newArena: number | null) => void;
 }
 
 const BASE_MATCH_HEIGHT = 100;
@@ -153,6 +154,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   onComplete,
   thirdPlaceMatch = false,
   arenaCount = 4,
+  onMatchArenaChange,
 }) => {
   const { showToast } = useToast();
   const [tableauSize, setTableauSize] = useState<number>(0);
@@ -1635,10 +1637,12 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 <button
                   className={`btn ${!matches.find(m => m.id === selectedMatchForArena)?.arena ? 'btn-primary' : 'btn-secondary'}`}
                   onClick={() => {
+                    const oldArena = matches.find(m => m.id === selectedMatchForArena)?.arena ?? null;
                     const updatedMatches = matches.map(m =>
                       m.id === selectedMatchForArena ? { ...m, arena: null } : m
                     );
                     onMatchesChange(updatedMatches);
+                    onMatchArenaChange?.(selectedMatchForArena!, oldArena, null);
                     setShowArenaModal(false);
                     setSelectedMatchForArena(null);
                   }}
@@ -1655,10 +1659,12 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                       key={arenaNum}
                       className={`btn ${matches.find(m => m.id === selectedMatchForArena)?.arena === arenaNum ? 'btn-primary' : 'btn-secondary'}`}
                       onClick={() => {
+                        const oldArena = matches.find(m => m.id === selectedMatchForArena)?.arena ?? null;
                         const updatedMatches = matches.map(m =>
                           m.id === selectedMatchForArena ? { ...m, arena: arenaNum } : m
                         );
                         onMatchesChange(updatedMatches);
+                        onMatchArenaChange?.(selectedMatchForArena!, oldArena, arenaNum);
                         setShowArenaModal(false);
                         setSelectedMatchForArena(null);
                       }}

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -303,6 +303,11 @@ export interface RemoteServerAPI {
   getSession: () => Promise<{ success: boolean; session?: any; error?: string }>;
   getArenas: () => Promise<{ success: boolean; arenas?: any[]; error?: string }>;
   updateStripCount: (count: number) => Promise<{ success: boolean; session?: any; error?: string }>;
+  updateMatchArena: (
+    matchId: string,
+    fromArena: number | null,
+    toArena: number | null
+  ) => Promise<{ success: boolean; error?: string }>;
 }
 
 // ============================================================================


### PR DESCRIPTION
- Ajoute `updateMatchArena()` dans remoteScoreServer pour déplacer un match
  d'une arène à une autre (queue ou currentMatch) avec broadcast immédiat
- Ajoute handler IPC `remote:updateMatchArena` dans main.ts
- Expose la méthode dans preload.ts et son type dans RemoteServerAPI
- Ajoute prop `onMatchArenaChange` à TableauView ; appelée à chaque
  assignation/désassignation dans le modal de piste
- CompetitionView transmet le callback et appelle l'IPC si la session
  distante est active

Corrige : match assigné à l'arène 2 invisible sur l'arène 2 (#bug1)
Corrige : match déplacé de l'arène 2 vers 3 resté dans les matchs suivants
          de l'arène 2 (#bug2)

https://claude.ai/code/session_01FGRS1rj7jsfi7taJyLyhik