### PR TITLE
claude/improve-score-visibility-NxJHf

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -311,11 +311,11 @@
       }
 
       .score-big {
-        font-family: 'Arial', 'Helvetica Neue', Helvetica, sans-serif;
+        font-family: Impact, 'Arial Black', 'Haettenschweiler', sans-serif;
         font-size: clamp(8rem, 26vw, 50vh);
         font-weight: 900;
         line-height: 1;
-        letter-spacing: 0.01em;
+        letter-spacing: 0.03em;
         font-variant-numeric: tabular-nums;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
@@ -323,16 +323,16 @@
 
       .score-big.red {
         color: #dc2626;
-        text-shadow: 0 0 20px rgba(220, 38, 38, 0.9),
-                     0 0 50px rgba(220, 38, 38, 0.5),
-                     0 0 80px rgba(220, 38, 38, 0.2);
+        text-shadow: 0 0 10px rgba(220, 38, 38, 0.7),
+                     0 0 40px rgba(220, 38, 38, 0.4),
+                     0 0 80px rgba(220, 38, 38, 0.15);
       }
 
       .score-big.green {
         color: #16a34a;
-        text-shadow: 0 0 20px rgba(22, 163, 74, 0.9),
-                     0 0 50px rgba(22, 163, 74, 0.5),
-                     0 0 80px rgba(22, 163, 74, 0.2);
+        text-shadow: 0 0 10px rgba(22, 163, 74, 0.7),
+                     0 0 40px rgba(22, 163, 74, 0.4),
+                     0 0 80px rgba(22, 163, 74, 0.15);
       }
 
       .vs-divider {

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -296,11 +296,11 @@
       }
 
       .score-big {
-        font-family: 'Arial', 'Helvetica Neue', Helvetica, sans-serif;
+        font-family: Impact, 'Arial Black', 'Haettenschweiler', sans-serif;
         font-size: clamp(8rem, 22vw, 38vh);
         font-weight: 900;
         line-height: 1;
-        letter-spacing: 0.01em;
+        letter-spacing: 0.03em;
         font-variant-numeric: tabular-nums;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
@@ -308,16 +308,16 @@
 
       .score-big.red {
         color: #dc2626;
-        text-shadow: 0 0 20px rgba(220, 38, 38, 0.9),
-                     0 0 50px rgba(220, 38, 38, 0.5),
-                     0 0 80px rgba(220, 38, 38, 0.2);
+        text-shadow: 0 0 10px rgba(220, 38, 38, 0.7),
+                     0 0 40px rgba(220, 38, 38, 0.4),
+                     0 0 80px rgba(220, 38, 38, 0.15);
       }
 
       .score-big.green {
         color: #16a34a;
-        text-shadow: 0 0 20px rgba(22, 163, 74, 0.9),
-                     0 0 50px rgba(22, 163, 74, 0.5),
-                     0 0 80px rgba(22, 163, 74, 0.2);
+        text-shadow: 0 0 10px rgba(22, 163, 74, 0.7),
+                     0 0 40px rgba(22, 163, 74, 0.4),
+                     0 0 80px rgba(22, 163, 74, 0.15);
       }
 
       .vs-divider {


### PR DESCRIPTION
Remplace Arial par Impact (police d'affichage préinstallée partout,
queue du "9" très distincte de l'"8") et réduit le halo intérieur
pour ne plus boucher les creux des chiffres.

https://claude.ai/code/session_01SvfrqZB3MohAKKA5KyAWxn