### PR TITLE
fix: permettre la création d'une poule unique dans le tableau de préparation

### DIFF
--- a/src/renderer/components/PoolPrepView.tsx
+++ b/src/renderer/components/PoolPrepView.tsx
@@ -442,6 +442,16 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
             >
               +
             </button>
+            {poolCount !== 1 && (
+              <button
+                className="btn btn-secondary"
+                onClick={() => handlePoolCountChange(1)}
+                title="Mettre tous les tireurs dans une seule poule"
+                style={{ fontSize: '0.8rem', padding: '0.25rem 0.6rem', marginLeft: '0.25rem' }}
+              >
+                Poule unique
+              </button>
+            )}
           </div>
         </div>
 
@@ -559,13 +569,30 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
                 borderBottom: '1px solid #e5e7eb',
               }}
             >
-              <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: 0 }}>Poule {pool.number}</h3>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: 0 }}>Poule {pool.number}</h3>
+                {pools.length === 1 && (
+                  <span
+                    style={{
+                      fontSize: '0.7rem',
+                      background: '#dbeafe',
+                      color: '#1d4ed8',
+                      borderRadius: '4px',
+                      padding: '0.1rem 0.4rem',
+                      fontWeight: 500,
+                    }}
+                  >
+                    Poule unique
+                  </span>
+                )}
+              </div>
               <span
                 style={{
                   fontSize: '0.875rem',
                   color:
-                    pool.fencers.length < minFencersPerPool ||
-                    pool.fencers.length > maxFencersPerPool
+                    pools.length > 1 &&
+                    (pool.fencers.length < minFencersPerPool ||
+                      pool.fencers.length > maxFencersPerPool)
                       ? '#dc2626'
                       : '#6b7280',
                 }}


### PR DESCRIPTION
- Ajoute un bouton "Poule unique" qui ramène directement le nombre de
  poules à 1, évitant les clics multiples sur "−"
- Supprime l'indicateur rouge sur le nombre de tireurs quand il n'y a
  qu'une seule poule (maxFencersPerPool n'est pas pertinent en poule unique)
- Ajoute un badge "Poule unique" dans l'en-tête de la poule pour confirmer
  visuellement le format

Fixes: impossible de créer une poule unique dans le tableau de préparation

https://claude.ai/code/session_01Lx8SGPBQqvjwViBvJ4yuy4