### PR TITLE
Rename league to region throughout codebase

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -158,7 +158,7 @@ export class DatabaseManager {
         id TEXT PRIMARY KEY, competition_id TEXT NOT NULL,
         ref INTEGER NOT NULL, last_name TEXT NOT NULL, first_name TEXT NOT NULL,
         birth_date TEXT, gender TEXT NOT NULL, nationality TEXT DEFAULT 'FRA',
-        league TEXT, club TEXT, license TEXT, ranking INTEGER,
+        region TEXT, club TEXT, license TEXT, ranking INTEGER,
         status TEXT DEFAULT 'N', seed_number INTEGER, final_ranking INTEGER,
         pool_stats TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
       )
@@ -254,6 +254,13 @@ export class DatabaseManager {
       this.db.run(`ALTER TABLE fencers ADD COLUMN photo TEXT`);
     } catch {
       /* colonne déjà présente */
+    }
+
+    // Renommage league → region (migration idempotente)
+    try {
+      this.db.run(`ALTER TABLE fencers RENAME COLUMN league TO region`);
+    } catch {
+      /* colonne déjà renommée */
     }
 
     // Création des index pour optimiser les performances
@@ -561,7 +568,7 @@ export class DatabaseManager {
     try {
       this.db.run(
         `
-        INSERT INTO fencers (id, competition_id, ref, last_name, first_name, birth_date, gender, nationality, club, league, license, ranking, status, photo, created_at, updated_at)
+        INSERT INTO fencers (id, competition_id, ref, last_name, first_name, birth_date, gender, nationality, club, region, license, ranking, status, photo, created_at, updated_at)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         [
@@ -574,7 +581,7 @@ export class DatabaseManager {
           fencer.gender || 'M',
           fencer.nationality || 'FRA',
           fencer.club || null,
-          fencer.league || null,
+          fencer.region || null,
           fencer.license || null,
           fencer.ranking || null,
           fencer.status || 'N',
@@ -626,7 +633,7 @@ export class DatabaseManager {
         birthDate: row.birth_date ? new Date(row.birth_date as string) : undefined,
         gender: row.gender as Gender,
         nationality: row.nationality as string,
-        league: row.league as string,
+        region: row.region as string,
         club: row.club as string,
         license: row.license as string,
         ranking: row.ranking as number,
@@ -763,7 +770,7 @@ export class DatabaseManager {
       gender: 'gender',
       nationality: 'nationality',
       club: 'club',
-      league: 'league',
+      region: 'region',
       license: 'license',
       ranking: 'ranking',
       status: 'status',

--- a/src/database/validation.ts
+++ b/src/database/validation.ts
@@ -206,7 +206,7 @@ export const validateFencerData = (data: Partial<Fencer>): void => {
 
   // Optional fields
   validateOptionalDate(data.birthDate, 'birthDate');
-  validateOptionalString(data.league, 'league', 100);
+  validateOptionalString(data.region, 'region', 100);
   validateOptionalString(data.club, 'club', 100);
   validateOptionalString(data.license, 'license', 50);
   validateOptionalNumber(data.ranking, 'ranking', 1);

--- a/src/renderer/components/AddFencerModal.tsx
+++ b/src/renderer/components/AddFencerModal.tsx
@@ -18,7 +18,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
   const [lastName, setLastName] = useState('');
   const [firstName, setFirstName] = useState('');
   const [club, setClub] = useState('');
-  const [league, setLeague] = useState('');
+  const [region, setRegion] = useState('');
   const [license, setLicense] = useState('');
   const [ranking, setRanking] = useState('');
   const [gender, setGender] = useState<Gender>(Gender.MALE);
@@ -37,7 +37,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
       lastName: lastName.trim().toUpperCase(),
       firstName: firstName.trim(),
       club: club.trim() || undefined,
-      league: league.trim() || undefined,
+      region: region.trim() || undefined,
       license: license.trim() || undefined,
       ranking: ranking ? parseInt(ranking, 10) : undefined,
       gender,
@@ -138,13 +138,13 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
 
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
               <div className="form-group">
-                <label className="form-label">Ligue</label>
+                <label className="form-label">Région</label>
                 <input
                   type="text"
                   className="form-input"
                   placeholder="Île-de-France"
-                  value={league}
-                  onChange={e => setLeague(e.target.value)}
+                  value={region}
+                  onChange={e => setRegion(e.target.value)}
                 />
               </div>
               <div className="form-group">

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -389,7 +389,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     const poolCount = calculateOptimalPoolCount(rankedFencers.length, 5, 7);
     const distribution = distributeFencersToPoolsSerpentine(rankedFencers, poolCount, {
       byClub: true,
-      byLeague: true,
+      byRegion: true,
       byNation: false,
     });
 

--- a/src/renderer/components/EditFencerModal.tsx
+++ b/src/renderer/components/EditFencerModal.tsx
@@ -18,7 +18,7 @@ const EditFencerModal: React.FC<EditFencerModalProps> = ({ fencer, onSave, onClo
   const [firstName, setFirstName] = useState(fencer.firstName);
   const [gender, setGender] = useState<Gender>(fencer.gender);
   const [club, setClub] = useState(fencer.club || '');
-  const [league, setLeague] = useState(fencer.league || '');
+  const [region, setRegion] = useState(fencer.region || '');
   const [nationality, setNationality] = useState(fencer.nationality || 'FRA');
   const [license, setLicense] = useState(fencer.license || '');
   const [ranking, setRanking] = useState(fencer.ranking?.toString() || '');
@@ -33,7 +33,7 @@ const EditFencerModal: React.FC<EditFencerModalProps> = ({ fencer, onSave, onClo
       firstName,
       gender,
       club: club || undefined,
-      league: league || undefined,
+      region: region || undefined,
       nationality,
       license: license || undefined,
       ranking: ranking ? parseInt(ranking) : undefined,
@@ -133,12 +133,12 @@ const EditFencerModal: React.FC<EditFencerModalProps> = ({ fencer, onSave, onClo
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
             <div className="form-group">
-              <label className="form-label">Ligue</label>
+              <label className="form-label">Région</label>
               <input
                 type="text"
                 className="form-input"
-                value={league}
-                onChange={e => setLeague(e.target.value)}
+                value={region}
+                onChange={e => setRegion(e.target.value)}
                 placeholder="Ex: IDF"
               />
             </div>

--- a/src/renderer/components/PoolPrepView.tsx
+++ b/src/renderer/components/PoolPrepView.tsx
@@ -49,7 +49,7 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
 
   const [separationConfig, setSeparationConfig] = useState({
     byClub: true,
-    byLeague: true,
+    byRegion: true,
     byNation: false,
   });
 
@@ -480,7 +480,7 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
           {(
             [
               { key: 'byClub', label: 'Séparer par club' },
-              { key: 'byLeague', label: 'Séparer par ligue' },
+              { key: 'byRegion', label: 'Séparer par région' },
               { key: 'byNation', label: 'Séparer par nation' },
             ] as { key: keyof typeof separationConfig; label: string }[]
           ).map(({ key, label }) => (

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -70,7 +70,7 @@ export const usePoolManagement = ({
       const poolCount = calculateOptimalPoolCount(checkedInFencers.length, 5, 7);
       const distribution = distributeFencersToPoolsSerpentine(checkedInFencers, poolCount, {
         byClub: true,
-        byLeague: true,
+        byRegion: true,
         byNation: false,
       });
 
@@ -189,7 +189,7 @@ export const usePoolManagement = ({
       const newPoolCount = calculateOptimalPoolCount(checkedInFencers.length, 5, 7);
       const distribution = distributeFencersToPoolsSerpentine(checkedInFencers, newPoolCount, {
         byClub: true,
-        byLeague: true,
+        byRegion: true,
         byNation: false,
       });
 

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -51,7 +51,7 @@
     "birth_date": "Date de naissance",
     "gender": "Genre",
     "nationality": "Nationalité",
-    "league": "Ligue",
+    "league": "Région",
     "club": "Club",
     "license": "Licence",
     "ranking": "Classement",

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -174,7 +174,7 @@ export interface Fencer extends BaseEntity {
   birthDate?: Date; // Date de naissance
   gender: Gender; // Sexe
   nationality: string; // Nation (code ISO)
-  league?: string; // Ligue/Région
+  region?: string; // Région
   club?: string; // Club
   license?: string; // Numéro de licence
   ranking?: number; // Classement
@@ -217,7 +217,7 @@ export interface Referee extends BaseEntity {
   birthDate?: Date;
   gender: Gender;
   nationality: string;
-  league?: string;
+  region?: string;
   club?: string; // Club d'affiliation pour éviter les conflits d'intérêts
   license?: string;
   category?: string; // Niveau d'arbitrage (Régional, National, International)
@@ -327,7 +327,7 @@ export interface PoolPhaseConfig {
   seeding: 'serpentine' | 'sequential' | 'random'; // Méthode de répartition
   separation: {
     byClub: boolean; // Séparer par club
-    byLeague: boolean; // Séparer par ligue
+    byRegion: boolean; // Séparer par région
     byNation: boolean; // Séparer par nation
   };
 }

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -48,7 +48,7 @@ export interface FencerCreateData {
   birthDate?: Date;
   gender: string;
   nationality: string;
-  league?: string;
+  region?: string;
   club?: string;
   license?: string;
   ranking?: number;
@@ -62,7 +62,7 @@ export interface FencerUpdateData {
   birthDate?: Date;
   gender?: string;
   nationality?: string;
-  league?: string;
+  region?: string;
   club?: string;
   license?: string;
   ranking?: number;

--- a/src/shared/utils/fencerExport.ts
+++ b/src/shared/utils/fencerExport.ts
@@ -59,7 +59,7 @@ export function exportFencersToFFF(fencers: Fencer[]): string {
     // Section 2: Licence,Ligue,Club,Classement,Nationalité?,?
     const section2 = [
       fencer.license || '',
-      fencer.league || '',
+      fencer.region || '',
       fencer.club || '',
       fencer.ranking != null ? String(fencer.ranking) : '',
       '', // Nationalité (doublon)

--- a/src/shared/utils/fileParser.ts
+++ b/src/shared/utils/fileParser.ts
@@ -752,7 +752,7 @@ function parseFFELine(
 
   // Nettoyer les autres champs en fonction du format
   let nationality: string;
-  let league: string | undefined;
+  let region: string | undefined;
   let club: string | undefined;
   let license: string | undefined;
   let ranking: number | undefined;
@@ -766,7 +766,7 @@ function parseFFELine(
       // Champs inconnus (indices 5, 6, 7) - ignorés pour l'instant
       // Section club (indices 8-13): Licence,Ligue,Club,Classement,Nationalité?,?
       license = (parts[8] || '').trim() || undefined;
-      league = (parts[9] || '').trim() || undefined;
+      region = (parts[9] || '').trim() || undefined;
       club = (parts[10] || '').trim() || undefined;
 
       // La position finale est dans la section positionInfo (indice 14)
@@ -795,7 +795,7 @@ function parseFFELine(
       nationality = (parts[4] || '').trim() || 'FRA';
 
       license = (parts[8] || '').trim() || undefined;
-      league = (parts[9] || '').trim() || undefined;
+      region = (parts[9] || '').trim() || undefined;
       club = (parts[10] || '').trim() || undefined;
 
       // Chercher le classement à l'index 10 (4ème position dans section 2: Licence,Ligue,Club,Classement,?,?)
@@ -812,7 +812,7 @@ function parseFFELine(
 
       // Essayer d'extraire les infos club des champs disponibles
       license = (parts[7] || '').trim() || undefined;
-      league = (parts[8] || '').trim() || undefined;
+      region = (parts[8] || '').trim() || undefined;
       club = (parts[9] || '').trim() || undefined;
 
       // Chercher le classement dans les derniers champs (avant le ? final)
@@ -833,7 +833,7 @@ function parseFFELine(
   } else {
     // Format standard: NOM, PRENOM, SEXE, DATE, NATION, LIGUE, CLUB, LICENCE
     nationality = (parts[4] || '').trim() || 'FRA';
-    league = (parts[5] || '').trim() || undefined;
+    region = (parts[5] || '').trim() || undefined;
     club = (parts[6] || '').trim() || undefined;
     license = (parts[7] || '').trim() || undefined;
   }
@@ -859,7 +859,7 @@ function parseFFELine(
     gender,
     birthDate,
     nationality,
-    league,
+    region,
     club,
     license,
     ranking,
@@ -904,7 +904,7 @@ export function parseXMLFile(content: string): ImportResult {
           firstName,
           gender,
           nationality: getName('Nation') || 'FRA',
-          league: getName('Ligue') || undefined,
+          region: getName('Ligue') || undefined,
           club: getName('Club') || undefined,
           license: getName('Licence') || undefined,
           ranking: parseInt(getName('Classement')) || undefined,

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -374,7 +374,7 @@ type CriterionKey = (f: Fencer) => string;
 
 /**
  * Distribue les tireurs dans les poules selon la méthode serpentine
- * en respectant les critères de séparation (club, ligue, nation)
+ * en respectant les critères de séparation (club, région, nation)
  *
  * Algorithme:
  * 1. Distribution serpentine pure: 1→2→3→...→8→8→7→6→...→1→1→2→...
@@ -386,7 +386,7 @@ export function distributeFencersToPoolsSerpentine(
   poolCount: number,
   separation: {
     byClub: boolean;
-    byLeague: boolean;
+    byRegion: boolean;
     byNation: boolean;
   }
 ): Fencer[][] {
@@ -427,21 +427,21 @@ export function distributeFencersToPoolsSerpentine(
     }
   }
 
-  // Résoudre les conflits par ordre de priorité : Club > Ligue > Nation
+  // Résoudre les conflits par ordre de priorité : Club > Région > Nation
   const clubKey: CriterionKey = f => f.club ?? '';
-  const leagueKey: CriterionKey = f => f.league ?? '';
+  const regionKey: CriterionKey = f => f.region ?? '';
   const nationKey: CriterionKey = f => f.nationality ?? '';
 
   if (separation.byClub) {
     resolveConflictsForCriterion(pools, clubKey, []);
   }
-  if (separation.byLeague) {
-    resolveConflictsForCriterion(pools, leagueKey, separation.byClub ? [clubKey] : []);
+  if (separation.byRegion) {
+    resolveConflictsForCriterion(pools, regionKey, separation.byClub ? [clubKey] : []);
   }
   if (separation.byNation) {
     resolveConflictsForCriterion(pools, nationKey, [
       ...(separation.byClub ? [clubKey] : []),
-      ...(separation.byLeague ? [leagueKey] : []),
+      ...(separation.byRegion ? [regionKey] : []),
     ]);
   }
 
@@ -452,7 +452,7 @@ export function distributeFencersToPoolsSerpentine(
 }
 
 /**
- * Résout les conflits pour un critère donné (club, ligue, nation) en échangeant des tireurs
+ * Résout les conflits pour un critère donné (club, région, nation) en échangeant des tireurs
  * entre poules tout en préservant au mieux l'équilibre de la serpentine.
  * Les critères de priorité supérieure (protectedCriteria) ne sont jamais aggravés.
  */
@@ -618,7 +618,7 @@ function canSwapResolveConflict(
  */
 function rebalancePools(
   pools: Fencer[][],
-  separation: { byClub: boolean; byLeague: boolean; byNation: boolean }
+  separation: { byClub: boolean; byRegion: boolean; byNation: boolean }
 ): void {
   const poolCount = pools.length;
   if (poolCount === 0) return;
@@ -662,14 +662,14 @@ function rebalancePools(
 
           // Vérifier que le déplacement ne crée pas de conflit sur les critères actifs
           const clubVal = fencer.club ?? '';
-          const leagueVal = fencer.league ?? '';
+          const regionVal = fencer.region ?? '';
           const wouldCreateConflict =
             (separation.byClub &&
               clubVal !== '' &&
               target.pool.some(f => (f.club ?? '') === clubVal)) ||
-            (separation.byLeague &&
-              leagueVal !== '' &&
-              target.pool.some(f => (f.league ?? '') === leagueVal)) ||
+            (separation.byRegion &&
+              regionVal !== '' &&
+              target.pool.some(f => (f.region ?? '') === regionVal)) ||
             (separation.byNation && target.pool.some(f => f.nationality === fencer.nationality));
 
           if (!wouldCreateConflict) {

--- a/src/shared/utils/tournamentTemplates.ts
+++ b/src/shared/utils/tournamentTemplates.ts
@@ -58,7 +58,7 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       seeding: 'serpentine',
       separation: {
         byClub: true,
-        byLeague: true,
+        byRegion: true,
         byNation: false,
       },
     },
@@ -90,7 +90,7 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       seeding: 'serpentine',
       separation: {
         byClub: true,
-        byLeague: true,
+        byRegion: true,
         byNation: false,
       },
     },
@@ -122,7 +122,7 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       seeding: 'serpentine',
       separation: {
         byClub: true,
-        byLeague: true,
+        byRegion: true,
         byNation: false,
       },
     },
@@ -154,7 +154,7 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       seeding: 'serpentine',
       separation: {
         byClub: false,
-        byLeague: false,
+        byRegion: false,
         byNation: false,
       },
     },
@@ -186,7 +186,7 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       seeding: 'serpentine',
       separation: {
         byClub: true,
-        byLeague: false,
+        byRegion: false,
         byNation: false,
       },
     },


### PR DESCRIPTION
## Summary
This PR renames all references to "league" (ligue) to "region" (région) throughout the codebase to better reflect the actual organizational structure used in fencing competitions. This is a comprehensive refactoring that updates database schema, type definitions, UI components, and business logic.

## Key Changes

- **Database Schema**: Renamed `league` column to `region` in the `fencers` table with an idempotent migration
- **Type Definitions**: Updated `Fencer` and `Referee` interfaces to use `region` property instead of `league`
- **Pool Configuration**: Changed `PoolPhaseConfig.separation.byLeague` to `byRegion` throughout the codebase
- **Pool Distribution Algorithm**: Updated `distributeFencersToPoolsSerpentine()` function and related conflict resolution logic to use region-based separation
- **UI Components**: 
  - Updated `AddFencerModal` and `EditFencerModal` to display "Région" label instead of "Ligue"
  - Updated `PoolPrepView` separation configuration UI
- **File Parsing**: Updated FFE file parser and XML parser to map league data to region field
- **File Export**: Updated fencer export function to use region field
- **Tournament Templates**: Updated all official tournament templates to use `byRegion` in separation config
- **Localization**: Updated French locale to display "Région" for the league field
- **Validation**: Updated validation rules to check `region` field instead of `league`
- **Hooks & Utilities**: Updated all references in `usePoolManagement`, `CompetitionView`, and other utility files

## Implementation Details

- The database migration is idempotent, catching errors if the column has already been renamed
- All separation logic in pool distribution maintains the same priority order: Club > Region > Nation
- The change is backward compatible at the data level - existing "league" data is preserved during migration
- UI labels and documentation strings have been updated to use "Région" terminology consistently

https://claude.ai/code/session_01UmAL8Nhcx1XDdHApWoM94M