### PR TITLE
fix: ne plus forcer le recalcul du nombre de poules quand min/max tireurs change

### DIFF
--- a/src/renderer/components/PoolPrepView.tsx
+++ b/src/renderer/components/PoolPrepView.tsx
@@ -154,26 +154,13 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
     }
   }, [fencers.length, initialPools]);
 
-  // Recalculate optimal pool count when min/max fencers change
-  useEffect(() => {
-    if (fencers.length > 0 && pools.length > 0) {
-      const optimalCount = calculateOptimalPoolCount(
-        fencers.length,
-        minFencersPerPool,
-        maxFencersPerPool
-      );
-      if (optimalCount !== poolCount) {
-        setPoolCount(optimalCount);
-      }
-    }
-  }, [minFencersPerPool, maxFencersPerPool]);
-
-  // Regenerate pools when count changes
+  // Regenerate pools when count or min/max fencers per pool changes
+  // Note: on ne recalcule pas le nombre optimal de poules ici pour respecter le choix manuel de l'utilisateur
   useEffect(() => {
     if (poolCount > 0 && fencers.length > 0) {
       generatePools(poolCount);
     }
-  }, [poolCount]);
+  }, [poolCount, minFencersPerPool, maxFencersPerPool]);
 
   const generatePools = (count: number) => {
     if (fencers.length === 0) return;


### PR DESCRIPTION
L'effet qui recalculait le nombre "optimal" de poules à chaque changement de
min/max par poule écrasait le choix manuel de l'utilisateur. Suppression de
cet effet et fusion avec l'effet de régénération (poolCount, min, max comme
dépendances), de sorte que les poules sont redistribuées selon le nouveau
min/max sans modifier le nombre de poules choisi.

https://claude.ai/code/session_01KAjnYwXn7ekP3FQSVRve4W