### PR TITLE
Système d'annulation d'abandon avec restauration des scores historiques

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -232,6 +232,19 @@ export class DatabaseManager {
       )
     `);
 
+    // Table pour les snapshots d'abandon (annulation d'abandon)
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS fencer_abandons (
+        id TEXT PRIMARY KEY,
+        fencer_id TEXT NOT NULL,
+        competition_id TEXT NOT NULL,
+        previous_status TEXT NOT NULL,
+        abandon_type TEXT NOT NULL,
+        match_snapshots TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      )
+    `);
+
     // Colonnes de timing sur les matchs (migration idempotente)
     try {
       this.db.run(`ALTER TABLE matches ADD COLUMN start_time TEXT`);
@@ -1600,6 +1613,72 @@ export class DatabaseManager {
     });
 
     return { matches };
+  }
+
+  // ─── Abandon snapshots ──────────────────────────────────────────────────────
+
+  public saveAbandonSnapshot(
+    fencerId: string,
+    competitionId: string,
+    previousStatus: string,
+    abandonType: string,
+    matchSnapshots: { matchId: string; status: string; scoreA: unknown; scoreB: unknown }[]
+  ): void {
+    if (!this.db) throw new Error('Database not open');
+    const now = new Date().toISOString();
+    // Supprime un éventuel snapshot existant pour ce tireur
+    this.db.run('DELETE FROM fencer_abandons WHERE fencer_id = ?', [fencerId]);
+    this.db.run(
+      `INSERT INTO fencer_abandons (id, fencer_id, competition_id, previous_status, abandon_type, match_snapshots, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        `abandon-${fencerId}-${Date.now()}`,
+        fencerId,
+        competitionId,
+        previousStatus,
+        abandonType,
+        JSON.stringify(matchSnapshots),
+        now,
+      ]
+    );
+    this.save();
+  }
+
+  public getAbandonSnapshot(fencerId: string): {
+    id: string;
+    fencerId: string;
+    competitionId: string;
+    previousStatus: string;
+    abandonType: string;
+    matchSnapshots: { matchId: string; status: string; scoreA: unknown; scoreB: unknown }[];
+    createdAt: string;
+  } | null {
+    if (!this.db) return null;
+    const stmt = this.db.prepare(
+      'SELECT * FROM fencer_abandons WHERE fencer_id = ? ORDER BY created_at DESC LIMIT 1'
+    );
+    stmt.bind([fencerId]);
+    if (!stmt.step()) {
+      stmt.free();
+      return null;
+    }
+    const row = stmt.getAsObject();
+    stmt.free();
+    return {
+      id: row.id as string,
+      fencerId: row.fencer_id as string,
+      competitionId: row.competition_id as string,
+      previousStatus: row.previous_status as string,
+      abandonType: row.abandon_type as string,
+      matchSnapshots: JSON.parse(row.match_snapshots as string),
+      createdAt: row.created_at as string,
+    };
+  }
+
+  public deleteAbandonSnapshot(fencerId: string): void {
+    if (!this.db) return;
+    this.db.run('DELETE FROM fencer_abandons WHERE fencer_id = ?', [fencerId]);
+    this.save();
   }
 
   // Export/Import

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -778,6 +778,22 @@ ipcMain.handle('db:getFencerHistory', async (_, fencerId) => {
   return db.getFencerHistory(fencerId);
 });
 
+// Abandon snapshot handlers
+ipcMain.handle(
+  'db:saveAbandonSnapshot',
+  async (_, fencerId, competitionId, previousStatus, abandonType, snapshots) => {
+    db.saveAbandonSnapshot(fencerId, competitionId, previousStatus, abandonType, snapshots);
+  }
+);
+
+ipcMain.handle('db:getAbandonSnapshot', async (_, fencerId) => {
+  return db.getAbandonSnapshot(fencerId);
+});
+
+ipcMain.handle('db:deleteAbandonSnapshot', async (_, fencerId) => {
+  db.deleteAbandonSnapshot(fencerId);
+});
+
 // File handlers
 ipcMain.handle('file:export', async (_, filepath) => {
   db.exportToFile(filepath);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -23,6 +23,7 @@ import type {
   MatchTouchData,
   MatchCardData,
   MatchTimingData,
+  MatchSnapshot,
 } from '../shared/types/preload';
 
 // Input validation functions
@@ -219,6 +220,25 @@ contextBridge.exposeInMainWorld('electronAPI', {
       }
       return ipcRenderer.invoke('db:getFencerHistory', fencerId);
     },
+    saveAbandonSnapshot: (
+      fencerId: string,
+      competitionId: string,
+      previousStatus: string,
+      abandonType: string,
+      snapshots: MatchSnapshot[]
+    ) =>
+      ipcRenderer.invoke(
+        'db:saveAbandonSnapshot',
+        fencerId,
+        competitionId,
+        previousStatus,
+        abandonType,
+        snapshots
+      ),
+    getAbandonSnapshot: (fencerId: string) =>
+      ipcRenderer.invoke('db:getAbandonSnapshot', fencerId),
+    deleteAbandonSnapshot: (fencerId: string) =>
+      ipcRenderer.invoke('db:deleteAbandonSnapshot', fencerId),
   },
 
   // File operations with validation

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -115,8 +115,9 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     computeOverallRanking,
     areAllPoolsComplete,
     handleFencerForfeit,
+    handleUndoAbandon,
     syncFencersToPool,
-  } = usePoolManagement({ isLaserSabre, poolMaxScore, showToast });
+  } = usePoolManagement({ isLaserSabre, poolMaxScore, showToast, competitionId: competition?.id });
 
   const { exportFencersList, exportRanking, exportResults, exportPoolsPDF } = useExport({
     competition,
@@ -744,6 +745,17 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                 handleFencerForfeit(id, 'abandon');
               } else if (status === FencerStatus.EXCLUDED) {
                 handleFencerForfeit(id, 'exclusion');
+              } else if (status === FencerStatus.CHECKED_IN) {
+                // Si réactivation depuis un statut spécial pendant la phase de poules,
+                // restaurer les matchs affectés via le système d'annulation d'abandon
+                const currentFencer = fencers.find(f => f.id === id);
+                const wasInSpecialStatus =
+                  currentFencer?.status === FencerStatus.ABANDONED ||
+                  currentFencer?.status === FencerStatus.FORFAIT ||
+                  currentFencer?.status === FencerStatus.EXCLUDED;
+                if (wasInSpecialStatus && currentPhase === 'pools') {
+                  handleUndoAbandon(id);
+                }
               }
               updateFencer(id, { status });
             }}

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -13,9 +13,11 @@ import {
   FencerStatus,
   Weapon,
   PoolRanking,
+  Score,
 } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { useToast } from '../components/Toast';
+import type { AbandonSnapshot } from '../../shared/types/preload';
 import {
   distributeFencersToPoolsSerpentine,
   calculateOptimalPoolCount,
@@ -30,12 +32,14 @@ interface UsePoolManagementProps {
   isLaserSabre: boolean;
   poolMaxScore: number;
   showToast: ReturnType<typeof useToast>['showToast'];
+  competitionId?: string;
 }
 
 export const usePoolManagement = ({
   isLaserSabre,
   poolMaxScore,
   showToast,
+  competitionId,
 }: UsePoolManagementProps) => {
   const [pools, setPools] = useState<Pool[]>([]);
   const [poolHistory, setPoolHistory] = useState<Pool[][]>([]);
@@ -260,7 +264,37 @@ export const usePoolManagement = ({
   // Gérer le forfait/abandon/exclusion d'un tireur sur tous ses matchs non encore disputés
   // Met à jour le statut du tireur et grise ses matchs restants dans la grille
   const handleFencerForfeit = useCallback(
-    (fencerId: string, status: 'abandon' | 'forfait' | 'exclusion') => {
+    async (fencerId: string, status: 'abandon' | 'forfait' | 'exclusion') => {
+      // --- Snapshot AVANT modification (pour pouvoir annuler) ---
+      const previousStatus =
+        pools.flatMap(p => p.fencers).find(f => f.id === fencerId)?.status ??
+        FencerStatus.CHECKED_IN;
+
+      const affectedSnapshots = pools.flatMap(pool =>
+        pool.matches
+          .filter(m => {
+            const involved = m.fencerA?.id === fencerId || m.fencerB?.id === fencerId;
+            const alreadyPlayed =
+              m.status === MatchStatus.FINISHED && !m.scoreA?.isForfait && !m.scoreB?.isForfait;
+            return involved && !alreadyPlayed;
+          })
+          .map(m => ({
+            matchId: m.id,
+            status: m.status as string,
+            scoreA: m.scoreA ? { ...m.scoreA } : null,
+            scoreB: m.scoreB ? { ...m.scoreB } : null,
+          }))
+      );
+
+      if (competitionId && window.electronAPI?.db?.saveAbandonSnapshot) {
+        await window.electronAPI.db
+          .saveAbandonSnapshot(fencerId, competitionId, previousStatus, status, affectedSnapshots)
+          .catch((e: Error) =>
+            logger.warn(LogCategory.DB, 'Snapshot abandon échoué', e)
+          );
+      }
+
+      // --- Logique existante ---
       const newFencerStatus =
         status === 'abandon'
           ? FencerStatus.ABANDONED
@@ -340,7 +374,98 @@ export const usePoolManagement = ({
         return updatedPools;
       });
     },
-    [computePoolRanking, computeOverallRanking, showToast]
+    [competitionId, pools, computePoolRanking, computeOverallRanking, showToast]
+  );
+
+  // Annuler un abandon/forfait/exclusion et restaurer les matchs affectés
+  const handleUndoAbandon = useCallback(
+    async (fencerId: string) => {
+      let snapshot: AbandonSnapshot | null = null;
+
+      if (competitionId && window.electronAPI?.db?.getAbandonSnapshot) {
+        snapshot = await window.electronAPI.db
+          .getAbandonSnapshot(fencerId)
+          .catch(() => null);
+      }
+
+      setPools(prevPools => {
+        const updatedPools = [...prevPools];
+        let restoredCount = 0;
+
+        updatedPools.forEach(pool => {
+          // Restaurer le statut du tireur dans la poule
+          const poolFencer = pool.fencers.find(f => f.id === fencerId);
+          if (poolFencer) {
+            poolFencer.status = snapshot
+              ? (snapshot.previousStatus as FencerStatus)
+              : FencerStatus.CHECKED_IN;
+          }
+
+          pool.matches.forEach(match => {
+            const isFencerA = match.fencerA?.id === fencerId;
+            const isFencerB = match.fencerB?.id === fencerId;
+            if (!isFencerA && !isFencerB) return;
+
+            if (snapshot) {
+              // Restauration depuis le snapshot
+              const saved = snapshot.matchSnapshots.find(s => s.matchId === match.id);
+              if (saved) {
+                match.status = saved.status as MatchStatus;
+                match.scoreA = saved.scoreA as Score | null;
+                match.scoreB = saved.scoreB as Score | null;
+                if (isFencerA && match.fencerA) {
+                  match.fencerA.status = snapshot.previousStatus as FencerStatus;
+                } else if (isFencerB && match.fencerB) {
+                  match.fencerB.status = snapshot.previousStatus as FencerStatus;
+                }
+                restoredCount++;
+              }
+            } else {
+              // Fallback sans snapshot : réinitialise les matchs marqués abandon/forfait/exclusion
+              // uniquement si l'adversaire n'est pas lui-même en statut spécial
+              const myScore = isFencerA ? match.scoreA : match.scoreB;
+              const oppScore = isFencerA ? match.scoreB : match.scoreA;
+              if (
+                (myScore?.isAbstention || myScore?.isForfait || myScore?.isExclusion) &&
+                !oppScore?.isAbstention &&
+                !oppScore?.isForfait &&
+                !oppScore?.isExclusion
+              ) {
+                match.status = MatchStatus.NOT_STARTED;
+                match.scoreA = null;
+                match.scoreB = null;
+                if (isFencerA && match.fencerA) {
+                  match.fencerA.status = FencerStatus.CHECKED_IN;
+                } else if (isFencerB && match.fencerB) {
+                  match.fencerB.status = FencerStatus.CHECKED_IN;
+                }
+                restoredCount++;
+              }
+            }
+          });
+
+          pool.ranking = computePoolRanking(pool);
+          pool.updatedAt = new Date();
+        });
+
+        const newOverallRanking = computeOverallRanking(updatedPools);
+        setOverallRanking(newOverallRanking);
+
+        if (restoredCount > 0) {
+          showToast(`Abandon annulé — ${restoredCount} match(s) restauré(s)`, 'success');
+        } else {
+          showToast('Statut restauré (aucun match à rétablir)', 'info');
+        }
+
+        return updatedPools;
+      });
+
+      // Supprimer le snapshot après restauration
+      if (snapshot && window.electronAPI?.db?.deleteAbandonSnapshot) {
+        await window.electronAPI.db.deleteAbandonSnapshot(fencerId).catch(() => {});
+      }
+    },
+    [competitionId, computePoolRanking, computeOverallRanking, showToast]
   );
 
   // Mettre à jour un match depuis une source externe (serveur distant)
@@ -449,6 +574,7 @@ export const usePoolManagement = ({
     computePoolRanking,
     computeOverallRanking,
     handleFencerForfeit,
+    handleUndoAbandon,
     syncFencersToPool,
   };
 };

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -176,6 +176,35 @@ export interface FencerHistory {
   matches: FencerMatchRecord[];
 }
 
+export interface MatchSnapshot {
+  matchId: string;
+  status: string;
+  scoreA: {
+    value: number | null;
+    isVictory: boolean;
+    isAbstention: boolean;
+    isExclusion: boolean;
+    isForfait: boolean;
+  } | null;
+  scoreB: {
+    value: number | null;
+    isVictory: boolean;
+    isAbstention: boolean;
+    isExclusion: boolean;
+    isForfait: boolean;
+  } | null;
+}
+
+export interface AbandonSnapshot {
+  id: string;
+  fencerId: string;
+  competitionId: string;
+  previousStatus: string;
+  abandonType: 'abandon' | 'forfait' | 'exclusion';
+  matchSnapshots: MatchSnapshot[];
+  createdAt: string;
+}
+
 export interface SessionState {
   currentPhase?: number;
   selectedPool?: string;
@@ -362,6 +391,15 @@ export interface DatabaseAPI {
   saveCard: (card: MatchCardData) => Promise<void>;
   updateMatchTiming: (timing: MatchTimingData) => Promise<void>;
   getFencerHistory: (fencerId: string) => Promise<FencerHistory>;
+  saveAbandonSnapshot: (
+    fencerId: string,
+    competitionId: string,
+    previousStatus: string,
+    abandonType: string,
+    matchSnapshots: MatchSnapshot[]
+  ) => Promise<void>;
+  getAbandonSnapshot: (fencerId: string) => Promise<AbandonSnapshot | null>;
+  deleteAbandonSnapshot: (fencerId: string) => Promise<void>;
 }
 
 export interface FileAPI {


### PR DESCRIPTION
- Table fencer_abandons : snapshot persistant des états de matchs avant abandon
- Méthodes DB : saveAbandonSnapshot / getAbandonSnapshot / deleteAbandonSnapshot
- IPC handlers correspondants + exposition via contextBridge
- handleFencerForfeit devient async : capture le snapshot avant modification
- handleUndoAbandon : restaure matchs + statut depuis snapshot (ou fallback sans snapshot)
- CompetitionView : route le bouton ✅ vers handleUndoAbandon pour les poules

https://claude.ai/code/session_01VYq4iazbpLtm9Bi19mbWP7