### PR TITLE
Renomme sortie A/B en sortie rouge/verte sur l'interface arbitre

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -383,8 +383,16 @@
         margin-top: 0.5rem;
       }
 
-      .btn-arena-exit {
-        background: linear-gradient(135deg, #f97316, #ea580c);
+      .btn-arena-exit-red {
+        background: linear-gradient(135deg, #ef4444, #dc2626);
+        color: white;
+        font-size: 0.8rem;
+        padding: 0.65rem 0.4rem;
+        min-height: 48px;
+      }
+
+      .btn-arena-exit-green {
+        background: linear-gradient(135deg, #22c55e, #16a34a);
         color: white;
         font-size: 0.8rem;
         padding: 0.65rem 0.4rem;
@@ -828,11 +836,11 @@
         <!-- Boutons secondaires : sortie d'arène + annuler -->
         <div class="control-buttons-extra">
           <button
-            class="control-btn btn-arena-exit"
+            class="control-btn btn-arena-exit-red"
             id="btn-exit-a"
             onclick="refereeApp.arenaExit('A')"
           >
-            🚪 Sortie A
+            🚪 Sortie rouge
           </button>
           <button
             class="control-btn btn-undo"
@@ -843,11 +851,11 @@
             ↩ Annuler
           </button>
           <button
-            class="control-btn btn-arena-exit"
+            class="control-btn btn-arena-exit-green"
             id="btn-exit-b"
             onclick="refereeApp.arenaExit('B')"
           >
-            🚪 Sortie B
+            🚪 Sortie verte
           </button>
         </div>
       </div>


### PR DESCRIPTION
Boutons colorés : rouge (#ef4444) pour sortie A, vert (#22c55e) pour sortie B.

https://claude.ai/code/session_016eiaWdCTxkCMfeKknLwepd