### PR TITLE
Fix kiosk display scrollbars visibility

### DIFF
--- a/src/renderer/components/KioskDisplay.tsx
+++ b/src/renderer/components/KioskDisplay.tsx
@@ -400,7 +400,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
           </div>
 
           {/* Tableau défilant */}
-          <div ref={rankingScrollRef} style={{ flex: 1, overflowY: 'hidden', paddingBottom: '40px' }}>
+          <div ref={rankingScrollRef} data-kiosk-scroll="" style={{ flex: 1, overflowY: 'auto', paddingBottom: '40px' }}>
             <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '1.05rem' }}>
               <thead>
                 <tr style={{ color: '#64748b', textAlign: 'left', borderBottom: '1px solid #334155' }}>
@@ -454,7 +454,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
 
           {/* Contenu */}
           {activeRound !== null ? (
-            <div ref={tableauScrollRef} style={{ flex: 1, overflowY: 'hidden', paddingBottom: '40px' }}>
+            <div ref={tableauScrollRef} data-kiosk-scroll="" style={{ flex: 1, overflowY: 'auto', paddingBottom: '40px' }}>
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(400px, 1fr))', gap: '16px' }}>
                 {activeRoundMatches.map(match => {
                   if (match.isBye) {
@@ -543,6 +543,8 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
           0%, 100% { opacity: 1; }
           50% { opacity: 0.6; }
         }
+        [data-kiosk-scroll]::-webkit-scrollbar { display: none; }
+        [data-kiosk-scroll] { scrollbar-width: none; -ms-overflow-style: none; }
       `}</style>
     </div>
   );


### PR DESCRIPTION
## Summary
This PR fixes the scrollbar visibility in the kiosk display by enabling scrolling functionality and hiding scrollbars across all browsers for a cleaner UI.

## Key Changes
- Changed `overflowY: 'hidden'` to `overflowY: 'auto'` on two scroll containers (ranking table and matches content) to enable scrolling when content exceeds container height
- Added `data-kiosk-scroll=""` attribute to both scrollable containers for CSS targeting
- Added cross-browser scrollbar hiding styles:
  - WebKit browsers (Chrome, Safari): `::-webkit-scrollbar { display: none; }`
  - Firefox: `scrollbar-width: none;`
  - Internet Explorer/Edge: `-ms-overflow-style: none;`

## Implementation Details
The changes ensure that:
1. Content can be scrolled when it overflows the container (previously hidden overflow prevented any scrolling)
2. Scrollbars are visually hidden while maintaining scroll functionality, providing a cleaner kiosk display experience
3. The solution is compatible with all major browsers through vendor-specific CSS properties

https://claude.ai/code/session_0137QsV5tCYRFjfy5PEN8fZQ