### PR TITLE
Increase maximum fencers per pool from 10 to 64

### DIFF
--- a/src/renderer/components/PoolPrepView.tsx
+++ b/src/renderer/components/PoolPrepView.tsx
@@ -247,7 +247,7 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
   };
 
   const handleMaxFencersChange = (value: number) => {
-    if (value >= minFencersPerPool && value <= 10) {
+    if (value >= minFencersPerPool && value <= 64) {
       saveToHistory();
       setMaxFencersPerPool(value);
       onSettingsChange?.(minFencersPerPool, value);
@@ -492,7 +492,7 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
             value={maxFencersPerPool}
             onChange={e => handleMaxFencersChange(parseInt(e.target.value) || 7)}
             min={minFencersPerPool}
-            max={10}
+            max={64}
             style={{ width: '80px', padding: '0.5rem' }}
           />
         </div>


### PR DESCRIPTION
## Summary
Updated the maximum fencers per pool constraint from 10 to 64 to support larger pool configurations.

## Changes
- Modified the validation logic in `handleMaxFencersChange()` to allow values up to 64 instead of 10
- Updated the max attribute on the fencers input field from 10 to 64

## Details
This change increases the upper limit for pool size configuration, enabling users to create larger pools with up to 64 fencers. The minimum fencers per pool constraint remains unchanged and continues to be enforced through the `minFencersPerPool` validation.

https://claude.ai/code/session_01XgbJhtvgfCPxe82HEY5Ao5