### PR TITLE
fix: restaurer rankingValidated au rechargement si phase tableau/résultats

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -157,6 +157,9 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       ] as const;
       const restoredPhase = phaseMap[restoredState.currentPhase || 0];
       if (restoredPhase) setCurrentPhase(restoredPhase);
+      if (['tableau', 'results', 'remote'].includes(restoredPhase)) {
+        setRankingValidated(true);
+      }
       if (restoredState.currentPoolRound) setCurrentPoolRound(restoredState.currentPoolRound);
       if (restoredState.pools) setPools(restoredState.pools);
       if (restoredState.poolHistory) setPoolHistory(restoredState.poolHistory || []);


### PR DESCRIPTION
Lors de la réouverture de l'application en phase tableau, résultats ou
remote, le flag rankingValidated était réinitialisé à false (état local
non persisté), bloquant l'accès à l'onglet Tableau.

On infère maintenant que le classement a nécessairement été validé si
la phase restaurée est postérieure à la phase de classement.

https://claude.ai/code/session_01KDvFDUJ3W9vjYysYqFTqWz