### PR TITLE
feat: options d'affichage kiosk (poules / classement / matchs)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1007,7 +1007,14 @@ ipcMain.handle('remote:getServerInfo', async () => {
 // Remote session handlers
 ipcMain.handle(
   'remote:startSession',
-  async (_, competitionId: string, strips: number, matches?: any[], showPhotos?: boolean) => {
+  async (
+    _,
+    competitionId: string,
+    strips: number,
+    matches?: any[],
+    showPhotos?: boolean,
+    kioskViews?: { poules: boolean; classement: boolean; direct: boolean }
+  ) => {
     try {
       if (!remoteScoreServer) {
         return { success: false, error: 'Le serveur distant n est pas démarré' };
@@ -1017,7 +1024,8 @@ ipcMain.handle(
         competitionId,
         strips,
         matches,
-        showPhotos
+        showPhotos,
+        kioskViews
       );
       return { success: true, session };
     } catch (error) {
@@ -1118,6 +1126,22 @@ ipcMain.handle('remote:updateShowPhotos', async (_, value: boolean) => {
     return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
   }
 });
+
+ipcMain.handle(
+  'remote:updateKioskViews',
+  async (_, views: { poules: boolean; classement: boolean; direct: boolean }) => {
+    try {
+      if (!remoteScoreServer) {
+        return { success: false, error: 'Le serveur distant n est pas démarré' };
+      }
+      remoteScoreServer.updateKioskViews(views);
+      return { success: true };
+    } catch (error) {
+      console.error('Error updating kioskViews:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+    }
+  }
+);
 
 ipcMain.handle('remote:setArenaPassword', async (_, arenaId: string, password: string) => {
   try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -365,13 +365,28 @@ contextBridge.exposeInMainWorld('electronAPI', {
     startServer: () => ipcRenderer.invoke('remote:startServer'),
     stopServer: () => ipcRenderer.invoke('remote:stopServer'),
     getServerInfo: () => ipcRenderer.invoke('remote:getServerInfo'),
-    startSession: (competitionId: string, strips: number, matches?: any[], showPhotos?: boolean) =>
-      ipcRenderer.invoke('remote:startSession', competitionId, strips, matches, showPhotos),
+    startSession: (
+      competitionId: string,
+      strips: number,
+      matches?: any[],
+      showPhotos?: boolean,
+      kioskViews?: { poules: boolean; classement: boolean; direct: boolean }
+    ) =>
+      ipcRenderer.invoke(
+        'remote:startSession',
+        competitionId,
+        strips,
+        matches,
+        showPhotos,
+        kioskViews
+      ),
     stopSession: () => ipcRenderer.invoke('remote:stopSession'),
     getSession: () => ipcRenderer.invoke('remote:getSession'),
     getArenas: () => ipcRenderer.invoke('remote:getArenas'),
     updateStripCount: (count: number) => ipcRenderer.invoke('remote:updateStripCount', count),
     updateShowPhotos: (value: boolean) => ipcRenderer.invoke('remote:updateShowPhotos', value),
+    updateKioskViews: (views: { poules: boolean; classement: boolean; direct: boolean }) =>
+      ipcRenderer.invoke('remote:updateKioskViews', views),
     updateMatchArena: (matchId: string, fromArena: number | null, toArena: number | null) =>
       ipcRenderer.invoke('remote:updateMatchArena', matchId, fromArena, toArena),
     updatePoolFencers: (updates: Array<{ poolId: string; fencers: any[] }>) =>

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -38,6 +38,11 @@ export class RemoteScoreServer {
   private poolFencersCache: Map<string, any[]> = new Map(); // Tireurs par poolId (depuis le renderer)
   private sessionMatchScores: Map<string, { scoreA: any; scoreB: any; status: string }> = new Map(); // Scores en mémoire
   private sessionShowPhotos: boolean = false; // Afficher les photos des combattants avant le combat
+  private sessionKioskViews: { poules: boolean; classement: boolean; direct: boolean } = {
+    poules: true,
+    classement: true,
+    direct: true,
+  };
 
   // Stocker le contenu des fichiers HTML en mémoire pour éviter les problèmes de chemin
   private htmlFiles: Map<string, string> = new Map();
@@ -386,7 +391,7 @@ export class RemoteScoreServer {
       if (!this.session) {
         return res.status(404).json({ error: 'Aucune session active' });
       }
-      res.json({ ...this.session, weapon: this.sessionWeapon });
+      res.json({ ...this.session, weapon: this.sessionWeapon, kioskViews: this.sessionKioskViews });
     });
 
     this.app.post('/api/session/start', async (req, res) => {
@@ -2178,7 +2183,8 @@ export class RemoteScoreServer {
     competitionId: string,
     strips: number,
     matchesFromRenderer?: any[],
-    showPhotos?: boolean
+    showPhotos?: boolean,
+    kioskViews?: { poules: boolean; classement: boolean; direct: boolean }
   ): Promise<RemoteSession> {
     if (this.session) {
       throw new Error('Session déjà active');
@@ -2191,6 +2197,9 @@ export class RemoteScoreServer {
 
     // Stocker le réglage d'affichage des photos
     this.sessionShowPhotos = showPhotos ?? false;
+
+    // Stocker les vues kiosk activées
+    this.sessionKioskViews = kioskViews ?? { poules: true, classement: true, direct: true };
 
     // Stocker le type d'arme pour l'arrêt automatique à 15 points en Laser Sabre
     this.sessionWeapon = competition.weapon || null;
@@ -2511,6 +2520,11 @@ export class RemoteScoreServer {
         fencerB: arena.currentMatch?.fencerB,
       });
     }
+  }
+
+  public updateKioskViews(views: { poules: boolean; classement: boolean; direct: boolean }): void {
+    if (!this.session) throw new Error('Aucune session active');
+    this.sessionKioskViews = views;
   }
 
   public updatePoolFencers(updates: Array<{ poolId: string; fencers: any[] }>): void {

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -534,6 +534,8 @@
 
     <script>
       // ─── État ────────────────────────────────────────────────────────────────
+      const ALL_VIEWS = ['poules', 'classement', 'direct'];
+
       const state = {
         currentView: 'poules',
         views: ['poules', 'classement', 'direct'],
@@ -660,6 +662,24 @@
 
           document.getElementById('menu-competition-name').textContent =
             state.session.competitionName || '';
+
+          // Appliquer les vues kiosk configurées
+          if (state.session.kioskViews) {
+            const kv = state.session.kioskViews;
+            const enabled = ALL_VIEWS.filter(v => kv[v] !== false);
+            state.views = enabled.length > 0 ? enabled : ALL_VIEWS;
+          } else {
+            state.views = ALL_VIEWS.slice();
+          }
+          // Masquer/afficher les boutons de navigation
+          ALL_VIEWS.forEach(v => {
+            const btn = document.getElementById('btn-' + v);
+            if (btn) btn.style.display = state.views.includes(v) ? '' : 'none';
+          });
+          // Si la vue courante n'est plus dans les vues actives, basculer sur la première
+          if (!state.views.includes(state.currentView)) {
+            switchView(state.views[0]);
+          }
 
           // 2. Données poules + classements
           const poolsRes = await fetch('/api/competitions/' + competitionId + '/results-data');

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -57,6 +57,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const [arenaPasswords, setArenaPasswords] = useState<Record<string, string>>({});
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [showPhotos, setShowPhotos] = useState(false);
+  const [kioskViews, setKioskViews] = useState({ poules: true, classement: true, direct: true });
 
   useEffect(() => {
     if (!activeQR) {
@@ -157,7 +158,8 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         competition.id,
         count,
         allMatches,
-        showPhotos
+        showPhotos,
+        kioskViews
       );
       if (result.success && result.session) {
         setSession(result.session);
@@ -316,6 +318,30 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             />
             Afficher les photos des combattants avant le combat
           </label>
+          <div style={{ margin: '0.5rem 0' }}>
+            <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem', color: 'inherit' }}>
+              Vues kiosk :
+            </div>
+            {(
+              [
+                { key: 'poules', label: 'Poules' },
+                { key: 'classement', label: 'Classement' },
+                { key: 'direct', label: 'Matchs en direct' },
+              ] as const
+            ).map(({ key, label }) => (
+              <label
+                key={key}
+                style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}
+              >
+                <input
+                  type="checkbox"
+                  checked={kioskViews[key]}
+                  onChange={e => setKioskViews(v => ({ ...v, [key]: e.target.checked }))}
+                />
+                {label}
+              </label>
+            ))}
+          </div>
           <button className="btn-primary" onClick={onStartRemote}>
             ⚡ Démarrer la saisie distante
           </button>
@@ -364,6 +390,34 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           />
           Afficher les photos des combattants avant le combat
         </label>
+        <div style={{ margin: '0.5rem 0' }}>
+          <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem', color: 'inherit' }}>
+            Vues kiosk :
+          </div>
+          {(
+            [
+              { key: 'poules', label: 'Poules' },
+              { key: 'classement', label: 'Classement' },
+              { key: 'direct', label: 'Matchs en direct' },
+            ] as const
+          ).map(({ key, label }) => (
+            <label
+              key={key}
+              style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}
+            >
+              <input
+                type="checkbox"
+                checked={kioskViews[key]}
+                onChange={async e => {
+                  const next = { ...kioskViews, [key]: e.target.checked };
+                  setKioskViews(next);
+                  await window.electronAPI.remote.updateKioskViews(next);
+                }}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
 
         <div className="arena-url-grid">
           {arenaUrls.map(arena => (


### PR DESCRIPTION
Permet de cocher quelles vues afficher en mode kiosk lors de la saisie
distante. Les cases à cocher sont disponibles avant et pendant la session ;
le kiosk adapte sa rotation en temps réel.

https://claude.ai/code/session_012EkLVBH1zuFTA3MmGPk8wV