### PR TITLE
perf: réduire la complexité algorithmique dans les points chauds

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,7 +3,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Competition, Fencer, FencerStatus, Pool, Match, PhaseType } from '../shared/types';
 import CompetitionList from './components/CompetitionList';
 import CompetitionView from './components/CompetitionView';
@@ -83,7 +83,7 @@ const AppContent: React.FC = () => {
     };
   }, []);
 
-  const loadCompetitions = async () => {
+  const loadCompetitions = useCallback(async () => {
     setIsLoading(true);
     try {
       if (window.electronAPI) {
@@ -94,9 +94,9 @@ const AppContent: React.FC = () => {
       console.error('Failed to load competitions:', error);
     }
     setIsLoading(false);
-  };
+  }, []);
 
-  const handleCreateCompetition = async (data: Partial<Competition>) => {
+  const handleCreateCompetition = useCallback(async (data: Partial<Competition>) => {
     try {
       if (window.electronAPI) {
         // Assurer que le titre est défini
@@ -109,7 +109,7 @@ const AppContent: React.FC = () => {
           ...data,
         };
         const newComp = await window.electronAPI.db.createCompetition(competitionData as any);
-        setCompetitions([newComp, ...competitions]);
+        setCompetitions(prev => [newComp, ...prev]);
 
         // Ouvrir la compétition dans un nouvel onglet
         const fencers = await window.electronAPI.db.getFencersByCompetition(newComp.id);
@@ -124,7 +124,7 @@ const AppContent: React.FC = () => {
       console.error('Failed to create competition:', error);
     }
     setShowNewCompetitionModal(false);
-  };
+  }, []);
 
   const handleSelectCompetition = async (competition: Competition) => {
     console.log('=== handleSelectCompetition ===');

--- a/src/renderer/components/LiveDashboard.tsx
+++ b/src/renderer/components/LiveDashboard.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Competition, Pool, Match, MatchStatus, PoolRanking, Weapon } from '../../shared/types';
 import { formatIndex } from '../../shared/utils/poolCalculations';
 
@@ -36,18 +36,23 @@ export const LiveDashboard: React.FC<LiveDashboardProps> = ({
     return () => clearInterval(timer);
   }, []);
 
-  // Get matches in progress
-  const matchesInProgress = pools.flatMap(pool =>
-    pool.matches.filter(m => m.status === MatchStatus.IN_PROGRESS)
+  // Get matches in progress — mémorisé pour ne pas recalculer à chaque tick d'horloge (1 Hz)
+  const matchesInProgress = useMemo(
+    () => pools.flatMap(pool => pool.matches.filter(m => m.status === MatchStatus.IN_PROGRESS)),
+    [pools]
   );
 
   // Get completed matches
-  const completedMatches = pools.flatMap(pool =>
-    pool.matches.filter(m => m.status === MatchStatus.FINISHED)
+  const completedMatches = useMemo(
+    () => pools.flatMap(pool => pool.matches.filter(m => m.status === MatchStatus.FINISHED)),
+    [pools]
   );
 
   // Calculate completion percentage
-  const totalMatches = pools.reduce((sum, pool) => sum + pool.matches.length, 0);
+  const totalMatches = useMemo(
+    () => pools.reduce((sum, pool) => sum + pool.matches.length, 0),
+    [pools]
+  );
   const completionRate =
     totalMatches > 0 ? Math.round((completedMatches.length / totalMatches) * 100) : 0;
 

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -411,6 +411,17 @@ function resolveClubConflicts(
   let maxIterations = 100; // Éviter les boucles infinies
   let improved = true;
 
+  // Construire un compteur de clubs par poule pour éviter les some() O(n) en boucle
+  const buildClubMap = (pool: Fencer[]) => {
+    const m = new Map<string, number>();
+    for (const f of pool) {
+      const key = f.club ?? '';
+      m.set(key, (m.get(key) ?? 0) + 1);
+    }
+    return m;
+  };
+  const clubMaps = pools.map(buildClubMap);
+
   while (improved && maxIterations > 0) {
     improved = false;
     maxIterations--;
@@ -423,10 +434,8 @@ function resolveClubConflicts(
       for (let fencerIdx = 0; fencerIdx < pool.length; fencerIdx++) {
         const fencer = pool[fencerIdx];
 
-        // Vérifier si ce tireur a un conflit de club dans cette poule
-        const hasClubConflict = pool.some(
-          (other, idx) => idx !== fencerIdx && other.club === fencer.club
-        );
+        // Vérifier si ce tireur a un conflit de club dans cette poule (O(1) au lieu de O(n))
+        const hasClubConflict = (clubMaps[poolIdx].get(fencer.club ?? '') ?? 0) > 1;
 
         if (!hasClubConflict) continue;
 
@@ -436,9 +445,15 @@ function resolveClubConflicts(
         if (swapPartner) {
           // Effectuer l'échange
           const { poolIdx: otherPoolIdx, fencerIdx: otherFencerIdx } = swapPartner;
-          const temp = pools[poolIdx][fencerIdx];
-          pools[poolIdx][fencerIdx] = pools[otherPoolIdx][otherFencerIdx];
-          pools[otherPoolIdx][otherFencerIdx] = temp;
+          const fencerA = pools[poolIdx][fencerIdx];
+          const fencerB = pools[otherPoolIdx][otherFencerIdx];
+          pools[poolIdx][fencerIdx] = fencerB;
+          pools[otherPoolIdx][otherFencerIdx] = fencerA;
+
+          // Mettre à jour les Maps de clubs pour les deux poules concernées
+          clubMaps[poolIdx] = buildClubMap(pools[poolIdx]);
+          clubMaps[otherPoolIdx] = buildClubMap(pools[otherPoolIdx]);
+
           improved = true;
           break;
         }
@@ -523,18 +538,15 @@ function canSwapResolveConflict(
   const conflicts2Before = pool2.filter(f => f !== fencer2 && f.club === fencer2.club).length;
 
   // Simuler l'échange et compter les conflits après
+  // conflicts1After > 0 équivaut à « fencer2 créerait un conflit dans pool1 »
+  // conflicts2After > 0 équivaut à « fencer1 créerait un conflit dans pool2 »
   const conflicts1After = pool1.filter(f => f !== fencer1 && f.club === fencer2.club).length;
   const conflicts2After = pool2.filter(f => f !== fencer2 && f.club === fencer1.club).length;
-
-  // Vérifier si le tireur 1 créerait un conflit dans la poule 2
-  const newConflict1InPool2 = pool2.some(f => f !== fencer2 && f.club === fencer1.club);
-  // Vérifier si le tireur 2 créerait un conflit dans la poule 1
-  const newConflict2InPool1 = pool1.some(f => f !== fencer1 && f.club === fencer2.club);
 
   // L'échange est valide si:
   // 1. Il ne crée pas de nouveaux conflits
   // 2. Il réduit ou maintient le nombre total de conflits
-  if (newConflict1InPool2 || newConflict2InPool1) {
+  if (conflicts1After > 0 || conflicts2After > 0) {
     return false;
   }
 

--- a/src/shared/utils/tableCalculations.ts
+++ b/src/shared/utils/tableCalculations.ts
@@ -268,12 +268,20 @@ export function updateTableAfterMatch(
     return node;
   });
 
+  // Construire des Maps en une passe unique pour éviter les find() O(n) répétés
+  const byMatchId = new Map<string, TableNode>();
+  // byParent : childId → parent node (le nœud dont parentA ou parentB === childId)
+  const byParent = new Map<string, TableNode>();
+  for (const node of updatedNodes) {
+    if (node.match) byMatchId.set(node.match.id, node);
+    if (node.parentA) byParent.set(node.parentA, node);
+    if (node.parentB) byParent.set(node.parentB, node);
+  }
+
   // Propager le gagnant vers le tour suivant
-  const nodeWithMatch = updatedNodes.find(n => n.match?.id === matchId);
+  const nodeWithMatch = byMatchId.get(matchId);
   if (nodeWithMatch) {
-    const nextNode = updatedNodes.find(
-      n => n.parentA === nodeWithMatch.id || n.parentB === nodeWithMatch.id
-    );
+    const nextNode = byParent.get(nodeWithMatch.id);
 
     if (nextNode) {
       const isFromA = nextNode.parentA === nodeWithMatch.id;
@@ -296,8 +304,8 @@ export function updateTableAfterMatch(
     }
   }
 
-  // Vérifier si le tableau est complet
-  const isComplete = updatedNodes.filter(n => n.round === 1).every(n => n.winner);
+  // Vérifier si le tableau est complet (une seule passe, pas de filter+every)
+  const isComplete = updatedNodes.every(n => n.round !== 1 || !!n.winner);
 
   return {
     ...table,
@@ -378,6 +386,18 @@ export function calculateTableRanking(table: DirectEliminationTable): TableRanki
   const rankings: TableRanking[] = [];
   const firstPlace = table.firstPlace;
 
+  // Pré-calculer les touches tableau par tireur en une seule passe (O(n) au lieu de O(n²))
+  const tableTouchesMap = new Map<string, number>();
+  for (const node of table.nodes) {
+    if (!node.match || node.match.status !== MatchStatus.FINISHED) continue;
+    const scoreA = node.match.scoreA;
+    const scoreB = node.match.scoreB;
+    const valA = typeof scoreA === 'number' ? scoreA : (scoreA as any)?.value ?? 0;
+    const valB = typeof scoreB === 'number' ? scoreB : (scoreB as any)?.value ?? 0;
+    if (node.fencerA) tableTouchesMap.set(node.fencerA.id, (tableTouchesMap.get(node.fencerA.id) ?? 0) + valA);
+    if (node.fencerB) tableTouchesMap.set(node.fencerB.id, (tableTouchesMap.get(node.fencerB.id) ?? 0) + valB);
+  }
+
   // Finale (place 1 et 2)
   const finale = table.nodes.find(n => n.round === 1);
   if (finale?.winner) {
@@ -431,7 +451,8 @@ export function calculateTableRanking(table: DirectEliminationTable): TableRanki
       if (node.winner) {
         const loser = node.fencerA?.id === node.winner.id ? node.fencerB : node.fencerA;
         if (loser) {
-          const totalTouches = calculateTotalTouches(loser, table);
+          const totalTouches =
+            (loser.poolStats?.touchesScored ?? 0) + (tableTouchesMap.get(loser.id) ?? 0);
           losers.push({ fencer: loser, totalTouches });
         }
       }


### PR DESCRIPTION
- tableCalculations: updateTableAfterMatch passe de 3 find/filter O(n)
  à des lookups O(1) via Map (byMatchId + byParent) construites en une passe
- tableCalculations: calculateTableRanking passe de O(n²) à O(n) en
  pré-calculant les touches tableau dans un Map avant la boucle des rounds
- poolCalculations: resolveClubConflicts remplace pool.some() O(n)
  par un Map<club, count> pré-construit, mis à jour après chaque échange
- poolCalculations: canSwapResolveConflict supprime 2 some() redondants
  (conflicts1After > 0 suffit, les some() dupliquaient la même vérification)
- LiveDashboard: matchesInProgress, completedMatches, totalMatches
  enveloppés dans useMemo([pools]) pour ne pas recalculer au tick 1Hz
- App.tsx: loadCompetitions et handleCreateCompetition stabilisés avec
  useCallback; setCompetitions utilise la forme fonctionnelle prev =>

https://claude.ai/code/session_01CN82ZGmPeWyZPUmFEuq5ab