### PR TITLE
Sync fencer data updates to pool matches in real-time

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -114,6 +114,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     computeOverallRanking,
     areAllPoolsComplete,
     handleFencerForfeit,
+    syncFencersToPool,
   } = usePoolManagement({ isLaserSabre, poolMaxScore, showToast });
 
   const { exportFencersList, exportRanking, exportResults, exportPoolsPDF } = useExport({
@@ -177,6 +178,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   useEffect(() => {
     loadFencers();
   }, [loadFencers]);
+
+  // Synchroniser les photos/données tireurs dans les matches de poule à chaque mise à jour
+  useEffect(() => {
+    if (fencers.length > 0) {
+      syncFencersToPool(fencers);
+    }
+  }, [fencers]);
 
   // Écouter les mises à jour des matches distants
   // Note: pas de garde sur currentPhase car la phase 'remote' affiche le panel de saisie distante

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -405,6 +405,26 @@ export const usePoolManagement = ({
     [computePoolRanking, computeOverallRanking]
   );
 
+  // Synchroniser les données des tireurs (ex: photo) dans les matches de poule
+  const syncFencersToPool = useCallback((updatedFencers: Fencer[]) => {
+    if (updatedFencers.length === 0) return;
+    const fencerMap = new Map(updatedFencers.map(f => [f.id, f]));
+
+    const syncPools = (poolList: Pool[]): Pool[] =>
+      poolList.map(pool => ({
+        ...pool,
+        fencers: pool.fencers.map(f => fencerMap.get(f.id) ?? f),
+        matches: pool.matches.map(match => ({
+          ...match,
+          fencerA: match.fencerA ? (fencerMap.get(match.fencerA.id) ?? match.fencerA) : match.fencerA,
+          fencerB: match.fencerB ? (fencerMap.get(match.fencerB.id) ?? match.fencerB) : match.fencerB,
+        })),
+      }));
+
+    setPools(prev => (prev.length === 0 ? prev : syncPools(prev)));
+    setPoolHistory(prev => (prev.length === 0 ? prev : prev.map(round => syncPools(round))));
+  }, []);
+
   return {
     pools,
     setPools,
@@ -423,6 +443,7 @@ export const usePoolManagement = ({
     computePoolRanking,
     computeOverallRanking,
     handleFencerForfeit,
+    syncFencersToPool,
   };
 };
 


### PR DESCRIPTION
## Summary
This PR adds automatic synchronization of fencer data (such as photos and other attributes) to all pool matches whenever fencers are updated. This ensures that match displays always reflect the latest fencer information without requiring manual refreshes.

## Key Changes
- **New `syncFencersToPool` function**: Added to `usePoolManagement` hook to synchronize updated fencer data across all pools and their matches
  - Updates fencer references in pool participant lists
  - Updates both `fencerA` and `fencerB` references in all matches
  - Maintains referential integrity by using a Map for efficient lookups
  - Safely handles empty pools and history

- **Auto-sync effect in CompetitionView**: Added `useEffect` hook that triggers `syncFencersToPool` whenever the fencers list changes
  - Ensures pool matches always display current fencer data
  - Only syncs when fencers data is available

## Implementation Details
- Uses a Map-based lookup for O(1) fencer data retrieval during synchronization
- Preserves existing match data while updating only fencer references
- Safely handles null/undefined fencer references in matches
- Avoids unnecessary updates when pools or history are empty

https://claude.ai/code/session_01NYTdg4h2GpjoGPoYBAAam3