### PR TITLE
Clean up debug code and add showPhotos parameter to session API

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -462,13 +462,6 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     // Propager les gagnants avant de sauvegarder
     propagateWinners(updatedMatches, tableauSize);
 
-    // Debug: vérifier que les matchs sont bien mis à jour
-    const finalMatch = updatedMatches.find(m => m.round === 2);
-    const thirdPlaceMatch = updatedMatches.find(m => m.round === 3);
-    // DEBUG: console.log('=== Après propagateWinners ===');
-    // DEBUG: console.log('Finale:', finalMatch?.fencerA?.lastName, 'vs', finalMatch?.fencerB?.lastName);
-    // DEBUG: console.log('Petite finale:', thirdPlaceMatch?.fencerA?.lastName, 'vs', thirdPlaceMatch?.fencerB?.lastName);
-
     // Créer une copie profonde pour forcer React à re-renderer
     const matchesCopy = updatedMatches.map(m => ({ ...m }));
     onMatchesChange(matchesCopy);

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -299,7 +299,8 @@ export interface RemoteServerAPI {
   startSession: (
     competitionId: string,
     strips: number,
-    matches?: any[]
+    matches?: any[],
+    showPhotos?: boolean
   ) => Promise<{ success: boolean; session?: any; error?: string }>;
   stopSession: () => Promise<{ success: boolean; error?: string }>;
   getSession: () => Promise<{ success: boolean; session?: any; error?: string }>;


### PR DESCRIPTION
## Summary
This PR removes debug logging code from the TableauView component and extends the RemoteServerAPI interface to support an optional `showPhotos` parameter when starting a session.

## Key Changes
- **Removed debug code**: Deleted commented-out console.log statements and debug variable declarations from the match propagation logic in TableauView.tsx that were used for verifying final and third-place match updates
- **Extended session API**: Added optional `showPhotos` boolean parameter to the `startSession` method in the RemoteServerAPI interface to support photo display configuration during session initialization

## Implementation Details
- The debug removal simplifies the codebase by eliminating unused diagnostic code that was no longer needed
- The `showPhotos` parameter is optional (defaults to undefined) to maintain backward compatibility with existing callers of the `startSession` method

https://claude.ai/code/session_01XPkbwQjfJbiJ8LyYGmVhqa