### PR TITLE
Améliore la visibilité des scores arène et public

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -312,19 +312,25 @@
       }
 
       .score-big {
-        font-size: clamp(6rem, 18vw, 30vh);
+        font-size: clamp(8rem, 22vw, 38vh);
         font-weight: 900;
         line-height: 1;
+        letter-spacing: -0.02em;
+        -webkit-text-stroke: 2px currentColor;
       }
 
       .score-big.red {
         color: #dc2626;
-        text-shadow: 2px 2px 4px rgba(220, 38, 38, 0.3);
+        text-shadow: 0 0 20px rgba(220, 38, 38, 0.9),
+                     0 0 50px rgba(220, 38, 38, 0.5),
+                     0 0 80px rgba(220, 38, 38, 0.2);
       }
 
       .score-big.green {
         color: #16a34a;
-        text-shadow: 2px 2px 4px rgba(22, 163, 74, 0.3);
+        text-shadow: 0 0 20px rgba(22, 163, 74, 0.9),
+                     0 0 50px rgba(22, 163, 74, 0.5),
+                     0 0 80px rgba(22, 163, 74, 0.2);
       }
 
       .vs-divider {

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -290,19 +290,25 @@
       }
 
       .score-big {
-        font-size: clamp(6rem, 18vw, 30vh);
+        font-size: clamp(8rem, 22vw, 38vh);
         font-weight: 900;
         line-height: 1;
+        letter-spacing: -0.02em;
+        -webkit-text-stroke: 2px currentColor;
       }
 
       .score-big.red {
         color: #dc2626;
-        text-shadow: 2px 2px 4px rgba(220, 38, 38, 0.3);
+        text-shadow: 0 0 20px rgba(220, 38, 38, 0.9),
+                     0 0 50px rgba(220, 38, 38, 0.5),
+                     0 0 80px rgba(220, 38, 38, 0.2);
       }
 
       .score-big.green {
         color: #16a34a;
-        text-shadow: 2px 2px 4px rgba(22, 163, 74, 0.3);
+        text-shadow: 0 0 20px rgba(22, 163, 74, 0.9),
+                     0 0 50px rgba(22, 163, 74, 0.5),
+                     0 0 80px rgba(22, 163, 74, 0.2);
       }
 
       .vs-divider {


### PR DESCRIPTION
- Taille +25% : clamp(6rem,18vw,30vh) → clamp(8rem,22vw,38vh)
- Glow néon triple couche (0 0 20/50/80px) au lieu de l'ombre subtile
- Ajout -webkit-text-stroke: 2px pour renforcer l'épaisseur perçue
- letter-spacing: -0.02em pour éviter débordement

https://claude.ai/code/session_018Y5p946hSwohTHSGoBCVwU