### PR TITLE
claude/add-theme-system-ZYA6I

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1192,6 +1192,19 @@ ipcMain.handle('remote:updateShowPhotos', async (_, value: boolean) => {
   }
 });
 
+ipcMain.handle('remote:updateTheme', async (_, theme: string) => {
+  try {
+    if (!remoteScoreServer) {
+      return { success: false, error: 'Le serveur distant n est pas démarré' };
+    }
+    remoteScoreServer.updateTheme(theme as any);
+    return { success: true };
+  } catch (error) {
+    console.error('Error updating theme:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle(
   'remote:updateKioskViews',
   async (_, views: { poules: boolean; classement: boolean; direct: boolean }) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -394,6 +394,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getArenas: () => ipcRenderer.invoke('remote:getArenas'),
     updateStripCount: (count: number) => ipcRenderer.invoke('remote:updateStripCount', count),
     updateShowPhotos: (value: boolean) => ipcRenderer.invoke('remote:updateShowPhotos', value),
+    updateTheme: (theme: string) => ipcRenderer.invoke('remote:updateTheme', theme),
     updateKioskViews: (views: { poules: boolean; classement: boolean; direct: boolean }) =>
       ipcRenderer.invoke('remote:updateKioskViews', views),
     updateMatchArena: (matchId: string, fromArena: number | null, toArena: number | null) =>

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -19,6 +19,7 @@ import {
   ArenaSettings,
   ArenaUpdate,
   OrgNote,
+  DisplayTheme,
 } from '../shared/types/remote';
 import { Competition, Match, Fencer, MatchStatus, Score } from '../shared/types';
 import { DatabaseManager } from '../database';
@@ -39,6 +40,7 @@ export class RemoteScoreServer {
   private poolFencersCache: Map<string, any[]> = new Map(); // Tireurs par poolId (depuis le renderer)
   private sessionMatchScores: Map<string, { scoreA: any; scoreB: any; status: string }> = new Map(); // Scores en mémoire
   private sessionShowPhotos: boolean = false; // Afficher les photos des combattants avant le combat
+  private sessionTheme: DisplayTheme = 'dark'; // Thème visuel de l'affichage distant
   private orgNote: OrgNote | null = null; // Note d'organisation affichée sur le kiosk
   private sessionKioskViews: { poules: boolean; classement: boolean; direct: boolean } = {
     poules: true,
@@ -2091,8 +2093,12 @@ export class RemoteScoreServer {
   }
 
   private broadcastArenaUpdate(arenaId: string, update: ArenaUpdate): void {
-    // Injecter le réglage showPhotos dans chaque mise à jour
-    const updateWithPhotos: ArenaUpdate = { ...update, showPhotos: this.sessionShowPhotos };
+    // Injecter le réglage showPhotos et theme dans chaque mise à jour
+    const updateWithPhotos: ArenaUpdate = {
+      ...update,
+      showPhotos: this.sessionShowPhotos,
+      theme: this.sessionTheme,
+    };
     // Envoyer via Socket.IO aux clients connectés aux arènes
     this.io.emit(`arena:${arenaId}:update`, updateWithPhotos);
 
@@ -2511,6 +2517,22 @@ export class RemoteScoreServer {
     if (!this.session) throw new Error('Aucune session active');
     this.sessionShowPhotos = value;
     // Re-broadcast à toutes les pistes pour propager le nouveau réglage
+    for (const [arenaId, arena] of this.arenas.entries()) {
+      this.broadcastArenaUpdate(arenaId, {
+        arenaId,
+        match: arena.currentMatch,
+        scoreA: arena.currentMatch?.scoreA,
+        scoreB: arena.currentMatch?.scoreB,
+        status: arena.status,
+        fencerA: arena.currentMatch?.fencerA,
+        fencerB: arena.currentMatch?.fencerB,
+      });
+    }
+  }
+
+  public updateTheme(theme: DisplayTheme): void {
+    if (!this.session) throw new Error('Aucune session active');
+    this.sessionTheme = theme;
     for (const [arenaId, arena] of this.arenas.entries()) {
       this.broadcastArenaUpdate(arenaId, {
         arenaId,

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -23,6 +23,94 @@
         font-display: block;
       }
 
+    /* ── Thème Dark (défaut) ── */
+    :root,
+    [data-theme="dark"] {
+      --bg: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+      --text: #fff;
+      --header-bg: rgba(0, 0, 0, 0.4);
+      --match-bg: rgba(255, 255, 255, 0.95);
+      --fencer-name-color: #1f2937;
+      --fencer-club-color: #6b7280;
+      --green-side-bg: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
+      --green-side-border: #16a34a;
+      --red-side-bg: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+      --red-side-border: #dc2626;
+      --score-bg: #0c0c09;
+      --score-green: #00e640;
+      --score-green-glow: rgba(0, 230, 64, 0.65), rgba(0, 230, 64, 0.3);
+      --score-red: #ff2200;
+      --score-red-glow: rgba(255, 34, 0, 0.65), rgba(255, 34, 0, 0.3);
+      --timer-bg: #0a0800;
+      --timer-color: #ffaa00;
+      --timer-glow: rgba(255, 170, 0, 0.9), rgba(255, 170, 0, 0.45);
+      --timer-border: rgba(255, 170, 0, 0.18);
+      --timer-run-color: #00e640;
+      --timer-run-glow: rgba(0, 230, 64, 0.95), rgba(0, 230, 64, 0.5);
+      --timer-run-border: rgba(0, 230, 64, 0.5);
+      --waiting-color: white;
+      --idle-number-color: rgba(255, 255, 255, 0.9);
+      --idle-label-color: rgba(255, 255, 255, 0.5);
+    }
+
+    /* ── Thème Light ── */
+    [data-theme="light"] {
+      --bg: linear-gradient(135deg, #e8edf5 0%, #c8d8f0 100%);
+      --text: #1a2340;
+      --header-bg: rgba(255, 255, 255, 0.75);
+      --match-bg: #ffffff;
+      --fencer-name-color: #111827;
+      --fencer-club-color: #374151;
+      --green-side-bg: linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%);
+      --green-side-border: #059669;
+      --red-side-bg: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%);
+      --red-side-border: #b91c1c;
+      --score-bg: #f1f5f9;
+      --score-green: #059669;
+      --score-green-glow: rgba(5, 150, 105, 0.4), rgba(5, 150, 105, 0.15);
+      --score-red: #dc2626;
+      --score-red-glow: rgba(220, 38, 38, 0.4), rgba(220, 38, 38, 0.15);
+      --timer-bg: #f8fafc;
+      --timer-color: #d97706;
+      --timer-glow: rgba(217, 119, 6, 0.7), rgba(217, 119, 6, 0.3);
+      --timer-border: rgba(217, 119, 6, 0.3);
+      --timer-run-color: #059669;
+      --timer-run-glow: rgba(5, 150, 105, 0.8), rgba(5, 150, 105, 0.35);
+      --timer-run-border: rgba(5, 150, 105, 0.4);
+      --waiting-color: #1a2340;
+      --idle-number-color: rgba(26, 35, 64, 0.85);
+      --idle-label-color: rgba(26, 35, 64, 0.45);
+    }
+
+    /* ── Thème Neon ── */
+    [data-theme="neon"] {
+      --bg: #0a0a0a;
+      --text: #e0e0e0;
+      --header-bg: rgba(0, 0, 0, 0.8);
+      --match-bg: #111111;
+      --fencer-name-color: #f0f0f0;
+      --fencer-club-color: #a0a0a0;
+      --green-side-bg: linear-gradient(135deg, #001a0d 0%, #002e15 100%);
+      --green-side-border: #00ff88;
+      --red-side-bg: linear-gradient(135deg, #1a0000 0%, #2e0000 100%);
+      --red-side-border: #ff2244;
+      --score-bg: #050505;
+      --score-green: #00ff88;
+      --score-green-glow: rgba(0, 255, 136, 0.9), rgba(0, 255, 136, 0.5);
+      --score-red: #ff2244;
+      --score-red-glow: rgba(255, 34, 68, 0.9), rgba(255, 34, 68, 0.5);
+      --timer-bg: #030303;
+      --timer-color: #ff9900;
+      --timer-glow: rgba(255, 153, 0, 0.95), rgba(255, 153, 0, 0.5);
+      --timer-border: rgba(255, 153, 0, 0.3);
+      --timer-run-color: #00ff88;
+      --timer-run-glow: rgba(0, 255, 136, 1), rgba(0, 255, 136, 0.6);
+      --timer-run-border: rgba(0, 255, 136, 0.6);
+      --waiting-color: #e0e0e0;
+      --idle-number-color: rgba(255, 255, 255, 0.9);
+      --idle-label-color: rgba(255, 255, 255, 0.35);
+    }
+
     * {
         margin: 0;
         padding: 0;
@@ -31,17 +119,17 @@
 
       body {
         font-family: 'Arial', 'Helvetica Neue', Helvetica, sans-serif;
-        background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+        background: var(--bg);
         height: 100vh;
         overflow: hidden;
-        color: #fff;
+        color: var(--text);
         display: flex;
         flex-direction: column;
         padding-top: 52px;
       }
 
       .header {
-        background: rgba(0, 0, 0, 0.4);
+        background: var(--header-bg);
         padding: 0.4rem 1rem;
         display: flex;
         justify-content: space-between;
@@ -192,7 +280,7 @@
 
       /* Affichage du match */
       .match-display {
-        background: rgba(255, 255, 255, 0.95);
+        background: var(--match-bg);
         border-radius: 0.5rem;
         padding: 0.5rem;
         width: 100%;
@@ -236,13 +324,13 @@
       }
 
       .fencer-display.red-side {
-        background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
-        border-color: #dc2626;
+        background: var(--red-side-bg);
+        border-color: var(--red-side-border);
       }
 
       .fencer-display.green-side {
-        background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
-        border-color: #16a34a;
+        background: var(--green-side-bg);
+        border-color: var(--green-side-border);
       }
 
       .color-badge {
@@ -264,13 +352,13 @@
       .fencer-name {
         font-size: clamp(1rem, 3.5vw, 5vh);
         font-weight: 800;
-        color: #1f2937;
+        color: var(--fencer-name-color);
         margin-bottom: 0.15rem;
       }
 
       .fencer-club {
         font-size: clamp(0.7rem, 2vw, 3vh);
-        color: #6b7280;
+        color: var(--fencer-club-color);
         margin-bottom: 0.4rem;
         font-weight: 500;
       }
@@ -333,24 +421,23 @@
         line-height: 1.1;
         letter-spacing: 0.02em;
         display: inline-block;
-        background: #0c0c09;
+        background: var(--score-bg);
         padding: 0.04em 0.14em;
         border-radius: 0.06em;
         box-shadow: inset 0 0 14px rgba(0, 0, 0, 0.85);
+        transition: color 0.4s, background 0.4s;
       }
 
       .score-big.red {
-        color: #ff2200;
+        color: var(--score-red);
         text-shadow: 0 0 6px rgba(255, 34, 0, 0.95),
-                     0 0 18px rgba(255, 34, 0, 0.65),
-                     0 0 50px rgba(255, 34, 0, 0.3);
+                     0 0 18px var(--score-red-glow);
       }
 
       .score-big.green {
-        color: #00e640;
+        color: var(--score-green);
         text-shadow: 0 0 6px rgba(0, 230, 64, 0.95),
-                     0 0 18px rgba(0, 230, 64, 0.65),
-                     0 0 50px rgba(0, 230, 64, 0.3);
+                     0 0 18px var(--score-green-glow);
       }
 
       .vs-divider {
@@ -371,36 +458,33 @@
 
       .timer-display {
         display: block;
-        background: #0a0800;
+        background: var(--timer-bg);
         padding: 0.4rem 1rem;
         border-radius: 0.5rem;
         font-size: clamp(3.5rem, 11vw, 18vh);
         font-weight: bold;
         font-family: 'DSEG7Classic', monospace;
-        color: #ffaa00;
-        text-shadow: 0 0 8px rgba(255, 170, 0, 0.9),
-                     0 0 28px rgba(255, 170, 0, 0.45);
+        color: var(--timer-color);
+        text-shadow: 0 0 8px var(--timer-glow);
         letter-spacing: 0.05em;
         box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5),
                     inset 0 0 22px rgba(0, 0, 0, 0.7);
-        border: 3px solid rgba(255, 170, 0, 0.18);
+        border: 3px solid var(--timer-border);
         transition: all 0.3s;
         width: 100%;
         line-height: 1.1;
       }
 
       .timer-display.running {
-        border-color: rgba(0, 230, 64, 0.5);
-        color: #00e640;
-        text-shadow: 0 0 8px rgba(0, 230, 64, 0.95),
-                     0 0 28px rgba(0, 230, 64, 0.5);
+        border-color: var(--timer-run-border);
+        color: var(--timer-run-color);
+        text-shadow: 0 0 8px var(--timer-run-glow);
       }
 
       .timer-display.paused {
-        border-color: rgba(255, 170, 0, 0.5);
-        color: #ffaa00;
-        text-shadow: 0 0 8px rgba(255, 170, 0, 0.9),
-                     0 0 28px rgba(255, 170, 0, 0.45);
+        border-color: var(--timer-border);
+        color: var(--timer-color);
+        text-shadow: 0 0 8px var(--timer-glow);
       }
 
       .timer-display.warning {
@@ -451,7 +535,7 @@
       /* Écran d'attente */
       .waiting-screen {
         text-align: center;
-        color: white;
+        color: var(--waiting-color);
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -466,7 +550,7 @@
         font-size: 20vw;
         font-weight: 900;
         line-height: 1;
-        color: rgba(255, 255, 255, 0.9);
+        color: var(--idle-number-color);
         text-shadow: 0 4px 40px rgba(0, 0, 0, 0.5);
       }
 
@@ -475,7 +559,7 @@
         font-weight: 300;
         letter-spacing: 0.5em;
         text-transform: uppercase;
-        color: rgba(255, 255, 255, 0.5);
+        color: var(--idle-label-color);
         margin-top: 0.5rem;
       }
 
@@ -705,6 +789,7 @@
           this.isSuddenDeath = false;
           this.inversionEnabled = localStorage.getItem('inversionEnabled') === 'true';
           this.showPhotos = false;
+          this.theme = localStorage.getItem('displayTheme') || 'dark';
 
           this.init();
         }
@@ -724,8 +809,16 @@
           document.getElementById('arena-idle-number').textContent = this.arenaNumber;
           this.setupInversionToggle();
           this.applyInversionState();
+          this.applyTheme(this.theme);
           this.setupHeaderAutoHide();
           this.setupSocketListeners();
+        }
+
+        applyTheme(theme) {
+          const valid = ['dark', 'light', 'neon'];
+          this.theme = valid.includes(theme) ? theme : 'dark';
+          document.documentElement.setAttribute('data-theme', this.theme);
+          localStorage.setItem('displayTheme', this.theme);
         }
 
         setupHeaderAutoHide() {
@@ -796,6 +889,11 @@
         }
 
         handleArenaUpdate(data) {
+          // Mise à jour du thème visuel
+          if (data.theme && data.theme !== this.theme) {
+            this.applyTheme(data.theme);
+          }
+
           // Mise à jour du réglage photos
           if (data.showPhotos !== undefined) {
             this.showPhotos = data.showPhotos;

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -61,6 +61,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const [arenaPasswords, setArenaPasswords] = useState<Record<string, string>>({});
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [showPhotos, setShowPhotos] = useState(false);
+  const [displayTheme, setDisplayTheme] = useState<'dark' | 'light' | 'neon'>('dark');
   const [kioskViews, setKioskViews] = useState({ poules: true, classement: true, direct: true });
   const [orgNoteType, setOrgNoteType] = useState<'free' | 'target_time'>('free');
   const [orgNoteMessage, setOrgNoteMessage] = useState('');
@@ -419,6 +420,42 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           />
           Afficher les photos des combattants avant le combat
         </label>
+        <div style={{ margin: '0.5rem 0' }}>
+          <div style={{ fontSize: '0.875rem', marginBottom: '0.4rem', color: 'inherit' }}>
+            Thème de l'affichage :
+          </div>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            {(
+              [
+                { value: 'dark', label: 'Sombre', icon: '🌙' },
+                { value: 'light', label: 'Clair', icon: '☀️' },
+                { value: 'neon', label: 'Néon', icon: '⚡' },
+              ] as const
+            ).map(({ value, label, icon }) => (
+              <button
+                key={value}
+                onClick={async () => {
+                  setDisplayTheme(value);
+                  await window.electronAPI.remote.updateTheme(value);
+                }}
+                style={{
+                  flex: 1,
+                  padding: '0.35rem 0.5rem',
+                  borderRadius: '0.375rem',
+                  border: `2px solid ${displayTheme === value ? '#3b82f6' : '#475569'}`,
+                  background: displayTheme === value ? '#1d4ed8' : 'transparent',
+                  color: '#e2e8f0',
+                  cursor: 'pointer',
+                  fontWeight: displayTheme === value ? 700 : 400,
+                  fontSize: '0.8rem',
+                  transition: 'all 0.15s',
+                }}
+              >
+                {icon} {label}
+              </button>
+            ))}
+          </div>
+        </div>
         <div style={{ margin: '0.5rem 0' }}>
           <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem', color: 'inherit' }}>
             Vues kiosk :

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -103,11 +103,14 @@ export interface Arena {
   password?: string;
 }
 
+export type DisplayTheme = 'dark' | 'light' | 'neon';
+
 export interface ArenaSettings {
   matchDuration: number; // in seconds
   breakDuration: number; // between matches
   autoAdvance: boolean; // automatically load next match
   showPhotos?: boolean; // afficher les photos avant le combat
+  theme?: DisplayTheme; // thème visuel de l'affichage distant
 }
 
 export interface ArenaMatch {
@@ -138,6 +141,7 @@ export interface ArenaUpdate {
   cardsB?: string[];
   suddenDeath?: boolean;
   showPhotos?: boolean; // afficher les photos avant le combat
+  theme?: DisplayTheme; // thème visuel de l'affichage distant
 }
 
 export interface RefereeControl {


### PR DESCRIPTION
- Ajout du type DisplayTheme ('dark' | 'light' | 'neon') dans remote.ts
- CSS variables par thème dans arena.html (sombre, clair, néon)
- Le thème est diffusé à toutes les arènes via Socket.IO
- Persistance du thème côté client (localStorage)
- IPC remote:updateTheme dans main.ts + preload.ts
- Sélecteur de thème dans RemoteScoreManager (boutons 🌙/☀️/⚡)

https://claude.ai/code/session_01WhcameuYKPY2BSs87BkwBQ