### PR TITLE
Refactor button event handling to use event listeners instead of onclick

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -633,21 +633,18 @@
               <button
                 id="btn-plus-1-a"
                 class="score-btn btn-plus-1"
-                onclick="refereeApp.addScore('A', 1)"
               >
                 +1
               </button>
               <button
                 id="btn-plus-3-a"
                 class="score-btn btn-plus-3"
-                onclick="refereeApp.addScore('A', 3)"
               >
                 +3
               </button>
               <button
                 id="btn-plus-5-a"
                 class="score-btn btn-plus-5"
-                onclick="refereeApp.addScore('A', 5)"
               >
                 +5
               </button>
@@ -656,7 +653,6 @@
               <button
                 id="btn-card-white-a"
                 class="card-btn card-btn-white"
-                onclick="refereeApp.addCard('A', 'white')"
                 title="Carton blanc"
               >
                 B
@@ -664,7 +660,6 @@
               <button
                 id="btn-card-yellow-a"
                 class="card-btn card-btn-yellow"
-                onclick="refereeApp.addCard('A', 'yellow')"
                 title="Carton jaune (+3 adv)"
               >
                 J
@@ -672,7 +667,6 @@
               <button
                 id="btn-card-red-a"
                 class="card-btn card-btn-red"
-                onclick="refereeApp.addCard('A', 'red')"
                 title="Carton rouge (+5 adv)"
               >
                 R
@@ -693,21 +687,18 @@
               <button
                 id="btn-plus-1-b"
                 class="score-btn btn-plus-1"
-                onclick="refereeApp.addScore('B', 1)"
               >
                 +1
               </button>
               <button
                 id="btn-plus-3-b"
                 class="score-btn btn-plus-3"
-                onclick="refereeApp.addScore('B', 3)"
               >
                 +3
               </button>
               <button
                 id="btn-plus-5-b"
                 class="score-btn btn-plus-5"
-                onclick="refereeApp.addScore('B', 5)"
               >
                 +5
               </button>
@@ -716,7 +707,6 @@
               <button
                 id="btn-card-white-b"
                 class="card-btn card-btn-white"
-                onclick="refereeApp.addCard('B', 'white')"
                 title="Carton blanc"
               >
                 B
@@ -724,7 +714,6 @@
               <button
                 id="btn-card-yellow-b"
                 class="card-btn card-btn-yellow"
-                onclick="refereeApp.addCard('B', 'yellow')"
                 title="Carton jaune (+3 adv)"
               >
                 J
@@ -732,7 +721,6 @@
               <button
                 id="btn-card-red-b"
                 class="card-btn card-btn-red"
-                onclick="refereeApp.addCard('B', 'red')"
                 title="Carton rouge (+5 adv)"
               >
                 R
@@ -868,30 +856,25 @@
             if (!btn) return;
 
             let longPressTimer = null;
