### PR TITLE
fix: saisie distante Windows – Socket.IO local + détection IP LAN

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2100,15 +2100,38 @@ export class RemoteScoreServer {
 
   public getLocalIPAddress(): string {
     const interfaces = os.networkInterfaces();
-    for (const name of Object.keys(interfaces)) {
-      for (const iface of interfaces[name] || []) {
-        // Ignorer les adresses internes (loopback) et IPv6
+    // Adaptateurs virtuels courants sur Windows (Hyper-V, WSL, VirtualBox, VMware…)
+    const VIRTUAL_KEYWORDS = [
+      'virtual',
+      'hyper-v',
+      'vmware',
+      'virtualbox',
+      'vethernet',
+      'loopback adapter',
+      'pseudo',
+      'teredo',
+      'isatap',
+    ];
+    const candidates: string[] = [];
+
+    for (const [name, addrs] of Object.entries(interfaces)) {
+      const nameLower = name.toLowerCase();
+      if (VIRTUAL_KEYWORDS.some(kw => nameLower.includes(kw))) continue;
+      for (const iface of addrs || []) {
         if (iface.family === 'IPv4' && !iface.internal) {
-          return iface.address;
+          candidates.push(iface.address);
         }
       }
     }
-    return 'localhost';
+
+    // Préférer une adresse LAN classique (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
+    const preferred = candidates.find(
+      ip =>
+        ip.startsWith('192.168.') ||
+        ip.startsWith('10.') ||
+        /^172\.(1[6-9]|2\d|3[01])\./.test(ip)
+    );
+    return preferred ?? candidates[0] ?? 'localhost';
   }
 
   public getServerUrl(): string {

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Arène BellePoule</title>
-    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
     <style>
 
     * {

--- a/src/remote/dashboard.html
+++ b/src/remote/dashboard.html
@@ -10,7 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"
     />
-    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
     <style>
       * {
         margin: 0;

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Saisie Poule – BellePoule</title>
-    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
     <style>
       * {
         margin: 0;

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vue Publique – BellePoule</title>
-    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
     <style>
 @font-face {
       font-family: 'ArmadaBold';

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <title>Arbitrage - Arène BellePoule</title>
-    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
     <style>
 
       * {


### PR DESCRIPTION
- Remplace le CDN socket.io (cdn.socket.io) par /socket.io/socket.io.js
  servi en local par le serveur Express/Socket.IO dans les 5 pages remote
  (referee, arena, pool, public, dashboard). La tablette arbitre n'a pas
  besoin d'accès internet pour charger la bibliothèque.

- Améliore getLocalIPAddress() pour ignorer les adaptateurs virtuels
  Windows (Hyper-V vEthernet, WSL, VirtualBox, VMware, etc.) et préférer
  une adresse LAN classique (192.168.x.x / 10.x.x.x / 172.16-31.x.x).

Fixes: connexion rouge/clignotante + arène sans matches sur Windows.

https://claude.ai/code/session_01A5bYkXBzE7reRQzZuFxbBX