### PR TITLE
fix(print): corriger le bouton Imprimer cassé par la suppression de 'unsafe-inline'

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -739,6 +739,15 @@ ipcMain.handle('dialog:saveFile', async (_, options) => {
   return dialog.showSaveDialog(mainWindow!, options);
 });
 
+// Print handler
+ipcMain.handle('window:print', () => {
+  return new Promise<void>((resolve) => {
+    mainWindow?.webContents.print({ silent: false, printBackground: true }, () => {
+      resolve();
+    });
+  });
+});
+
 // Shell handlers
 ipcMain.handle('shell:openExternal', async (_, url: string) => {
   // N'autoriser que les URLs https:// pour éviter les exploits via des schémas arbitraires

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -321,6 +321,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onAutosaveFailed: (callback: () => void) => ipcRenderer.on('autosave:failed', callback),
 
   // Utility functions
+  print: () => ipcRenderer.invoke('window:print'),
   openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
   getVersionInfo: () => ipcRenderer.invoke('app:getVersionInfo'),
 

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -139,7 +139,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   };
 
   const handlePrint = () => {
-    window.print();
+    window.electronAPI.print();
   };
 
   // Déplacer un tireur vers le haut

--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -318,7 +318,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
         }}
       >
         <button
-          onClick={() => window.print()}
+          onClick={() => window.electronAPI.print()}
           style={{
             padding: '0.75rem 1.5rem',
             background: '#3b82f6',

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -402,6 +402,7 @@ export interface MenuAPI {
 }
 
 export interface UtilityAPI {
+  print: () => Promise<void>;
   openExternal: (url: string) => Promise<void>;
   getVersionInfo: () => Promise<VersionInfo>;
   removeAllListeners: (channel: string) => void;

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -285,24 +285,9 @@ function generatePoolHTML(pool: Pool, title: string): string {
     .pending-match { background: #fef3c7; }
     .finished-match { background: #d1fae5; }
     
-    /* Bouton imprimer */
-    .print-btn {
-      position: fixed;
-      top: 10px;
-      right: 10px;
-      padding: 8px 16px;
-      background: #3182ce;
-      color: white;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-      font-size: 12pt;
-    }
-    .print-btn:hover { background: #2c5282; }
   </style>
 </head>
 <body>
-  <button class="print-btn no-print" onclick="window.print()">🖨️ Imprimer / PDF</button>
   <h1>${title}</h1>
   <h2>${fencers.length} tireurs • ${finishedCount}/${matches.length} matchs joués</h2>
   ${gridHTML}
@@ -333,6 +318,11 @@ export async function exportPoolToPDF(pool: Pool, options: PoolExportOptions = {
   if (printWindow) {
     printWindow.document.write(html);
     printWindow.document.close();
+    printWindow.focus();
+    // Déclencher depuis l'ouvreur pour éviter les inline scripts bloqués par CSP
+    setTimeout(() => {
+      if (!printWindow.closed) printWindow.print();
+    }, 300);
   } else {
     throw new Error(
       "Impossible d'ouvrir la fenêtre d'impression. Vérifiez que les popups sont autorisés."
@@ -482,16 +472,9 @@ function generateTableauHTML(
       height: 18mm; vertical-align: middle; text-align: center;
     }
     .sig-box { height: 18mm; }
-    .print-btn {
-      position: fixed; top: 10px; right: 10px;
-      padding: 8px 16px; background: #3182ce; color: white;
-      border: none; border-radius: 4px; cursor: pointer; font-size: 12pt;
-    }
-    .print-btn:hover { background: #2c5282; }
   </style>
 </head>
 <body>
-  <button class="print-btn no-print" onclick="window.print()">🖨️ Imprimer / PDF</button>
   <h1>${title}</h1>
   ${pagesHTML}
 </body>
@@ -517,6 +500,11 @@ export async function exportTableauToPDF(
   if (printWindow) {
     printWindow.document.write(html);
     printWindow.document.close();
+    printWindow.focus();
+    // Déclencher depuis l'ouvreur pour éviter les inline scripts bloqués par CSP
+    setTimeout(() => {
+      if (!printWindow.closed) printWindow.print();
+    }, 300);
   } else {
     throw new Error(
       "Impossible d'ouvrir la fenêtre d'impression. Vérifiez que les popups sont autorisés."


### PR DESCRIPTION
- pdfExport.ts : supprimer les boutons onclick="window.print()" des popups HTML
  (bloqués par CSP car about:blank hérite du script-src de l'ouvreur)
  et déclencher printWindow.print() depuis l'ouvreur via setTimeout(300ms)
- main.ts : ajouter ipcMain.handle('window:print') via webContents.print()
- preload.ts : exposer print() dans le bridge contextBridge
- types/preload.ts : ajouter print() à UtilityAPI
- PoolRankingView, ResultsView : window.print() → window.electronAPI.print()

https://claude.ai/code/session_01YJdga7rULjWk7e3XbuoppL