### PR TITLE
Fix remote pool display bugs: fencer order and next matches

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -630,36 +630,46 @@ export class RemoteScoreServer {
         const competitionId = this.session.competitionId;
         console.log(`[RemoteScoreServer] CompetitionId: ${competitionId}`);
 
-        // D'abord, essayer de récupérer les matches depuis la mémoire (arènes)
         const arena = this.arenas.get(arenaId);
-        const allArenaMatches: any[] = [];
 
-        // Match courant de CETTE arène uniquement
-        if (arena && arena.currentMatch) {
-          console.log(
-            `[RemoteScoreServer] Match trouvé en mémoire pour arène ${arenaId}:`,
-            arena.currentMatch.id
-          );
-          allArenaMatches.push({
-            id: arena.currentMatch.id,
-            poolId: arena.currentMatch.poolId,
-            fencerA: arena.currentMatch.fencerA,
-            fencerB: arena.currentMatch.fencerB,
-            scoreA: arena.currentMatch.scoreA,
-            scoreB: arena.currentMatch.scoreB,
-            status: arena.currentMatch.status,
+        // Si l'arène a un pool associé, retourner TOUS les matchs en attente du pool
+        // (pas seulement le match courant) pour que l'arbitre voie les prochains matchs.
+        const currentPoolId = arena?.currentMatch?.poolId;
+        if (currentPoolId && this.sessionMatches.length > 0) {
+          const poolMatches = this.sessionMatches
+            .filter((m: any) => {
+              const matchPoolId = m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`;
+              return matchPoolId === currentPoolId;
+            })
+            .map((m: any) => {
+              const scoreUpdate = this.sessionMatchScores.get(m.id);
+              return scoreUpdate ? { ...m, ...scoreUpdate } : m;
+            });
+          console.log(`[RemoteScoreServer] ${poolMatches.length} matchs de pool pour arène ${arenaId} (pool ${currentPoolId})`);
+          if (poolMatches.length > 0) {
+            return res.json({ matches: poolMatches, poolId: currentPoolId, poolName: null });
+          }
+        }
+
+        // Fallback: match courant seul
+        if (arena?.currentMatch) {
+          console.log(`[RemoteScoreServer] Fallback match courant pour arène ${arenaId}: ${arena.currentMatch.id}`);
+          return res.json({
+            matches: [{
+              id: arena.currentMatch.id,
+              poolId: arena.currentMatch.poolId,
+              fencerA: arena.currentMatch.fencerA,
+              fencerB: arena.currentMatch.fencerB,
+              scoreA: arena.currentMatch.scoreA,
+              scoreB: arena.currentMatch.scoreB,
+              status: arena.currentMatch.status,
+            }],
+            poolId: null,
+            poolName: null,
           });
-        } else {
-          console.log(`[RemoteScoreServer] Pas de match en mémoire pour arène ${arenaId}`);
         }
 
-        console.log(`[RemoteScoreServer] Matches pour arène ${arenaId}: ${allArenaMatches.length}`);
-
-        if (allArenaMatches.length > 0) {
-          return res.json({ matches: allArenaMatches, poolId: null, poolName: null });
-        }
-
-        // Fallback: file d'attente DE de CETTE arène uniquement
+        // File d'attente DE
         const arenaQueue = this.arenaMatchQueue.get(arenaId) || [];
         if (arenaQueue.length > 0) {
           console.log(`[RemoteScoreServer] ${arenaQueue.length} matchs en file DE pour arène ${arenaId}`);
@@ -1540,14 +1550,12 @@ export class RemoteScoreServer {
       );
     }
 
-    // Remettre l'arène en état idle après un délai (l'arbitre choisit le prochain match manuellement)
+    // Charger automatiquement le prochain match après un délai
+    // (loadNextMatch gère aussi le cas "plus de matchs" → arène idle)
     setTimeout(() => {
       const a = this.arenas.get(arenaId);
       if (a && a.status === 'finished') {
-        a.currentMatch = null;
-        a.status = 'idle';
-        a.startTime = null;
-        this.updateArena(arenaId, { currentMatch: null, status: 'idle', startTime: null });
+        this.loadNextMatch(arenaId);
       }
     }, 3000);
   }
@@ -1771,7 +1779,26 @@ export class RemoteScoreServer {
     let allMatches: any[] = [];
     if (matchesFromRenderer && matchesFromRenderer.length > 0) {
       console.log(`[RemoteScoreServer] ${matchesFromRenderer.length} matchs reçus du renderer`);
-      allMatches = matchesFromRenderer.filter(
+
+      // Extraire les marqueurs d'ordre des tireurs injectés par le renderer (__poolFencers)
+      // Nécessaire car l'ordre FIE (ex: 4 tireurs: [1,4],[2,3],...) ne permet pas de reconstruire
+      // l'ordre correct par simple extraction des paires de matchs.
+      const fencerOrderMap = new Map<string, any[]>();
+      const realMatches: any[] = [];
+      for (const m of matchesFromRenderer) {
+        if ((m as any).__poolFencers) {
+          fencerOrderMap.set(m.poolId, m.fencers);
+        } else {
+          realMatches.push(m);
+        }
+      }
+      // Pré-remplir le cache avec l'ordre correct fourni par le renderer
+      for (const [poolId, fencers] of fencerOrderMap) {
+        this.poolFencersCache.set(poolId, fencers);
+        console.log(`[RemoteScoreServer] Cache tireurs pre-rempli pour pool ${poolId}: ${fencers.length} tireurs`);
+      }
+
+      allMatches = realMatches.filter(
         m => m.isTableau || m.status === 'not_started' || m.status === 'in_progress'
       );
       console.log(`[RemoteScoreServer] ${allMatches.length} matchs en attente après filtrage`);
@@ -1812,9 +1839,11 @@ export class RemoteScoreServer {
     );
 
     // Construire le cache des tireurs par pool depuis la DB (ordre par position)
-    this.poolFencersCache.clear();
+    // Note: les pools déjà remplis via les marqueurs __poolFencers du renderer sont conservés.
     this.sessionMatchScores.clear();
     for (const [poolId, poolMatches] of matchesByPool) {
+      // Déjà rempli par les marqueurs du renderer → ordre correct garanti
+      if (this.poolFencersCache.has(poolId)) continue;
       const dbFencers = this.db.getPoolFencers(poolId);
       if (dbFencers.length > 0) {
         this.poolFencersCache.set(poolId, dbFencers);

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -115,7 +115,13 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
 
   const startSession = async (baseUrl: string, count: number) => {
     try {
-      const poolMatches = pools.flatMap(pool => pool.matches || []);
+      // Prepend fencer-order markers so the server can rebuild poolFencersCache correctly.
+      // The FIE match order for 4-fencer pools starts with [1,4] not [1,2], so naively
+      // extracting fencers from match pairs produces the wrong order.
+      const poolMatches = pools.flatMap(pool => [
+        { __poolFencers: true, poolId: pool.id, fencers: pool.fencers || [] },
+        ...(pool.matches || []),
+      ]);
       const deMatches = (tableauMatches || [])
         .filter(m => m.winner === null && m.fencerA && m.fencerB)
         .map(m => ({ ...m, isTableau: true }));


### PR DESCRIPTION
Bug 1 – Fencer order in remote pool display:
The poolFencersCache fallback extracted fencers from match pairs in FIE
match order. For 4-fencer pools the first match is [1,4] not [1,2], so
the extracted order was [f1,f4,f2,f3] instead of [f1,f2,f3,f4].
Fix: RemoteScoreManager now prepends __poolFencers marker objects (one
per pool with the correct fencer array) before the match list. The
server extracts these markers in startSession() to pre-populate
poolFencersCache with the renderer's authoritative fencer order, then
skips the DB/fallback rebuild for pools already cached.

Bug 2 – Next matches not shown after first match finishes:
loadNextMatch() was never called automatically after finishArenaMatch();
it only ran when the referee explicitly emitted 'next'. The 3-second
timeout just cleared the arena to idle, so loadNextMatches() on the
tablet found only the finished match (filtered out) → "all done".
Fix 1: The 3-second timeout now calls loadNextMatch() instead of
clearing state manually; loadNextMatch() assigns the next pool match
and broadcasts 'ready', which the tablet's handleArenaUpdate() picks up.
Fix 2: /api/arenas/:id/matches now returns ALL pending pool matches
(not just currentMatch) when the arena has a pool, so the tablet's
next-matches screen shows upcoming bouts even before the auto-advance.

https://claude.ai/code/session_016eZowLGU5NEx9B2mSs6HCj