### PR TITLE
Ajouter la capture selfie webcam pour les photos de combattants

### DIFF
--- a/src/renderer/components/FencerPhoto.tsx
+++ b/src/renderer/components/FencerPhoto.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState, useRef, useCallback } from 'react';
 import { logger, LogCategory } from '@shared/services/logger';
+import PhotoBooth from './PhotoBooth';
 
 interface FencerPhotoProps {
   photo?: string;
@@ -26,6 +27,7 @@ export const FencerPhoto: React.FC<FencerPhotoProps> = ({
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [showWebcam, setShowWebcam] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const sizeClasses = {
@@ -206,6 +208,20 @@ export const FencerPhoto: React.FC<FencerPhotoProps> = ({
       )}
 
       {editable && (
+        <button
+          onClick={e => {
+            e.stopPropagation();
+            setShowWebcam(true);
+          }}
+          className="absolute -bottom-1 -right-1 w-5 h-5 bg-blue-500 text-white rounded-full flex items-center justify-center hover:bg-blue-600 transition-colors shadow-md"
+          title="Prendre une photo avec la webcam"
+          style={{ fontSize: '10px' }}
+        >
+          📷
+        </button>
+      )}
+
+      {editable && (
         <input
           ref={fileInputRef}
           type="file"
@@ -218,6 +234,60 @@ export const FencerPhoto: React.FC<FencerPhotoProps> = ({
       {isDragging && (
         <div className="absolute inset-0 bg-blue-500 bg-opacity-20 rounded-full flex items-center justify-center pointer-events-none">
           <span className="text-blue-700 text-xs font-medium">Déposer ici</span>
+        </div>
+      )}
+
+      {editable && showWebcam && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0, 0, 0, 0.7)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1100,
+          }}
+          onClick={() => setShowWebcam(false)}
+        >
+          <div
+            style={{
+              background: 'var(--color-surface)',
+              borderRadius: 'var(--radius-lg)',
+              boxShadow: 'var(--shadow-lg)',
+              padding: '1.5rem',
+              width: '480px',
+              maxWidth: '90vw',
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '1rem',
+              }}
+            >
+              <h3 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600 }}>
+                Prendre une photo
+              </h3>
+              <button
+                className="btn btn-icon btn-secondary"
+                onClick={() => setShowWebcam(false)}
+                style={{ padding: '0.25rem' }}
+              >
+                ✕
+              </button>
+            </div>
+            <PhotoBooth
+              onConfirm={photoData => {
+                onPhotoChange?.(photoData);
+                setShowWebcam(false);
+              }}
+              onClose={() => setShowWebcam(false)}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/renderer/components/PhotoBooth.tsx
+++ b/src/renderer/components/PhotoBooth.tsx
@@ -1,6 +1,6 @@
 /**
  * BellePoule Modern - Photo Booth Component
- * Fun photo capture for fencers
+ * Webcam selfie capture for fencers
  * Licensed under GPL-3.0
  */
 
@@ -8,26 +8,17 @@ import React, { useState, useRef, useCallback } from 'react';
 import { logger, LogCategory } from '@shared/services/logger';
 
 interface PhotoBoothProps {
-  fencerName: string;
-  onPhotoCapture: (photoData: string) => void;
+  onConfirm: (photoData: string) => void;
+  onClose: () => void;
 }
 
-export const PhotoBooth: React.FC<PhotoBoothProps> = ({ fencerName, onPhotoCapture }) => {
+export const PhotoBooth: React.FC<PhotoBoothProps> = ({ onConfirm, onClose }) => {
   const [isCapturing, setIsCapturing] = useState(false);
   const [countdown, setCountdown] = useState(0);
   const [photo, setPhoto] = useState<string | null>(null);
-  const [selectedOverlay, setSelectedOverlay] = useState<string>('none');
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
-
-  const overlays = [
-    { id: 'none', label: 'Aucun', icon: '✨' },
-    { id: 'champion', label: 'Champion', icon: '🏆' },
-    { id: 'gold', label: 'Or', icon: '🥇' },
-    { id: 'fencing', label: 'Escrime', icon: '🤺' },
-    { id: 'cool', label: 'Cool', icon: '😎' },
-  ];
 
   const startCamera = useCallback(async () => {
     try {
@@ -79,45 +70,30 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ fencerName, onPhotoCaptu
       if (ctx) {
         canvas.width = video.videoWidth;
         canvas.height = video.videoHeight;
+
+        // Mirror the capture to match the selfie preview
+        ctx.save();
+        ctx.translate(canvas.width, 0);
+        ctx.scale(-1, 1);
         ctx.drawImage(video, 0, 0);
+        ctx.restore();
 
-        // Add overlay
-        addOverlay(ctx, canvas.width, canvas.height);
-
-        const photoData = canvas.toDataURL('image/jpeg', 0.9);
-        setPhoto(photoData);
-        onPhotoCapture(photoData);
-        stopCamera();
+        // Resize to 300x300 with centered square crop
+        const outputCanvas = document.createElement('canvas');
+        outputCanvas.width = 300;
+        outputCanvas.height = 300;
+        const outCtx = outputCanvas.getContext('2d');
+        if (outCtx) {
+          const side = Math.min(canvas.width, canvas.height);
+          const sx = (canvas.width - side) / 2;
+          const sy = (canvas.height - side) / 2;
+          outCtx.drawImage(canvas, sx, sy, side, side, 0, 0, 300, 300);
+          const photoData = outputCanvas.toDataURL('image/jpeg', 0.8);
+          setPhoto(photoData);
+          stopCamera();
+        }
       }
     }
-  };
-
-  const addOverlay = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
-    ctx.font = 'bold 80px Arial';
-    ctx.textAlign = 'center';
-
-    switch (selectedOverlay) {
-      case 'champion':
-        ctx.fillText('🏆', width / 2, height / 3);
-        break;
-      case 'gold':
-        ctx.fillText('🥇', width / 2, height / 3);
-        break;
-      case 'fencing':
-        ctx.fillText('🤺', width / 2, height / 3);
-        break;
-      case 'cool':
-        ctx.fillText('😎', width / 2, height / 3);
-        break;
-    }
-
-    // Add name
-    ctx.font = 'bold 40px Arial';
-    ctx.fillStyle = 'white';
-    ctx.shadowColor = 'rgba(0,0,0,0.5)';
-    ctx.shadowBlur = 4;
-    ctx.fillText(fencerName || 'Tireur', width / 2, height - 40);
-    ctx.shadowBlur = 0;
   };
 
   const retake = () => {
@@ -126,52 +102,32 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ fencerName, onPhotoCaptu
   };
 
   return (
-    <div
-      style={{
-        padding: '24px',
-        backgroundColor: 'white',
-        borderRadius: '20px',
-        boxShadow: '0 10px 40px rgba(0,0,0,0.1)',
-        maxWidth: '500px',
-        margin: '0 auto',
-      }}
-    >
-      <h2 style={{ margin: '0 0 20px 0', textAlign: 'center', fontSize: '24px' }}>
-        📸 Photo Booth
-      </h2>
-
+    <div>
       {!isCapturing && !photo && (
         <div style={{ textAlign: 'center' }}>
           <div
             style={{
-              width: '200px',
-              height: '200px',
+              width: '160px',
+              height: '160px',
               borderRadius: '50%',
               backgroundColor: '#f3f4f6',
               margin: '0 auto 20px',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontSize: '80px',
+              fontSize: '64px',
             }}
           >
             📷
           </div>
-          <button
-            onClick={startCamera}
-            style={{
-              padding: '16px 32px',
-              backgroundColor: '#3b82f6',
-              color: 'white',
-              border: 'none',
-              borderRadius: '12px',
-              fontSize: '18px',
-              fontWeight: '600',
-              cursor: 'pointer',
-            }}
-          >
-            📸 Prendre une photo
-          </button>
+          <div style={{ display: 'flex', gap: '12px', justifyContent: 'center' }}>
+            <button className="btn btn-secondary" onClick={onClose}>
+              Annuler
+            </button>
+            <button className="btn btn-primary" onClick={startCamera}>
+              Démarrer la caméra
+            </button>
+          </div>
         </div>
       )}
 
@@ -183,8 +139,8 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ fencerName, onPhotoCaptu
             playsInline
             style={{
               width: '100%',
-              borderRadius: '12px',
-              transform: 'scaleX(-1)', // Mirror effect
+              borderRadius: '8px',
+              transform: 'scaleX(-1)',
             }}
           />
 
@@ -195,77 +151,30 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ fencerName, onPhotoCaptu
                 top: '50%',
                 left: '50%',
                 transform: 'translate(-50%, -50%)',
-                fontSize: '120px',
+                fontSize: '100px',
                 fontWeight: 'bold',
                 color: 'white',
                 textShadow: '0 4px 20px rgba(0,0,0,0.5)',
-                animation: 'pulse 1s infinite',
               }}
             >
               {countdown}
             </div>
           )}
 
-          {/* Overlay selector */}
-          <div
-            style={{
-              display: 'flex',
-              gap: '8px',
-              justifyContent: 'center',
-              marginTop: '16px',
-              flexWrap: 'wrap',
-            }}
-          >
-            {overlays.map(overlay => (
-              <button
-                key={overlay.id}
-                onClick={() => setSelectedOverlay(overlay.id)}
-                style={{
-                  padding: '8px 16px',
-                  borderRadius: '20px',
-                  border:
-                    selectedOverlay === overlay.id ? '2px solid #3b82f6' : '2px solid #e5e7eb',
-                  backgroundColor: selectedOverlay === overlay.id ? '#eff6ff' : 'white',
-                  cursor: 'pointer',
-                  fontSize: '14px',
-                }}
-              >
-                {overlay.icon} {overlay.label}
-              </button>
-            ))}
-          </div>
-
-          <div style={{ display: 'flex', gap: '12px', marginTop: '16px' }}>
+          <div style={{ display: 'flex', gap: '12px', marginTop: '12px' }}>
             <button
               onClick={capturePhoto}
               disabled={countdown > 0}
-              style={{
-                flex: 1,
-                padding: '16px',
-                backgroundColor: countdown > 0 ? '#9ca3af' : '#10b981',
-                color: 'white',
-                border: 'none',
-                borderRadius: '12px',
-                fontSize: '18px',
-                fontWeight: '600',
-                cursor: countdown > 0 ? 'not-allowed' : 'pointer',
-              }}
+              className="btn btn-primary"
+              style={{ flex: 1 }}
             >
-              {countdown > 0 ? '⏳ ...' : '📸 Capturer'}
+              {countdown > 0 ? `${countdown}…` : '📸 Capturer'}
             </button>
             <button
-              onClick={stopCamera}
-              style={{
-                padding: '16px 24px',
-                backgroundColor: '#ef4444',
-                color: 'white',
-                border: 'none',
-                borderRadius: '12px',
-                fontSize: '16px',
-                cursor: 'pointer',
-              }}
+              onClick={() => { stopCamera(); onClose(); }}
+              className="btn btn-secondary"
             >
-              ✕
+              Annuler
             </button>
           </div>
         </div>
@@ -275,46 +184,19 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ fencerName, onPhotoCaptu
         <div style={{ textAlign: 'center' }}>
           <img
             src={photo}
-            alt="Captured"
+            alt="Aperçu"
             style={{
               width: '100%',
-              borderRadius: '12px',
-              marginBottom: '16px',
+              borderRadius: '8px',
+              marginBottom: '12px',
             }}
           />
           <div style={{ display: 'flex', gap: '12px', justifyContent: 'center' }}>
-            <button
-              onClick={retake}
-              style={{
-                padding: '12px 24px',
-                backgroundColor: '#3b82f6',
-                color: 'white',
-                border: 'none',
-                borderRadius: '8px',
-                fontSize: '16px',
-                cursor: 'pointer',
-              }}
-            >
-              🔄 Recommencer
+            <button onClick={retake} className="btn btn-secondary">
+              Recommencer
             </button>
-            <button
-              onClick={() => {
-                const link = document.createElement('a');
-                link.download = `${fencerName || 'photo'}.jpg`;
-                link.href = photo;
-                link.click();
-              }}
-              style={{
-                padding: '12px 24px',
-                backgroundColor: '#10b981',
-                color: 'white',
-                border: 'none',
-                borderRadius: '8px',
-                fontSize: '16px',
-                cursor: 'pointer',
-              }}
-            >
-              💾 Télécharger
+            <button onClick={() => onConfirm(photo)} className="btn btn-primary">
+              Utiliser cette photo
             </button>
           </div>
         </div>


### PR DESCRIPTION
- PhotoBooth.tsx : refactorisé en panneau embarquable (props onConfirm/onClose),
  suppression du texte du nom et du sélecteur d'overlays, resize 300x300 JPEG 0.8,
  correction du mirroring canvas, étape de confirmation avant d'utiliser la photo
- FencerPhoto.tsx : ajout du bouton 📷 (z-index 1100) qui ouvre PhotoBooth dans
  un overlay modal flottant au-dessus des modals combattant existants

https://claude.ai/code/session_01BYUF7Lo322A9N2gkVG4CUp