### PR TITLE
Add showPhotos flag to arena status update

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1126,6 +1126,7 @@ export class RemoteScoreServer {
             scoreA: arena.currentMatch?.scoreA,
             scoreB: arena.currentMatch?.scoreB,
             status: arena.status,
+            showPhotos: this.sessionShowPhotos,
             fencerA: arena.currentMatch?.fencerA,
             fencerB: arena.currentMatch?.fencerB,
           });


### PR DESCRIPTION
## Summary
Added the `showPhotos` session property to the arena status data being sent to clients, enabling photo display settings to be synchronized across the remote score server.

## Key Changes
- Include `showPhotos: this.sessionShowPhotos` in the arena status object sent during match updates
- This allows the client to respect the server's photo display configuration

## Implementation Details
The `showPhotos` flag is now passed alongside other match metadata (scores, status, fencer information) when updating arena state, ensuring consistent photo display behavior across all connected clients.

https://claude.ai/code/session_01HdHAeBWPU1bb4gHKcUXyiC