### PR TITLE
Add undo/history, sudden death modes, and arena exit to referee UI

### DIFF
--- a/.planning/current-phase.md
+++ b/.planning/current-phase.md
@@ -1,7 +1,7 @@
 # Phase Actuelle : Interface de Saisie Distante + Mode Hors-Ligne
 
 **Phase** : 3  
-**Statut** : À DÉMARRER  
+**Statut** : EN COURS (~55%)  
 **Priorité** : HIGH
 
 ## Contexte
@@ -392,14 +392,16 @@ Les arbitres utilisent des tablettes pour saisir les scores à distance pendant 
 ## Critères de succès Phase 3
 
 ### Interface de saisie distante
-- [ ] Zones A/B/C fonctionnelles avec bon scoring
-- [ ] Système de cartons FFE complet
-- [ ] Mort subite (Challenger + Timeout) fonctionnelle
-- [ ] Sortie d'arène fonctionnelle
-- [ ] Chronomètre synchronisé
-- [ ] Undo / Historique fonctionnel
-- [ ] UI optimisée tablette (boutons larges, pas de scroll)
-- [ ] Sélection de match intuitive
+- [x] Zones A/B/C fonctionnelles avec bon scoring ✅
+- [x] Système de cartons (blanc→jaune, jaune, rouge + pénalités) ✅
+- [x] Mort subite Timeout (timer=0 + égalité → 30s) ✅
+- [x] Mort subite Challenger (écart ≥ 10 pts) ✅
+- [x] Blocage zones A/B en mort subite (seule Zone C active) ✅
+- [x] Sortie d'arène (+3 pts adversaire) ✅
+- [x] Chronomètre synchronisé ✅
+- [x] Undo / Historique fonctionnel (10 actions) ✅
+- [ ] UI optimisée tablette (boutons ≥48px, pas de scroll, paysage)
+- [ ] Sélection de match avancée
 
 ### Mode hors-ligne
 - [ ] Saisie fonctionne sans connexion

--- a/.planning/roadmap.md
+++ b/.planning/roadmap.md
@@ -5,7 +5,7 @@
 ```
 Phase 1: Core Sabre Laser        ████████████████████ 100% ✅
 Phase 2: Tests Unitaires         ████████████████████ 100% ✅
-Phase 3: Saisie Distante + PWA   ░░░░░░░░░░░░░░░░░░░░   0% 🔜 ← ACTUELLE
+Phase 3: Saisie Distante + PWA   ████████████░░░░░░░░  ~55% 🔜 ← ACTUELLE
 Phase 4: Dashboard Live          ░░░░░░░░░░░░░░░░░░░░   0% 📋
 Phase 5: Formule ASL             ░░░░░░░░░░░░░░░░░░░░   0% 📋
 ```
@@ -48,17 +48,17 @@ Interface `referee.html` 100% fonctionnelle sur tablette avec mode hors-ligne.
 
 ### Partie A : Interface de Saisie Distante
 
-| Tâche | Description | Durée |
-|-------|-------------|-------|
-| remote-1 | Audit referee.html existant | 1j |
-| remote-2 | Zones A/B/C fonctionnelles | 1j |
-| remote-3 | Système de cartons complet | 1j |
-| remote-4 | Mort subite (2 modes) | 1j |
-| remote-5 | Sortie d'arène | 0.5j |
-| remote-6 | Chronomètre synchronisé | 1j |
-| remote-7 | Undo et historique | 1j |
-| remote-8 | UI optimisée tablette | 1j |
-| remote-9 | Sélection du match | 1j |
+| Tâche | Description | Durée | Statut |
+|-------|-------------|-------|--------|
+| remote-1 | Audit referee.html existant | 1j | 🔜 |
+| remote-2 | Zones A/B/C fonctionnelles | 1j | ✅ |
+| remote-3 | Système de cartons (blanc/jaune/rouge) | 1j | ✅ |
+| remote-4 | Mort subite (Timeout + Challenger ≥10 pts) + blocage zones | 1j | ✅ |
+| remote-5 | Sortie d'arène (+3 pts) | 0.5j | ✅ |
+| remote-6 | Chronomètre synchronisé | 1j | ✅ |
+| remote-7 | Undo et historique (10 actions) | 1j | ✅ |
+| remote-8 | UI optimisée tablette (boutons ≥48px) | 1j | 🔜 |
+| remote-9 | Sélection du match avancée | 1j | 🔜 |
 
 ### Partie B : Mode Hors-Ligne
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ _Dernière mise à jour : avril 2026_
 | Couverture tests | ~5% (11 fichiers / 136) | 60% |
 | `console.log` en prod | ~325 occurrences | 0 |
 | Composants > 500 lignes | 5 fichiers | 0 |
