### PR TITLE
Fix: align Language type in LanguageSelector and SettingsModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.2-build.446",
+  "version": "1.0.2-build.456",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.2-build.446",
+      "version": "1.0.2-build.456",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/renderer/components/LanguageSelector.tsx
+++ b/src/renderer/components/LanguageSelector.tsx
@@ -5,12 +5,13 @@
 
 import React from 'react';
 import { useTranslation } from '../hooks/useTranslation';
+import type { Language } from '../contexts/TranslationContext';
 
 interface LanguageSelectorProps {
   className?: string;
   showLabel?: boolean;
-  onLanguageChange?: (language: 'fr' | 'en' | 'br') => void;
-  value?: 'fr' | 'en' | 'br';
+  onLanguageChange?: (language: Language) => void;
+  value?: Language;
 }
 
 const LanguageSelector: React.FC<LanguageSelectorProps> = ({
@@ -22,7 +23,7 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   const { language, changeLanguage, availableLanguages, isLoading } = useTranslation();
 
   const handleLanguageChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const newLanguage = event.target.value as 'fr' | 'en' | 'br';
+    const newLanguage = event.target.value as Language;
 
     if (onLanguageChange) {
       // Mode "sélection" - ne pas appliquer immédiatement

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from '../hooks/useTranslation';
+import type { Language } from '../contexts/TranslationContext';
 import LanguageSelector from './LanguageSelector';
 
 interface SettingsModalProps {
@@ -28,7 +29,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
     setSettings(prev => ({ ...prev, language, theme }));
   }, [language, theme]);
 
-  const handleLanguageChange = (newLanguage: 'fr' | 'en' | 'br') => {
+  const handleLanguageChange = (newLanguage: Language) => {
     console.log(
       `🔄 SettingsModal: Language selected: ${newLanguage} (current: ${settings.language})`
     );


### PR DESCRIPTION
LanguageSelector and SettingsModal used a hardcoded 'fr'|'en'|'br' type
while TranslationContext.Language now includes 'ca'|'de'|'es'|'zh-HK'.
Import Language from TranslationContext to keep types in sync.

https://claude.ai/code/session_01B2RXnv5Zf3nEm1uAdrJ1LK