### PR TITLE
feat: archive tireurs + photos (.bpf)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -650,6 +650,101 @@ export class DatabaseManager {
     return results;
   }
 
+  public getFencerPhotos(competitionId: string): { license: string; photo: string }[] {
+    if (!this.db) throw new Error('Database not open');
+    const results: { license: string; photo: string }[] = [];
+    const stmt = this.db.prepare(
+      "SELECT license, photo FROM fencers WHERE competition_id = ? AND photo IS NOT NULL AND license IS NOT NULL AND license != ''"
+    );
+    stmt.bind([competitionId]);
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      results.push({ license: row.license as string, photo: row.photo as string });
+    }
+    stmt.free();
+    return results;
+  }
+
+  public updateFencerPhotosByLicense(
+    competitionId: string,
+    photos: { license: string; photo: string }[]
+  ): { matched: number; total: number } {
+    if (!this.db) throw new Error('Database not open');
+    let matched = 0;
+    const now = new Date().toISOString();
+
+    for (const { license, photo } of photos) {
+      const stmt = this.db.prepare(
+        'SELECT id FROM fencers WHERE competition_id = ? AND license = ? LIMIT 1'
+      );
+      stmt.bind([competitionId, license]);
+      const exists = stmt.step();
+      stmt.free();
+
+      if (exists) {
+        this.db.run(
+          'UPDATE fencers SET photo = ?, updated_at = ? WHERE competition_id = ? AND license = ?',
+          [photo, now, competitionId, license]
+        );
+        matched++;
+      }
+    }
+
+    this.save();
+    return { matched, total: photos.length };
+  }
+
+  public upsertFencersByLicense(
+    competitionId: string,
+    fencers: Partial<Fencer>[]
+  ): { added: number; updated: number } {
+    if (!this.db) throw new Error('Database not open');
+    let added = 0;
+    let updated = 0;
+
+    for (const fencer of fencers) {
+      let existing: Fencer | null = null;
+      const key = fencer.license?.trim();
+
+      if (key) {
+        const stmt = this.db.prepare(
+          'SELECT id FROM fencers WHERE competition_id = ? AND license = ? LIMIT 1'
+        );
+        stmt.bind([competitionId, key]);
+        if (stmt.step()) {
+          const row = stmt.getAsObject();
+          existing = this.getFencer(row.id as string);
+        }
+        stmt.free();
+      }
+
+      if (!existing && fencer.lastName && fencer.firstName) {
+        const stmt = this.db.prepare(
+          'SELECT id FROM fencers WHERE competition_id = ? AND LOWER(last_name) = LOWER(?) AND LOWER(first_name) = LOWER(?) LIMIT 1'
+        );
+        stmt.bind([competitionId, fencer.lastName, fencer.firstName]);
+        if (stmt.step()) {
+          const row = stmt.getAsObject();
+          existing = this.getFencer(row.id as string);
+        }
+        stmt.free();
+      }
+
+      if (existing) {
+        const updates = { ...fencer };
+        if (existing.photo) delete updates.photo;
+        this.updateFencer(existing.id, updates);
+        updated++;
+      } else {
+        this.addFencer(competitionId, fencer);
+        added++;
+      }
+    }
+
+    this.save();
+    return { added, updated };
+  }
+
   public updateFencer(id: string, updates: Partial<Fencer>): void {
     if (!this.db) throw new Error('Database not open');
     const now = new Date().toISOString();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,6 +6,7 @@
 import { app, BrowserWindow, ipcMain, dialog, Menu, shell } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
+import JSZip from 'jszip';
 import { DatabaseManager } from '../database';
 import { RemoteScoreServer } from './remoteScoreServer';
 import { AutoUpdater } from './autoUpdater';
@@ -175,6 +176,7 @@ function createMenu(): void {
             { type: 'separator' },
             { label: 'Exporter tireurs (.txt)', click: () => handleExport('fencers-txt') },
             { label: 'Exporter tireurs (.fff)', click: () => handleExport('fencers-fff') },
+            { label: 'Exporter tireurs + photos (.bpf)', click: () => handleExport('fencers-bpf') },
           ],
         },
         {
@@ -183,6 +185,7 @@ function createMenu(): void {
             { label: 'Importer XML (BellePoule)', click: () => handleImport('xml') },
             { label: 'Importer liste FFE (.fff)', click: () => handleImport('fff') },
             { label: 'Importer classement FFE', click: () => handleImport('ranking') },
+            { label: 'Importer tireurs + photos (.bpf)', click: () => handleImport('fencers-bpf') },
           ],
         },
         { type: 'separator' },
