### PR TITLE
feat: note d'organisation en overlay sur le kiosk

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1156,6 +1156,34 @@ ipcMain.handle('remote:setArenaPassword', async (_, arenaId: string, password: s
   }
 });
 
+ipcMain.handle('remote:setOrgNote', async (_, note) => {
+  try {
+    if (!remoteScoreServer) {
+      return { success: false, error: 'Le serveur distant n est pas démarré' };
+    }
+    remoteScoreServer.setOrgNote(note);
+    mainWindow?.webContents.send('kiosk:note', note);
+    return { success: true };
+  } catch (error) {
+    console.error('Error setting org note:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('remote:clearOrgNote', async () => {
+  try {
+    if (!remoteScoreServer) {
+      return { success: false, error: 'Le serveur distant n est pas démarré' };
+    }
+    remoteScoreServer.clearOrgNote();
+    mainWindow?.webContents.send('kiosk:note', null);
+    return { success: true };
+  } catch (error) {
+    console.error('Error clearing org note:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 // App info handlers
 ipcMain.handle('app:getVersionInfo', async () => {
   return getVersionInfo();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -393,6 +393,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:updatePoolFencers', updates),
     setArenaPassword: (arenaId: string, password: string) =>
       ipcRenderer.invoke('remote:setArenaPassword', arenaId, password),
+    setOrgNote: (note: any) => ipcRenderer.invoke('remote:setOrgNote', note),
+    clearOrgNote: () => ipcRenderer.invoke('remote:clearOrgNote'),
   },
 
   // Remote event listeners (for real-time updates)
@@ -401,6 +403,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   onRemoteMatchFinished: (callback: (data: any) => void) => {
     ipcRenderer.on('match:finished', (_, data) => callback(data));
+  },
+  onKioskNoteUpdate: (callback: (note: any) => void) => {
+    const handler = (_: any, note: any) => callback(note);
+    ipcRenderer.on('kiosk:note', handler);
+    return () => ipcRenderer.removeListener('kiosk:note', handler);
   },
 
   // Remove listeners

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -18,6 +18,7 @@ import {
   ArenaMatch,
   ArenaSettings,
   ArenaUpdate,
+  OrgNote,
 } from '../shared/types/remote';
 import { Competition, Match, Fencer, MatchStatus, Score } from '../shared/types';
 import { DatabaseManager } from '../database';
@@ -38,6 +39,7 @@ export class RemoteScoreServer {
   private poolFencersCache: Map<string, any[]> = new Map(); // Tireurs par poolId (depuis le renderer)
   private sessionMatchScores: Map<string, { scoreA: any; scoreB: any; status: string }> = new Map(); // Scores en mémoire
   private sessionShowPhotos: boolean = false; // Afficher les photos des combattants avant le combat
+  private orgNote: OrgNote | null = null; // Note d'organisation affichée sur le kiosk
   private sessionKioskViews: { poules: boolean; classement: boolean; direct: boolean } = {
     poules: true,
     classement: true,
@@ -391,7 +393,7 @@ export class RemoteScoreServer {
       if (!this.session) {
         return res.status(404).json({ error: 'Aucune session active' });
       }
-      res.json({ ...this.session, weapon: this.sessionWeapon, kioskViews: this.sessionKioskViews });
+      res.json({ ...this.session, weapon: this.sessionWeapon, kioskViews: this.sessionKioskViews, orgNote: this.orgNote });
     });
 
     this.app.post('/api/session/start', async (req, res) => {
@@ -2559,6 +2561,16 @@ export class RemoteScoreServer {
 
   public getSession(): RemoteSession | null {
     return this.session;
+  }
+
+  public setOrgNote(note: OrgNote): void {
+    this.orgNote = note;
+    this.io.emit('kiosk:note', note);
+  }
+
+  public clearOrgNote(): void {
+    this.orgNote = null;
+    this.io.emit('kiosk:note', null);
   }
 
   public setArenaPassword(arenaId: string, password: string): void {

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -543,12 +543,62 @@
         height: 14px;
         cursor: pointer;
       }
+    /* ─── Overlay note d'organisation ── */
+    #org-note-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 10500;
+      background: rgba(2, 6, 23, 0.88);
+      backdrop-filter: blur(6px);
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 4rem;
+    }
+    #org-note-overlay.visible { display: flex; }
+    #org-note-label {
+      font-size: clamp(0.9rem, 2.5vw, 1.4rem);
+      color: #64748b;
+      font-weight: 600;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      margin-bottom: 1.5rem;
+    }
+    #org-note-time {
+      font-size: clamp(2rem, 5.5vw, 3.5rem);
+      font-weight: 700;
+      color: #f1f5f9;
+      margin-bottom: 0.5rem;
+    }
+    #org-note-countdown {
+      font-size: clamp(1.5rem, 4vw, 2.5rem);
+      font-weight: 800;
+      color: #3b82f6;
+      margin-bottom: 2rem;
+      font-variant-numeric: tabular-nums;
+    }
+    #org-note-message {
+      font-size: clamp(1.1rem, 3vw, 1.8rem);
+      color: #94a3b8;
+      font-style: italic;
+      max-width: 70ch;
+    }
     </style>
   </head>
   <body>
     <!-- Barre de progression rotation -->
     <div id="progress-bar-container">
       <div id="progress-bar"></div>
+    </div>
+
+    <!-- Overlay note d'organisation -->
+    <div id="org-note-overlay">
+      <div id="org-note-label">⏸ Pause</div>
+      <div id="org-note-time"></div>
+      <div id="org-note-countdown"></div>
+      <div id="org-note-message"></div>
     </div>
 
     <!-- Menu escamotable -->
@@ -670,6 +720,48 @@
         lastUpdate: null,
         prevArenaScores: {},  // { [arenaId]: { scoreA, scoreB } }
       };
+
+      // ─── Note d'organisation ─────────────────────────────────────────────────
+      let _orgNoteInterval = null;
+      let _currentOrgNote = null;
+
+      function renderOrgNote(note) {
+        clearInterval(_orgNoteInterval);
+        _orgNoteInterval = null;
+        _currentOrgNote = note;
+        const overlay = document.getElementById('org-note-overlay');
+        if (!note) { overlay.classList.remove('visible'); return; }
+
+        document.getElementById('org-note-message').innerHTML = note.message
+          ? '\u00ab\u00a0' + escHtml(note.message) + '\u00a0\u00bb'
+          : '';
+
+        if (note.type === 'target_time' && note.targetTime) {
+          const [hh, mm] = note.targetTime.split(':').map(Number);
+          const fmtTime = String(hh).padStart(2, '0') + 'h' + String(mm).padStart(2, '0');
+          document.getElementById('org-note-time').textContent = 'Reprise à ' + fmtTime;
+
+          const computeCountdown = () => {
+            const now = new Date();
+            const target = new Date(now);
+            target.setHours(hh, mm, 0, 0);
+            if (target <= now) target.setDate(target.getDate() + 1);
+            const diffSec = Math.max(0, Math.floor((target.getTime() - now.getTime()) / 1000));
+            const m = Math.floor(diffSec / 60);
+            const s = diffSec % 60;
+            document.getElementById('org-note-countdown').textContent =
+              'dans ' + m + ' min ' + String(s).padStart(2, '0') + ' s';
+            if (diffSec === 0) { clearInterval(_orgNoteInterval); overlay.classList.remove('visible'); }
+          };
+          computeCountdown();
+          _orgNoteInterval = setInterval(computeCountdown, 1000);
+        } else {
+          document.getElementById('org-note-time').textContent = '';
+          document.getElementById('org-note-countdown').textContent = '';
+        }
+
+        overlay.classList.add('visible');
+      }
 
       // ─── Rotation automatique ────────────────────────────────────────────────
       function startRotation() {
@@ -839,6 +931,9 @@
 
           document.getElementById('menu-competition-name').textContent =
             state.session.competitionName || '';
+
+          // Note d'organisation
+          renderOrgNote(state.session.orgNote || null);
 
           // Appliquer les vues kiosk : localStorage en priorité, sinon config serveur
           const localViews = loadLocalViews();

--- a/src/renderer/components/KioskDisplay.tsx
+++ b/src/renderer/components/KioskDisplay.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { Competition, Pool, Weapon, MatchStatus, Fencer } from '../../shared/types';
+import { OrgNote } from '../../shared/types/remote';
 import { TableauMatch } from './TableauView';
 import {
   calculateOverallRanking,
@@ -257,6 +258,41 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
       cancelAnimationFrame(animId);
     };
   }, [currentView, activeRound]);
+
+  // Note d'organisation
+  const [orgNote, setOrgNote] = useState<OrgNote | null>(null);
+  const [orgNoteCountdown, setOrgNoteCountdown] = useState<string>('');
+
+  useEffect(() => {
+    if (!window.electronAPI?.onKioskNoteUpdate) return;
+    const unsub = window.electronAPI.onKioskNoteUpdate(note => setOrgNote(note));
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    if (!orgNote || orgNote.type !== 'target_time' || !orgNote.targetTime) {
+      setOrgNoteCountdown('');
+      return;
+    }
+    const compute = () => {
+      const now = new Date();
+      const [hh, mm] = orgNote.targetTime!.split(':').map(Number);
+      const target = new Date(now);
+      target.setHours(hh, mm, 0, 0);
+      if (target <= now) target.setDate(target.getDate() + 1); // lendemain si dépassé
+      const diffSec = Math.max(0, Math.floor((target.getTime() - now.getTime()) / 1000));
+      if (diffSec === 0) {
+        window.electronAPI.remote.clearOrgNote();
+        return;
+      }
+      const m = Math.floor(diffSec / 60);
+      const s = diffSec % 60;
+      setOrgNoteCountdown(`${m} min ${s.toString().padStart(2, '0')} s`);
+    };
+    compute();
+    const id = setInterval(compute, 1000);
+    return () => clearInterval(id);
+  }, [orgNote]);
 
   // Données de la poule courante
   const currentPool = pools[currentPoolIndex];
@@ -1153,6 +1189,44 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                   </table>
                 </div>
               )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ===== OVERLAY NOTE D'ORGANISATION ===== */}
+      {orgNote && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 10500,
+            background: 'rgba(2, 6, 23, 0.88)',
+            backdropFilter: 'blur(6px)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            padding: '4rem',
+          }}
+        >
+          <div style={{ fontSize: 'clamp(1rem, 3vw, 1.5rem)', color: '#64748b', fontWeight: 600, letterSpacing: '0.2em', textTransform: 'uppercase', marginBottom: '1.5rem' }}>
+            ⏸ Pause
+          </div>
+          {orgNote.type === 'target_time' && orgNote.targetTime && (
+            <>
+              <div style={{ fontSize: 'clamp(2rem, 6vw, 4rem)', fontWeight: 700, color: '#f1f5f9', marginBottom: '0.5rem' }}>
+                Reprise à {orgNote.targetTime.replace(':', 'h')}
+              </div>
+              <div style={{ fontSize: 'clamp(1.5rem, 4vw, 2.5rem)', fontWeight: 800, color: '#3b82f6', marginBottom: '2rem', fontVariantNumeric: 'tabular-nums' }}>
+                dans {orgNoteCountdown}
+              </div>
+            </>
+          )}
+          {orgNote.message && (
+            <div style={{ fontSize: 'clamp(1.2rem, 3.5vw, 2rem)', color: '#94a3b8', fontStyle: 'italic', maxWidth: '70ch' }}>
+              «&nbsp;{orgNote.message}&nbsp;»
             </div>
           )}
         </div>

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -58,6 +58,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [showPhotos, setShowPhotos] = useState(false);
   const [kioskViews, setKioskViews] = useState({ poules: true, classement: true, direct: true });
+  const [orgNoteType, setOrgNoteType] = useState<'free' | 'target_time'>('free');
+  const [orgNoteMessage, setOrgNoteMessage] = useState('');
+  const [orgNoteTime, setOrgNoteTime] = useState('');
+  const [orgNoteActive, setOrgNoteActive] = useState(false);
 
   useEffect(() => {
     if (!activeQR) {
@@ -417,6 +421,82 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               {label}
             </label>
           ))}
+        </div>
+
+        {/* Note d'organisation */}
+        <div style={{ margin: '0.75rem 0', padding: '0.75rem', border: '1px solid #334155', borderRadius: '0.5rem', background: '#1e293b' }}>
+          <div style={{ fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.5rem', color: '#94a3b8' }}>
+            Note d'organisation (kiosk)
+          </div>
+          <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.5rem' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer' }}>
+              <input
+                type="radio"
+                name="orgNoteType"
+                checked={orgNoteType === 'free'}
+                onChange={() => setOrgNoteType('free')}
+              />
+              Message libre
+            </label>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer' }}>
+              <input
+                type="radio"
+                name="orgNoteType"
+                checked={orgNoteType === 'target_time'}
+                onChange={() => setOrgNoteType('target_time')}
+              />
+              Heure de reprise
+            </label>
+          </div>
+          <input
+            type="text"
+            placeholder="Message (ex: Déjeuner des arbitres)"
+            value={orgNoteMessage}
+            onChange={e => setOrgNoteMessage(e.target.value)}
+            style={{ width: '100%', padding: '0.4rem 0.6rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#0f172a', color: 'inherit', boxSizing: 'border-box', marginBottom: '0.4rem' }}
+          />
+          {orgNoteType === 'target_time' && (
+            <input
+              type="time"
+              value={orgNoteTime}
+              onChange={e => setOrgNoteTime(e.target.value)}
+              style={{ padding: '0.4rem 0.6rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#0f172a', color: 'inherit', marginBottom: '0.4rem' }}
+            />
+          )}
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.25rem' }}>
+            <button
+              disabled={!orgNoteMessage.trim() || (orgNoteType === 'target_time' && !orgNoteTime)}
+              onClick={async () => {
+                const note = {
+                  type: orgNoteType,
+                  message: orgNoteMessage.trim(),
+                  ...(orgNoteType === 'target_time' ? { targetTime: orgNoteTime } : {}),
+                  createdAt: new Date().toISOString(),
+                };
+                await window.electronAPI.remote.setOrgNote(note);
+                setOrgNoteActive(true);
+              }}
+              style={{ flex: 1, padding: '0.4rem', borderRadius: '0.3rem', border: 'none', background: orgNoteActive ? '#1d4ed8' : '#2563eb', color: '#fff', cursor: 'pointer', fontWeight: 500 }}
+            >
+              {orgNoteActive ? '↻ Mettre à jour' : '▶ Afficher'}
+            </button>
+            {orgNoteActive && (
+              <button
+                onClick={async () => {
+                  await window.electronAPI.remote.clearOrgNote();
+                  setOrgNoteActive(false);
+                }}
+                style={{ padding: '0.4rem 0.75rem', borderRadius: '0.3rem', border: 'none', background: '#475569', color: '#fff', cursor: 'pointer' }}
+              >
+                ✕ Masquer
+              </button>
+            )}
+          </div>
+          {orgNoteActive && (
+            <div style={{ fontSize: '0.75rem', color: '#22c55e', marginTop: '0.4rem' }}>
+              ● Note visible sur le kiosk
+            </div>
+          )}
         </div>
 
         <div className="arena-url-grid">

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -354,6 +354,8 @@ export interface RemoteServerAPI {
   updateKioskViews: (
     views: Record<string, boolean>
   ) => Promise<{ success: boolean; error?: string }>;
+  setOrgNote: (note: import('../types/remote').OrgNote) => Promise<{ success: boolean; error?: string }>;
+  clearOrgNote: () => Promise<{ success: boolean; error?: string }>;
 }
 
 // ============================================================================
@@ -461,6 +463,7 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   remote: RemoteServerAPI;
   onRemoteArenaUpdate: (callback: (data: any) => void) => void;
   onRemoteMatchFinished: (callback: (data: any) => void) => void;
+  onKioskNoteUpdate: (callback: (note: import('../types/remote').OrgNote | null) => void) => () => void;
   notifyLanguageChanged: (lang: string) => void;
 }
 

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -148,3 +148,10 @@ export interface RefereeControl {
   finishMatch: () => void;
   nextMatch: () => void;
 }
+
+export interface OrgNote {
+  type: 'target_time' | 'free';
+  message: string;      // texte libre affiché sous le titre
+  targetTime?: string;  // "HH:MM" uniquement pour type target_time
+  createdAt: string;    // ISO timestamp
+}


### PR DESCRIPTION
Permet à l'organisateur d'afficher un message ou une heure de reprise
en overlay sur le grand écran kiosk (Electron + kiosk.html web).

- OrgNote interface (type: 'target_time' | 'free', message, targetTime)
- IPC setOrgNote / clearOrgNote + événement kiosk:note
- RemoteScoreServer : stocke la note, la diffuse via Socket.IO, l'expose dans /api/session
- RemoteScoreManager : panneau UI (radio mode, champ texte, sélecteur heure, bouton afficher/masquer)
- KioskDisplay : overlay plein écran avec countdown dynamique, auto-clear à l'heure prévue
- kiosk.html : overlay HTML + JS polling (renderOrgNote depuis /api/session)

https://claude.ai/code/session_01Hkw9bZN8Lx4DVpfu5sWukJ