### PR TITLE
Fix DE match arena assignment when pool phase is still active

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -811,12 +811,12 @@ ipcMain.handle(
 
 ipcMain.handle(
   'remote:updateMatchArena',
-  async (_, matchId: string, fromArena: number | null, toArena: number | null) => {
+  async (_, matchId: string, fromArena: number | null, toArena: number | null, fencerA?: any, fencerB?: any) => {
     try {
       if (!remoteScoreServer) {
         return { success: false, error: 'Serveur non démarré' };
       }
-      remoteScoreServer.updateMatchArena(matchId, fromArena, toArena);
+      remoteScoreServer.updateMatchArena(matchId, fromArena, toArena, fencerA, fencerB);
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Erreur' };

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1558,7 +1558,9 @@ export class RemoteScoreServer {
   public updateMatchArena(
     matchId: string,
     fromArena: number | null,
-    toArena: number | null
+    toArena: number | null,
+    fencerA?: any,
+    fencerB?: any
   ): void {
     let matchToMove: ArenaMatch | undefined;
 
@@ -1597,7 +1599,7 @@ export class RemoteScoreServer {
       }
     }
 
-    // Si le match n'est dans aucune arène, le construire depuis sessionMatches
+    // Si le match n'est dans aucune arène, le construire depuis sessionMatches ou les données passées
     if (!matchToMove) {
       const sm = this.sessionMatches.find((m: any) => m.id === matchId);
       if (sm) {
@@ -1612,6 +1614,21 @@ export class RemoteScoreServer {
           endTime: null,
           isTableau: true,
         };
+      } else if (fencerA && fencerB) {
+        // Match DE non encore en session (ex: session de poule toujours active) → créer depuis les données passées
+        matchToMove = {
+          id: matchId,
+          fencerA,
+          fencerB,
+          scoreA: 0,
+          scoreB: 0,
+          status: 'not_started',
+          startTime: null,
+          endTime: null,
+          isTableau: true,
+        };
+        this.sessionMatches.push({ id: matchId, fencerA, fencerB, isTableau: true, status: 'not_started' } as any);
+        console.log(`[RemoteScoreServer] Match DE ${matchId} ajouté à sessionMatches depuis updateMatchArena`);
       }
     }
 
@@ -1955,9 +1972,15 @@ export class RemoteScoreServer {
     this.sessionWeapon = competition.weapon || null;
     console.log(`[RemoteScoreServer] Type d'arme de la compétition: ${this.sessionWeapon}`);
 
-    // Auto-detect number of strips from pool count if not specified or too small
+    // Auto-detect number of strips from pool count if not specified or too small.
+    // Ne pas ajuster pour une session DE pure (uniquement des matchs tableau) car le nombre de
+    // poules de la phase précédente ne doit pas gonfler le nombre d'arènes d'élimination.
     const poolCount = this.db.getPoolCount(competitionId);
-    if (strips <= 0 || strips < poolCount) {
+    const isDeOnlySession =
+      matchesFromRenderer &&
+      matchesFromRenderer.length > 0 &&
+      matchesFromRenderer.every((m: any) => m.isTableau || m.__poolFencers);
+    if (!isDeOnlySession && (strips <= 0 || strips < poolCount)) {
       const actualStrips = poolCount > 0 ? poolCount : 1;
       console.log(
         `[RemoteScoreServer] Nombre de pistes ajusté: ${strips} -> ${actualStrips} (basé sur ${poolCount} poules)`

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -815,7 +815,12 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             }}
             onMatchArenaChange={(matchId, oldArena, newArena) => {
               if (isRemoteActive) {
-                window.electronAPI.remote.updateMatchArena(matchId, oldArena, newArena);
+                const match = tableauMatches.find(m => m.id === matchId);
+                window.electronAPI.remote.updateMatchArena(
+                  matchId, oldArena, newArena,
+                  match?.fencerA ?? null,
+                  match?.fencerB ?? null
+                );
               }
             }}
           />

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -310,7 +310,9 @@ export interface RemoteServerAPI {
   updateMatchArena: (
     matchId: string,
     fromArena: number | null,
-    toArena: number | null
+    toArena: number | null,
+    fencerA?: Fencer | null,
+    fencerB?: Fencer | null
   ) => Promise<{ success: boolean; error?: string }>;
   setArenaPassword: (arenaId: string, password: string) => Promise<{ success: boolean; error?: string }>;
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue where DE (elimination) matches could not be properly assigned to arenas when the pool phase was still active in the same session. The fix allows the system to create and track DE matches that don't yet exist in the session, and prevents the arena count from being incorrectly inflated by pool counts during pure DE phases.

## Key Changes

- **Enhanced `updateMatchArena` method**: Added optional `fencerA` and `fencerB` parameters to allow creating DE matches on-demand when they don't exist in `sessionMatches`. This handles the case where a DE match needs to be assigned to an arena before it's been formally added to the session.

- **Improved arena auto-detection logic**: Added detection for "DE-only sessions" to prevent the strip count from being adjusted based on pool counts when the session contains only tableau (elimination) matches. This ensures that the number of arenas for a DE phase isn't incorrectly inflated by the pool count from a previous phase.

- **Updated IPC and type definitions**: Extended the `updateMatchArena` IPC handler and TypeScript interface to accept and pass through the fencer data.

- **Enhanced renderer integration**: Modified `CompetitionView` to extract and pass fencer information when calling `updateMatchArena`, enabling the backend to construct match objects when needed.

## Implementation Details

- When a DE match is moved to an arena but doesn't exist in `sessionMatches`, it's now created from the provided fencer data and added to the session with appropriate defaults (score 0-0, not_started status).
- The DE-only session detection checks if all matches in the renderer data are either tableau matches or have pool fencer data, ensuring accurate arena count calculation.
- Console logging added to track when DE matches are dynamically added to the session for debugging purposes.

https://claude.ai/code/session_01WZ9bHcJJdrVo1gRKzZpxTZ