### PR TITLE
Add manual quest points editing and ranking change callback

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -350,8 +350,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
   const handleGoToTableau = () => {
     setRankingValidated(true);
-    const ranking = computeOverallRanking(pools);
-    setOverallRanking(ranking);
+    // Ne pas recalculer : overallRanking est déjà à jour
+    // (calculé à l'entrée dans handleGoToRanking, mis à jour par onRankingChange si édité manuellement)
 
     // Si le classement a changé, réinitialiser les matches du tableau
     if (rankingChanged) {
@@ -848,6 +848,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                 setRankingChanged(true);
               }
             }}
+            onRankingChange={ranking => setOverallRanking(ranking)}
           />
         )}
 

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -25,6 +25,7 @@ interface PoolRankingViewProps {
   hasDirectElimination?: boolean;
   onExport?: (format: 'csv' | 'xml' | 'pdf') => void;
   onPoolsChange?: (pools: Pool[], rankingChanged: boolean) => void;
+  onRankingChange?: (ranking: PoolRanking[]) => void;
 }
 
 const PoolRankingView: React.FC<PoolRankingViewProps> = ({
@@ -35,6 +36,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   hasDirectElimination = true,
   onExport,
   onPoolsChange,
+  onRankingChange,
 }) => {
   const { showToast } = useToast();
   const { isColumnVisible, toggleColumn } = useColumnVisibility();
@@ -186,6 +188,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
       }
     }
 
+    onRankingChange?.(editedRanking);
     setIsEditing(false);
     showToast(
       rankingChanged
@@ -271,7 +274,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
           </button>
           <button
             className="btn btn-secondary"
-            onClick={() => setIsEditing(!isEditing)}
+            onClick={() => (isEditing ? saveChanges() : setIsEditing(true))}
             title={isEditing ? 'Terminer la modification' : 'Modifier le classement'}
           >
             {isEditing ? '✓ Terminer' : '✏️ Modifier'}
@@ -433,7 +436,22 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
                 )}
                 {isVisible('quest') && isLaserSabre && (
                   <td style={{ textAlign: 'center', fontWeight: '600', color: '#7c3aed' }}>
-                    {ranking.questPoints || 0}
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        min="0"
+                        value={ranking.questPoints ?? 0}
+                        onChange={e => {
+                          const val = Math.max(0, parseInt(e.target.value) || 0);
+                          setEditedRanking(prev =>
+                            prev.map((r, i) => (i === index ? { ...r, questPoints: val } : r))
+                          );
+                        }}
+                        style={{ width: '52px', textAlign: 'center', padding: '1px 4px' }}
+                      />
+                    ) : (
+                      ranking.questPoints ?? 0
+                    )}
                   </td>
                 )}
                 {isVisible('index') && (


### PR DESCRIPTION
## Summary
Enhanced the pool ranking view to support manual editing of quest points and added a callback mechanism to propagate ranking changes to parent components.

## Key Changes
- **New callback prop**: Added `onRankingChange` callback to `PoolRankingViewProps` to notify parent components when rankings are manually edited
- **Quest points editing**: Made quest points editable in-place when in edit mode with a number input field (min value: 0)
- **Edit button behavior**: Changed the edit button to trigger `saveChanges()` when already in edit mode, ensuring changes are persisted before exiting edit mode
- **Ranking propagation**: Updated `CompetitionView` to use the `onRankingChange` callback to keep `overallRanking` in sync with manual edits, eliminating unnecessary recalculation in `handleGoToTableau`

## Implementation Details
- Quest points input is only visible when `isEditing` is true and the competition is laser sabre type
- The input validates to ensure non-negative values using `Math.max(0, ...)`
- The edited ranking state is properly updated via `setEditedRanking` before being passed to the callback
- Removed redundant ranking recalculation logic in `handleGoToTableau` with explanatory comments

https://claude.ai/code/session_01L2z1VKwkwcivw4mQ8nvEKJ