### PR TITLE
fix: classement par ratio V/M au lieu du nombre absolu de victoires

### DIFF
--- a/src/shared/utils/poolCalculations.test.ts
+++ b/src/shared/utils/poolCalculations.test.ts
@@ -240,6 +240,47 @@ describe('calculatePoolRanking', () => {
     expect(ranking[1].victories).toBe(0);
   });
 
+  it('should rank by ratio, not absolute victories — same wins but different match counts', () => {
+    // fencerA: 2 wins / 3 matches → ratio 0.667
+    // fencerB: 2 wins / 2 matches → ratio 1.000
+    // Same absolute victories, fencerB must rank first
+    const fencerA = createMockFencer('fA', 1, 'TwoThree');
+    const fencerB = createMockFencer('fB', 2, 'TwoTwo');
+    const fencerC = createMockFencer('fC', 3, 'Helper1');
+    const fencerD = createMockFencer('fD', 4, 'Helper2');
+
+    // fencerA: beats C (m1), beats D (m2), loses to C (m3) → 2W/3M
+    // fencerB: beats C (m4), beats D (m5)                  → 2W/2M
+    const matches: Match[] = [
+      createMockMatch('m1', fencerA, fencerC, 5, 2), // A beats C
+      createMockMatch('m2', fencerA, fencerD, 5, 2), // A beats D
+      createMockMatch('m3', fencerC, fencerA, 5, 2), // C beats A
+      createMockMatch('m4', fencerB, fencerC, 5, 2), // B beats C
+      createMockMatch('m5', fencerB, fencerD, 5, 2), // B beats D
+    ];
+
+    const pool: Pool = {
+      id: 'p1',
+      number: 1,
+      phaseId: 'ph1',
+      fencers: [fencerA, fencerB, fencerC, fencerD],
+      matches,
+      referees: [],
+      isComplete: true,
+      hasError: false,
+      ranking: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const ranking = calculatePoolRanking(pool);
+
+    expect(ranking[0].fencer.id).toBe(fencerB.id); // ratio 1.000 (2V/2M)
+    expect(ranking[0].ratio).toBeCloseTo(1.0);
+    expect(ranking[1].fencer.id).toBe(fencerA.id); // ratio 0.667 (2V/3M)
+    expect(ranking[1].ratio).toBeCloseTo(2 / 3);
+  });
+
   it('should rank active fencer first and append excluded/forfeit/abandoned at the end', () => {
     const fencer1 = createMockFencer('f1', 1, 'Active');
     const fencer2 = createMockFencer('f2', 2, 'Excluded');

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -232,7 +232,7 @@ function assignRanks(rankings: PoolRanking[]): void {
     if (i > 0) {
       const prev = rankings[i - 1];
       const curr = rankings[i];
-      const sameVictories = prev.victories === curr.victories;
+      const sameVictories = prev.ratio === curr.ratio;
       const sameQuest = (prev.questPoints ?? 0) === (curr.questPoints ?? 0);
       const sameIndex = prev.index === curr.index;
 
@@ -330,9 +330,9 @@ export function calculatePoolRanking(pool: Pool): PoolRanking[] {
 
   // Trier selon les critères demandés
   rankings.sort((a, b) => {
-    // 1. Nombre de victoires (décroissant)
-    if (a.victories !== b.victories) {
-      return b.victories - a.victories;
+    // 1. Ratio de victoires V/M (décroissant)
+    if (a.ratio !== b.ratio) {
+      return b.ratio - a.ratio;
     }
 
     // 2. Points Quest (décroissant)
@@ -941,9 +941,9 @@ export function calculatePoolRankingQuest(pool: Pool): PoolRanking[] {
 
   // Trier selon les critères demandés (même ordre que calculatePoolRanking)
   rankings.sort((a, b) => {
-    // 1. Nombre de victoires (décroissant)
-    if (a.victories !== b.victories) {
-      return b.victories - a.victories;
+    // 1. Ratio de victoires V/M (décroissant)
+    if (a.ratio !== b.ratio) {
+      return b.ratio - a.ratio;
     }
 
     // 2. Points Quest (décroissant)
@@ -985,9 +985,9 @@ export function calculateOverallRankingQuest(pools: Pool[]): PoolRanking[] {
 
   // Trier selon les critères demandés (même ordre que calculateOverallRanking)
   allRankings.sort((a, b) => {
-    // 1. Nombre de victoires (décroissant)
-    if (a.victories !== b.victories) {
-      return b.victories - a.victories;
+    // 1. Ratio de victoires V/M (décroissant)
+    if (a.ratio !== b.ratio) {
+      return b.ratio - a.ratio;
     }
     // 2. Points Quest (décroissant)
     const aQuest = a.questPoints ?? 0;
@@ -1027,13 +1027,13 @@ export function calculateOverallRanking(pools: Pool[]): PoolRanking[] {
   });
 
   // Trier selon les critères demandés:
-  // 1. Nombre de victoires (décroissant)
+  // 1. Ratio de victoires V/M (décroissant)
   // 2. Points Quest (décroissant)
   // 3. Indice (TD-TR) (décroissant)
   allRankings.sort((a, b) => {
-    // 1. Nombre de victoires
-    if (a.victories !== b.victories) {
-      return b.victories - a.victories;
+    // 1. Ratio de victoires V/M
+    if (a.ratio !== b.ratio) {
+      return b.ratio - a.ratio;
     }
     // 2. Points Quest
     const aQuest = a.questPoints ?? 0;


### PR DESCRIPTION
Remplace le critère primaire de tri (victoires absolues) par le ratio
V/M dans calculatePoolRanking, calculatePoolRankingQuest,
calculateOverallRanking et calculateOverallRankingQuest. Un combattant
avec 6V/6M (ratio 1.000) est désormais classé devant un combattant
avec 6V/7M (ratio 0.857). Le champ ratio était déjà calculé et stocké.

Ajoute un test unitaire couvrant le scénario exact.

https://claude.ai/code/session_01VG3KZhEXpD2FK2fvgX8Gvy