### PR TITLE
fix: correction du partage de résultats (QR code + route manquante)

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -725,6 +725,162 @@ export class RemoteScoreServer {
         res.status(500).json({ error: 'Erreur lors de la mise à jour du score' });
       }
     });
+
+    // API : données de résultats d'une compétition (classements de poules)
+    this.app.get('/api/competitions/:competitionId/results-data', (req, res) => {
+      try {
+        const { competitionId } = req.params;
+        const competition = this.db.getCompetition(competitionId);
+        if (!competition) {
+          return res.status(404).json({ error: 'Compétition introuvable' });
+        }
+
+        const pools = this.db.getCompetitionPools(competitionId);
+        const poolResults = pools.map(pool => {
+          const fencers = this.db.getPoolFencers(pool.id);
+          const matches = this.db.getMatchesByPool(pool.id);
+
+          // Calcul des statistiques par tireur
+          const stats: Record<string, { victories: number; touchesFor: number; touchesAgainst: number }> = {};
+          for (const f of fencers) {
+            stats[f.id] = { victories: 0, touchesFor: 0, touchesAgainst: 0 };
+          }
+
+          for (const match of matches) {
+            if (match.status !== MatchStatus.FINISHED) continue;
+            const sA = match.scoreA;
+            const sB = match.scoreB;
+            if (!sA || !sB || !match.fencerA || !match.fencerB) continue;
+            const idA = match.fencerA.id;
+            const idB = match.fencerB.id;
+            if (stats[idA]) {
+              stats[idA].touchesFor += sA.value ?? 0;
+              stats[idA].touchesAgainst += sB.value ?? 0;
+              if (sA.isVictory) stats[idA].victories += 1;
+            }
+            if (stats[idB]) {
+              stats[idB].touchesFor += sB.value ?? 0;
+              stats[idB].touchesAgainst += sA.value ?? 0;
+              if (sB.isVictory) stats[idB].victories += 1;
+            }
+          }
+
+          const rankings = fencers
+            .map(f => ({
+              id: f.id,
+              lastName: f.lastName,
+              firstName: f.firstName,
+              club: f.club ?? '',
+              victories: stats[f.id]?.victories ?? 0,
+              touchesFor: stats[f.id]?.touchesFor ?? 0,
+              touchesAgainst: stats[f.id]?.touchesAgainst ?? 0,
+              index: (stats[f.id]?.touchesFor ?? 0) - (stats[f.id]?.touchesAgainst ?? 0),
+            }))
+            .sort((a, b) => b.victories - a.victories || b.index - a.index || b.touchesFor - a.touchesFor);
+
+          return { id: pool.id, name: pool.name, rankings };
+        });
+
+        res.json({
+          competition: { id: competition.id, title: competition.title, date: competition.date, weapon: competition.weapon },
+          pools: poolResults,
+        });
+      } catch (error) {
+        console.error('[RemoteScoreServer] Erreur résultats:', error);
+        res.status(500).json({ error: 'Erreur lors de la récupération des résultats' });
+      }
+    });
+
+    // Page HTML : résultats d'une compétition (pour les spectateurs)
+    this.app.get('/competition/:competitionId/results', (req, res) => {
+      const { competitionId } = req.params;
+      const html = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Résultats – BellePoule</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; padding: 1rem; }
+    header { text-align: center; padding: 1.5rem 0 1rem; }
+    header h1 { font-size: 1.5rem; color: #f8fafc; }
+    header p { color: #94a3b8; font-size: 0.875rem; margin-top: 0.25rem; }
+    .pool { background: #1e293b; border-radius: 10px; margin: 1rem 0; overflow: hidden; }
+    .pool-title { background: #3b82f6; color: white; padding: 0.6rem 1rem; font-weight: 600; font-size: 0.95rem; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+    th { background: #0f172a; color: #94a3b8; padding: 0.5rem 0.75rem; text-align: left; font-weight: 500; }
+    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #334155; }
+    tr:last-child td { border-bottom: none; }
+    tr:nth-child(even) td { background: rgba(255,255,255,0.03); }
+    .rank { color: #94a3b8; width: 2rem; }
+    .name { font-weight: 600; }
+    .club { color: #94a3b8; font-size: 0.8rem; }
+    .num { text-align: center; }
+    .pos { color: #4ade80; }
+    .neg { color: #f87171; }
+    .loading { text-align: center; padding: 3rem; color: #94a3b8; }
+    .error { background: #450a0a; color: #fca5a5; padding: 1rem; border-radius: 8px; margin: 1rem 0; }
+    .refresh { position: fixed; bottom: 1rem; right: 1rem; background: #3b82f6; color: white;
+      border: none; border-radius: 50%; width: 3rem; height: 3rem; font-size: 1.2rem;
+      cursor: pointer; box-shadow: 0 4px 12px rgba(59,130,246,0.4); }
+  </style>
+</head>
+<body>
+  <div id="app"><div class="loading">Chargement des résultats…</div></div>
+  <button class="refresh" onclick="load()" title="Actualiser">↻</button>
+  <script>
+    const competitionId = ${JSON.stringify(competitionId)};
+    async function load() {
+      try {
+        const r = await fetch('/api/competitions/' + competitionId + '/results-data');
+        if (!r.ok) throw new Error('Compétition introuvable');
+        const data = await r.json();
+        render(data);
+      } catch(e) {
+        document.getElementById('app').innerHTML = '<div class="error">Erreur : ' + e.message + '</div>';
+      }
+    }
+    function render(data) {
+      const dateStr = data.competition.date
+        ? new Date(data.competition.date).toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' })
+        : '';
+      let html = '<header><h1>' + escHtml(data.competition.title) + '</h1>' +
+        (dateStr ? '<p>' + dateStr + '</p>' : '') + '</header>';
+      if (!data.pools || data.pools.length === 0) {
+        html += '<p style="text-align:center;color:#94a3b8;padding:2rem">Aucune poule disponible</p>';
+      } else {
+        for (const pool of data.pools) {
+          html += '<div class="pool"><div class="pool-title">' + escHtml(pool.name) + '</div><table>' +
+            '<thead><tr><th class="rank">#</th><th>Tireur</th>' +
+            '<th class="num">V</th><th class="num">TD</th><th class="num">TR</th><th class="num">Ind.</th></tr></thead><tbody>';
+          pool.rankings.forEach((f, i) => {
+            const ind = f.index >= 0 ? '+' + f.index : '' + f.index;
+            const cls = f.index > 0 ? 'pos' : f.index < 0 ? 'neg' : '';
+            html += '<tr><td class="rank">' + (i+1) + '</td>' +
+              '<td><span class="name">' + escHtml(f.lastName.toUpperCase()) + ' ' + escHtml(f.firstName) + '</span>' +
+              (f.club ? ' <span class="club">(' + escHtml(f.club) + ')</span>' : '') + '</td>' +
+              '<td class="num">' + f.victories + '</td>' +
+              '<td class="num">' + f.touchesFor + '</td>' +
+              '<td class="num">' + f.touchesAgainst + '</td>' +
+              '<td class="num ' + cls + '">' + ind + '</td></tr>';
+          });
+          html += '</tbody></table></div>';
+        }
+      }
+      document.getElementById('app').innerHTML = html;
+    }
+    function escHtml(s) {
+      return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+    load();
+    setInterval(load, 30000);
+  </script>
+</body>
+</html>`;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.send(html);
+    });
   }
 
   private setupSocketHandlers(): void {

--- a/src/renderer/components/QRCodeShare.tsx
+++ b/src/renderer/components/QRCodeShare.tsx
@@ -3,7 +3,8 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
+import QRCode from 'qrcode';
 import { Competition } from '../../shared/types';
 
 interface QRCodeShareProps {
@@ -12,7 +13,6 @@ interface QRCodeShareProps {
 }
 
 export const QRCodeShare: React.FC<QRCodeShareProps> = ({ competition, onClose }) => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const [qrCodeUrl, setQrCodeUrl] = useState<string>('');
   const [isGenerating, setIsGenerating] = useState(true);
   const [error, setError] = useState<string>('');
@@ -27,99 +27,26 @@ export const QRCodeShare: React.FC<QRCodeShareProps> = ({ competition, onClose }
     setError('');
 
     try {
-      // Créer une URL unique pour la compétition
-      const baseUrl = window.location.origin;
-      const url = `${baseUrl}/competition/${competition.id}/results`;
+      const info = await window.electronAPI.remote.getServerInfo();
+      if (!info.success || !info.serverInfo) {
+        setError(
+          'Le serveur distant doit être démarré pour partager les résultats.\nActivez la saisie distante depuis l\'onglet correspondant.'
+        );
+        setIsGenerating(false);
+        return;
+      }
+
+      const url = `${info.serverInfo.url}/competition/${competition.id}/results`;
       setShareUrl(url);
 
-      // Essayer d'utiliser l'API QR Code si disponible
-      if (typeof window !== 'undefined') {
-        // Générer un QR code simple avec une API externe (pas besoin de librairie)
-        const qrApiUrl = `https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(url)}`;
-
-        // Créer une image
-        const img = new Image();
-        img.crossOrigin = 'anonymous';
-
-        img.onload = () => {
-          if (canvasRef.current) {
-            const canvas = canvasRef.current;
-            const ctx = canvas.getContext('2d');
-            if (ctx) {
-              // Dessiner le QR code
-              ctx.drawImage(img, 0, 0, 300, 300);
-
-              // Ajouter un logo au centre (optionnel)
-              drawLogo(ctx, 300, 300);
-
-              setQrCodeUrl(canvas.toDataURL('image/png'));
-              setIsGenerating(false);
-            }
-          }
-        };
-
-        img.onerror = () => {
-          // Fallback : générer un QR code manuellement simple
-          generateManualQRCode(url);
-        };
-
-        img.src = qrApiUrl;
-      }
+      const dataUrl = await QRCode.toDataURL(url, { width: 300, margin: 1 });
+      setQrCodeUrl(dataUrl);
     } catch (err) {
       console.error('Erreur génération QR:', err);
       setError('Erreur lors de la génération du QR code');
+    } finally {
       setIsGenerating(false);
     }
-  };
-
-  const drawLogo = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
-    // Dessiner un cercle blanc au centre pour le logo
-    const centerX = width / 2;
-    const centerY = height / 2;
-    const radius = 35;
-
-    ctx.beginPath();
-    ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
-    ctx.fillStyle = 'white';
-    ctx.fill();
-    ctx.strokeStyle = '#3B82F6';
-    ctx.lineWidth = 2;
-    ctx.stroke();
-
-    // Ajouter le texte BP
-    ctx.font = 'bold 24px Arial';
-    ctx.fillStyle = '#3B82F6';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('BP', centerX, centerY);
-  };
-
-  const generateManualQRCode = (url: string) => {
-    // Fallback simple si l'API échoue
-    if (canvasRef.current) {
-      const canvas = canvasRef.current;
-      const ctx = canvas.getContext('2d');
-      if (ctx) {
-        // Fond blanc
-        ctx.fillStyle = 'white';
-        ctx.fillRect(0, 0, 300, 300);
-
-        // Bordure
-        ctx.strokeStyle = '#3B82F6';
-        ctx.lineWidth = 4;
-        ctx.strokeRect(0, 0, 300, 300);
-
-        // Texte
-        ctx.font = '16px Arial';
-        ctx.fillStyle = '#1F2937';
-        ctx.textAlign = 'center';
-        ctx.fillText('QR Code non disponible', 150, 130);
-        ctx.fillText("Utilisez l'URL ci-dessous", 150, 160);
-
-        setQrCodeUrl(canvas.toDataURL('image/png'));
-      }
-    }
-    setIsGenerating(false);
   };
 
   const downloadQRCode = () => {
@@ -152,7 +79,7 @@ export const QRCodeShare: React.FC<QRCodeShareProps> = ({ competition, onClose }
         <div className="modal__body">
           <div className="qrcode__container">
             <p className="qrcode__description">
-              Scannez ce QR code pour accéder aux résultats de la compétition
+              Scannez ce QR code pour accéder aux résultats de la compétition{' '}
               <strong>"{competition.title}"</strong>
             </p>
 
@@ -163,21 +90,25 @@ export const QRCodeShare: React.FC<QRCodeShareProps> = ({ competition, onClose }
                   <p>Génération du QR code...</p>
                 </div>
               ) : error ? (
-                <div className="alert alert--error">{error}</div>
+                <div className="alert alert--error" style={{ whiteSpace: 'pre-line' }}>
+                  {error}
+                </div>
               ) : (
-                <canvas ref={canvasRef} width={300} height={300} className="qrcode__canvas" />
+                <img src={qrCodeUrl} alt="QR Code" className="qrcode__canvas" width={300} height={300} />
               )}
             </div>
 
-            <div className="qrcode__url">
-              <label className="form-label">URL de partage :</label>
-              <div className="qrcode__url-input">
-                <input type="text" value={shareUrl} readOnly className="form-control" />
-                <button className="btn btn-secondary" onClick={copyToClipboard}>
-                  📋 Copier
-                </button>
+            {!error && shareUrl && (
+              <div className="qrcode__url">
+                <label className="form-label">URL de partage :</label>
+                <div className="qrcode__url-input">
+                  <input type="text" value={shareUrl} readOnly className="form-control" />
+                  <button className="btn btn-secondary" onClick={copyToClipboard}>
+                    📋 Copier
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
 
             <div className="qrcode__info">
               <div className="alert alert--info">


### PR DESCRIPTION
- QRCodeShare: remplace window.location.origin par electronAPI.remote.getServerInfo()
  pour obtenir l'URL réseau réelle du serveur Express (IP locale:8066)
- QRCodeShare: remplace l'API externe qrserver.com par le package qrcode déjà installé
  (offline-first, pas de dépendance réseau externe)
- QRCodeShare: affiche un message d'erreur si le serveur distant n'est pas démarré
- remoteScoreServer: ajoute la route GET /competition/:id/results (page HTML responsive
  pour les spectateurs avec auto-refresh toutes les 30s)
- remoteScoreServer: ajoute l'endpoint GET /api/competitions/:id/results-data
  (JSON classements de poules calculés depuis la DB)

https://claude.ai/code/session_01FJJKNRXYRcQVh8SWi8GUun