### PR TITLE
Fix QRCodeShare dependency array to prevent unnecessary re-renders

### DIFF
--- a/src/renderer/components/QRCodeShare.tsx
+++ b/src/renderer/components/QRCodeShare.tsx
@@ -20,7 +20,8 @@ export const QRCodeShare: React.FC<QRCodeShareProps> = ({ competition, onClose }
 
   useEffect(() => {
     generateQRCode();
-  }, [competition]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [competition.id]);
 
   const generateQRCode = async () => {
     setIsGenerating(true);


### PR DESCRIPTION
## Summary
Updated the `useEffect` dependency array in the QRCodeShare component to use `competition.id` instead of the entire `competition` object, preventing unnecessary QR code regeneration when the competition object reference changes but the ID remains the same.

## Key Changes
- Changed the `useEffect` dependency from `[competition]` to `[competition.id]`
- Added an ESLint disable comment to acknowledge the intentional dependency array modification

## Implementation Details
This change optimizes the component by ensuring the QR code is only regenerated when the actual competition ID changes, rather than whenever the competition object reference changes. This is a common pattern when dealing with object dependencies in React hooks, as object identity changes even when the underlying data remains the same.

https://claude.ai/code/session_013r6SBHV6FJ2ZDckXmWe3c7