### PR TITLE
Ajout d'un mot de passe optionnel par piste pour les pages d'arbitrage

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -772,6 +772,19 @@ ipcMain.handle('remote:updateStripCount', async (_, newCount: number) => {
   }
 });
 
+ipcMain.handle('remote:setArenaPassword', async (_, arenaId: string, password: string) => {
+  try {
+    if (!remoteScoreServer) {
+      return { success: false, error: 'Le serveur distant n est pas démarré' };
+    }
+    remoteScoreServer.setArenaPassword(arenaId, password);
+    return { success: true };
+  } catch (error) {
+    console.error('Error setting arena password:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 // App info handlers
 ipcMain.handle('app:getVersionInfo', async () => {
   return getVersionInfo();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -316,6 +316,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     updateStripCount: (count: number) => ipcRenderer.invoke('remote:updateStripCount', count),
     updateMatchArena: (matchId: string, fromArena: number | null, toArena: number | null) =>
       ipcRenderer.invoke('remote:updateMatchArena', matchId, fromArena, toArena),
+    setArenaPassword: (arenaId: string, password: string) =>
+      ipcRenderer.invoke('remote:setArenaPassword', arenaId, password),
   },
 
   // Remote event listeners (for real-time updates)

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -9,6 +9,7 @@ import { Server as SocketIOServer } from 'socket.io';
 import { createServer } from 'http';
 import path from 'path';
 import os from 'os';
+import { randomBytes } from 'crypto';
 import {
   RemoteSession,
   RemoteScoreUpdate,
@@ -40,6 +41,9 @@ export class RemoteScoreServer {
   // Stocker le contenu des fichiers HTML en mémoire pour éviter les problèmes de chemin
   private htmlFiles: Map<string, string> = new Map();
 
+  // Tokens d'authentification par arène (password protection)
+  private arenaTokens: Map<string, Set<string>> = new Map();
+
   constructor(db: DatabaseManager, port: number = 8066) {
     console.log('[RemoteScoreServer] Initialisation du serveur de saisie distante...');
     this.db = db;
@@ -69,7 +73,7 @@ export class RemoteScoreServer {
     const isDev = process.env.NODE_ENV === 'development';
 
     // Liste des fichiers à charger
-    const filesToLoad = ['referee.html', 'arena.html', 'dashboard.html', 'index.html', 'pool.html', 'kiosk.html'];
+    const filesToLoad = ['referee.html', 'arena.html', 'dashboard.html', 'index.html', 'pool.html', 'kiosk.html', 'login.html'];
 
     // Essayer plusieurs chemins pour trouver les fichiers
     const possiblePaths = isDev
@@ -131,6 +135,27 @@ export class RemoteScoreServer {
       console.error(`[RemoteScoreServer] ERREUR: Fichier ${filename} non trouvé en mémoire`);
       res.status(500).send(`Erreur: fichier ${filename} non trouvé`);
     }
+  }
+
+  private parseCookies(header: string | undefined): Record<string, string> {
+    if (!header) return {};
+    const result: Record<string, string> = {};
+    for (const part of header.split(';')) {
+      const idx = part.indexOf('=');
+      if (idx < 0) continue;
+      const key = decodeURIComponent(part.slice(0, idx).trim());
+      const val = decodeURIComponent(part.slice(idx + 1).trim());
+      if (key) result[key] = val;
+    }
+    return result;
+  }
+
+  private checkArenaAuth(arenaId: string, cookieHeader: string | undefined): boolean {
+    const fullId = arenaId.startsWith('arena') ? arenaId : `arena${arenaId}`;
+    const arena = this.arenas.get(fullId);
+    if (!arena?.password) return true;
+    const token = this.parseCookies(cookieHeader)[`bp_token_${fullId}`];
+    return !!token && (this.arenaTokens.get(fullId)?.has(token) ?? false);
   }
 
   private setupMiddleware(): void {
@@ -439,7 +464,9 @@ export class RemoteScoreServer {
     this.app.get('/arena:arenaId/referee', (req, res) => {
       const arenaId = req.params.arenaId;
       console.log(`[RemoteScoreServer] Accès à l'interface arbitre pour l'arène ${arenaId}`);
-
+      if (!this.checkArenaAuth(arenaId, req.headers.cookie)) {
+        return res.redirect(302, `/login?arena=arena${arenaId}&return=${encodeURIComponent(req.path)}`);
+      }
       this.sendHtmlFromMemory('referee.html', res);
     });
 
@@ -449,7 +476,9 @@ export class RemoteScoreServer {
       console.log(
         `[RemoteScoreServer] Accès à l'interface arbitre pour l'arène ${arenaId} (arene)`
       );
-
+      if (!this.checkArenaAuth(arenaId, req.headers.cookie)) {
+        return res.redirect(302, `/login?arena=arena${arenaId}&return=${encodeURIComponent(req.path)}`);
+      }
       this.sendHtmlFromMemory('referee.html', res);
     });
 
@@ -459,7 +488,9 @@ export class RemoteScoreServer {
       console.log(
         `[RemoteScoreServer] Accès à l'interface arbitre (alias /arbitre) pour l'arène ${arenaId}`
       );
-
+      if (!this.checkArenaAuth(arenaId, req.headers.cookie)) {
+        return res.redirect(302, `/login?arena=arena${arenaId}&return=${encodeURIComponent(req.path)}`);
+      }
       this.sendHtmlFromMemory('referee.html', res);
     });
 
@@ -467,7 +498,9 @@ export class RemoteScoreServer {
     this.app.get('/arbitre/arene:arenaId', (req, res) => {
       const arenaId = req.params.arenaId;
       console.log(`[RemoteScoreServer] Accès à l'interface arbitre /arbitre/arene${arenaId}`);
-
+      if (!this.checkArenaAuth(arenaId, req.headers.cookie)) {
+        return res.redirect(302, `/login?arena=arena${arenaId}&return=${encodeURIComponent(req.path)}`);
+      }
       this.sendHtmlFromMemory('referee.html', res);
     });
 
@@ -475,7 +508,9 @@ export class RemoteScoreServer {
     this.app.get('/arene:arenaId/arbitre', (req, res) => {
       const arenaId = req.params.arenaId;
       console.log(`[RemoteScoreServer] Accès à l'interface arbitre /arene${arenaId}/arbitre`);
-
+      if (!this.checkArenaAuth(arenaId, req.headers.cookie)) {
+        return res.redirect(302, `/login?arena=arena${arenaId}&return=${encodeURIComponent(req.path)}`);
+      }
       this.sendHtmlFromMemory('referee.html', res);
     });
 
@@ -483,6 +518,9 @@ export class RemoteScoreServer {
     this.app.get('/arene:arenaId/poule', (req, res) => {
       const arenaId = req.params.arenaId;
       console.log(`[RemoteScoreServer] Accès à la vue poule /arene${arenaId}/poule`);
+      if (!this.checkArenaAuth(arenaId, req.headers.cookie)) {
+        return res.redirect(302, `/login?arena=arena${arenaId}&return=${encodeURIComponent(req.path)}`);
+      }
       this.sendHtmlFromMemory('pool.html', res);
     });
 
@@ -490,6 +528,33 @@ export class RemoteScoreServer {
     this.app.get('/kiosk', (req, res) => {
       console.log('[RemoteScoreServer] Accès au mode kiosk');
       this.sendHtmlFromMemory('kiosk.html', res);
+    });
+
+    // Page de connexion pour les pages protégées par mot de passe
+    this.app.get('/login', (_req, res) => {
+      this.sendHtmlFromMemory('login.html', res);
+    });
+
+    // API: authentification par mot de passe pour une arène
+    this.app.post('/api/auth/login/:arenaId', (req, res) => {
+      const rawId = req.params.arenaId;
+      const fullId = rawId.startsWith('arena') ? rawId : `arena${rawId}`;
+      const arena = this.arenas.get(fullId);
+      if (!arena?.password) {
+        return res.json({ success: true });
+      }
+      const { password } = req.body as { password: string };
+      if (!password || password !== arena.password) {
+        return res.status(401).json({ success: false, error: 'Mot de passe incorrect' });
+      }
+      const token = randomBytes(32).toString('hex');
+      if (!this.arenaTokens.has(fullId)) this.arenaTokens.set(fullId, new Set());
+      this.arenaTokens.get(fullId)!.add(token);
+      res.setHeader(
+        'Set-Cookie',
+        `bp_token_${fullId}=${token}; HttpOnly; SameSite=Strict; Max-Age=${8 * 3600}; Path=/`
+      );
+      res.json({ success: true });
     });
 
     // API: données complètes de la poule pour une arène
@@ -1013,6 +1078,13 @@ export class RemoteScoreServer {
         console.log(
           `Client ${socket.id} joining arena ${data.arenaId} as ${data.role || 'spectator'}`
         );
+        if (data.role === 'referee') {
+          if (!this.checkArenaAuth(data.arenaId, socket.handshake.headers.cookie as string)) {
+            socket.emit('auth_error', { message: 'Authentification requise' });
+            socket.disconnect(true);
+            return;
+          }
+        }
         socket.join(`arena:${data.arenaId}`);
 
         // Envoyer l'état actuel de l'arène
@@ -1304,6 +1376,11 @@ export class RemoteScoreServer {
   private initializeArenas(arenaCount: number = 4): void {
     this.arenaCount = arenaCount;
     console.log(`[RemoteScoreServer] Initialisation de ${arenaCount} arènes...`);
+    // Sauvegarder les mots de passe avant de vider la map
+    const savedPasswords = new Map<string, string>();
+    this.arenas.forEach((arena, id) => {
+      if (arena.password) savedPasswords.set(id, arena.password);
+    });
     this.arenas.clear();
 
     for (let i = 1; i <= arenaCount; i++) {
@@ -1324,6 +1401,11 @@ export class RemoteScoreServer {
       this.arenaMatchQueue.set(arena.id, []);
       console.log(`[RemoteScoreServer] Arène ${i} créée ✓`);
     }
+    // Restaurer les mots de passe sauvegardés
+    savedPasswords.forEach((pwd, id) => {
+      const arena = this.arenas.get(id);
+      if (arena) arena.password = pwd;
+    });
     console.log(`[RemoteScoreServer] ${arenaCount} arènes initialisées avec succès ✓`);
   }
 
@@ -2005,6 +2087,7 @@ export class RemoteScoreServer {
     this.arenaNextMatchIndex.clear();
     this.poolFencersCache.clear();
     this.sessionMatchScores.clear();
+    this.arenaTokens.clear();
   }
 
   public updateStripCount(newCount: number): RemoteSession | null {
@@ -2053,5 +2136,15 @@ export class RemoteScoreServer {
 
   public getSession(): RemoteSession | null {
     return this.session;
+  }
+
+  public setArenaPassword(arenaId: string, password: string): void {
+    const fullId = arenaId.startsWith('arena') ? arenaId : `arena${arenaId}`;
+    const arena = this.arenas.get(fullId);
+    if (!arena) throw new Error(`Arène ${arenaId} introuvable`);
+    arena.password = password || undefined;
+    // Invalider tous les tokens existants pour cette arène
+    this.arenaTokens.delete(fullId);
+    console.log(`[RemoteScoreServer] Mot de passe ${password ? 'défini' : 'supprimé'} pour ${fullId}`);
   }
 }

--- a/src/remote/login.html
+++ b/src/remote/login.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>Accès protégé - BellePoule</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+        -webkit-tap-highlight-color: transparent;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+        min-height: 100vh;
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .login-card {
+        background: rgba(0, 0, 0, 0.35);
+        border-radius: 16px;
+        padding: 2.5rem 2rem;
+        width: 100%;
+        max-width: 380px;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+        text-align: center;
+      }
+
+      .lock-icon {
+        font-size: 3rem;
+        margin-bottom: 1rem;
+      }
+
+      h1 {
+        font-size: 1.4rem;
+        font-weight: 700;
+        margin-bottom: 0.4rem;
+      }
+
+      .subtitle {
+        font-size: 0.9rem;
+        opacity: 0.75;
+        margin-bottom: 1.8rem;
+      }
+
+      label {
+        display: block;
+        text-align: left;
+        font-size: 0.85rem;
+        font-weight: 600;
+        opacity: 0.9;
+        margin-bottom: 0.4rem;
+      }
+
+      input[type="password"] {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 2px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.1);
+        color: #fff;
+        font-size: 1rem;
+        outline: none;
+        transition: border-color 0.2s;
+        margin-bottom: 1.2rem;
+      }
+
+      input[type="password"]:focus {
+        border-color: rgba(255, 255, 255, 0.6);
+      }
+
+      input[type="password"]::placeholder {
+        opacity: 0.5;
+      }
+
+      button {
+        width: 100%;
+        padding: 0.85rem;
+        border: none;
+        border-radius: 8px;
+        background: #4caf50;
+        color: #fff;
+        font-size: 1rem;
+        font-weight: 700;
+        cursor: pointer;
+        transition: background 0.2s, transform 0.1s;
+      }
+
+      button:hover {
+        background: #43a047;
+      }
+
+      button:active {
+        transform: scale(0.98);
+      }
+
+      button:disabled {
+        background: #555;
+        cursor: not-allowed;
+      }
+
+      .error-msg {
+        display: none;
+        margin-top: 1rem;
+        padding: 0.65rem 1rem;
+        background: rgba(244, 67, 54, 0.25);
+        border: 1px solid rgba(244, 67, 54, 0.5);
+        border-radius: 8px;
+        font-size: 0.9rem;
+        color: #ff8a80;
+      }
+
+      .error-msg.visible {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="login-card">
+      <div class="lock-icon">🔒</div>
+      <h1 id="title">Accès protégé</h1>
+      <p class="subtitle" id="subtitle">Piste —</p>
+      <label for="password">Mot de passe</label>
+      <input type="password" id="password" placeholder="Saisir le mot de passe" autofocus />
+      <button id="submit-btn" onclick="doLogin()">Valider</button>
+      <div class="error-msg" id="error-msg">Mot de passe incorrect</div>
+    </div>
+
+    <script>
+      (function () {
+        const params = new URLSearchParams(window.location.search);
+        const arenaParam = params.get('arena') || '';
+        const returnPath = params.get('return') || '/';
+
+        // Extraire le numéro de piste pour l'affichage
+        const arenaNum = arenaParam.replace(/^arena/, '');
+        if (arenaNum) {
+          document.getElementById('subtitle').textContent = 'Piste ' + arenaNum;
+          document.title = 'Piste ' + arenaNum + ' – Accès protégé';
+        }
+
+        // Permettre validation par Entrée
+        document.getElementById('password').addEventListener('keydown', function (e) {
+          if (e.key === 'Enter') doLogin();
+        });
+
+        window.doLogin = async function () {
+          const pwd = document.getElementById('password').value;
+          const btn = document.getElementById('submit-btn');
+          const errEl = document.getElementById('error-msg');
+
+          if (!pwd) return;
+
+          btn.disabled = true;
+          errEl.classList.remove('visible');
+
+          try {
+            const res = await fetch('/api/auth/login/' + encodeURIComponent(arenaParam), {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ password: pwd }),
+            });
+            const data = await res.json();
+            if (data.success) {
+              window.location.href = returnPath;
+            } else {
+              errEl.textContent = data.error || 'Mot de passe incorrect';
+              errEl.classList.add('visible');
+              document.getElementById('password').value = '';
+              document.getElementById('password').focus();
+            }
+          } catch (e) {
+            errEl.textContent = 'Erreur de connexion au serveur';
+            errEl.classList.add('visible');
+          } finally {
+            btn.disabled = false;
+          }
+        };
+      })();
+    </script>
+  </body>
+</html>

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -53,6 +53,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const [committedCount, setCommittedCount] = useState<number | null>(null);
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [activeQR, setActiveQR] = useState<{ url: string; label: string } | null>(null);
+  const [arenaPasswords, setArenaPasswords] = useState<Record<string, string>>({});
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -378,6 +379,63 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                   title="QR code"
                 >
                   📱
+                </button>
+              </div>
+              <div className="arena-url-row">
+                <span className="arena-url-label">🔒 MDP</span>
+                <input
+                  type="password"
+                  className="arena-password-input"
+                  placeholder="Aucun (accès libre)"
+                  value={arenaPasswords[`arena${arena.number}`] ?? ''}
+                  onChange={e =>
+                    setArenaPasswords(p => ({
+                      ...p,
+                      [`arena${arena.number}`]: e.target.value,
+                    }))
+                  }
+                  onKeyDown={async e => {
+                    if (e.key === 'Enter') {
+                      const pwd = arenaPasswords[`arena${arena.number}`] ?? '';
+                      const result = await window.electronAPI.remote.setArenaPassword(
+                        `arena${arena.number}`,
+                        pwd
+                      );
+                      if (result.success) {
+                        showToast(
+                          pwd
+                            ? `Mot de passe défini pour la piste ${arena.number}`
+                            : `Mot de passe supprimé pour la piste ${arena.number}`,
+                          'success'
+                        );
+                      } else {
+                        showToast(result.error ?? 'Erreur', 'error');
+                      }
+                    }
+                  }}
+                />
+                <button
+                  className="btn-copy"
+                  title="Définir le mot de passe"
+                  onClick={async () => {
+                    const pwd = arenaPasswords[`arena${arena.number}`] ?? '';
+                    const result = await window.electronAPI.remote.setArenaPassword(
+                      `arena${arena.number}`,
+                      pwd
+                    );
+                    if (result.success) {
+                      showToast(
+                        pwd
+                          ? `Mot de passe défini pour la piste ${arena.number}`
+                          : `Mot de passe supprimé pour la piste ${arena.number}`,
+                        'success'
+                      );
+                    } else {
+                      showToast(result.error ?? 'Erreur', 'error');
+                    }
+                  }}
+                >
+                  ✓
                 </button>
               </div>
             </div>

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -1470,6 +1470,22 @@ body {
   border-radius: 4px;
 }
 
+.arena-password-input {
+  flex: 1;
+  font-size: 0.78rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.15rem 0.35rem;
+  outline: none;
+  min-width: 0;
+}
+
+.arena-password-input:focus {
+  border-color: var(--color-primary);
+}
+
 .btn-copy {
   background: none;
   border: 1px solid var(--color-border);

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -308,6 +308,7 @@ export interface RemoteServerAPI {
     fromArena: number | null,
     toArena: number | null
   ) => Promise<{ success: boolean; error?: string }>;
+  setArenaPassword: (arenaId: string, password: string) => Promise<{ success: boolean; error?: string }>;
 }
 
 // ============================================================================

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -100,6 +100,7 @@ export interface Arena {
   status: 'idle' | 'ready' | 'in_progress' | 'finished';
   startTime: Date | null;
   settings: ArenaSettings;
+  password?: string;
 }
 
 export interface ArenaSettings {


### PR DESCRIPTION
- Nouveau champ `password?` sur l'interface Arena (remote.ts)
- Page de connexion HTML (login.html) servie en mémoire avec cookie HttpOnly
- Middleware d'auth dans remoteScoreServer : /arene{N}/arbitre, /arene{N}/poule et alias protégés si MDP défini
- Endpoint POST /api/auth/login/:arenaId pour valider le MDP et émettre un token
- Vérification du token Socket.IO pour le rôle referee (join_arena)
- Préservation des mots de passe lors de la réinitialisation des arènes
- IPC remote:setArenaPassword exposé dans main.ts et preload.ts
- UI RemoteScoreManager : champ mot de passe par piste avec bouton de confirmation

https://claude.ai/code/session_01DU1wkuC9i3xPa93BWJvKwv