### PR TITLE
Add auto-hide header with mouse trigger on arena page

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -22,6 +22,7 @@
         color: #fff;
         display: flex;
         flex-direction: column;
+        padding-top: 52px;
       }
 
       .header {
@@ -32,6 +33,27 @@
         align-items: center;
         backdrop-filter: blur(10px);
         flex-shrink: 0;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 100;
+        transition: transform 0.4s ease, opacity 0.4s ease;
+      }
+
+      .header.hidden {
+        transform: translateY(-110%);
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      .header-trigger {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 8px;
+        z-index: 101;
       }
 
       .arena-title {
@@ -672,7 +694,28 @@
           document.getElementById('arena-idle-number').textContent = this.arenaNumber;
           this.setupInversionToggle();
           this.applyInversionState();
+          this.setupHeaderAutoHide();
           this.setupSocketListeners();
+        }
+
+        setupHeaderAutoHide() {
+          const header = document.querySelector('.header');
+          let hideTimer = null;
+
+          const showHeader = () => {
+            header.classList.remove('hidden');
+            clearTimeout(hideTimer);
+            hideTimer = setTimeout(() => header.classList.add('hidden'), 4000);
+          };
+
+          const trigger = document.createElement('div');
+          trigger.className = 'header-trigger';
+          document.body.appendChild(trigger);
+          trigger.addEventListener('mouseenter', showHeader);
+
+          document.addEventListener('mousemove', showHeader);
+
+          hideTimer = setTimeout(() => header.classList.add('hidden'), 4000);
         }
 
         setupInversionToggle() {


### PR DESCRIPTION
## Summary
Implemented an auto-hiding header feature on the arena page that automatically hides after 4 seconds of inactivity and reappears on mouse movement or when hovering near the top of the screen.

## Key Changes
- Made the header fixed position and added smooth hide/show animations with CSS transitions
- Added `padding-top: 52px` to the body to prevent content from being hidden under the fixed header
- Created a hidden header state with `transform: translateY(-110%)` and `opacity: 0` for smooth animations
- Implemented `setupHeaderAutoHide()` method that:
  - Automatically hides the header after 4 seconds of inactivity
  - Shows the header on any mouse movement
  - Provides a trigger zone (8px height) at the top of the page for mouse enter detection
  - Resets the hide timer whenever the header is shown
- Added a `.header-trigger` element positioned at the top of the viewport to detect mouse entry and restore the header

## Implementation Details
- The header uses `z-index: 100` while the trigger zone uses `z-index: 101` to ensure proper layering
- Smooth transitions (0.4s ease) are applied to both transform and opacity for a polished UX
- The auto-hide timer is cleared and reset each time the header is shown, preventing unnecessary hiding during active use
- Mouse movement anywhere on the page triggers the show action, providing responsive behavior

https://claude.ai/code/session_01TzK3ztjRLNzbCv3SP5AVET