### PR TITLE
Add photo display toggle for remote score server

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -772,6 +772,19 @@ ipcMain.handle('remote:updateStripCount', async (_, newCount: number) => {
   }
 });
 
+ipcMain.handle('remote:updateShowPhotos', async (_, value: boolean) => {
+  try {
+    if (!remoteScoreServer) {
+      return { success: false, error: 'Le serveur distant n est pas démarré' };
+    }
+    remoteScoreServer.updateShowPhotos(value);
+    return { success: true };
+  } catch (error) {
+    console.error('Error updating showPhotos:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle('remote:setArenaPassword', async (_, arenaId: string, password: string) => {
   try {
     if (!remoteScoreServer) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -314,6 +314,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getSession: () => ipcRenderer.invoke('remote:getSession'),
     getArenas: () => ipcRenderer.invoke('remote:getArenas'),
     updateStripCount: (count: number) => ipcRenderer.invoke('remote:updateStripCount', count),
+    updateShowPhotos: (value: boolean) => ipcRenderer.invoke('remote:updateShowPhotos', value),
     updateMatchArena: (matchId: string, fromArena: number | null, toArena: number | null) =>
       ipcRenderer.invoke('remote:updateMatchArena', matchId, fromArena, toArena),
     setArenaPassword: (arenaId: string, password: string) =>

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2183,6 +2183,23 @@ export class RemoteScoreServer {
     return this.session;
   }
 
+  public updateShowPhotos(value: boolean): void {
+    if (!this.session) throw new Error('Aucune session active');
+    this.sessionShowPhotos = value;
+    // Re-broadcast à toutes les pistes pour propager le nouveau réglage
+    for (const [arenaId, arena] of this.arenas.entries()) {
+      this.broadcastArenaUpdate(arenaId, {
+        arenaId,
+        match: arena.currentMatch,
+        scoreA: arena.currentMatch?.scoreA,
+        scoreB: arena.currentMatch?.scoreB,
+        status: arena.status,
+        fencerA: arena.currentMatch?.fencerA,
+        fencerB: arena.currentMatch?.fencerB,
+      });
+    }
+  }
+
   public getSession(): RemoteSession | null {
     return this.session;
   }

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -318,6 +318,17 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           <h4 style={{ margin: 0 }}>Pistes ({arenaCount})</h4>
           {stripCountControls}
         </div>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.5rem 0', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={showPhotos}
+            onChange={async e => {
+              setShowPhotos(e.target.checked);
+              await window.electronAPI.remote.updateShowPhotos(e.target.checked);
+            }}
+          />
+          Afficher les photos des combattants avant le combat
+        </label>
 
         <div className="arena-url-grid">
           {arenaUrls.map(arena => (

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -305,6 +305,7 @@ export interface RemoteServerAPI {
   getSession: () => Promise<{ success: boolean; session?: any; error?: string }>;
   getArenas: () => Promise<{ success: boolean; arenas?: any[]; error?: string }>;
   updateStripCount: (count: number) => Promise<{ success: boolean; session?: any; error?: string }>;
+  updateShowPhotos: (value: boolean) => Promise<{ success: boolean; error?: string }>;
   updateMatchArena: (
     matchId: string,
     fromArena: number | null,


### PR DESCRIPTION
## Summary
This PR adds a new feature to toggle the display of fencer photos before matches in the remote score server system. The setting is controlled via a checkbox in the RemoteScoreManager UI and is propagated to all connected arenas.

## Key Changes
- **RemoteScoreServer**: Added `updateShowPhotos()` method that updates the session setting and broadcasts the change to all arenas
- **IPC Handler**: Added `remote:updateShowPhotos` handler in main.ts to expose the functionality to the renderer process
- **UI Component**: Added a checkbox in RemoteScoreManager to toggle photo display with label "Afficher les photos des combattants avant le combat"
- **Preload Bridge**: Exposed `updateShowPhotos` method in the electron API
- **Type Definitions**: Updated RemoteServerAPI interface to include the new `updateShowPhotos` method signature

## Implementation Details
- The setting is stored in `sessionShowPhotos` property on the RemoteScoreServer instance
- When toggled, the change is broadcast to all arenas via `broadcastArenaUpdate()` to ensure all connected clients receive the updated setting
- The UI immediately updates local state while the IPC call propagates the change to the server
- Includes proper error handling with French error messages consistent with the codebase

https://claude.ai/code/session_01VVWXJfVmwxb6LQLqUFco1P