### PR TITLE
claude/fix-sudden-death-points-nrPVT

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1418,15 +1418,17 @@
           }
 
           this.updateScores();
-          this.broadcastUpdate();
-          this.saveScore();
 
           // Mode Challenger : mort subite si les DEUX combattants ≥ 10 pts (Laser Sabre uniquement)
+          // Vérifier AVANT broadcastUpdate pour que le serveur reçoive l'état correct
           if (this.isLaserSabre && !this.isSuddenDeath) {
             if (this.scoreA >= 10 && this.scoreB >= 10) {
               this.triggerSuddenDeathChallenger();
             }
           }
+
+          this.broadcastUpdate();
+          this.saveScore();
         }
 
         addCard(fencer, cardType) {
@@ -1559,6 +1561,14 @@
             this.scoreB = Math.max(0, this.scoreB - points);
           }
 
+          // Ré-évaluer la mort subite : si un score repasse sous 10, on quitte la mort subite
+          if (this.isSuddenDeath && this.isLaserSabre) {
+            if (!(this.scoreA >= 10 && this.scoreB >= 10)) {
+              this.isSuddenDeath = false;
+              this.updateSuddenDeathUI();
+            }
+          }
+
           this.updateScores();
           this.broadcastUpdate();
           this.saveScore();
@@ -1592,6 +1602,14 @@
             this.scoreB = Math.max(0, this.scoreB - 5);
           } else if (cardType === 'red' && fencer === 'B') {
             this.scoreA = Math.max(0, this.scoreA - 5);
+          }
+
+          // Ré-évaluer la mort subite : si un score repasse sous 10, on quitte la mort subite
+          if (this.isSuddenDeath && this.isLaserSabre) {
+            if (!(this.scoreA >= 10 && this.scoreB >= 10)) {
+              this.isSuddenDeath = false;
+              this.updateSuddenDeathUI();
+            }
           }
 
           this.updateScores();


### PR DESCRIPTION
Trois correctifs dans la tablette arbitre (referee.html) :

1. removeScore() : après retrait de points en appui long, réévaluer
   isSuddenDeath — si l'un des scores repasse sous 10, quitter la mort
   subite et réactiver les boutons Zone A (+1) et Zone B (+3).

2. removeCard() : même correction après suppression d'un carton rouge/jaune
   qui réduit le score de l'adversaire en dessous du seuil.

3. addScore() : déplacer le déclenchement de triggerSuddenDeathChallenger()
   avant broadcastUpdate() pour que le serveur reçoive l'état suddenDeath
   correct dès le premier broadcast (évite une race condition).

https://claude.ai/code/session_01HoYzLbPPUrDm6sWQcZUF1S