### PR TITLE
feat: port de saisie distante configurable (défaut 8066)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,6 +18,7 @@ const db = new DatabaseManager();
 
 // Remote score server
 let remoteScoreServer: any = null;
+let remoteScoreServerPort: number = 8066;
 
 // Auto updater
 let autoUpdater: AutoUpdater | null = null;
@@ -487,7 +488,7 @@ function createMenu(language?: string): void {
 // Remote Score Server
 // ============================================================================
 
-function startRemoteScoreServer(): void {
+function startRemoteScoreServer(port: number = 8066): void {
   if (remoteScoreServer) {
     dialog.showMessageBox(mainWindow!, {
       type: 'info',
@@ -499,7 +500,8 @@ function startRemoteScoreServer(): void {
   }
 
   try {
-    remoteScoreServer = new RemoteScoreServer(db, 8066);
+    remoteScoreServer = new RemoteScoreServer(db, port);
+    remoteScoreServerPort = port;
     remoteScoreServer.start();
 
     const serverUrl = remoteScoreServer.getServerUrl();
@@ -507,7 +509,7 @@ function startRemoteScoreServer(): void {
       type: 'info',
       title: 'Saisie distante démarrée',
       message: `Les arbitres peuvent maintenant se connecter`,
-      detail: `Arène 1: ${serverUrl}/arene1/arbitre\nArène 2: ${serverUrl}/arene2/arbitre\nArène 3: ${serverUrl}/arene3/arbitre\nArène 4: ${serverUrl}/arene4/arbitre\n\nAffichage kiosk (grand écran public): ${serverUrl}/kiosk\nClassement en direct: ${serverUrl}/\n\nPartagez ces URLs avec les arbitres munis de tablettes.\nAssurez-vous que le pare-feu Windows autorise les connexions sur le port 8066.`,
+      detail: `Arène 1: ${serverUrl}/arene1/arbitre\nArène 2: ${serverUrl}/arene2/arbitre\nArène 3: ${serverUrl}/arene3/arbitre\nArène 4: ${serverUrl}/arene4/arbitre\n\nAffichage kiosk (grand écran public): ${serverUrl}/kiosk\nClassement en direct: ${serverUrl}/\n\nPartagez ces URLs avec les arbitres munis de tablettes.\nAssurez-vous que le pare-feu Windows autorise les connexions sur le port ${port}.`,
       buttons: ['OK'],
     });
 
@@ -1008,20 +1010,22 @@ ipcMain.handle('shell:openExternal', async (_, url: string) => {
 });
 
 // Remote score server handlers
-ipcMain.handle('remote:startServer', async () => {
+ipcMain.handle('remote:startServer', async (_event, port?: number) => {
   try {
     if (remoteScoreServer) {
       return { success: false, error: 'Le serveur est déjà démarré' };
     }
 
-    remoteScoreServer = new RemoteScoreServer(db, 8066);
+    const effectivePort = port ?? 8066;
+    remoteScoreServer = new RemoteScoreServer(db, effectivePort);
+    remoteScoreServerPort = effectivePort;
     remoteScoreServer.start();
 
     const serverUrl = remoteScoreServer.getServerUrl();
     const serverInfo = {
       url: serverUrl,
       ip: remoteScoreServer.getLocalIPAddress(),
-      port: 8066,
+      port: effectivePort,
     };
 
     // Stocker la référence globale pour le serveur distant
@@ -1060,7 +1064,7 @@ ipcMain.handle('remote:getServerInfo', async () => {
     serverInfo: {
       url: remoteScoreServer.getServerUrl(),
       ip: remoteScoreServer.getLocalIPAddress(),
-      port: 8066,
+      port: remoteScoreServerPort,
     },
   };
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -371,7 +371,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Remote score server functions
   remote: {
-    startServer: () => ipcRenderer.invoke('remote:startServer'),
+    startServer: (port?: number) => ipcRenderer.invoke('remote:startServer', port),
     stopServer: () => ipcRenderer.invoke('remote:stopServer'),
     getServerInfo: () => ipcRenderer.invoke('remote:getServerInfo'),
     startSession: (

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -47,7 +47,11 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const { showToast } = useToast();
   const [session, setSession] = useState<RemoteSession | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [serverUrl, setServerUrl] = useState<string>('http://localhost:8066');
+  const [serverUrl, setServerUrl] = useState<string>('');
+  const [remotePort, setRemotePort] = useState<number>(() => {
+    const saved = localStorage.getItem('bellepoule-remote-port');
+    return saved ? parseInt(saved, 10) : 8066;
+  });
   // pendingCount : valeur affichée (modifiée par +/−, non encore appliquée)
   const [pendingCount, setPendingCount] = useState<number | null>(null);
   // committedCount : valeur appliquée au serveur ou confirmée par l'utilisateur
@@ -126,7 +130,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const startRemoteServer = async () => {
     try {
       setIsLoading(true);
-      const result = await window.electronAPI.remote.startServer();
+      const result = await window.electronAPI.remote.startServer(remotePort);
 
       if (result.success && result.serverInfo) {
         setServerUrl(result.serverInfo.url);
@@ -204,6 +208,12 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       onArenaCountChange?.(newCount);
       showToast('Préférence sauvegardée', 'success');
     }
+  };
+
+  const handlePortChange = (value: number) => {
+    const port = Math.max(1024, Math.min(65535, value || 8066));
+    setRemotePort(port);
+    localStorage.setItem('bellepoule-remote-port', String(port));
   };
 
   const handleStopRemote = async () => {
@@ -346,6 +356,20 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                 {label}
               </label>
             ))}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.75rem 0' }}>
+            <label htmlFor="remote-port" style={{ whiteSpace: 'nowrap' }}>Port :</label>
+            <input
+              id="remote-port"
+              type="number"
+              min={1024}
+              max={65535}
+              value={remotePort}
+              onChange={e => handlePortChange(parseInt(e.target.value, 10))}
+              style={{ width: '80px' }}
+              disabled={isLoading}
+            />
+            <span style={{ fontSize: '0.8rem', opacity: 0.6 }}>1024–65535, défaut 8066</span>
           </div>
           <button className="btn-primary" onClick={onStartRemote}>
             ⚡ Démarrer la saisie distante

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -322,7 +322,7 @@ export interface RemoteServerInfo {
 }
 
 export interface RemoteServerAPI {
-  startServer: () => Promise<{ success: boolean; serverInfo?: RemoteServerInfo; error?: string }>;
+  startServer: (port?: number) => Promise<{ success: boolean; serverInfo?: RemoteServerInfo; error?: string }>;
   stopServer: () => Promise<{ success: boolean; error?: string }>;
   getServerInfo: () => Promise<{ success: boolean; serverInfo?: RemoteServerInfo; error?: string }>;
   startSession: (


### PR DESCRIPTION
Permet de lancer plusieurs instances simultanées sur des ports différents.
Le port est saisi dans l'UI (panneau inactif du RemoteScoreManager),
persisté dans localStorage, et transmis via IPC au serveur Express/Socket.IO.

https://claude.ai/code/session_01Pi7EaH9CAsT9SXKYs8Vbbs