### PR TITLE
Support in-memory match score updates for non-persisted pools

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -680,9 +680,10 @@ export class RemoteScoreServer {
         console.log(`[RemoteScoreServer] POST /api/matches/${matchId}/finish`);
         console.log(`[RemoteScoreServer] Score final: ${scoreA}-${scoreB}`);
 
-        // Mettre à jour le match dans la base de données
-        const match = this.db.getMatch(matchId);
-        if (!match) {
+        // Vérifier que le match existe (en DB ou en mémoire)
+        const dbMatch = this.db.getMatch(matchId);
+        const inMemoryMatch = !dbMatch && this.sessionMatches.find((m: any) => m.id === matchId);
+        if (!dbMatch && !inMemoryMatch) {
           return res.status(404).json({ error: 'Match non trouvé' });
         }
 
@@ -706,12 +707,31 @@ export class RemoteScoreServer {
           isForfait: false,
         };
 
-        // Mettre à jour le match
-        this.db.updateMatch(matchId, {
-          scoreA: scoreAObj,
-          scoreB: scoreBObj,
-          status: MatchStatus.FINISHED,
-        });
+        if (dbMatch) {
+          // Match persisté en DB : mise à jour directe
+          this.db.updateMatch(matchId, {
+            scoreA: scoreAObj,
+            scoreB: scoreBObj,
+            status: MatchStatus.FINISHED,
+          });
+        } else {
+          // Match en mémoire uniquement (poule non persistée)
+          // Synchroniser les scores dans l'arène et déclencher l'IPC vers le renderer
+          this.sessionMatchScores.set(matchId, {
+            scoreA: scoreAObj,
+            scoreB: scoreBObj,
+            status: MatchStatus.FINISHED,
+          });
+          // Mettre à jour les scores de l'arène puis terminer le match via l'IPC
+          for (const [arenaId, arena] of this.arenas) {
+            if (arena.currentMatch?.id === matchId) {
+              arena.currentMatch.scoreA = scoreA;
+              arena.currentMatch.scoreB = scoreB;
+              this.finishArenaMatch(arenaId);
+              break;
+            }
+          }
+        }
 
         // Notifier tous les clients
         this.broadcastMessage({
@@ -1167,12 +1187,6 @@ export class RemoteScoreServer {
   }
 
   private async updateMatchScore(matchId: string, update: RemoteScoreUpdate): Promise<void> {
-    // Mettre à jour le match dans la base de données
-    const match = this.db.getMatch(matchId);
-    if (!match) {
-      throw new Error('Match non trouvé');
-    }
-
     const scoreA: Score = {
       value: update.scoreA,
       isVictory: update.winner === 'A',
@@ -1189,11 +1203,34 @@ export class RemoteScoreServer {
       isForfait: update.specialStatus === 'forfait' && update.winner !== 'B',
     };
 
-    this.db.updateMatch(matchId, {
-      scoreA,
-      scoreB,
-      status: update.status === 'finished' ? MatchStatus.FINISHED : MatchStatus.IN_PROGRESS,
-    });
+    const dbMatch = this.db.getMatch(matchId);
+    if (dbMatch) {
+      // Match en base de données : mise à jour directe
+      this.db.updateMatch(matchId, {
+        scoreA,
+        scoreB,
+        status: update.status === 'finished' ? MatchStatus.FINISHED : MatchStatus.IN_PROGRESS,
+      });
+    } else {
+      // Match en mémoire uniquement (poule non persistée) : mettre à jour via Socket.IO
+      const inMemory = this.sessionMatches.find((m: any) => m.id === matchId);
+      if (!inMemory) {
+        throw new Error('Match non trouvé');
+      }
+      // Synchroniser les scores dans l'arène en mémoire
+      for (const [arenaId, arena] of this.arenas) {
+        if (arena.currentMatch?.id === matchId) {
+          this.updateArenaScore(arenaId, update.scoreA, update.scoreB);
+          break;
+        }
+      }
+      // Stocker dans sessionMatchScores pour cohérence
+      this.sessionMatchScores.set(matchId, {
+        scoreA,
+        scoreB,
+        status: update.status === 'finished' ? MatchStatus.FINISHED : MatchStatus.IN_PROGRESS,
+      });
+    }
   }
 
   private broadcastMessage(message: WebSocketMessage): void {
@@ -1456,6 +1493,8 @@ export class RemoteScoreServer {
   public finishArenaMatch(arenaId: string): void {
     const arena = this.arenas.get(arenaId);
     if (!arena || !arena.currentMatch) return;
+    // Éviter le double-déclenchement (REST + Socket.IO)
+    if (arena.status === 'finished') return;
 
     const finishedMatch = { ...arena.currentMatch };
 

--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -276,7 +276,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                   id="poolMaxScore"
                   className="form-input"
                   value={poolMaxScore}
-                  onChange={e => setPoolMaxScore(parseInt(e.target.value) || 0)}
+                  onChange={e => setPoolMaxScore(Math.max(1, parseInt(e.target.value) || 1))}
                   min="1"
                   placeholder="21"
                 />

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -200,13 +200,15 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     const scoreB = parseInt(editScoreB, 10) || 0;
 
     // Valider que les scores ne dépassent pas le maximum
-    if (maxScore > 0) {
-      if (scoreA > maxScore) {
-        showToast(`Le score du tireur A ne peut pas dépasser ${maxScore}`, 'error');
+    // Utiliser le maxScore stocké sur le match comme référence, avec fallback sur la prop
+    const effectiveMax = pool.matches[editingMatch]?.maxScore || maxScore || 0;
+    if (effectiveMax > 0) {
+      if (scoreA > effectiveMax) {
+        showToast(`Le score du tireur A ne peut pas dépasser ${effectiveMax}`, 'error');
         return;
       }
-      if (scoreB > maxScore) {
-        showToast(`Le score du tireur B ne peut pas dépasser ${maxScore}`, 'error');
+      if (scoreB > effectiveMax) {
+        showToast(`Le score du tireur B ne peut pas dépasser ${effectiveMax}`, 'error');
         return;
       }
     }
@@ -477,18 +479,18 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
                   fontSize: '3rem',
                   padding: '0.75rem',
                   borderColor:
-                    (parseInt(editScoreA, 10) || 0) > (maxScore > 0 ? maxScore : 999)
+                    (parseInt(editScoreA, 10) || 0) > ((editingMatch !== null ? pool.matches[editingMatch]?.maxScore : 0) || maxScore || 999)
                       ? '#ef4444'
                       : undefined,
                   borderWidth:
-                    (parseInt(editScoreA, 10) || 0) > (maxScore > 0 ? maxScore : 999)
+                    (parseInt(editScoreA, 10) || 0) > ((editingMatch !== null ? pool.matches[editingMatch]?.maxScore : 0) || maxScore || 999)
                       ? '2px'
                       : undefined,
                 }}
                 value={editScoreA}
                 onChange={e => setEditScoreA(e.target.value)}
                 min="0"
-                max={maxScore > 0 ? maxScore : undefined}
+                max={(editingMatch !== null ? pool.matches[editingMatch]?.maxScore : 0) || maxScore || undefined}
                 autoFocus
                 onKeyDown={e => {
                   if (e.key === 'Enter') {
@@ -522,18 +524,18 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
                   fontSize: '3rem',
                   padding: '0.75rem',
                   borderColor:
-                    (parseInt(editScoreB, 10) || 0) > (maxScore > 0 ? maxScore : 999)
+                    (parseInt(editScoreB, 10) || 0) > ((editingMatch !== null ? pool.matches[editingMatch]?.maxScore : 0) || maxScore || 999)
                       ? '#ef4444'
                       : undefined,
                   borderWidth:
-                    (parseInt(editScoreB, 10) || 0) > (maxScore > 0 ? maxScore : 999)
+                    (parseInt(editScoreB, 10) || 0) > ((editingMatch !== null ? pool.matches[editingMatch]?.maxScore : 0) || maxScore || 999)
                       ? '2px'
                       : undefined,
                 }}
                 value={editScoreB}
                 onChange={e => setEditScoreB(e.target.value)}
                 min="0"
-                max={maxScore > 0 ? maxScore : undefined}
+                max={(editingMatch !== null ? pool.matches[editingMatch]?.maxScore : 0) || maxScore || undefined}
                 onKeyDown={e => {
                   if (e.key === 'Enter') {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
This PR extends the remote score server to properly handle score updates for matches in non-persisted pools (stored in memory only), while maintaining backward compatibility with database-persisted matches. It also improves score validation in the pool view to use match-specific max scores.

## Key Changes

### Remote Score Server (`remoteScoreServer.ts`)
- **Match finish endpoint (`/api/matches/{matchId}/finish`)**: Added logic to check both database and in-memory matches, with separate update paths:
  - Database matches: Direct database update (existing behavior)
  - In-memory matches: Update `sessionMatchScores`, sync arena scores, and trigger IPC to renderer
  
- **Score update method (`updateMatchScore`)**: Refactored to handle both storage types:
  - Removed premature match existence check that prevented in-memory match updates
  - Added conditional logic to update database or in-memory matches appropriately
  - For in-memory matches: Updates arena scores and stores in `sessionMatchScores` for consistency
  
- **Arena match finish guard**: Added check to prevent double-triggering of `finishArenaMatch` when called from both REST and Socket.IO paths

### Pool View (`PoolView.tsx`)
- **Score validation**: Changed to use match-specific `maxScore` from the pool data with fallback to component prop
- **Visual feedback**: Updated border color/width indicators to use the effective max score (match-specific or prop-based)
- **Input constraints**: Updated `max` attribute on score inputs to reflect match-specific limits

### Competition Properties Modal (`CompetitionPropertiesModal.tsx`)
- **Pool max score input**: Added validation to ensure minimum value of 1 (prevents invalid zero/negative values)

## Implementation Details
- In-memory matches are identified by checking `sessionMatches` when no database match exists
- Score synchronization for in-memory matches happens at the arena level to maintain consistency
- The `sessionMatchScores` map is used as a single source of truth for in-memory match scores
- Backward compatibility is maintained: database-persisted matches continue to use the original update path

https://claude.ai/code/session_01NASNs4ikfQ8pgNqsJVJuJ8