### PR TITLE
Ajoute la vue de saisie de poule par arène (/areneN/poule)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -787,6 +787,21 @@ export class DatabaseManager {
     };
   }
 
+  public getPoolFencers(poolId: string): Fencer[] {
+    if (!this.db) throw new Error('Database not open');
+    const results: Fencer[] = [];
+    const stmt = this.db.prepare(
+      'SELECT fencer_id FROM pool_fencers WHERE pool_id = ? ORDER BY position'
+    );
+    stmt.bind([poolId]);
+    while (stmt.step()) {
+      const fencer = this.getFencer(stmt.getAsObject().fencer_id as string);
+      if (fencer) results.push(fencer);
+    }
+    stmt.free();
+    return results;
+  }
+
   public getMatchesByPool(poolId: string): Match[] {
     if (!this.db) throw new Error('Database not open');
     const results: Match[] = [];

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -67,7 +67,7 @@ export class RemoteScoreServer {
     const isDev = process.env.NODE_ENV === 'development';
 
     // Liste des fichiers à charger
-    const filesToLoad = ['referee.html', 'arena.html', 'dashboard.html', 'index.html'];
+    const filesToLoad = ['referee.html', 'arena.html', 'dashboard.html', 'index.html', 'pool.html'];
 
     // Essayer plusieurs chemins pour trouver les fichiers
     const possiblePaths = isDev
@@ -477,6 +477,93 @@ export class RemoteScoreServer {
       this.sendHtmlFromMemory('referee.html', res);
     });
 
+    // Vue de saisie de poule par arène
+    this.app.get('/arene:arenaId/poule', (req, res) => {
+      const arenaId = req.params.arenaId;
+      console.log(`[RemoteScoreServer] Accès à la vue poule /arene${arenaId}/poule`);
+      this.sendHtmlFromMemory('pool.html', res);
+    });
+
+    // API: données complètes de la poule pour une arène
+    this.app.get('/api/arenas/:arenaId/pool-data', (req, res) => {
+      const rawId = req.params.arenaId;
+      // Accepte "1" ou "arena1" comme arenaId
+      const arenaId = rawId.startsWith('arena') ? rawId : `arena${rawId}`;
+      try {
+        const arena = this.arenas.get(arenaId);
+        const poolId = arena?.currentMatch?.poolId;
+        if (!poolId) {
+          return res.status(404).json({ error: 'Aucune poule assignée à cette arène' });
+        }
+
+        const fencers = this.db.getPoolFencers(poolId);
+        const matches = this.db.getMatchesByPool(poolId);
+        const isComplete =
+          matches.length > 0 && matches.every(m => m.status === MatchStatus.FINISHED);
+
+        const poolName = (() => {
+          if (!this.session) return 'Poule';
+          const allPools = this.db.getCompetitionPools(this.session.competitionId);
+          return allPools.find(p => p.id === poolId)?.name ?? 'Poule';
+        })();
+
+        res.json({ poolId, poolName, arenaId, fencers, matches, isComplete });
+      } catch (err) {
+        console.error('[RemoteScoreServer] Erreur pool-data:', err);
+        res.status(500).json({ error: 'Erreur interne' });
+      }
+    });
+
+    // API: saisir le score d'un match de poule
+    this.app.post('/api/pools/:poolId/matches/:matchId/score', (req, res) => {
+      const { poolId, matchId } = req.params;
+      const { scoreA, scoreB, specialStatus } = req.body as {
+        scoreA: number;
+        scoreB: number;
+        specialStatus?: string;
+      };
+      try {
+        const winner = scoreA > scoreB ? 'A' : scoreB > scoreA ? 'B' : null;
+        const scoreAObj: Score = {
+          value: scoreA,
+          isVictory: winner === 'A',
+          isAbstention: specialStatus === 'abandon_A',
+          isExclusion: specialStatus === 'exclusion_A',
+          isForfait: specialStatus === 'forfait_A',
+        };
+        const scoreBObj: Score = {
+          value: scoreB,
+          isVictory: winner === 'B',
+          isAbstention: specialStatus === 'abandon_B',
+          isExclusion: specialStatus === 'exclusion_B',
+          isForfait: specialStatus === 'forfait_B',
+        };
+        this.db.updateMatch(matchId, {
+          scoreA: scoreAObj,
+          scoreB: scoreBObj,
+          status: MatchStatus.FINISHED,
+        });
+
+        // Broadcaster la mise à jour vers toutes les vues /poule connectées
+        const matches = this.db.getMatchesByPool(poolId);
+        const fencers = this.db.getPoolFencers(poolId);
+        const isComplete = matches.every(m => m.status === MatchStatus.FINISHED);
+        for (const [aId, arena] of this.arenas) {
+          if (arena.currentMatch?.poolId === poolId) {
+            this.io
+              .to(`pool:${aId}`)
+              .emit(`pool:${aId}:update`, { poolId, fencers, matches, isComplete });
+            break;
+          }
+        }
+
+        res.json({ success: true, isComplete });
+      } catch (err) {
+        console.error('[RemoteScoreServer] Erreur score poule:', err);
+        res.status(500).json({ error: 'Erreur enregistrement score' });
+      }
+    });
+
     // API pour récupérer les matchs d'une arène/poule
     this.app.get('/api/arenas/:arenaId/matches', (req, res) => {
       try {
@@ -664,6 +751,10 @@ export class RemoteScoreServer {
             fencerB: arena.currentMatch?.fencerB,
           });
         }
+      });
+
+      socket.on('join_pool', (data: { arenaId: string }) => {
+        socket.join(`pool:${data.arenaId}`);
       });
 
       socket.on(

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -1,0 +1,693 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Saisie Poule – BellePoule</title>
+    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        background: #1a1a2e;
+        min-height: 100vh;
+        color: #fff;
+        display: flex;
+        flex-direction: column;
+      }
+
+      /* ── Header ── */
+      .header {
+        background: rgba(0, 0, 0, 0.5);
+        padding: 1rem 1.5rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        backdrop-filter: blur(8px);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      }
+
+      .header-title {
+        font-size: 1.4rem;
+        font-weight: 700;
+        color: #e2e8f0;
+      }
+
+      .header-subtitle {
+        font-size: 0.9rem;
+        color: #94a3b8;
+        margin-top: 0.2rem;
+      }
+
+      .connection-badge {
+        font-size: 0.8rem;
+        padding: 0.3rem 0.7rem;
+        border-radius: 1rem;
+        background: rgba(239, 68, 68, 0.2);
+        color: #fca5a5;
+        border: 1px solid rgba(239, 68, 68, 0.4);
+        transition: all 0.3s;
+      }
+
+      .connection-badge.connected {
+        background: rgba(34, 197, 94, 0.2);
+        color: #86efac;
+        border-color: rgba(34, 197, 94, 0.4);
+      }
+
+      /* ── Pool container ── */
+      .pool-container {
+        flex: 1;
+        padding: 1.5rem;
+        overflow: auto;
+      }
+
+      /* ── Pool table ── */
+      .pool-table-wrapper {
+        overflow-x: auto;
+      }
+
+      table.pool-grid {
+        border-collapse: collapse;
+        width: 100%;
+        min-width: 400px;
+      }
+
+      table.pool-grid th,
+      table.pool-grid td {
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        text-align: center;
+        font-size: 0.85rem;
+        padding: 0;
+      }
+
+      /* Row/col header cells */
+      table.pool-grid .fencer-header {
+        background: rgba(30, 60, 120, 0.6);
+        padding: 0.5rem 0.7rem;
+        font-weight: 600;
+        white-space: nowrap;
+        max-width: 130px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: #cbd5e1;
+        font-size: 0.8rem;
+        min-width: 90px;
+      }
+
+      table.pool-grid .fencer-header.row-header {
+        text-align: right;
+      }
+
+      table.pool-grid .fencer-header.col-header {
+        text-align: center;
+        writing-mode: initial;
+      }
+
+      /* Corner cell */
+      table.pool-grid .corner-cell {
+        background: rgba(0, 0, 0, 0.3);
+        min-width: 90px;
+      }
+
+      /* Score cells */
+      table.pool-grid .score-cell {
+        width: 52px;
+        min-width: 52px;
+        height: 44px;
+        cursor: pointer;
+        transition: background 0.15s, transform 0.1s;
+        font-weight: 700;
+        font-size: 0.9rem;
+      }
+
+      table.pool-grid .score-cell:hover {
+        filter: brightness(1.3);
+        transform: scale(1.05);
+        z-index: 1;
+        position: relative;
+      }
+
+      /* Diagonal */
+      table.pool-grid .score-cell.diagonal {
+        background: rgba(15, 23, 42, 0.7);
+        color: #475569;
+        cursor: default;
+        font-size: 1.2rem;
+      }
+
+      table.pool-grid .score-cell.diagonal:hover {
+        filter: none;
+        transform: none;
+      }
+
+      /* Not played */
+      table.pool-grid .score-cell.not-played {
+        background: rgba(30, 41, 59, 0.6);
+        color: transparent;
+      }
+
+      table.pool-grid .score-cell.not-played:hover {
+        background: rgba(59, 130, 246, 0.3);
+        color: #93c5fd;
+      }
+
+      table.pool-grid .score-cell.not-played:hover::after {
+        content: '+';
+        font-size: 1.2rem;
+        color: #93c5fd;
+      }
+
+      /* Victory */
+      table.pool-grid .score-cell.victory {
+        background: rgba(21, 128, 61, 0.55);
+        color: #bbf7d0;
+      }
+
+      /* Defeat */
+      table.pool-grid .score-cell.defeat {
+        background: rgba(185, 28, 28, 0.45);
+        color: #fecaca;
+      }
+
+      /* Abstention / Forfait / Exclusion */
+      table.pool-grid .score-cell.special {
+        background: rgba(100, 100, 100, 0.4);
+        color: #cbd5e1;
+        font-size: 0.75rem;
+      }
+
+      /* ── Loading / Error ── */
+      .status-message {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 200px;
+        font-size: 1.1rem;
+        color: #94a3b8;
+      }
+
+      /* ── Modal ── */
+      .modal-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.7);
+        z-index: 100;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .modal-overlay.visible {
+        display: flex;
+      }
+
+      .modal {
+        background: #1e293b;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        width: 360px;
+        max-width: 95vw;
+        box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
+      }
+
+      .modal h2 {
+        font-size: 1.1rem;
+        color: #e2e8f0;
+        margin-bottom: 1.2rem;
+        text-align: center;
+      }
+
+      .score-inputs {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 0.5rem;
+        align-items: center;
+        margin-bottom: 1rem;
+      }
+
+      .score-fencer {
+        text-align: center;
+      }
+
+      .score-fencer-name {
+        font-size: 0.8rem;
+        color: #94a3b8;
+        margin-bottom: 0.4rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 120px;
+        margin: 0 auto 0.4rem;
+        display: block;
+      }
+
+      .score-fencer input[type='number'] {
+        width: 80px;
+        text-align: center;
+        font-size: 2rem;
+        font-weight: 700;
+        background: rgba(255, 255, 255, 0.08);
+        border: 2px solid rgba(255, 255, 255, 0.2);
+        border-radius: 0.5rem;
+        color: #fff;
+        padding: 0.4rem;
+        display: block;
+        margin: 0 auto;
+        -moz-appearance: textfield;
+      }
+
+      .score-fencer input[type='number']::-webkit-inner-spin-button,
+      .score-fencer input[type='number']::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+      }
+
+      .score-fencer input[type='number']:focus {
+        outline: none;
+        border-color: #3b82f6;
+      }
+
+      .score-vs {
+        font-size: 1.2rem;
+        color: #64748b;
+        font-weight: 700;
+      }
+
+      .modal-actions {
+        display: flex;
+        gap: 0.7rem;
+        justify-content: center;
+        margin-top: 1.2rem;
+      }
+
+      .btn {
+        padding: 0.55rem 1.2rem;
+        border: none;
+        border-radius: 0.5rem;
+        font-size: 0.9rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: opacity 0.2s;
+      }
+
+      .btn:hover {
+        opacity: 0.85;
+      }
+
+      .btn-primary {
+        background: #2563eb;
+        color: #fff;
+      }
+
+      .btn-secondary {
+        background: rgba(255, 255, 255, 0.12);
+        color: #cbd5e1;
+      }
+
+      .btn-danger {
+        background: rgba(239, 68, 68, 0.25);
+        color: #fca5a5;
+      }
+
+      .modal-error {
+        color: #fca5a5;
+        font-size: 0.8rem;
+        text-align: center;
+        margin-top: 0.5rem;
+        min-height: 1.2rem;
+      }
+
+      /* ── FIN overlay ── */
+      .fin-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 100%);
+        z-index: 200;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 1.5rem;
+        text-align: center;
+      }
+
+      .fin-overlay.visible {
+        display: flex;
+      }
+
+      .fin-overlay h1 {
+        font-size: clamp(1.8rem, 5vw, 3.5rem);
+        font-weight: 800;
+        color: #e2e8f0;
+        letter-spacing: 0.02em;
+      }
+
+      .fin-overlay .fin-icon {
+        font-size: 4rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <div>
+        <div class="header-title" id="pool-title">Chargement…</div>
+        <div class="header-subtitle" id="pool-subtitle"></div>
+      </div>
+      <div class="connection-badge" id="connection-badge">⚡ Connexion…</div>
+    </div>
+
+    <div class="pool-container" id="pool-container">
+      <div class="status-message" id="status-message">Chargement de la poule…</div>
+    </div>
+
+    <!-- Modal de saisie de score -->
+    <div class="modal-overlay" id="modal-overlay">
+      <div class="modal">
+        <h2 id="modal-title">Match</h2>
+        <div class="score-inputs">
+          <div class="score-fencer">
+            <span class="score-fencer-name" id="modal-fencer-a"></span>
+            <input type="number" id="input-score-a" min="0" max="99" value="0" />
+          </div>
+          <div class="score-vs">–</div>
+          <div class="score-fencer">
+            <span class="score-fencer-name" id="modal-fencer-b"></span>
+            <input type="number" id="input-score-b" min="0" max="99" value="0" />
+          </div>
+        </div>
+        <div class="modal-error" id="modal-error"></div>
+        <div class="modal-actions">
+          <button class="btn btn-secondary" id="btn-cancel">Annuler</button>
+          <button class="btn btn-primary" id="btn-submit">Valider</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Overlay fin de poule -->
+    <div class="fin-overlay" id="fin-overlay">
+      <div class="fin-icon">🏆</div>
+      <h1>FIN DES PHASES DE POULES</h1>
+    </div>
+
+    <script>
+      // ── Extraction de l'arenaId depuis l'URL (/areneN/poule → "N") ──
+      const pathMatch = window.location.pathname.match(/\/arene(\w+)\/poule/);
+      const arenaNumber = pathMatch ? pathMatch[1] : '1';
+      const arenaId = `arena${arenaNumber}`;
+
+      // ── État global ──
+      let poolData = null;
+      let pendingMatch = null; // match en cours d'édition
+
+      // ── Socket.IO ──
+      const socket = io();
+
+      socket.on('connect', () => {
+        document.getElementById('connection-badge').textContent = '🟢 Connecté';
+        document.getElementById('connection-badge').classList.add('connected');
+        socket.emit('join_pool', { arenaId });
+        loadPoolData();
+      });
+
+      socket.on('disconnect', () => {
+        document.getElementById('connection-badge').textContent = '🔴 Déconnecté';
+        document.getElementById('connection-badge').classList.remove('connected');
+      });
+
+      socket.on(`pool:${arenaId}:update`, data => {
+        poolData = data;
+        renderAll(data);
+      });
+
+      // ── Chargement initial ──
+      async function loadPoolData() {
+        try {
+          const res = await fetch(`/api/arenas/${arenaNumber}/pool-data`);
+          if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            showStatusMessage(err.error || 'Aucune poule assignée à cette arène.');
+            return;
+          }
+          poolData = await res.json();
+          renderAll(poolData);
+        } catch (e) {
+          showStatusMessage('Erreur de connexion au serveur.');
+        }
+      }
+
+      function showStatusMessage(msg) {
+        document.getElementById('pool-container').innerHTML =
+          `<div class="status-message">${msg}</div>`;
+      }
+
+      // ── Rendu principal ──
+      function renderAll(data) {
+        if (data.isComplete) {
+          document.getElementById('fin-overlay').classList.add('visible');
+          return;
+        }
+        document.getElementById('fin-overlay').classList.remove('visible');
+
+        document.getElementById('pool-title').textContent =
+          `${data.poolName || 'Poule'} – Piste ${arenaNumber}`;
+        document.getElementById('pool-subtitle').textContent =
+          `${data.fencers.length} tireur(s) · ${data.matches.length} match(s)`;
+
+        renderGrid(data.fencers, data.matches);
+      }
+
+      // ── Construction de la grille NxN ──
+      function renderGrid(fencers, matches) {
+        const container = document.getElementById('pool-container');
+
+        const table = document.createElement('table');
+        table.className = 'pool-grid';
+
+        // En-tête (ligne de titres colonnes)
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+
+        // Coin vide
+        const corner = document.createElement('th');
+        corner.className = 'corner-cell';
+        headerRow.appendChild(corner);
+
+        fencers.forEach(f => {
+          const th = document.createElement('th');
+          th.className = 'fencer-header col-header';
+          th.textContent = shortName(f);
+          th.title = fullName(f);
+          headerRow.appendChild(th);
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        // Corps
+        const tbody = document.createElement('tbody');
+        fencers.forEach((rowFencer, rowIdx) => {
+          const tr = document.createElement('tr');
+
+          // En-tête de ligne
+          const th = document.createElement('th');
+          th.className = 'fencer-header row-header';
+          th.textContent = shortName(rowFencer);
+          th.title = fullName(rowFencer);
+          tr.appendChild(th);
+
+          fencers.forEach((colFencer, colIdx) => {
+            const td = document.createElement('td');
+            td.className = 'score-cell';
+
+            if (rowIdx === colIdx) {
+              td.classList.add('diagonal');
+              td.textContent = '—';
+            } else {
+              // Chercher le match où rowFencer est fencerA ET colFencer est fencerB
+              const match = findMatch(matches, rowFencer.id, colFencer.id);
+              renderCell(td, match, rowFencer, colFencer);
+            }
+
+            tr.appendChild(td);
+          });
+
+          tbody.appendChild(tr);
+        });
+
+        table.appendChild(tbody);
+
+        container.innerHTML = '';
+        const wrapper = document.createElement('div');
+        wrapper.className = 'pool-table-wrapper';
+        wrapper.appendChild(table);
+        container.appendChild(wrapper);
+      }
+
+      function findMatch(matches, fencerAId, fencerBId) {
+        return matches.find(
+          m =>
+            (m.fencerA && m.fencerA.id === fencerAId && m.fencerB && m.fencerB.id === fencerBId) ||
+            (m.fencerA && m.fencerA.id === fencerBId && m.fencerB && m.fencerB.id === fencerAId)
+        ) || null;
+      }
+
+      function renderCell(td, match, rowFencer, colFencer) {
+        if (!match) {
+          td.classList.add('not-played');
+          return;
+        }
+
+        const isRowA = match.fencerA && match.fencerA.id === rowFencer.id;
+        const scoreForRow = isRowA ? match.scoreA : match.scoreB;
+
+        if (!scoreForRow || match.status !== 'finished') {
+          td.classList.add('not-played');
+          td.addEventListener('click', () => openModal(match, rowFencer, colFencer));
+          return;
+        }
+
+        // Cas spéciaux
+        if (scoreForRow.isAbstention) {
+          td.classList.add('special');
+          td.textContent = 'Ab';
+        } else if (scoreForRow.isForfait) {
+          td.classList.add('special');
+          td.textContent = 'Ff';
+        } else if (scoreForRow.isExclusion) {
+          td.classList.add('special');
+          td.textContent = 'Ex';
+        } else if (scoreForRow.isVictory) {
+          td.classList.add('victory');
+          td.textContent = `V${scoreForRow.value ?? ''}`;
+        } else {
+          td.classList.add('defeat');
+          td.textContent = `D${scoreForRow.value ?? ''}`;
+        }
+
+        // Permettre la ré-édition
+        td.style.cursor = 'pointer';
+        td.addEventListener('click', () => openModal(match, rowFencer, colFencer));
+      }
+
+      // ── Nommage ──
+      function shortName(f) {
+        const last = (f.lastName || f.last_name || '').toUpperCase();
+        const first = f.firstName || f.first_name || '';
+        return first ? `${last} ${first.charAt(0)}.` : last;
+      }
+
+      function fullName(f) {
+        const last = (f.lastName || f.last_name || '').toUpperCase();
+        const first = f.firstName || f.first_name || '';
+        return `${last} ${first}`.trim();
+      }
+
+      // ── Modal ──
+      function openModal(match, rowFencer, colFencer) {
+        pendingMatch = { match, rowFencer, colFencer };
+
+        const isRowA = match.fencerA && match.fencerA.id === rowFencer.id;
+        const fA = isRowA ? (match.fencerA || rowFencer) : (match.fencerB || colFencer);
+        const fB = isRowA ? (match.fencerB || colFencer) : (match.fencerA || rowFencer);
+
+        document.getElementById('modal-title').textContent = 'Saisie du score';
+        document.getElementById('modal-fencer-a').textContent = fullName(fA);
+        document.getElementById('modal-fencer-b').textContent = fullName(fB);
+
+        // Pré-remplir si score existant
+        const saVal = isRowA
+          ? (match.scoreA?.value ?? 0)
+          : (match.scoreB?.value ?? 0);
+        const sbVal = isRowA
+          ? (match.scoreB?.value ?? 0)
+          : (match.scoreA?.value ?? 0);
+
+        document.getElementById('input-score-a').value = saVal;
+        document.getElementById('input-score-b').value = sbVal;
+        document.getElementById('modal-error').textContent = '';
+
+        document.getElementById('modal-overlay').classList.add('visible');
+        document.getElementById('input-score-a').focus();
+        document.getElementById('input-score-a').select();
+      }
+
+      function closeModal() {
+        pendingMatch = null;
+        document.getElementById('modal-overlay').classList.remove('visible');
+      }
+
+      document.getElementById('btn-cancel').addEventListener('click', closeModal);
+
+      document.getElementById('modal-overlay').addEventListener('click', e => {
+        if (e.target === document.getElementById('modal-overlay')) closeModal();
+      });
+
+      document.getElementById('btn-submit').addEventListener('click', submitScore);
+
+      // Valider avec Entrée
+      document.addEventListener('keydown', e => {
+        if (e.key === 'Escape') closeModal();
+        if (e.key === 'Enter' && document.getElementById('modal-overlay').classList.contains('visible')) {
+          submitScore();
+        }
+      });
+
+      async function submitScore() {
+        if (!pendingMatch || !poolData) return;
+        const { match, rowFencer } = pendingMatch;
+
+        const rawA = parseInt(document.getElementById('input-score-a').value, 10);
+        const rawB = parseInt(document.getElementById('input-score-b').value, 10);
+
+        if (isNaN(rawA) || isNaN(rawB) || rawA < 0 || rawB < 0) {
+          document.getElementById('modal-error').textContent = 'Scores invalides.';
+          return;
+        }
+
+        if (rawA === rawB) {
+          document.getElementById('modal-error').textContent =
+            'Le score ne peut pas être nul (égalité non autorisée).';
+          return;
+        }
+
+        // Déterminer si rowFencer est fencerA ou fencerB dans le match
+        const isRowA = match.fencerA && match.fencerA.id === rowFencer.id;
+        const finalScoreA = isRowA ? rawA : rawB;
+        const finalScoreB = isRowA ? rawB : rawA;
+
+        document.getElementById('btn-submit').disabled = true;
+        document.getElementById('modal-error').textContent = '';
+
+        try {
+          const res = await fetch(
+            `/api/pools/${poolData.poolId}/matches/${match.id}/score`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ scoreA: finalScoreA, scoreB: finalScoreB }),
+            }
+          );
+          if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            document.getElementById('modal-error').textContent =
+              err.error || 'Erreur lors de la sauvegarde.';
+            return;
+          }
+          closeModal();
+          // La mise à jour de la grille arrive via Socket.IO (pool:arenaId:update)
+          // Fallback: recharger si pas de socket
+          setTimeout(() => { if (poolData) loadPoolData(); }, 1500);
+        } catch (e) {
+          document.getElementById('modal-error').textContent = 'Erreur réseau.';
+        } finally {
+          document.getElementById('btn-submit').disabled = false;
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -216,6 +216,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     number: i + 1,
     refereeUrl: `${serverUrl}/arene${i + 1}/arbitre`,
     displayUrl: `${serverUrl}/arene${i + 1}`,
+    poolUrl: `${serverUrl}/arene${i + 1}/poule`,
   }));
 
   // Contrôles +/− communs aux deux vues (pending uniquement, sans appel IPC direct)