-            let longPressExecuted = false;
 
             // Mouse events
             btn.addEventListener('mousedown', e => {
-              longPressExecuted = false;
               btn.classList.add('long-press-active');
               longPressTimer = setTimeout(() => {
                 btn.classList.remove('long-press-active');
                 this.removeScore(config.fencer, config.points);
-                longPressExecuted = true;
                 longPressTimer = null;
               }, LONG_PRESS_DURATION);
             });
 
             btn.addEventListener('mouseup', e => {
               if (longPressTimer) {
+                // Appui court : ajouter le score
                 clearTimeout(longPressTimer);
                 longPressTimer = null;
+                this.addScore(config.fencer, config.points);
               }
               btn.classList.remove('long-press-active');
-              if (longPressExecuted) {
-                e.preventDefault();
-                e.stopPropagation();
-              }
             });
 
             btn.addEventListener('mouseleave', () => {
@@ -905,26 +888,23 @@
             // Touch events pour mobile
             btn.addEventListener('touchstart', e => {
               e.preventDefault();
-              longPressExecuted = false;
               btn.classList.add('long-press-active');
               longPressTimer = setTimeout(() => {
                 btn.classList.remove('long-press-active');
                 this.removeScore(config.fencer, config.points);
-                longPressExecuted = true;
                 longPressTimer = null;
               }, LONG_PRESS_DURATION);
             });
 
             btn.addEventListener('touchend', e => {
+              e.preventDefault(); // empêche les ghost clicks souris
               if (longPressTimer) {
+                // Appui court : ajouter le score
                 clearTimeout(longPressTimer);
                 longPressTimer = null;
+                this.addScore(config.fencer, config.points);
               }
               btn.classList.remove('long-press-active');
-              if (longPressExecuted) {
-                e.preventDefault();
-                e.stopPropagation();
-              }
             });
 
             btn.addEventListener('touchcancel', () => {
@@ -951,30 +931,25 @@
             if (!btn) return;
 
             let longPressTimer = null;
-            let longPressExecuted = false;
 
             // Mouse events
             btn.addEventListener('mousedown', e => {
-              longPressExecuted = false;
               btn.classList.add('long-press-active');
               longPressTimer = setTimeout(() => {
                 btn.classList.remove('long-press-active');
                 this.removeCard(config.fencer, config.cardType);
-                longPressExecuted = true;
                 longPressTimer = null;
               }, LONG_PRESS_DURATION);
             });
 
             btn.addEventListener('mouseup', e => {
               if (longPressTimer) {
+                // Appui court : ajouter le carton
                 clearTimeout(longPressTimer);
                 longPressTimer = null;
+                this.addCard(config.fencer, config.cardType);
               }
               btn.classList.remove('long-press-active');
-              if (longPressExecuted) {
-                e.preventDefault();
-                e.stopPropagation();
-              }
             });
 
             btn.addEventListener('mouseleave', () => {
@@ -988,26 +963,23 @@
             // Touch events pour mobile
             btn.addEventListener('touchstart', e => {
               e.preventDefault();
-              longPressExecuted = false;
               btn.classList.add('long-press-active');
               longPressTimer = setTimeout(() => {
                 btn.classList.remove('long-press-active');
                 this.removeCard(config.fencer, config.cardType);
-                longPressExecuted = true;
                 longPressTimer = null;
               }, LONG_PRESS_DURATION);
             });
 
             btn.addEventListener('touchend', e => {
+              e.preventDefault(); // empêche les ghost clicks souris
               if (longPressTimer) {
+                // Appui court : ajouter le carton
                 clearTimeout(longPressTimer);
                 longPressTimer = null;
+                this.addCard(config.fencer, config.cardType);
               }
               btn.classList.remove('long-press-active');
-              if (longPressExecuted) {
-                e.preventDefault();
-                e.stopPropagation();
-              }
             });
 
             btn.addEventListener('touchcancel', () => {


### PR DESCRIPTION
## Summary
Migrated from inline `onclick` attributes to event listener-based architecture for score and card buttons in the referee interface. This change improves code maintainability and fixes event handling logic for long-press functionality.

## Key Changes
- **Removed inline onclick handlers**: Deleted all `onclick="refereeApp.addScore(...)"` and `onclick="refereeApp.addCard(...)"` attributes from HTML buttons
- **Implemented event listener-based handlers**: Added proper `mousedown`/`mouseup` and `touchstart`/`touchend` event listeners that handle both short taps (add action) and long presses (remove action)
- **Simplified long-press state management**: Removed the `longPressExecuted` flag and replaced it with cleaner logic that checks if `longPressTimer` is still active
- **Fixed event propagation**: Moved `e.preventDefault()` to appropriate locations (`touchend` for mobile, removed unnecessary calls from `mouseup`)
- **Added inline comments**: Clarified the intent of short-press actions in both mouse and touch handlers

## Implementation Details
- Short press (quick tap): Triggers `addScore()` or `addCard()` when timer is cleared before long-press duration
- Long press (held): Triggers `removeScore()` or `removeCard()` after `LONG_PRESS_DURATION` timeout
- Touch events now properly prevent ghost clicks with `e.preventDefault()` on `touchend`
- Code is now DRY with event listeners handling all interaction logic in one place rather than split between HTML and JavaScript

https://claude.ai/code/session_01KUzYj4cBP1Ctj5hNZ5jPAX