### PR TITLE
Résultats : supprimer les Quest Points, classer les éliminés par rang de poules

### DIFF
--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Fencer, PoolRanking, Competition, Weapon, FencerStatus } from '../../shared/types';
+import { Fencer, PoolRanking, Competition, FencerStatus } from '../../shared/types';
 import { useToast } from './Toast';
 import { exportResultsXMLFFE } from '../../shared/utils/multiFormatExport';
 
@@ -13,7 +13,6 @@ interface FinalResult {
   rank: number;
   fencer: Fencer;
   eliminatedAt?: string; // "Finale", "Demi-finale", etc.
-  questPoints?: number; // Points Quest pour Sabre Laser
 }
 
 interface ResultsViewProps {
@@ -24,7 +23,6 @@ interface ResultsViewProps {
 
 const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, finalResults }) => {
   const { showToast } = useToast();
-  const isLaserSabre = competition.weapon === Weapon.LASER;
 
   const getMedalEmoji = (rank: number): string => {
     if (rank === 1) return '🥇';
@@ -48,19 +46,11 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
           rank: idx + 1,
           fencer: pr.fencer,
           eliminatedAt: 'Poules',
-          questPoints: pr.questPoints,
         }));
-
-  // Récupérer les points Quest depuis poolRanking si disponibles
-  const getQuestPoints = (fencerId: string): number | undefined => {
-    const pr = poolRanking.find(p => p.fencer.id === fencerId);
-    return pr?.questPoints;
-  };
 
   // Export CSV
   const exportCSV = () => {
     const headers = ['Rang', 'Nom', 'Prénom', 'Club', 'Statut', 'Éliminé à'];
-    if (isLaserSabre) headers.push('Points Quest');
 
     const getStatusLabel = (status: FencerStatus) => {
       switch (status) {
@@ -76,7 +66,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
     };
 
     const rows = resultsToDisplay.map(r => {
-      const row = [
+      return [
         r.rank,
         r.fencer.lastName,
         r.fencer.firstName,
@@ -84,10 +74,6 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
         getStatusLabel(r.fencer.status),
         r.eliminatedAt || '',
       ];
-      if (isLaserSabre) {
-        row.push(String(r.questPoints ?? getQuestPoints(r.fencer.id) ?? ''));
-      }
-      return row;
     });
 
     const csv = [headers.join(';'), ...rows.map(r => r.join(';'))].join('\n');
@@ -255,54 +241,36 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
               <th style={{ padding: '0.75rem', textAlign: 'left', width: '60px' }}>Rang</th>
               <th style={{ padding: '0.75rem', textAlign: 'left' }}>Tireur</th>
               <th style={{ padding: '0.75rem', textAlign: 'left' }}>Club</th>
-              {isLaserSabre && (
-                <th style={{ padding: '0.75rem', textAlign: 'center' }}>Pts Quest</th>
-              )}
               <th style={{ padding: '0.75rem', textAlign: 'center' }}>Éliminé en</th>
             </tr>
           </thead>
           <tbody>
-            {resultsToDisplay.map(result => {
-              const questPts = result.questPoints ?? getQuestPoints(result.fencer.id);
-              return (
-                <tr
-                  key={result.fencer.id}
-                  style={{
-                    ...getRowStyle(result.rank),
-                    borderBottom: '1px solid #e5e7eb',
-                  }}
-                >
-                  <td style={{ padding: '0.75rem' }}>
-                    <span style={{ marginRight: '0.5rem' }}>{getMedalEmoji(result.rank)}</span>
-                    {result.rank}
-                  </td>
-                  <td style={{ padding: '0.75rem' }}>
-                    {result.fencer.firstName} {result.fencer.lastName}
-                    {result.fencer.status === FencerStatus.ABANDONED && ' (A)'}
-                    {result.fencer.status === FencerStatus.FORFAIT && ' (F)'}
-                    {result.fencer.status === FencerStatus.EXCLUDED && ' (X)'}
-                  </td>
-                  <td style={{ padding: '0.75rem', color: '#6b7280' }}>
-                    {result.fencer.club || '-'}
-                  </td>
-                  {isLaserSabre && (
-                    <td
-                      style={{
-                        padding: '0.75rem',
-                        textAlign: 'center',
-                        fontWeight: '600',
-                        color: '#7c3aed',
-                      }}
-                    >
-                      {questPts ?? '-'}
-                    </td>
-                  )}
-                  <td style={{ padding: '0.75rem', textAlign: 'center', color: '#6b7280' }}>
-                    {result.eliminatedAt || '-'}
-                  </td>
-                </tr>
-              );
-            })}
+            {resultsToDisplay.map(result => (
+              <tr
+                key={result.fencer.id}
+                style={{
+                  ...getRowStyle(result.rank),
+                  borderBottom: '1px solid #e5e7eb',
+                }}
+              >
+                <td style={{ padding: '0.75rem' }}>
+                  <span style={{ marginRight: '0.5rem' }}>{getMedalEmoji(result.rank)}</span>
+                  {result.rank}
+                </td>
+                <td style={{ padding: '0.75rem' }}>
+                  {result.fencer.firstName} {result.fencer.lastName}
+                  {result.fencer.status === FencerStatus.ABANDONED && ' (A)'}
+                  {result.fencer.status === FencerStatus.FORFAIT && ' (F)'}
+                  {result.fencer.status === FencerStatus.EXCLUDED && ' (X)'}
+                </td>
+                <td style={{ padding: '0.75rem', color: '#6b7280' }}>
+                  {result.fencer.club || '-'}
+                </td>
+                <td style={{ padding: '0.75rem', textAlign: 'center', color: '#6b7280' }}>
+                  {result.eliminatedAt || '-'}
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -40,7 +40,6 @@ export interface FinalResult {
   rank: number;
   fencer: Fencer;
   eliminatedAt: string;
-  questPoints?: number; // Total points Quest (Sabre Laser)
   poolTouches?: number; // Touches marquées en poules
   tableTouches?: number; // Touches marquées en tableau
   totalTouches?: number; // Total pour départage (poules + tableau)
@@ -552,12 +551,6 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     return touches;
   };
 
-  // Helper: récupérer les points Quest d'un tireur depuis le ranking des poules
-  const getPoolQuestPoints = (fencerId: string): number => {
-    const poolRank = ranking.find(r => r.fencer.id === fencerId);
-    return poolRank?.questPoints ?? 0;
-  };
-
   // Helper: récupérer les touches marquées en poules
   const getPoolTouches = (fencerId: string): number => {
     const poolRank = ranking.find(r => r.fencer.id === fencerId);
@@ -581,7 +574,6 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         rank: 1,
         fencer: finalMatch.winner,
         eliminatedAt: 'Vainqueur',
-        questPoints: winnerPoolData?.questPoints,
         poolTouches: winnerPoolData?.touchesScored,
         tableTouches: getTableTouches(finalMatch.winner.id, matchList),
         totalTouches:
@@ -598,7 +590,6 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
           rank: 2,
           fencer: loser,
           eliminatedAt: 'Finale',
-          questPoints: loserPoolData?.questPoints,
           poolTouches: loserPoolData?.touchesScored,
           tableTouches: getTableTouches(loser.id, matchList),
           totalTouches: (loserPoolData?.touchesScored ?? 0) + getTableTouches(loser.id, matchList),
@@ -618,7 +609,6 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         rank: 3,
         fencer: thirdPlaceMatch.winner,
         eliminatedAt: 'Petite Finale',
-        questPoints: winnerPoolData?.questPoints,
         poolTouches: winnerPoolData?.touchesScored,
         tableTouches: getTableTouches(thirdPlaceMatch.winner.id, matchList),
         totalTouches:
@@ -639,7 +629,6 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
           rank: 4,
           fencer: fourthPlace,
           eliminatedAt: 'Petite Finale',
-          questPoints: fourthPoolData?.questPoints,
           poolTouches: fourthPoolData?.touchesScored,
           tableTouches: getTableTouches(fourthPlace.id, matchList),
           totalTouches:
@@ -664,45 +653,32 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
       const roundMatches = matchList.filter(m => m.round === round && m.winner);
       const losersData: Array<{
         fencer: Fencer;
-        poolQuestPoints: number;
+        poolRank: number;
         poolTouches: number;
         tableTouches: number;
-        totalQuest: number;
         totalTouches: number;
       }> = [];
-
-      // DEBUG: console.log(`Round ${round}: ${roundMatches.length} matchs avec gagnant`);
 
       for (const match of roundMatches) {
         const loser = match.fencerA?.id === match.winner?.id ? match.fencerB : match.fencerA;
         if (loser && !processed.has(loser.id)) {
-          const poolQuest = getPoolQuestPoints(loser.id);
+          const poolRankEntry = ranking.find(r => r.fencer.id === loser.id);
           const poolTou = getPoolTouches(loser.id);
           const tableTou = getTableTouches(loser.id, matchList);
 
           losersData.push({
             fencer: loser,
-            poolQuestPoints: poolQuest,
+            poolRank: poolRankEntry?.rank ?? 9999,
             poolTouches: poolTou,
             tableTouches: tableTou,
-            totalQuest: poolQuest + tableTou, // Points Quest totaux pour départage
             totalTouches: poolTou + tableTou,
           });
           processed.add(loser.id);
-          // DEBUG: console.log(`  Perdant: ${loser.lastName} - Points Quest poules: ${poolQuest}, Tableau touches: ${tableTou}, Total: ${poolQuest + tableTou}`);
         }
       }
 
-      // Issue #59: Trier les perdants par points Quest décroissants (poules + tableau)
-      // En cas d'égalité, utiliser les touches marquées
-      losersData.sort((a, b) => {
-        // D'abord par points Quest totaux (décroissant)
-        if (b.totalQuest !== a.totalQuest) {
-          return b.totalQuest - a.totalQuest;
-        }
-        // En cas d'égalité, par touches totales (décroissant)
-        return b.totalTouches - a.totalTouches;
-      });
+      // Trier par classement de poules (croissant — meilleur classé en poules = meilleur rang final)
+      losersData.sort((a, b) => a.poolRank - b.poolRank);
 
       // Issue #60: Assigner des rangs distincts (pas le même rang pour tous)
       for (const loserData of losersData) {
@@ -710,12 +686,10 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
           rank: currentRank,
           fencer: loserData.fencer,
           eliminatedAt: getRoundName(round),
-          questPoints: loserData.totalQuest,
           poolTouches: loserData.poolTouches,
           tableTouches: loserData.tableTouches,
           totalTouches: loserData.totalTouches,
         });
-        // DEBUG: console.log(`  Rang ${currentRank}: ${loserData.fencer.lastName} (${loserData.totalQuest} pts Quest)`);
         currentRank++;
       }
     }


### PR DESCRIPTION
- Supprime la colonne "Pts Quest" de ResultsView (affichage + export CSV)
- Supprime questPoints de l'interface FinalResult et de calculateFinalResults()
- Remplace le tri par totalQuest (incohérent) par le classement de poules (croissant)
  pour les fencers éliminés au même tour du tableau d'élimination

https://claude.ai/code/session_01UrvrwTcLBsTeGop24EhkEq