### PR TITLE
Fix: ranking modifications (order + quest points) lost after clicking Terminer

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -838,6 +838,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         {currentPhase === 'ranking' && (
           <PoolRankingView
             pools={pools}
+            ranking={overallRanking}
             weapon={competition.weapon}
             hasDirectElimination={hasDirectElimination}
             onGoToTableau={handleGoToTableau}

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -20,6 +20,7 @@ import { useColumnVisibility, RANKING_COLUMNS, ColumnId } from '../hooks/useColu
 interface PoolRankingViewProps {
   pools: Pool[];
   weapon?: Weapon;
+  ranking?: PoolRanking[];
   onGoToTableau?: () => void;
   onGoToResults?: () => void;
   hasDirectElimination?: boolean;
@@ -31,6 +32,7 @@ interface PoolRankingViewProps {
 const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   pools,
   weapon,
+  ranking: externalRanking,
   onGoToTableau,
   onGoToResults,
   hasDirectElimination = true,
@@ -46,13 +48,17 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   const [editedRanking, setEditedRanking] = useState<PoolRanking[]>([]);
   const [showColumnMenu, setShowColumnMenu] = useState(false);
   const columnMenuRef = useRef<HTMLDivElement>(null);
+  const justSaved = useRef(false);
 
   // Calculer le classement général selon le type d'arme
-  const overallRanking = useMemo(() => {
+  const computedRanking = useMemo(() => {
     // Utiliser recalcKey pour forcer le recalcul
     const _ = recalcKey;
     return isLaserSabre ? calculateOverallRankingQuest(pools) : calculateOverallRanking(pools);
   }, [pools, isLaserSabre, recalcKey]);
+
+  // Utiliser le classement fourni par le parent s'il existe, sinon le calculé
+  const overallRanking = externalRanking?.length ? externalRanking : computedRanking;
 
   // Recalculer les classements de toutes les poules
   const handleRecalculate = useCallback(() => {
@@ -76,10 +82,11 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
       JSON.stringify(overallRanking.map(r => r.fencer.id)) !==
       JSON.stringify(newOverallRanking.map(r => r.fencer.id));
 
-    // Mettre à jour les pools si callback fourni
+    // Mettre à jour les pools et le classement global dans le parent
     if (onPoolsChange) {
       onPoolsChange(updatedPools, rankingChanged);
     }
+    onRankingChange?.(newOverallRanking);
 
     // Forcer le recalcul du classement général
     setRecalcKey(prev => prev + 1);
@@ -89,11 +96,15 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     } else {
       showToast('Classement recalculé avec succès !', 'success');
     }
-  }, [pools, isLaserSabre, onPoolsChange, showToast, overallRanking]);
+  }, [pools, isLaserSabre, onPoolsChange, onRankingChange, showToast, overallRanking]);
 
   // Initialiser le classement édité quand le classement global change
   useEffect(() => {
     if (!isEditing) {
+      if (justSaved.current) {
+        justSaved.current = false;
+        return;
+      }
       setEditedRanking(overallRanking);
     }
   }, [overallRanking, isEditing]);
@@ -171,24 +182,22 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
       JSON.stringify(editedRanking.map(r => r.fencer.id));
 
     if (onPoolsChange) {
-      if (rankingChanged) {
-        // Propager les rangs globaux manuels dans chaque pool pour que le bracket
-        // puisse utiliser le bon ordre de qualification
-        const fencerToGlobalRank = new Map(editedRanking.map(r => [r.fencer.id, r.rank]));
-        const updatedPools = pools.map(pool => ({
-          ...pool,
-          ranking: pool.ranking.map(pr => ({
-            ...pr,
-            rank: fencerToGlobalRank.get(pr.fencer.id) ?? pr.rank,
-          })),
-        }));
-        onPoolsChange(updatedPools, true);
-      } else {
-        onPoolsChange(pools, false);
-      }
+      // Propager rang ET questPoints dans chaque pool (les deux peuvent avoir changé)
+      const fencerToGlobalRank = new Map(editedRanking.map(r => [r.fencer.id, r.rank]));
+      const fencerToQuestPoints = new Map(editedRanking.map(r => [r.fencer.id, r.questPoints]));
+      const updatedPools = pools.map(pool => ({
+        ...pool,
+        ranking: pool.ranking.map(pr => ({
+          ...pr,
+          rank: fencerToGlobalRank.get(pr.fencer.id) ?? pr.rank,
+          questPoints: fencerToQuestPoints.get(pr.fencer.id) ?? pr.questPoints,
+        })),
+      }));
+      onPoolsChange(updatedPools, rankingChanged);
     }
 
     onRankingChange?.(editedRanking);
+    justSaved.current = true;
     setIsEditing(false);
     showToast(
       rankingChanged


### PR DESCRIPTION
- saveChanges() now unconditionally propagates rank AND questPoints from
  editedRanking back into every pool.ranking, instead of only updating ranks
  when order changed and passing the original pools unchanged otherwise
- Add justSaved ref to prevent the useEffect from resetting editedRanking
  with the algorithmically-recomputed overallRanking immediately after save
- Accept optional ranking prop from parent (CompetitionView.overallRanking)
  and use it as authoritative source, falling back to computedRanking only
  when no prop is provided — ensures edits survive navigation away and back
- handleRecalculate now also calls onRankingChange so the parent state stays
  in sync after a forced recalculation
- Pass ranking={overallRanking} from CompetitionView to PoolRankingView

https://claude.ai/code/session_017iXHJ92qBSMsNCQHKAapxG