### PR TITLE
Fix pool regeneration on session restore across platforms

### DIFF
--- a/src/renderer/components/PoolPrepView.tsx
+++ b/src/renderer/components/PoolPrepView.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Fencer, Pool, Match, MatchStatus } from '../../shared/types';
 import {
   calculateOptimalPoolCount,
@@ -52,6 +52,9 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
     byLeague: true,
     byNation: false,
   });
+
+  // Flag pour éviter la régénération des poules quand poolCount est défini depuis initialPools
+  const skipNextPoolGeneration = useRef(false);
 
   // Historique des modifications pour la fonction restore
   const [history, setHistory] = useState<PoolStateHistory[]>([]);
@@ -137,6 +140,7 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
   // Initialize pools from initialPools when component mounts or initialPools changes
   useEffect(() => {
     if (initialPools && initialPools.length > 0) {
+      skipNextPoolGeneration.current = true;
       setPools(initialPools);
       setPoolCount(initialPools.length);
       // Initialize history with the loaded state
@@ -163,6 +167,13 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
   // Regenerate pools when count or min/max fencers per pool changes
   // Note: on ne recalcule pas le nombre optimal de poules ici pour respecter le choix manuel de l'utilisateur
   useEffect(() => {
+    // Ignorer si poolCount vient d'être défini depuis initialPools (restauration de session)
+    // — sans cette garde, les poules restaurées seraient écrasées sur Linux où les tireurs
+    // se chargent plus vite que sur Windows (pas d'antivirus, FS natif).
+    if (skipNextPoolGeneration.current) {
+      skipNextPoolGeneration.current = false;
+      return;
+    }
     if (poolCount > 0 && fencers.length > 0) {
       generatePools(poolCount);
     }


### PR DESCRIPTION
## Summary
Fixes an issue where pools loaded from a saved session would be immediately overwritten on platforms with faster filesystem access (Linux, or Windows without antivirus). The problem occurred because the `poolCount` state update triggered a pool regeneration before the initial pools could be properly set.

## Changes
- Added `useRef` hook to track when `poolCount` is being set from `initialPools` during session restoration
- Introduced `skipNextPoolGeneration` flag to prevent the pool regeneration effect from running immediately after loading saved pools
- Added guard clause in the pool regeneration effect to skip regeneration when the flag is set, then reset it for subsequent changes

## Implementation Details
The fix uses a ref-based flag rather than state to avoid additional re-renders. When `initialPools` are loaded:
1. The flag is set to `true` before updating `poolCount`
2. The pool regeneration effect checks this flag and returns early if set
3. The flag is reset to `false` for normal operation going forward

This ensures that manually restored pools are preserved while maintaining normal regeneration behavior when the user manually changes pool count or fencer constraints.

https://claude.ai/code/session_01Fv8xzD2qnpKt8qYCtD7ehx