-| Locales implémentées | 7 / 7 déclarées ⚠️ | 7 / 7 |
+| Locales implémentées | 7 / 7 ✅ | 7 / 7 |
 | Bundle size | ~1.8 MB | < 1.5 MB |
 
 ---
@@ -23,7 +23,7 @@ Détail dans `.planning/roadmap.md`.
 ```
 Phase 1 : Core Sabre Laser          ████████████████████ 100% ✅
 Phase 2 : Tests unitaires           ████████████████████ 100% ✅
-Phase 3 : Saisie distante + PWA     ░░░░░░░░░░░░░░░░░░░░   0% 🔜  ← ACTUELLE
+Phase 3 : Saisie distante + PWA     ████████████░░░░░░░░  ~55% 🔜  ← ACTUELLE
 Phase 4 : Dashboard Live            ░░░░░░░░░░░░░░░░░░░░   0% 📋
 Phase 5 : Formule ASL               ░░░░░░░░░░░░░░░░░░░░   0% 📋
 ```
@@ -33,13 +33,14 @@ Phase 5 : Formule ASL               ░░░░░░░░░░░░░░�
 Tâches clés :
 
 - [ ] `remote-1` Audit `referee.html` existant
-- [ ] `remote-2` Zones A/B/C fonctionnelles sur tablette
-- [ ] `remote-3` Cartons complets (groupes 1-4)
-- [ ] `remote-4` Mort subite (2 modes)
-- [ ] `remote-5` Sortie d'arène
-- [ ] `remote-6` Chronomètre synchronisé
-- [ ] `remote-7` Undo + historique
-- [ ] `remote-8` UI optimisée tactile
+- [x] `remote-2` Zones A/B/C fonctionnelles sur tablette ✅
+- [x] `remote-3` Cartons (blanc→jaune, jaune, rouge) avec pénalités ✅
+- [x] `remote-4` Mort subite (Timeout + Challenger ≥10 pts) + blocage zones A/B ✅
+- [x] `remote-5` Sortie d'arène (+3 pts adversaire) ✅
+- [x] `remote-6` Chronomètre synchronisé (start/pause/reset + alertes) ✅
+- [x] `remote-7` Undo + historique (10 actions) ✅
+- [ ] `remote-8` UI optimisée tactile (boutons ≥48px, paysage)
+- [ ] `remote-9` Sélection match avancée
 - [ ] `offline-1` IndexedDB côté referee
 - [ ] `offline-2` Service Worker PWA
 - [ ] `offline-3` Queue de sync + indicateurs UI
@@ -48,22 +49,20 @@ Tâches clés :
 
 ## Bugs critiques
 
-### 🔴 Crash potentiel
+### ✅ Résolus
 
-**1. Locale `nl` manquante**
-- `src/shared/types/index.ts:487` déclare `'nl'` dans l'union `language`
-- Aucun fichier `src/locales/nl.json` n'existe
-- Sélectionner "Dutch" dans les paramètres → crash `TranslationContext`
-- **Fix :** ajouter `nl.json` ou retirer `'nl'` du type
+**1. Locale `nl` manquante** — ~~`src/shared/types/index.ts:487` déclarait `'nl'`~~
+- Corrigé : union de types mise à jour avec les locales réelles (`br`, `ca`, `zh-HK`)
 
