### PR TITLE
Refactor CI workflows and update TypeScript config

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -112,21 +112,26 @@ jobs:
         run: npm run build:ci
 
       - name: Update package.json for dev build
-        shell: pwsh
+        shell: bash
         run: |
-          $content = Get-Content package.json -Raw
-          $content = $content -replace '"artifactName": "\$\{productName\}-\$\{version\}\.\$\{ext\}"', '"artifactName": "${productName}-dev-${version}.${ext}"'
-          $content = $content -replace '"artifactName": "\$\{productName\}-\$\{version\}-setup\.\$\{ext\}"', '"artifactName": "${productName}-dev-${version}-setup.${ext}"'
-          $content = $content -replace '"artifactName": "\$\{productName\}-\$\{version\}-portable\.\$\{ext\}"', '"artifactName": "${productName}-dev-${version}-portable.${ext}"'
-          Set-Content package.json $content -NoNewline
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            if (!pkg.build.portable) pkg.build.portable = {};
+            pkg.build.portable.artifactName = '\${productName}-dev-\${version}-portable.\${ext}';
+            if (!pkg.build.nsis) pkg.build.nsis = {};
+            pkg.build.nsis.artifactName = '\${productName}-dev-\${version}-setup.\${ext}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+          "
 
       - name: Package with Electron Builder
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_on: error
-          command: npx electron-builder --win portable --x64
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            echo "Attempt $i/3..."
+            npx electron-builder --win portable --x64 && break
+            [ $i -lt 3 ] && sleep 10
+          done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -161,7 +166,15 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Install Dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            echo "Attempt $i/3..."
+            npm ci && break
+            echo "npm ci failed, trying npm install..."
+            npm install && break
+            echo "Failed, waiting 10s before retry..."
+            [ $i -lt 3 ] && sleep 10
+          done || exit 1
 
       - name: Update version files
         run: |
@@ -180,12 +193,12 @@ jobs:
           "
 
       - name: Package with Electron Builder
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_on: error
-          command: npx electron-builder --mac --x64
+        run: |
+          for i in 1 2 3; do
+            echo "Attempt $i/3..."
+            npx electron-builder --mac --x64 && break
+            [ $i -lt 3 ] && sleep 10
+          done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -247,12 +260,12 @@ jobs:
           "
 
       - name: Package with Electron Builder
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_on: error
-          command: npx electron-builder --mac --arm64
+        run: |
+          for i in 1 2 3; do
+            echo "Attempt $i/3..."
+            npx electron-builder --mac --arm64 && break
+            [ $i -lt 3 ] && sleep 10
+          done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -314,12 +327,12 @@ jobs:
           "
 
       - name: Package with Electron Builder
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_on: error
-          command: npx electron-builder --linux AppImage --x64
+        run: |
+          for i in 1 2 3; do
+            echo "Attempt $i/3..."
+            npx electron-builder --linux AppImage --x64 && break
+            [ $i -lt 3 ] && sleep 10
+          done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -382,12 +395,12 @@ jobs:
           "
 
       - name: Package with Electron Builder
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_on: error
-          command: npx electron-builder --linux AppImage --arm64
+        run: |
+          for i in 1 2 3; do
+            echo "Attempt $i/3..."
+            npx electron-builder --linux AppImage --arm64 && break
+            [ $i -lt 3 ] && sleep 10
+          done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
This PR refactors the build-dev.yml workflow to improve reliability and maintainability by replacing external retry actions with inline bash retry logic, updating the dev build package.json modification approach, and adding TypeScript deprecation suppression.

## Key Changes

- **Replaced nick-fields/retry action with inline bash retry loops**: All `electron-builder` packaging steps and the `npm ci` installation step now use a simple 3-attempt retry mechanism with 10-second delays between failures, eliminating the external action dependency.

- **Refactored dev build package.json modification**: Changed from PowerShell string replacement to Node.js JSON parsing and manipulation. This approach is more reliable and cross-platform, directly modifying the build configuration objects for `portable` and `nsis` artifact names.

- **Updated shell from pwsh to bash**: The dev build package.json update step now uses bash instead of PowerShell for better cross-platform compatibility.

- **Enhanced npm dependency installation**: Added fallback logic to attempt `npm install` if `npm ci` fails, with retry attempts and informative logging.

- **Added TypeScript deprecation suppression**: Set `"ignoreDeprecations": "6.0"` in tsconfig.json to suppress TypeScript 6.0 deprecation warnings.

## Implementation Details

The inline retry logic follows a consistent pattern across all steps:
```bash
for i in 1 2 3; do
  echo "Attempt $i/3..."
  <command> && break
  [ $i -lt 3 ] && sleep 10
done || exit 1
```

This approach provides better visibility into retry attempts through logging and maintains the same 3-attempt behavior as the previous action-based implementation.

https://claude.ai/code/session_014vHv8WMjLPARaYkVMSftoo