@@ -432,6 +435,10 @@ async function handleImport(format: string): Promise<void> {
       title = 'Importer un classement FFE';
       filters = [{ name: 'Fichier classement', extensions: ['fff', 'csv', 'txt', 'xlsx'] }];
       break;
+    case 'fencers-bpf':
+      title = 'Importer tireurs + photos (.bpf)';
+      filters = [{ name: 'BellePoule Fencers', extensions: ['bpf'] }];
+      break;
     default:
       filters = [{ name: 'Tous les fichiers', extensions: ['*'] }];
   }
@@ -445,10 +452,13 @@ async function handleImport(format: string): Promise<void> {
   if (!result.canceled && result.filePaths.length > 0) {
     const filepath = result.filePaths[0];
     try {
-      // Lire le contenu du fichier
-      const content = fs.readFileSync(filepath, 'utf-8');
-      // Envoyer au renderer pour traitement
-      mainWindow?.webContents.send('menu:import', format, filepath, content);
+      if (format === 'fencers-bpf') {
+        // Fichier binaire : envoyer uniquement le chemin, le renderer appellera importFencersArchive
+        mainWindow?.webContents.send('menu:import', format, filepath, '');
+      } else {
+        const content = fs.readFileSync(filepath, 'utf-8');
+        mainWindow?.webContents.send('menu:import', format, filepath, content);
+      }
     } catch (error) {
       dialog.showErrorBox("Erreur d'import", `Impossible de lire le fichier: ${error}`);
     }
@@ -608,6 +618,92 @@ ipcMain.handle('file:import', async (_, filepath) => {
 // File content write handler
 ipcMain.handle('file:writeContent', async (_, filepath: string, content: string) => {
   fs.writeFileSync(filepath, content, 'utf-8');
+});
+
+// Photo ZIP export handler
+ipcMain.handle('file:exportPhotos', async (_, competitionId: string, filepath: string) => {
+  const photos = db.getFencerPhotos(competitionId);
+  const zip = new JSZip();
+
+  for (const { license, photo } of photos) {
+    const base64 = photo.replace(/^data:image\/\w+;base64,/, '');
+    const buffer = Buffer.from(base64, 'base64');
+    zip.file(`${license}.jpg`, buffer);
+  }
+
+  const content = await zip.generateAsync({ type: 'nodebuffer' });
+  const tmpPath = filepath + '.tmp';
+  try {
+    fs.writeFileSync(tmpPath, content);
+    try {
+      fs.renameSync(tmpPath, filepath);
+    } catch {
+      fs.writeFileSync(filepath, content);
+      try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+    }
+  } catch {
+    fs.writeFileSync(filepath, content);
+  }
+
+  return { count: photos.length };
+});
+
+// Photo ZIP import handler
+ipcMain.handle('file:importPhotos', async (_, competitionId: string, filepath: string) => {
+  const buffer = fs.readFileSync(filepath);
+  const zip = await JSZip.loadAsync(buffer);
+
+  const photos: { license: string; photo: string }[] = [];
+
+  for (const [filename, file] of Object.entries(zip.files)) {
+    if (file.dir) continue;
+    const ext = path.extname(filename).toLowerCase();
+    if (!['.jpg', '.jpeg', '.png'].includes(ext)) continue;
+    const basename = path.basename(filename, ext);
+    const data = await file.async('base64');
+    const mimeType = ext === '.png' ? 'image/png' : 'image/jpeg';
+    photos.push({ license: basename, photo: `data:${mimeType};base64,${data}` });
+  }
+
+  return db.updateFencerPhotosByLicense(competitionId, photos);
+});
+
+// Fencer archive (.bpf) export handler
+ipcMain.handle('file:exportFencersArchive', async (_, competitionId: string, filepath: string) => {
+  const fencers = db.getFencersByCompetition(competitionId);
+  const competition = db.getCompetition(competitionId);
+  const zip = new JSZip();
+  zip.file('meta.json', JSON.stringify({
+    version: '1',
+    competitionName: competition?.title ?? '',
+    exportDate: new Date().toISOString(),
+    count: fencers.length,
+  }));
+  zip.file('fencers.json', JSON.stringify(fencers));
+  const content = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+  const tmpPath = filepath + '.tmp';
+  try {
+    fs.writeFileSync(tmpPath, content);
+    try {
+      fs.renameSync(tmpPath, filepath);
+    } catch {
+      fs.writeFileSync(filepath, content);
+      try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+    }
+  } catch {
+    fs.writeFileSync(filepath, content);
+  }
+  return { count: fencers.length };
+});
+
+// Fencer archive (.bpf) import handler
+ipcMain.handle('file:importFencersArchive', async (_, competitionId: string, filepath: string) => {
+  const buffer = fs.readFileSync(filepath);
+  const zip = await JSZip.loadAsync(buffer);
+  const fencersFile = zip.file('fencers.json');
+  if (!fencersFile) throw new Error('Format .bpf invalide : fencers.json manquant');
+  const fencers = JSON.parse(await fencersFile.async('string'));
+  return db.upsertFencersByLicense(competitionId, fencers);
 });
 
 // Dialog handlers

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -244,6 +244,42 @@ contextBridge.exposeInMainWorld('electronAPI', {
       }
       return ipcRenderer.invoke('file:writeContent', filepath, content);
     },
+    exportPhotos: (competitionId: string, filepath: string) => {
+      if (!competitionId || typeof competitionId !== 'string') {
+        throw new Error('Competition ID is required and must be a string');
+      }
+      if (!filepath || typeof filepath !== 'string') {
+        throw new Error('Filepath is required and must be a string');
+      }
+      return ipcRenderer.invoke('file:exportPhotos', competitionId, filepath);
+    },
+    importPhotos: (competitionId: string, filepath: string) => {
+      if (!competitionId || typeof competitionId !== 'string') {
+        throw new Error('Competition ID is required and must be a string');
+      }
+      if (!filepath || typeof filepath !== 'string') {
+        throw new Error('Filepath is required and must be a string');
+      }
+      return ipcRenderer.invoke('file:importPhotos', competitionId, filepath);
+    },
+    exportFencersArchive: (competitionId: string, filepath: string) => {
+      if (!competitionId || typeof competitionId !== 'string') {
+        throw new Error('Competition ID is required and must be a string');
+      }
+      if (!filepath || typeof filepath !== 'string') {
+        throw new Error('Filepath is required and must be a string');
+      }
+      return ipcRenderer.invoke('file:exportFencersArchive', competitionId, filepath);
+    },
+    importFencersArchive: (competitionId: string, filepath: string) => {
+      if (!competitionId || typeof competitionId !== 'string') {
+        throw new Error('Competition ID is required and must be a string');
+      }
+      if (!filepath || typeof filepath !== 'string') {
+        throw new Error('Filepath is required and must be a string');
+      }
+      return ipcRenderer.invoke('file:importFencersArchive', competitionId, filepath);
+    },
   },
 
   // Dialog operations with validation

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -217,9 +217,30 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     onShowProperties: () => setShowPropertiesModal(true),
     onShowAddFencer: () => setShowAddFencerModal(true),
     onExportFencers: format => exportFencersList(fencers, format),
+    onExportFencersBpf: async () => {
+      const result = await window.electronAPI.dialog.saveFile({
+        title: 'Exporter tireurs + photos (.bpf)',
+        defaultPath: `tireurs-${competition.title}.bpf`,
+        filters: [{ name: 'BellePoule Fencers', extensions: ['bpf'] }],
+      });
+      if (result && !result.canceled && result.filePath) {
+        await window.electronAPI.file.exportFencersArchive(competition.id, result.filePath);
+      }
+    },
     onExportRanking: format => exportRanking(overallRanking, format, isLaserSabre),
     onExportResults: format => exportResults(finalResults, format),
-    onImport: (format, filepath, content) => setImportData({ format, filepath, content }),
+    onImport: async (format, filepath, content) => {
+      if (format === 'fencers-bpf') {
+        try {
+          await window.electronAPI.file.importFencersArchive(competition.id, filepath);
+          loadFencers();
+        } catch (err) {
+          console.error('Erreur import .bpf:', err);
+        }
+        return;
+      }
+      setImportData({ format, filepath, content });
+    },
     onReportIssue: () => {}, // À implémenter
     onNextPhase: () => {},
     loadFencers,
@@ -658,6 +679,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         {currentPhase === 'checkin' && (
           <FencerList
             fencers={fencers}
+            competitionId={competition.id}
             onCheckIn={handleCheckInFencer}
             onAddFencer={() => setShowAddFencerModal(true)}
             onEditFencer={updateFencer}
@@ -666,6 +688,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onCheckInAll={checkInAll}
             onUncheckAll={uncheckAll}
             onImport={handleOpenImportDialog}
+            onFencersImported={loadFencers}
             onSetFencerStatus={(id, status) => {
               // Si forfait, abandon ou exclusion, mettre à jour tous les matchs du tireur
               if (status === FencerStatus.FORFAIT) {

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -12,6 +12,7 @@ import { useConfirm } from './ConfirmDialog';
 
 interface FencerListProps {
   fencers: Fencer[];
+  competitionId?: string;
   onCheckIn: (id: string) => void;
   onAddFencer: () => void;
   onEditFencer?: (id: string, updates: Partial<Fencer>) => void;
@@ -21,10 +22,12 @@ interface FencerListProps {
   onUncheckAll?: () => void;
   onSetFencerStatus?: (id: string, status: FencerStatus) => void;
   onImport?: () => void;
+  onFencersImported?: () => void;
 }
 
 const FencerListComponent: React.FC<FencerListProps> = ({
   fencers,
+  competitionId,
   onCheckIn,
   onAddFencer,
   onEditFencer,
@@ -34,6 +37,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   onUncheckAll,
   onSetFencerStatus,
   onImport,
+  onFencersImported,
 }) => {
   const { t } = useTranslation();
   const { confirm } = useConfirm();
@@ -50,6 +54,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
 
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState<'name' | 'club' | 'ranking' | 'age'>('ranking');
+  const [photoMessage, setPhotoMessage] = useState<string | null>(null);
   const [editingFencer, setEditingFencer] = useState<Fencer | null>(null);
   const filteredFencers = fencers
     .filter(f => {
@@ -107,6 +112,78 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const handleImportFencers = () => {
     if (onImport) {
       onImport();
+    }
+  };
+
+  const showPhotoMessage = (msg: string) => {
+    setPhotoMessage(msg);
+    setTimeout(() => setPhotoMessage(null), 4000);
+  };
+
+  const handleExportPhotos = async () => {
+    if (!competitionId) return;
+    const result = await window.electronAPI.dialog.saveFile({
+      title: 'Exporter les photos (.zip)',
+      defaultPath: 'photos-tireurs.zip',
+      filters: [{ name: 'Archive ZIP', extensions: ['zip'] }],
+    });
+    if (result && !result.canceled && result.filePath) {
+      try {
+        const { count } = await window.electronAPI.file.exportPhotos(competitionId, result.filePath);
+        showPhotoMessage(`${count} photo${count !== 1 ? 's' : ''} exportée${count !== 1 ? 's' : ''}`);
+      } catch {
+        showPhotoMessage('Erreur lors de l\'export');
+      }
+    }
+  };
+
+  const handleImportPhotos = async () => {
+    if (!competitionId) return;
+    const result = await window.electronAPI.dialog.openFile({
+      title: 'Importer les photos (.zip)',
+      filters: [{ name: 'Archive ZIP', extensions: ['zip'] }],
+    });
+    if (result && result.filePath) {
+      try {
+        const { matched, total } = await window.electronAPI.file.importPhotos(competitionId, result.filePath);
+        showPhotoMessage(`${matched}/${total} photo${total !== 1 ? 's' : ''} importée${total !== 1 ? 's' : ''}`);
+      } catch {
+        showPhotoMessage('Erreur lors de l\'import');
+      }
+    }
+  };
+
+  const handleExportFencersArchive = async () => {
+    if (!competitionId) return;
+    const result = await window.electronAPI.dialog.saveFile({
+      title: 'Exporter tireurs + photos (.bpf)',
+      defaultPath: 'tireurs.bpf',
+      filters: [{ name: 'BellePoule Fencers', extensions: ['bpf'] }],
+    });
+    if (result && !result.canceled && result.filePath) {
+      try {
+        const { count } = await window.electronAPI.file.exportFencersArchive(competitionId, result.filePath);
+        showPhotoMessage(`${count} tireur${count !== 1 ? 's' : ''} exporté${count !== 1 ? 's' : ''} (.bpf)`);
+      } catch {
+        showPhotoMessage('Erreur lors de l\'export .bpf');
+      }
+    }
+  };
+
+  const handleImportFencersArchive = async () => {
+    if (!competitionId) return;
+    const result = await window.electronAPI.dialog.openFile({
+      title: 'Importer tireurs + photos (.bpf)',
+      filters: [{ name: 'BellePoule Fencers', extensions: ['bpf'] }],
+    });
+    if (result && result.filePath) {
+      try {
+        const { added, updated } = await window.electronAPI.file.importFencersArchive(competitionId, result.filePath);
+        showPhotoMessage(`${added} ajouté${added !== 1 ? 's' : ''}, ${updated} mis à jour (.bpf)`);
+        if (onFencersImported) onFencersImported();
+      } catch {
+        showPhotoMessage('Erreur lors de l\'import .bpf');
+      }
     }
   };
 
@@ -203,11 +280,49 @@ const FencerListComponent: React.FC<FencerListProps> = ({
           >
             FFF
           </button>
+          {competitionId && (
+            <>
+              <button
+                className="btn btn-secondary"
+                onClick={handleExportPhotos}
+                title="Exporter les photos des tireurs (.zip)"
+              >
+                📷 Photos
+              </button>
+              <button
+                className="btn btn-secondary"
+                onClick={handleImportPhotos}
+                title="Importer des photos depuis un .zip (matching par licence)"
+              >
+                📂 Photos
+              </button>
+              <button
+                className="btn btn-secondary"
+                onClick={handleExportFencersArchive}
+                title="Exporter tireurs + photos dans un fichier .bpf"
+              >
+                💾 .bpf
+              </button>
+              <button
+                className="btn btn-secondary"
+                onClick={handleImportFencersArchive}
+                title="Importer tireurs + photos depuis un fichier .bpf"
+              >
+                📦 .bpf
+              </button>
+            </>
+          )}
           <button className="btn btn-primary" onClick={onAddFencer}>
             + {t('fencer.add')}
           </button>
         </div>
       </div>
+
+      {photoMessage && (
+        <div className="alert alert-success mb-4" style={{ padding: '0.5rem 1rem', fontSize: '0.875rem' }}>
+          {photoMessage}
+        </div>
+      )}
 
       <div className="card mb-4">
         <div className="card-body flex gap-4">

--- a/src/renderer/hooks/useMenuEvents.ts
+++ b/src/renderer/hooks/useMenuEvents.ts
@@ -15,6 +15,7 @@ interface UseMenuEventsProps {
   onShowProperties: () => void;
   onShowAddFencer: () => void;
   onExportFencers: (format: 'txt' | 'fff') => void;
+  onExportFencersBpf: () => void;
   onExportRanking: (format: 'csv' | 'json') => void;
   onExportResults: (format: 'csv' | 'json') => void;
   onImport: (format: string, filepath: string, content: string) => void;
@@ -32,6 +33,7 @@ export const useMenuEvents = ({
   onShowProperties,
   onShowAddFencer,
   onExportFencers,
+  onExportFencersBpf,
   onExportRanking,
   onExportResults,
   onImport,
@@ -53,6 +55,10 @@ export const useMenuEvents = ({
       }
       if (format === 'fencers-fff') {
         onExportFencers('fff');
+        return;
+      }
+      if (format === 'fencers-bpf') {
+        onExportFencersBpf();
         return;
       }
 
@@ -87,6 +93,7 @@ export const useMenuEvents = ({
       overallRanking,
       finalResults,
       onExportFencers,
+      onExportFencersBpf,
       onExportRanking,
       onExportResults,
     ]

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -363,6 +363,10 @@ export interface FileAPI {
   export: (filepath: string) => Promise<FileSaveResult>;
   import: (filepath: string) => Promise<FileOpenResult>;
   writeContent: (filepath: string, content: string) => Promise<void>;
+  exportPhotos: (competitionId: string, filepath: string) => Promise<{ count: number }>;
+  importPhotos: (competitionId: string, filepath: string) => Promise<{ matched: number; total: number }>;
+  exportFencersArchive: (competitionId: string, filepath: string) => Promise<{ count: number }>;
+  importFencersArchive: (competitionId: string, filepath: string) => Promise<{ added: number; updated: number }>;
 }
 
 export interface DialogAPI {


### PR DESCRIPTION
## Summary
- Nouveau format de backup portable `.bpf` (ZIP) contenant données tireurs + photos en base64
- Import avec déduplication par licence (fallback nom+prénom), sans écraser les photos existantes
- Accessible via boutons dans la toolbar de FencerList et via menu Fichier

## Fichiers modifiés
- `src/database/index.ts` — `upsertFencersByLicense()`
- `src/main/main.ts` — 2 IPC handlers + 2 entrées menu
- `src/main/preload.ts` + `src/shared/types/preload.ts` — bridge IPC
- `src/renderer/components/FencerList.tsx` — boutons 💾 .bpf / 📦 .bpf
- `src/renderer/components/CompetitionView.tsx` + `src/renderer/hooks/useMenuEvents.ts` — intégration

## Test plan
- [ ] `npm run build:main` → 0 erreur TypeScript
- [ ] Créer une compétition avec tireurs + photos → exporter `.bpf`
- [ ] Ouvrir le `.bpf` dans 7-zip → vérifier `meta.json` + `fencers.json`
- [ ] Nouvelle compétition vide → importer `.bpf` → tireurs + photos présents
- [ ] Réimporter dans la même compétition → pas de doublons

🤖 Generated with [Claude Code](https://claude.com/claude-code)