### PR TITLE
claude/pause-timer-match-end-kX0gL

### DIFF
--- a/src/renderer/components/TouchOptimizedReferee.tsx
+++ b/src/renderer/components/TouchOptimizedReferee.tsx
@@ -159,7 +159,8 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
       onScoreUpdate(newScore, scoreB);
 
       if (newScore >= maxScore) {
-        handleMatchEnd();
+        // Pause le chronomètre pour permettre une correction d'arbitrage
+        setIsRunning(false);
       }
     } else {
       const newScore = Math.min(scoreB + points, maxScore);
@@ -167,7 +168,8 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
       onScoreUpdate(scoreA, newScore);
 
       if (newScore >= maxScore) {
-        handleMatchEnd();
+        // Pause le chronomètre pour permettre une correction d'arbitrage
+        setIsRunning(false);
       }
     }
   };


### PR DESCRIPTION
Au lieu d'appeler handleMatchEnd() automatiquement, on se contente
de mettre le chronomètre en pause. L'arbitre peut ainsi corriger
une erreur de saisie et reprendre le match si nécessaire.
onMatchEnd() reste un acte manuel.

https://claude.ai/code/session_01BNRo7DZzLNmvJLq96fYMda