### PR TITLE
fix: déverrouille l'onglet Résultats après saisie manuelle du tableau…

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -473,6 +473,15 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const matchesCopy = updatedMatches.map(m => ({ ...m }));
     onMatchesChange(matchesCopy);
 
+    // Vérifier si le tableau est complet (finale + petite finale si elle existe)
+    const champion = updatedMatches.find(m => m.round === 2)?.winner;
+    const thirdPlaceMatch = updatedMatches.find(m => m.round === 3);
+    const thirdPlaceDone = !thirdPlaceMatch || !!thirdPlaceMatch.winner;
+    if (champion && thirdPlaceDone && onComplete) {
+      const finalResults = calculateFinalResults(updatedMatches);
+      onComplete(finalResults);
+    }
+
     setShowScoreModal(false);
     setEditingMatch(null);
     setEditScoreA('');


### PR DESCRIPTION
… d'élimination

handleScoreSubmit() n'appelait jamais onComplete(), contrairement à handleAutoFillScores(). Ajout de la vérification de complétion après chaque saisie manuelle : si la finale (et la petite finale si elle existe) ont un vainqueur, on appelle onComplete() pour débloquer l'accès aux résultats.

https://claude.ai/code/session_01EKBi2RnR6ZpTnhnNfJMcuN