### PR TITLE
Reduce auto-scroll speed and add 2s delay before scrolling starts

### DIFF
--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -590,14 +590,16 @@
 
       // ─── Auto-scroll classement ──────────────────────────────────────────────
       let scrollAnimFrame = null;
+      let scrollDelayTimer = null;
 
       function startAutoScroll(wrapper) {
         cancelAnimationFrame(scrollAnimFrame);
-        const duration = 12000; // ms pour parcourir tout le contenu
-        const start = performance.now();
+        clearTimeout(scrollDelayTimer);
+        const duration = 20000; // ms pour parcourir tout le contenu
         const startTop = 0;
 
         function step(now) {
+          const start = step._start || (step._start = now);
           const elapsed = now - start;
           const maxScroll = wrapper.scrollHeight - wrapper.clientHeight;
           if (maxScroll <= 0) return;
@@ -610,7 +612,9 @@
           }
         }
 
-        scrollAnimFrame = requestAnimationFrame(step);
+        scrollDelayTimer = setTimeout(() => {
+          scrollAnimFrame = requestAnimationFrame(step);
+        }, 2000);
       }
 
       // ─── Menu escamotable ────────────────────────────────────────────────────

--- a/src/renderer/components/KioskDisplay.tsx
+++ b/src/renderer/components/KioskDisplay.tsx
@@ -196,20 +196,21 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
     el.scrollTop = 0;
     let animId: number;
     let last: number | null = null;
+    let delayId: ReturnType<typeof setTimeout>;
 
     const step = (t: number) => {
       if (last !== null) {
         const maxScroll = el.scrollHeight - el.clientHeight;
         if (maxScroll > 0) {
-          el.scrollTop += ((t - last) / 1000) * 40;
+          el.scrollTop += ((t - last) / 1000) * 20;
           if (el.scrollTop >= maxScroll) el.scrollTop = 0;
         }
       }
       last = t;
       animId = requestAnimationFrame(step);
     };
-    animId = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(animId);
+    delayId = setTimeout(() => { animId = requestAnimationFrame(step); }, 2000);
+    return () => { clearTimeout(delayId); cancelAnimationFrame(animId); };
   }, [currentView, overallRanking]);
 
   // Auto-scroll tableau
@@ -220,20 +221,21 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
     el.scrollTop = 0;
     let animId: number;
     let last: number | null = null;
+    let delayId: ReturnType<typeof setTimeout>;
 
     const step = (t: number) => {
       if (last !== null) {
         const maxScroll = el.scrollHeight - el.clientHeight;
         if (maxScroll > 0) {
-          el.scrollTop += ((t - last) / 1000) * 40;
+          el.scrollTop += ((t - last) / 1000) * 20;
           if (el.scrollTop >= maxScroll) el.scrollTop = 0;
         }
       }
       last = t;
       animId = requestAnimationFrame(step);
     };
-    animId = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(animId);
+    delayId = setTimeout(() => { animId = requestAnimationFrame(step); }, 2000);
+    return () => { clearTimeout(delayId); cancelAnimationFrame(animId); };
   }, [currentView, activeRound]);
 
   // Données de la poule courante


### PR DESCRIPTION
## Summary
This PR adjusts the auto-scroll behavior in the Kiosk display by reducing the scroll speed and adding a 2-second delay before scrolling begins. These changes apply to both the React component and the HTML-based kiosk interface.

## Key Changes
- **Reduced scroll speed**: Changed scroll velocity from 40 pixels per second to 20 pixels per second in both auto-scroll implementations
- **Added startup delay**: Implemented a 2-second delay before auto-scrolling begins using `setTimeout`
- **Improved cleanup**: Updated effect cleanup functions to properly clear both timeout and animation frame references
- **Extended scroll duration** (HTML version): Increased the duration for scrolling through content from 12 seconds to 20 seconds to accommodate the slower speed

## Implementation Details
- In the React component (`KioskDisplay.tsx`): Added `delayId` variable to track the timeout, wrapping `requestAnimationFrame` in a `setTimeout` call with 2000ms delay
- In the HTML kiosk (`kiosk.html`): Refactored the scroll animation to use a lazy-initialized `start` timestamp within the step function, allowing the 2-second delay to be applied before animation begins
- Both implementations now properly clean up both timeout and animation frame resources in their respective cleanup/cancellation functions

https://claude.ai/code/session_01YYmDLBiuVBL2bzDbkECbgG