### PR TITLE
fix: annuler les matchs déjà disputés contre un tireur forfait

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.2-build.509",
+  "version": "1.0.2-build.524",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.2-build.509",
+      "version": "1.0.2-build.524",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -272,12 +272,7 @@ export const usePoolManagement = ({
 
       const affectedSnapshots = pools.flatMap(pool =>
         pool.matches
-          .filter(m => {
-            const involved = m.fencerA?.id === fencerId || m.fencerB?.id === fencerId;
-            const alreadyPlayed =
-              m.status === MatchStatus.FINISHED && !m.scoreA?.isForfait && !m.scoreB?.isForfait;
-            return involved && !alreadyPlayed;
-          })
+          .filter(m => m.fencerA?.id === fencerId || m.fencerB?.id === fencerId)
           .map(m => ({
             matchId: m.id,
             status: m.status as string,
@@ -320,38 +315,44 @@ export const usePoolManagement = ({
 
             if (!isFencerA && !isFencerB) return;
 
-            // Ne pas écraser les matchs déjà disputés avec de vrais scores
+            // Ne pas écraser les matchs déjà disputés avec de vrais scores,
+            // mais propager quand même le statut forfait dans la référence fencer
+            // pour que calculateFencerPoolStats annule ces matchs pour les adversaires.
             const isAlreadyPlayed =
               match.status === MatchStatus.FINISHED &&
               !match.scoreA?.isForfait &&
               !match.scoreB?.isForfait;
-            if (isAlreadyPlayed) return;
 
-            // Mettre à jour le statut du tireur dans les références du match
             if (isFencerA && match.fencerA) {
               match.fencerA.status = newFencerStatus;
-              match.scoreA = {
-                value: 0,
-                isVictory: false,
-                isAbstention: status === 'abandon',
-                isExclusion: status === 'exclusion',
-                isForfait: status === 'forfait',
-              };
+              if (!isAlreadyPlayed) {
+                match.scoreA = {
+                  value: 0,
+                  isVictory: false,
+                  isAbstention: status === 'abandon',
+                  isExclusion: status === 'exclusion',
+                  isForfait: status === 'forfait',
+                };
+              }
             } else if (isFencerB && match.fencerB) {
               match.fencerB.status = newFencerStatus;
-              match.scoreB = {
-                value: 0,
-                isVictory: false,
-                isAbstention: status === 'abandon',
-                isExclusion: status === 'exclusion',
-                isForfait: status === 'forfait',
-              };
+              if (!isAlreadyPlayed) {
+                match.scoreB = {
+                  value: 0,
+                  isVictory: false,
+                  isAbstention: status === 'abandon',
+                  isExclusion: status === 'exclusion',
+                  isForfait: status === 'forfait',
+                };
+              }
             }
 
-            // Marquer le match comme terminé (non disputé)
-            match.status = MatchStatus.FINISHED;
-            match.updatedAt = new Date();
-            modifiedCount++;
+            if (!isAlreadyPlayed) {
+              // Marquer le match comme terminé (non disputé)
+              match.status = MatchStatus.FINISHED;
+              match.updatedAt = new Date();
+              modifiedCount++;
+            }
           });
 
           // Recalculer le classement de la poule

--- a/src/shared/utils/poolCalculations.test.ts
+++ b/src/shared/utils/poolCalculations.test.ts
@@ -182,6 +182,30 @@ describe('calculateFencerPoolStats', () => {
     expect(stats.matchesPlayed).toBe(0);
     expect(stats.victoryRatio).toBe(0);
   });
+
+  it("devrait annuler les matchs déjà disputés contre un tireur déclaré forfait", () => {
+    // Règle : si un adversaire est FORFAIT, les points acquis lors de TOUS
+    // ses matchs (même déjà joués) sont annulés pour les deux parties.
+    const forfaitFencer = createMockFencer('ff', 99, 'Forfait');
+    forfaitFencer.status = FencerStatus.FORFAIT;
+
+    // Match already played before forfeit was declared — statut FORFAIT
+    // maintenant propagé dans la référence fencer du match (comme handleFencerForfeit le fait)
+    const matchVsFF: Match = {
+      ...createMockMatch('m_ff', fencer1, forfaitFencer, 5, 2),
+      fencerB: forfaitFencer, // statut FORFAIT dans la référence
+    };
+
+    const otherMatch = createMockMatch('m2', fencer1, fencer2, 5, 3);
+
+    const stats = calculateFencerPoolStats(fencer1, [matchVsFF, otherMatch]);
+
+    // Seul le match contre fencer2 doit compter
+    expect(stats.matchesPlayed).toBe(1);
+    expect(stats.victories).toBe(1);
+    expect(stats.touchesScored).toBe(5);
+    expect(stats.touchesReceived).toBe(3);
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
Règle : si un tireur déclare forfait, les points acquis par lui-même
ET par ses adversaires lors de TOUS ses matchs (y compris déjà disputés)
sont annulés dans la poule.

Avant le correctif, handleFencerForfeit() sautait entièrement les matchs
déjà joués (isAlreadyPlayed), ce qui empêchait la propagation du statut
FORFAIT dans les références fencer des matchs. En conséquence,
calculateFencerPoolStats() ne détectait pas le statut FORFAIT pour ces
matchs et continuait à comptabiliser les touches des adversaires.

Corrections :
- Snapshot : inclure tous les matchs du tireur (y compris déjà disputés)
  pour garantir un undo complet
- Boucle matches : propager match.fencerX.status = FORFAIT même pour les
  matchs déjà disputés, sans toucher les scores ni le statut du match
- Test unitaire ajouté pour valider l'annulation des matchs déjà joués

https://claude.ai/code/session_01SvUK68CQTzLfgJR7mC2amf