### PR TITLE
fix: kiosk auto-switch vers tableau lors du changement de phase

### DIFF
--- a/src/renderer/components/KioskDisplay.tsx
+++ b/src/renderer/components/KioskDisplay.tsx
@@ -56,6 +56,14 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [currentView, setCurrentView] = useState<KioskView>(initialView);
+
+  // Auto-switch vers tableau quand les matchs d'élimination arrivent (changement de phase en direct)
+  useEffect(() => {
+    if (tableauMatches.length > 0 && currentView !== 'tableau') {
+      setCurrentView('tableau');
+    }
+  }, [tableauMatches.length]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const [menuVisible, setMenuVisible] = useState(true);
   const menuTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 


### PR DESCRIPTION
Ajout d'un useEffect qui surveille tableauMatches.length et bascule
currentView vers 'tableau' dès que les matchs d'élimination arrivent.
Corrige le bug où le kiosk restait bloqué sur la vue poules après
passage en phase tableau.

https://claude.ai/code/session_01YLCKr7ftu1VaAurTs5XpEa