-**2. TODO non résolu — propagation ranking poules**
-- `src/renderer/components/PoolRankingView.tsx:167`
-- Les changements de ranking ne se propagent pas vers le tableau d'élimination
-- Risque : qualifications incorrectes en tournoi multi-poules
+**2. Propagation ranking poules → tableau** — ~~TODO non résolu dans `PoolRankingView.tsx:167`~~
+- Corrigé : `saveChanges()` propage désormais les rangs globaux manuels via `onPoolsChange`
+
+**3. Null checks `pool.matches`**
+- Corrigé dans `pdfTemplates.ts`, `poolCalculations.ts`, `FencerComparison.tsx`
 
 ### 🟡 Implémentations incomplètes déclarées terminées
 
-**3. Cloud Sync — chiffrement non fonctionnel**
+**4. Cloud Sync — chiffrement non fonctionnel**
 - `src/shared/services/cloudSyncService.ts:70-82`
 - `generateKey()` crée une clé mais ne la persiste pas
 - Aucun workflow de déchiffrement implémenté

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -372,6 +372,39 @@
         gap: 0.75rem;
       }
 
+      .control-buttons-extra {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+      }
+
+      .btn-arena-exit {
+        background: linear-gradient(135deg, #f97316, #ea580c);
+        color: white;
+        font-size: 0.8rem;
+        padding: 0.65rem 0.4rem;
+      }
+
+      .btn-undo {
+        background: linear-gradient(135deg, #6366f1, #4f46e5);
+        color: white;
+        font-size: 0.85rem;
+        padding: 0.65rem 0.4rem;
+      }
+
+      .btn-undo:disabled {
+        background: #6b7280;
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+
+      .score-btn:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+        filter: grayscale(1);
+      }
+
       .control-btn {
         padding: 1rem;
         border: none;
@@ -754,6 +787,31 @@
             🏁 Terminer
           </button>
         </div>
+        <!-- Boutons secondaires : sortie d'arène + annuler -->
+        <div class="control-buttons-extra">
+          <button
+            class="control-btn btn-arena-exit"
+            id="btn-exit-a"
+            onclick="refereeApp.arenaExit('A')"
+          >
+            🚪 Sortie A
+          </button>
+          <button
+            class="control-btn btn-undo"
+            id="btn-undo"
+            onclick="refereeApp.undoLastAction()"
+            disabled
+          >
+            ↩ Annuler
+          </button>
+          <button
+            class="control-btn btn-arena-exit"
+            id="btn-exit-b"
+            onclick="refereeApp.arenaExit('B')"
+          >
+            🚪 Sortie B
+          </button>
+        </div>
       </div>
 
       <!-- Écran de sélection de match -->
@@ -810,6 +868,7 @@
           this.longPressTimer = null;
           this.isLaserSabre = false;
           this.isSuddenDeath = false;
+          this.actionHistory = []; // Historique pour undo (max 10)
 
           this.init();
         }
@@ -1091,7 +1150,10 @@
           this.matchStatus = match.status;
           this.timerSeconds = 180;
           this.isSuddenDeath = false;
+          this.actionHistory = [];
           this.stopTimer();
+          const undoBtn = document.getElementById('btn-undo');
+          if (undoBtn) undoBtn.disabled = true;
 
           // Charger les infos du match
           document.getElementById('fencer-a-name').textContent =
@@ -1127,6 +1189,14 @@
           if (!this.currentMatch) return;
           if (this.matchStatus === 'finished') return;
 
+          // En mort subite Laser Sabre, seule la zone C (+5) est autorisée
+          if (this.isSuddenDeath && this.isLaserSabre && points !== 5) {
+            this.showNotification('⚡ Mort subite : Zone C uniquement !');
+            return;
+          }
+
+          this.pushHistory('score');
+
           if (fencer === 'A') {
             this.scoreA = Math.max(0, this.scoreA + points);
           } else {
@@ -1136,11 +1206,21 @@
           this.updateScores();
           this.broadcastUpdate();
           this.saveScore();
+
+          // Mode Challenger : mort subite si écart ≥ 10 pts (Laser Sabre uniquement)
+          if (this.isLaserSabre && !this.isSuddenDeath) {
+            const gap = Math.abs(this.scoreA - this.scoreB);
+            if (gap >= 10) {
+              this.triggerSuddenDeathChallenger();
+            }
+          }
         }
 
         addCard(fencer, cardType) {
           if (!this.currentMatch) return;
           if (this.matchStatus === 'finished') return;
+
+          this.pushHistory('card');
 
           const cards = fencer === 'A' ? this.cardsA : this.cardsB;
           const otherFencer = fencer === 'A' ? 'B' : 'A';
@@ -1180,6 +1260,85 @@
           this.updateCardsDisplay();
           this.broadcastUpdate();
           this.saveScore();
+        }
+
+        // ── Historique / Undo ─────────────────────────────────────────────────
+
+        pushHistory(type) {
+          const snapshot = {
+            type,
+            scoreA: this.scoreA,
+            scoreB: this.scoreB,
+            cardsA: [...this.cardsA],
+            cardsB: [...this.cardsB],
+            isSuddenDeath: this.isSuddenDeath,
+          };
+          this.actionHistory.push(snapshot);
+          if (this.actionHistory.length > 10) this.actionHistory.shift();
+          document.getElementById('btn-undo').disabled = false;
+        }
+
+        undoLastAction() {
+          if (this.actionHistory.length === 0) return;
+          const prev = this.actionHistory.pop();
+          this.scoreA = prev.scoreA;
+          this.scoreB = prev.scoreB;
+          this.cardsA = prev.cardsA;
+          this.cardsB = prev.cardsB;
+          this.isSuddenDeath = prev.isSuddenDeath;
+          this.updateScores();
+          this.updateCardsDisplay();
+          this.updateSuddenDeathUI();
+          this.broadcastUpdate();
+          this.saveScore();
+          this.showNotification('↩ Action annulée');
+          document.getElementById('btn-undo').disabled = this.actionHistory.length === 0;
+        }
+
+        // ── Mort subite ───────────────────────────────────────────────────────
+
+        triggerSuddenDeathChallenger() {
+          this.isSuddenDeath = true;
+          this.stopTimer();
+          this.updateTimerDisplay();
+          this.broadcastTimerUpdate();
+          this.updateSuddenDeathUI();
+          this.showNotification('⚡ MORT SUBITE – Écart de 10 pts ! Zone C uniquement.');
+          // Lancer le chrono de mort subite (30s)
+          this.timerSeconds = 30;
+          this.updateTimerDisplay();
+          this.startTimer();
+        }
+
+        // Désactiver +1/+3 en mort subite (seule Zone C autorisée en Laser Sabre)
+        updateSuddenDeathUI() {
+          const disabled = this.isSuddenDeath && this.isLaserSabre;
+          ['btn-plus-1-a', 'btn-plus-3-a', 'btn-plus-1-b', 'btn-plus-3-b'].forEach(id => {
+            const btn = document.getElementById(id);
+            if (btn) btn.disabled = disabled;
+          });
+          const sdLabel = document.getElementById('sudden-death-label');
+          if (sdLabel) sdLabel.style.display = this.isSuddenDeath ? 'block' : 'none';
+        }
+
+        // ── Sortie d'arène ────────────────────────────────────────────────────
+
+        arenaExit(fencer) {
+          if (!this.currentMatch) return;
+          if (this.matchStatus === 'finished') return;
+
+          this.pushHistory('arena_exit');
+          const points = 3;
+          if (fencer === 'A') {
+            this.scoreB += points;
+          } else {
+            this.scoreA += points;
+          }
+          this.updateScores();
+          this.broadcastUpdate();
+          this.saveScore();
+          const label = fencer === 'A' ? 'Rouge' : 'Vert';
+          this.showNotification(`🚪 Sortie d'arène ${label} — +${points} pts adversaire`);
         }
 
         // Retirer des points (appui long)
@@ -1318,6 +1477,7 @@
           this.timerSeconds = 180;
           this.updateTimerDisplay();
           this.broadcastTimerUpdate();
+          this.updateSuddenDeathUI();
           this.showNotification('🔄 Chronomètre réinitialisé');
         }
 
@@ -1326,7 +1486,8 @@
           this.timerSeconds = 30;
           this.updateTimerDisplay();
           this.broadcastTimerUpdate();
-          this.showNotification('⚡ MORT SUBITE – 30 secondes !');
+          this.updateSuddenDeathUI();
+          this.showNotification('⚡ MORT SUBITE – Égalité à temps ! Zone C uniquement.');
           this.startTimer();
         }
 
