### PR TITLE
claude/add-pdf-logo-sPCLf

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -297,6 +297,15 @@ function createWindow(): void {
       // Fallback to default language
     }
     createMenu(currentMenuLanguage);
+
+    // Restore persisted logo and sync to renderer localStorage if not already set
+    try {
+      const logoPath = path.join(app.getPath('userData'), 'logo.dat');
+      if (fs.existsSync(logoPath)) {
+        const logo = fs.readFileSync(logoPath, 'utf-8');
+        if (logo) mainWindow!.webContents.send('app:logoLoaded', logo);
+      }
+    } catch { /* logo optionnel */ }
   });
 }
 
@@ -1273,6 +1282,26 @@ ipcMain.handle('remote:clearOrgNote', async () => {
     console.error('Error clearing org note:', error);
     return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
   }
+});
+
+ipcMain.handle('remote:updateLogo', async (_, logo: string | null) => {
+  try {
+    const logoPath = path.join(app.getPath('userData'), 'logo.dat');
+    if (logo) {
+      fs.writeFileSync(logoPath, logo, 'utf-8');
+    } else {
+      try { fs.unlinkSync(logoPath); } catch { /* déjà absent */ }
+    }
+    if (remoteScoreServer) remoteScoreServer.setLogo(logo);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('app:getLogo', async () => {
+  const logoPath = path.join(app.getPath('userData'), 'logo.dat');
+  try { return fs.readFileSync(logoPath, 'utf-8'); } catch { return null; }
 });
 
 // App info handlers

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -407,6 +407,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     clearOrgNote: () => ipcRenderer.invoke('remote:clearOrgNote'),
     updateArenaTheme: (arenaId: string, theme: string, customTheme?: any) =>
       ipcRenderer.invoke('remote:updateArenaTheme', arenaId, theme, customTheme),
+    updateLogo: (logo: string | null) => ipcRenderer.invoke('remote:updateLogo', logo),
   },
 
   // Remote event listeners (for real-time updates)
@@ -420,6 +421,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const handler = (_: any, note: any) => callback(note);
     ipcRenderer.on('kiosk:note', handler);
     return () => ipcRenderer.removeListener('kiosk:note', handler);
+  },
+
+  getLogo: () => ipcRenderer.invoke('app:getLogo'),
+  onLogoLoaded: (callback: (logo: string | null) => void) => {
+    const handler = (_: any, logo: string | null) => callback(logo);
+    ipcRenderer.on('app:logoLoaded', handler);
+    return () => ipcRenderer.removeListener('app:logoLoaded', handler);
   },
 
   // Remove listeners

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -44,6 +44,7 @@ export class RemoteScoreServer {
   private sessionTheme: DisplayTheme = 'dark'; // Thème visuel de l'affichage distant (global)
   private arenaThemeOverrides: Map<string, { theme: DisplayTheme; customTheme?: CustomTheme }> = new Map();
   private orgNote: OrgNote | null = null; // Note d'organisation affichée sur le kiosk
+  private sessionLogo: string | null = null; // Logo organisateur (base64) pour kiosk et affichages publics
   private sessionKioskViews: { poules: boolean; classement: boolean; direct: boolean } = {
     poules: true,
     classement: true,
@@ -420,6 +421,11 @@ export class RemoteScoreServer {
     this.app.post('/api/session/stop', (req, res) => {
       this.session = null;
       res.json({ success: true });
+    });
+
+    // Logo organisateur
+    this.app.get('/api/logo', (req, res) => {
+      res.json({ logo: this.sessionLogo });
     });
 
     // Arena routes
@@ -2615,6 +2621,11 @@ export class RemoteScoreServer {
   public clearOrgNote(): void {
     this.orgNote = null;
     this.io.emit('kiosk:note', null);
+  }
+
+  public setLogo(logo: string | null): void {
+    this.sessionLogo = logo;
+    this.io.emit('logo:update', { logo });
   }
 
   public setArenaPassword(arenaId: string, password: string): void {

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -600,6 +600,7 @@
     <!-- Menu escamotable -->
     <div id="kiosk-menu">
       <div style="display:flex;align-items:center">
+        <img id="org-logo" src="" alt="Logo" style="max-height:36px;max-width:120px;object-fit:contain;display:none;margin-right:10px;border-radius:3px;" />
         <span class="menu-title">🏆 BellePoule</span>
         <span class="menu-competition" id="menu-competition-name">—</span>
       </div>
@@ -1186,6 +1187,29 @@
         }
       }
 
+      // ─── Logo organisateur ───────────────────────────────────────────────────
+      function applyLogo(logo) {
+        const el = document.getElementById('org-logo');
+        if (!el) return;
+        if (logo) {
+          el.src = logo;
+          el.style.display = 'block';
+        } else {
+          el.style.display = 'none';
+          el.src = '';
+        }
+      }
+
+      async function fetchLogo() {
+        try {
+          const res = await fetch('/api/logo');
+          if (res.ok) {
+            const { logo } = await res.json();
+            applyLogo(logo || null);
+          }
+        } catch { /* logo optionnel */ }
+      }
+
       // ─── Helpers ─────────────────────────────────────────────────────────────
       function escHtml(s) {
         if (!s) return '';
@@ -1195,7 +1219,9 @@
       // ─── Init ─────────────────────────────────────────────────────────────────
       window.addEventListener('DOMContentLoaded', () => {
         fetchData();
+        fetchLogo();
         setInterval(fetchData, 15000);
+        setInterval(fetchLogo, 30000);
         startRotation();
 
         // Plein écran automatique au premier clic seulement

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -324,11 +324,13 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   // Export PDF function
   const handleExportPDF = async () => {
     try {
+      const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
       await exportPoolToPDF(pool, {
         title: `Poule ${pool.number} - ${pool.fencers.length} tireurs`,
         includeFinishedMatches: true,
         includePendingMatches: true,
         includePoolStats: true,
+        logoBase64: logo,
       });
       showToast(`Export PDF de la poule ${pool.number} généré avec succès`, 'success');
     } catch (error) {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -3,10 +3,41 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from '../hooks/useTranslation';
 import type { Language } from '../contexts/TranslationContext';
 import LanguageSelector from './LanguageSelector';
+
+const LOGO_STORAGE_KEY = 'bellepoule-logo';
+const LOGO_MAX_W = 600;
+const LOGO_MAX_H = 200;
+
+function resizeLogo(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      const img = new Image();
+      img.onload = () => {
+        let w = img.width;
+        let h = img.height;
+        if (w > LOGO_MAX_W || h > LOGO_MAX_H) {
+          const ratio = Math.min(LOGO_MAX_W / w, LOGO_MAX_H / h);
+          w = Math.round(w * ratio);
+          h = Math.round(h * ratio);
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        canvas.getContext('2d')!.drawImage(img, 0, 0, w, h);
+        resolve(canvas.toDataURL('image/jpeg', 0.85));
+      };
+      img.onerror = reject;
+      img.src = e.target!.result as string;
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
 
 interface SettingsModalProps {
   onClose: () => void;
@@ -18,13 +49,37 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
   const [settings, setSettings] = useState({
     language: language,
     theme: theme,
-    // Ajouter d'autres paramètres ici
   });
+  const [logo, setLogo] = useState<string | null>(() => localStorage.getItem(LOGO_STORAGE_KEY));
+  const [isDragging, setIsDragging] = useState(false);
+  const [logoError, setLogoError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Update local settings when global language/theme changes (e.g., from localStorage)
   useEffect(() => {
     setSettings(prev => ({ ...prev, language, theme }));
   }, [language, theme]);
+
+  // Sync persisted logo from main process if localStorage is empty
+  useEffect(() => {
+    if (!logo) {
+      const api = (window as any).electronAPI;
+      api?.getLogo?.().then((persisted: string | null) => {
+        if (persisted) {
+          setLogo(persisted);
+          localStorage.setItem(LOGO_STORAGE_KEY, persisted);
+        }
+      });
+    }
+    const api = (window as any).electronAPI;
+    const unsub = api?.onLogoLoaded?.((persisted: string | null) => {
+      if (persisted && !localStorage.getItem(LOGO_STORAGE_KEY)) {
+        setLogo(persisted);
+        localStorage.setItem(LOGO_STORAGE_KEY, persisted);
+      }
+    });
+    return () => { if (typeof unsub === 'function') unsub(); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleLanguageChange = (newLanguage: Language) => {
     setSettings(prev => ({ ...prev, language: newLanguage }));
@@ -32,6 +87,47 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
 
   const handleThemeChange = (newTheme: 'default' | 'light' | 'dark') => {
     setSettings(prev => ({ ...prev, theme: newTheme }));
+  };
+
+  const applyLogo = useCallback(async (file: File) => {
+    setLogoError(null);
+    if (file.size > 5 * 1024 * 1024) {
+      setLogoError('Image trop grande (max 5 Mo)');
+      return;
+    }
+    if (!file.type.startsWith('image/')) {
+      setLogoError('Fichier non supporté — choisissez une image');
+      return;
+    }
+    try {
+      const base64 = await resizeLogo(file);
+      setLogo(base64);
+      localStorage.setItem(LOGO_STORAGE_KEY, base64);
+      const api = (window as any).electronAPI;
+      if (api?.remote?.updateLogo) api.remote.updateLogo(base64).catch(() => {});
+    } catch {
+      setLogoError('Impossible de lire l\'image');
+    }
+  }, []);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) applyLogo(file);
+    e.target.value = '';
+  };
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) applyLogo(file);
+  }, [applyLogo]);
+
+  const handleRemoveLogo = () => {
+    setLogo(null);
+    localStorage.removeItem(LOGO_STORAGE_KEY);
+    const api = (window as any).electronAPI;
+    if (api?.remote?.updateLogo) api.remote.updateLogo(null).catch(() => {});
   };
 
   const handleSave = () => {
@@ -61,7 +157,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
             />
           </div>
 
-          {/* Ajouter d'autres paramètres ici */}
           <div className="form-group">
             <label>{t('settings.theme')}</label>
             <select
@@ -73,6 +168,63 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
               <option value="light">Light</option>
               <option value="dark">Dark</option>
             </select>
+          </div>
+
+          {/* Logo organisateur */}
+          <div className="form-group">
+            <label>Logo organisateur</label>
+            <p style={{ fontSize: '0.8rem', color: 'var(--text-muted, #6b7280)', marginBottom: '0.5rem' }}>
+              Affiché en haut à gauche des PDF exportés et dans le mode kiosque.
+            </p>
+            <div
+              onDragOver={e => { e.preventDefault(); setIsDragging(true); }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+              style={{
+                border: `2px dashed ${isDragging ? 'var(--primary, #3b82f6)' : 'var(--border, #d1d5db)'}`,
+                borderRadius: '8px',
+                padding: '1rem',
+                textAlign: 'center',
+                cursor: 'pointer',
+                background: isDragging ? 'var(--primary-light, #eff6ff)' : 'transparent',
+                transition: 'border-color 0.15s, background 0.15s',
+              }}
+            >
+              {logo ? (
+                <img
+                  src={logo}
+                  alt="Logo organisateur"
+                  style={{ maxHeight: '60px', maxWidth: '100%', objectFit: 'contain', display: 'block', margin: '0 auto 0.5rem' }}
+                />
+              ) : (
+                <span style={{ fontSize: '0.85rem', color: 'var(--text-muted, #6b7280)' }}>
+                  Glissez une image ici ou cliquez pour choisir
+                </span>
+              )}
+              <span style={{ fontSize: '0.75rem', color: 'var(--text-muted, #9ca3af)', display: 'block', marginTop: logo ? '0' : '0.25rem' }}>
+                PNG, JPG, SVG — max 5 Mo
+              </span>
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              style={{ display: 'none' }}
+              onChange={handleFileChange}
+            />
+            {logoError && (
+              <p style={{ fontSize: '0.8rem', color: 'var(--danger, #ef4444)', marginTop: '0.25rem' }}>{logoError}</p>
+            )}
+            {logo && (
+              <button
+                className="btn btn-secondary"
+                style={{ marginTop: '0.5rem', fontSize: '0.8rem', padding: '0.25rem 0.75rem' }}
+                onClick={handleRemoveLogo}
+              >
+                Supprimer le logo
+              </button>
+            )}
           </div>
         </div>
 

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -492,7 +492,8 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const perPage = Math.max(1, Math.min(pdfMatchesPerPage, MAX_MATCHES_PER_PAGE_TABLEAU));
     const title = `Tableau de ${tableauSize}`;
     try {
-      await exportTableauToPDF(matches, perPage, title);
+      const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+      await exportTableauToPDF(matches, perPage, title, logo);
       setShowPdfModal(false);
     } catch (e) {
       showToast((e as Error).message, 'error');

--- a/src/renderer/hooks/useExport.ts
+++ b/src/renderer/hooks/useExport.ts
@@ -211,9 +211,11 @@ export const useExport = ({ competition, showToast }: UseExportProps) => {
   const exportPoolsPDF = useCallback(
     async (pools: Pool[], currentPoolRound: number) => {
       try {
+        const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
         await exportMultiplePoolsToPDF(
           pools,
-          `Toutes les Poules - ${competition.title} - Tour ${currentPoolRound}`
+          `Toutes les Poules - ${competition.title} - Tour ${currentPoolRound}`,
+          logo
         );
         showToast(`Export PDF de ${pools.length} poules généré avec succès`, 'success');
       } catch (error) {

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -14,6 +14,7 @@ interface PoolExportOptions {
   includeFinishedMatches?: boolean;
   includePendingMatches?: boolean;
   includePoolStats?: boolean;
+  logoBase64?: string;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -120,6 +121,13 @@ const BASE_CSS = `
     justify-content: space-between;
     margin-bottom: 0;
   }
+  .doc-header-logo {
+    max-height: 10mm;
+    max-width: 35mm;
+    object-fit: contain;
+    margin-right: 4mm;
+    flex-shrink: 0;
+  }
   .doc-header-left h1 {
     font-size: 15pt;
     font-weight: 700;
@@ -202,7 +210,7 @@ const BASE_CSS = `
 // ─── HTML Poule ───────────────────────────────────────────────────────────────
 
 function generatePoolHTML(pool: Pool, options: PoolExportOptions): string {
-  const { title = `Poule ${pool.number}`, competitionName = '', weapon = '', category = '' } = options;
+  const { title = `Poule ${pool.number}`, competitionName = '', weapon = '', category = '', logoBase64 } = options;
   const fencers = pool.fencers ?? [];
   const matches = pool.matches ?? [];
   const finishedCount = matches.filter(m => m.status === MatchStatus.FINISHED).length;
@@ -367,6 +375,7 @@ function generatePoolHTML(pool: Pool, options: PoolExportOptions): string {
 </head>
 <body>
   <div class="doc-header">
+    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
     <div class="doc-header-left">
       <h1>${title}</h1>
       <div class="subtitle">Grille de poule • ${finishedCount}/${matches.length} matchs joués</div>
@@ -425,11 +434,12 @@ export async function exportPoolToPDF(pool: Pool, options: PoolExportOptions = {
 
 export async function exportMultiplePoolsToPDF(
   pools: Pool[],
-  title: string = 'Export des Poules'
+  title: string = 'Export des Poules',
+  logoBase64?: string
 ): Promise<void> {
   if (pools.length === 0) throw new Error('Aucune poule à exporter');
   for (const pool of pools) {
-    await exportPoolToPDF(pool, { title: `${title} - Poule ${pool.number}` });
+    await exportPoolToPDF(pool, { title: `${title} - Poule ${pool.number}`, logoBase64 });
   }
 }
 
@@ -468,7 +478,8 @@ function getTableauRoundName(round: number): string {
 function generateTableauHTML(
   matches: TableauMatchForPDF[],
   matchesPerPage: number,
-  title: string
+  title: string,
+  logoBase64?: string
 ): string {
   const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
   const sorted = [...real].sort((a, b) => b.round - a.round || a.position - b.position);
@@ -636,6 +647,7 @@ function generateTableauHTML(
 </head>
 <body>
   <div class="doc-header">
+    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
     <div class="doc-header-left">
       <h1>${title}</h1>
       <div class="subtitle">Feuilles d'arbitrage — Élimination directe</div>
@@ -657,14 +669,15 @@ function generateTableauHTML(
 export async function exportTableauToPDF(
   matches: TableauMatchForPDF[],
   matchesPerPage: number,
-  title: string = 'Tableau Élimination Directe'
+  title: string = 'Tableau Élimination Directe',
+  logoBase64?: string
 ): Promise<void> {
   const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
   if (real.length === 0) {
     throw new Error('Aucun match à exporter (tous sont des exempts ou sans tireurs assignés)');
   }
 
-  const html = generateTableauHTML(matches, matchesPerPage, title);
+  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64);
   await savePDF(html, `tableau-elimination.pdf`);
 }
 


### PR DESCRIPTION
- SettingsModal : section upload logo (glisser-déposer, resize auto 600×200 JPEG)
  stocké dans localStorage `bellepoule-logo`
- pdfExport.ts : logo injecté en haut à gauche du header des PDF (poules + tableau ED)
- PoolView / TableauView / useExport : passent le logo depuis localStorage à l'export
- main.ts : handlers IPC `remote:updateLogo` (persist userData/logo.dat) et `app:getLogo`
  + envoi `app:logoLoaded` au renderer au démarrage si logo persisté
- preload.ts : expose `remote.updateLogo`, `getLogo`, `onLogoLoaded`
- remoteScoreServer.ts : propriété `sessionLogo`, méthode `setLogo()`,
  endpoint GET `/api/logo`
- kiosk.html : affiche le logo dans la barre de menu, rafraîchi toutes les 30s

https://claude.ai/code/session_014mqNG3xZoqXDsYn78xtYA3