@@ -342,6 +343,29 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                     setActiveQR({
                       url: arena.displayUrl,
                       label: `Piste ${arena.number} – Affichage`,
+                    })
+                  }
+                  title="QR code"
+                >
+                  📱
+                </button>
+              </div>
+              <div className="arena-url-row">
+                <span className="arena-url-label">Poule</span>
+                <code className="arena-url-value">{arena.poolUrl}</code>
+                <button
+                  className="btn-copy"
+                  onClick={() => copyToClipboard(arena.poolUrl, arena.number * 10 + 2)}
+                  title="Copier l'URL"
+                >
+                  {copiedIndex === arena.number * 10 + 2 ? '✓' : '📋'}
+                </button>
+                <button
+                  className="btn-qr"
+                  onClick={() =>
+                    setActiveQR({
+                      url: arena.poolUrl,
+                      label: `Piste ${arena.number} – Poule`,
                     })
                   }
                   title="QR code"


### PR DESCRIPTION
- Nouvelle route GET /arene:id/poule servant pool.html
- API GET /api/arenas/:id/pool-data : fencers + matches + isComplete
- API POST /api/pools/:poolId/matches/:matchId/score : sauvegarde + broadcast Socket.IO
- Socket.IO room pool:<arenaId> avec événement join_pool
- DB : nouvelle méthode getPoolFencers(poolId) via pool_fencers.position
- pool.html : grille NxN, modal de saisie, overlay FIN DES PHASES DE POULES
- RemoteScoreManager : URL et QR code "Poule" par piste

https://claude.ai/code/session_01GptfwLt67SLvxpEF1LC65H