### PR TITLE
Notify renderer when pool match score is updated

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -597,6 +597,18 @@ export class RemoteScoreServer {
           }
         }
 
+        // Notifier le renderer de la mise à jour du score (pour affichage dans le tableau poule)
+        const mainWindow = (global as any).mainWindow;
+        if (mainWindow) {
+          mainWindow.webContents.send('match:finished', {
+            matchId,
+            scoreA: scoreAObj.value,
+            scoreB: scoreBObj.value,
+            poolId,
+            isTableau: false,
+          });
+        }
+
         res.json({ success: true, isComplete });
       } catch (err) {
         console.error('[RemoteScoreServer] Erreur score poule:', err);


### PR DESCRIPTION
## Summary
Added IPC notification to the renderer process when a pool match score is updated, enabling real-time UI updates in the pool standings table.

## Key Changes
- Added `match:finished` IPC event emission to notify the renderer when a pool match score is successfully updated
- The notification includes match details: `matchId`, `scoreA`, `scoreB`, `poolId`, and `isTableau` flag
- Event is sent via `mainWindow.webContents.send()` with a safety check to ensure the main window exists

## Implementation Details
- The notification is sent after the score update is processed but before the success response is returned to the client
- The `isTableau: false` flag indicates this is a pool match update (not a tableau/bracket match)
- This enables the frontend to reactively update the pool standings table without requiring a full page refresh

https://claude.ai/code/session_015NnS7gndp85XTXT5vyo1Dd