@@ -1352,9 +1513,8 @@
             timerEl.classList.add('warning');
           }
 
-          // Affichage mort subite
-          const sdLabel = document.getElementById('sudden-death-label');
-          if (sdLabel) sdLabel.style.display = this.isSuddenDeath ? 'block' : 'none';
+          // Affichage mort subite (synchronise label + état boutons)
+          this.updateSuddenDeathUI();
         }
 
         broadcastTimerUpdate() {

--- a/src/renderer/components/FencerComparison.tsx
+++ b/src/renderer/components/FencerComparison.tsx
@@ -79,7 +79,7 @@ export const FencerComparison: React.FC<FencerComparisonProps> = ({
 
     // Chercher les matchs de poule
     pools.forEach(pool => {
-      pool.matches.forEach(match => {
+      (pool.matches ?? []).forEach(match => {
         const matchFencerAId = match.fencerA?.id;
         const matchFencerBId = match.fencerB?.id;
 

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -162,11 +162,37 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     setEditedRanking(newRanking);
   };
 
-  // Sauvegarder les modifications
+  // Sauvegarder les modifications et propager vers le parent
   const saveChanges = () => {
-    // TODO: Propager les changements vers les pools si nécessaire
+    const rankingChanged =
+      JSON.stringify(overallRanking.map(r => r.fencer.id)) !==
+      JSON.stringify(editedRanking.map(r => r.fencer.id));
+
+    if (onPoolsChange) {
+      if (rankingChanged) {
+        // Propager les rangs globaux manuels dans chaque pool pour que le bracket
+        // puisse utiliser le bon ordre de qualification
+        const fencerToGlobalRank = new Map(editedRanking.map(r => [r.fencer.id, r.rank]));
+        const updatedPools = pools.map(pool => ({
+          ...pool,
+          ranking: pool.ranking.map(pr => ({
+            ...pr,
+            rank: fencerToGlobalRank.get(pr.fencer.id) ?? pr.rank,
+          })),
+        }));
+        onPoolsChange(updatedPools, true);
+      } else {
+        onPoolsChange(pools, false);
+      }
+    }
+
     setIsEditing(false);
-    showToast('Classement modifié avec succès !', 'success');
+    showToast(
+      rankingChanged
+        ? 'Classement modifié — le tableau sera régénéré avec le nouvel ordre.'
+        : 'Classement sauvegardé (inchangé).',
+      rankingChanged ? 'warning' : 'success'
+    );
   };
 
   const generateCSV = () => {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -484,7 +484,7 @@ export interface AppState {
 }
 
 export interface UISettings {
-  language: 'fr' | 'en' | 'de' | 'es' | 'nl';
+  language: 'fr' | 'en' | 'de' | 'es' | 'br' | 'ca' | 'zh-HK';
   theme: 'light' | 'dark' | 'system';
   fontSize: 'small' | 'medium' | 'large';
   showTips: boolean;

--- a/src/shared/utils/pdfTemplates.ts
+++ b/src/shared/utils/pdfTemplates.ts
@@ -165,8 +165,9 @@ export class SimplePdfTemplateManager {
     doc.setFont(fonts.body.family, 'normal');
     doc.setTextColor(colors.secondary);
 
-    const completedMatches = pool.matches.filter(m => m.status === MatchStatus.FINISHED).length;
-    const info = `Tireurs: ${pool.fencers.length} | Matchs: ${pool.matches.length} | Terminés: ${completedMatches}/${pool.matches.length}`;
+    const matches = pool.matches ?? [];
+    const completedMatches = matches.filter(m => m.status === MatchStatus.FINISHED).length;
+    const info = `Tireurs: ${pool.fencers?.length ?? 0} | Matchs: ${matches.length} | Terminés: ${completedMatches}/${matches.length}`;
     doc.text(info, DIMENSIONS.PAGE_WIDTH / 2, currentY, { align: 'center' });
     currentY += 10;
 

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -659,7 +659,7 @@ export function validatePool(pool: Pool): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
   // Vérifier que tous les matchs sont terminés
-  const incompleteMatches = pool.matches.filter(
+  const incompleteMatches = (pool.matches ?? []).filter(
     m => m.status !== MatchStatus.FINISHED && m.status !== MatchStatus.CANCELLED
   );
   if (incompleteMatches.length > 0) {
@@ -667,7 +667,7 @@ export function validatePool(pool: Pool): { valid: boolean; errors: string[] } {
   }
 
   // Vérifier la cohérence des scores
-  for (const match of pool.matches) {
+  for (const match of pool.matches ?? []) {
     if (match.status !== MatchStatus.FINISHED) continue;
 
     if (!match.scoreA || !match.scoreB) {


### PR DESCRIPTION
## Summary

Implements critical referee interface features for Phase 3 (Remote Entry + Offline Mode): undo/action history, two sudden death modes (Timeout and Challenger), arena exit scoring, and improved UI state management.

## Key Changes

### Referee Interface (`src/remote/referee.html`)

**New Features:**
- **Undo System**: Action history (max 10 snapshots) with undo button; tracks score, cards, and sudden death state
- **Sudden Death Modes**:
  - *Timeout Mode*: Triggered when timer reaches 0 with equal scores → 30s overtime, Zone C only
  - *Challenger Mode*: Auto-triggered when score gap ≥ 10 pts in Laser Sabre → 30s overtime, Zone C only
  - Both modes disable +1/+3 buttons (Zones A/B) to enforce Zone C-only scoring
- **Arena Exit**: New buttons for each fencer (A/B) that award 3 points to opponent and log action
- **UI Improvements**: 
  - New `.control-buttons-extra` grid layout for secondary buttons
  - Disabled state styling for undo button and score buttons during sudden death
  - Sudden death label display synchronized with button state

**Implementation Details:**
- `pushHistory(type)` captures snapshots before score/card changes
- `undoLastAction()` restores previous state and updates all UI elements
- `triggerSuddenDeathChallenger()` auto-activates when gap ≥ 10 pts
- `updateSuddenDeathUI()` centralizes sudden death state display and button disabling
- `arenaExit(fencer)` awards points to opponent and broadcasts update

### Bug Fixes & Corrections

**Type System** (`src/shared/types/index.ts`):
- Fixed language union type: replaced non-existent `'nl'` with actual locales (`'br'`, `'ca'`, `'zh-HK'`)

**Null Safety** (`src/shared/utils/pdfTemplates.ts`, `poolCalculations.ts`, `src/renderer/components/FencerComparison.tsx`):
- Added null checks for `pool.matches` (use `pool.matches ?? []`)
- Prevents crashes when matches array is undefined

**Pool Ranking Propagation** (`src/renderer/components/PoolRankingView.tsx`):
- Implemented `saveChanges()` to propagate manual ranking changes to parent pools
- Updates fencer ranks in each pool so bracket generation uses correct qualification order
- Improved toast messaging to indicate when ranking actually changed

### Documentation Updates

**Roadmap & Planning**:
- Updated Phase 3 progress: 0% → ~55%
- Marked completed tasks: remote-2 through remote-7 ✅
- Remaining: remote-8 (tablet UI optimization), remote-9 (advanced match selection)
- Moved resolved bugs from "critical" to "✅ Resolved" section
- Updated current-phase.md status to "EN COURS (~55%)"

## Testing Notes

- Undo button disabled until first action; enabled/disabled based on history length
- Sudden death restrictions enforced: only Zone C (+5) allowed in both modes
- Arena exit correctly awards points to opponent (not the exiting fencer)
- Action history limited to 10 entries (FIFO when exceeded)

https://claude.ai/code/session_01Lk2fb5QMFjHNt3HwVAzMA8