### PR TITLE
fix: sync poolFencersCache after fencer swap between pools

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1049,6 +1049,19 @@ ipcMain.handle(
   }
 );
 
+ipcMain.handle(
+  'remote:updatePoolFencers',
+  async (_, updates: Array<{ poolId: string; fencers: any[] }>) => {
+    try {
+      if (!remoteScoreServer) return { success: false, error: 'Serveur non démarré' };
+      remoteScoreServer.updatePoolFencers(updates);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+    }
+  }
+);
+
 ipcMain.handle('remote:stopSession', async () => {
   try {
     if (!remoteScoreServer) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -374,6 +374,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     updateShowPhotos: (value: boolean) => ipcRenderer.invoke('remote:updateShowPhotos', value),
     updateMatchArena: (matchId: string, fromArena: number | null, toArena: number | null) =>
       ipcRenderer.invoke('remote:updateMatchArena', matchId, fromArena, toArena),
+    updatePoolFencers: (updates: Array<{ poolId: string; fencers: any[] }>) =>
+      ipcRenderer.invoke('remote:updatePoolFencers', updates),
     setArenaPassword: (arenaId: string, password: string) =>
       ipcRenderer.invoke('remote:setArenaPassword', arenaId, password),
   },

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2513,6 +2513,36 @@ export class RemoteScoreServer {
     }
   }
 
+  public updatePoolFencers(updates: Array<{ poolId: string; fencers: any[] }>): void {
+    for (const { poolId, fencers } of updates) {
+      if (fencers && fencers.length > 0) {
+        this.poolFencersCache.set(poolId, fencers);
+      }
+    }
+    // Notifier les tablettes connectées sur une arène affichant une poule modifiée
+    for (const { poolId } of updates) {
+      for (const [aId, arena] of this.arenas) {
+        if (arena.currentMatch?.poolId !== poolId) continue;
+        const updatedFencers = this.poolFencersCache.get(poolId) ?? [];
+        const inMemory = this.sessionMatches
+          .filter(m => (m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`) === poolId)
+          .sort((a: any, b: any) => (a.number || 0) - (b.number || 0));
+        const matches =
+          inMemory.length > 0
+            ? inMemory.map(m => {
+                const u = this.sessionMatchScores.get(m.id);
+                return u ? { ...m, ...u } : m;
+              })
+            : this.db.getMatchesByPool(poolId);
+        const isComplete = matches.every((m: any) => m.status === MatchStatus.FINISHED);
+        this.io
+          .to(`pool:${aId}`)
+          .emit(`pool:${aId}:update`, { poolId, fencers: updatedFencers, matches, isComplete });
+        break;
+      }
+    }
+  }
+
   public getSession(): RemoteSession | null {
     return this.session;
   }

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import QRCode from 'qrcode';
 import { Competition, Pool } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
@@ -79,6 +79,23 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const effectivePending = pendingCount ?? pools.length ?? 1;
   const effectiveCommitted = committedCount ?? pools.length ?? 1;
   const hasPendingChanges = effectivePending !== effectiveCommitted;
+
+  // Synchroniser le cache poolFencersCache du serveur distant quand les poules changent
+  // (interversion de combattants entre poules pendant une session active).
+  const sessionPoolsFingerprintRef = useRef<string>('');
+  useEffect(() => {
+    const fingerprint = pools
+      .map(p => `${p.id}:${(p.fencers ?? []).map((f: any) => f.id).join(',')}`)
+      .join('|');
+    if (!isRemoteActive || !session) {
+      sessionPoolsFingerprintRef.current = fingerprint;
+      return;
+    }
+    if (fingerprint === sessionPoolsFingerprintRef.current) return;
+    sessionPoolsFingerprintRef.current = fingerprint;
+    const updates = pools.map(pool => ({ poolId: pool.id, fencers: pool.fencers ?? [] }));
+    window.electronAPI.remote.updatePoolFencers(updates).catch(() => {});
+  }, [pools, isRemoteActive, session]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -343,6 +343,9 @@ export interface RemoteServerAPI {
     fencerA?: Fencer | null,
     fencerB?: Fencer | null
   ) => Promise<{ success: boolean; error?: string }>;
+  updatePoolFencers: (
+    updates: Array<{ poolId: string; fencers: any[] }>
+  ) => Promise<{ success: boolean; error?: string }>;
   setArenaPassword: (
     arenaId: string,
     password: string


### PR DESCRIPTION
When fighters are swapped between pools while a remote scoring session
is active, the server's poolFencersCache was never updated, causing
referee tablets to display stale names.

- Add RemoteScoreServer.updatePoolFencers() to patch the cache and
  broadcast pool:update to any arena currently showing an affected pool
- Add IPC handler remote:updatePoolFencers (main.ts + preload.ts)
- Extend RemoteServerAPI type (types/preload.ts)
- RemoteScoreManager: useEffect watches pools prop, calls
  updatePoolFencers when fingerprint changes during an active session

https://claude.ai/code/session_01DCW9CYk9VKpiqsQB5AL9NF