### PR TITLE
Améliore le contraste et lisibilité du score sur l'affichage arène

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -220,12 +220,12 @@
       }
 
       .fencer-display.red-side {
-        background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+        background: linear-gradient(135deg, #1a0a0a 0%, #2d1010 100%);
         border-color: #dc2626;
       }
 
       .fencer-display.green-side {
-        background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
+        background: linear-gradient(135deg, #0a1a0a 0%, #0f2d10 100%);
         border-color: #16a34a;
       }
 
@@ -248,13 +248,14 @@
       .fencer-name {
         font-size: clamp(1rem, 3.5vw, 5vh);
         font-weight: 800;
-        color: #1f2937;
+        color: #f3f4f6;
         margin-bottom: 0.15rem;
+        text-shadow: 0 1px 4px rgba(0,0,0,0.6);
       }
 
       .fencer-club {
         font-size: clamp(0.7rem, 2vw, 3vh);
-        color: #6b7280;
+        color: #9ca3af;
         margin-bottom: 0.4rem;
         font-weight: 500;
       }
@@ -319,20 +320,33 @@
         font-variant-numeric: tabular-nums;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        transition: transform 0.15s ease-out;
+      }
+
+      .score-big.score-flash {
+        animation: score-bump 0.35s ease-out;
+      }
+
+      @keyframes score-bump {
+        0%   { transform: scale(1.0); }
+        40%  { transform: scale(1.18); }
+        100% { transform: scale(1.0); }
       }
 
       .score-big.red {
-        color: #dc2626;
-        text-shadow: 0 0 20px rgba(220, 38, 38, 0.9),
-                     0 0 50px rgba(220, 38, 38, 0.5),
-                     0 0 80px rgba(220, 38, 38, 0.2);
+        color: #f87171;
+        -webkit-text-stroke: 2px #dc2626;
+        text-shadow: 0 0 30px rgba(239, 68, 68, 0.9),
+                     0 0 60px rgba(220, 38, 38, 0.6),
+                     0 4px 8px rgba(0, 0, 0, 0.8);
       }
 
       .score-big.green {
-        color: #16a34a;
-        text-shadow: 0 0 20px rgba(22, 163, 74, 0.9),
-                     0 0 50px rgba(22, 163, 74, 0.5),
-                     0 0 80px rgba(22, 163, 74, 0.2);
+        color: #4ade80;
+        -webkit-text-stroke: 2px #16a34a;
+        text-shadow: 0 0 30px rgba(74, 222, 128, 0.9),
+                     0 0 60px rgba(22, 163, 74, 0.6),
+                     0 4px 8px rgba(0, 0, 0, 0.8);
       }
 
       .vs-divider {
@@ -797,10 +811,10 @@
 
           // Mise à jour des scores
           if (data.scoreA !== undefined) {
-            document.getElementById('score-a').textContent = data.scoreA;
+            this.updateScore('score-a', data.scoreA);
           }
           if (data.scoreB !== undefined) {
-            document.getElementById('score-b').textContent = data.scoreB;
+            this.updateScore('score-b', data.scoreB);
           }
 
           // Mise à jour des cartons
@@ -874,6 +888,17 @@
             (typeof sA === 'object' ? (sA?.value ?? 0) : sA) ?? 0;
           document.getElementById('score-b').textContent =
             (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
+        }
+
+        updateScore(id, value) {
+          const el = document.getElementById(id);
+          const prev = el.textContent;
+          el.textContent = value;
+          if (String(value) !== String(prev)) {
+            el.classList.remove('score-flash');
+            void el.offsetWidth; // reflow pour relancer l'animation
+            el.classList.add('score-flash');
+          }
         }
 
         updateCardsDisplay() {


### PR DESCRIPTION
- Fond sombre (quasi-noir teinté) sur les zones rouge/vert au lieu du fond rose pâle
- Scores en couleurs vives (#f87171 rouge clair / #4ade80 vert clair) + text-stroke pour contour net
- Ombres avec drop-shadow sombre pour ancrer le chiffre sur le fond
- Animation de rebond (scale bump) au changement de score
- Noms/clubs en blanc/gris clair pour rester lisibles sur fond sombre

https://claude.ai/code/session_01AcBnqckeAReiDgM4v81QEy