### PR TITLE
feat: sauter la phase de poules quand nombre de poules = 0

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -28,6 +28,7 @@ import {
   calculateOptimalPoolCount,
   distributeFencersToPoolsSerpentine,
   generatePoolMatchOrder,
+  generateInitialRanking,
 } from '../../shared/utils/poolCalculations';
 import { FencerComparison } from './FencerComparison';
 import { AnalyticsDashboard } from './AnalyticsDashboard';
@@ -86,6 +87,9 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   // Flag pour indiquer si le classement a été validé (débloque l'onglet Tableau)
   const [rankingValidated, setRankingValidated] = useState(false);
 
+  // Flag pour indiquer que la phase de poules est sautée (0 poules configurées)
+  const [skipPoolPhase, setSkipPoolPhase] = useState(false);
+
   // Hooks personnalisés
   const {
     fencers,
@@ -139,6 +143,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     overallRanking,
     tableauMatches,
     finalResults,
+    skipPoolPhase,
     poolPrepParams: {
       poolCount: pools.length,
       minFencersPerPool,
@@ -173,6 +178,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         setMinFencersPerPool(restoredState.poolPrepParams.minFencersPerPool);
         setMaxFencersPerPool(restoredState.poolPrepParams.maxFencersPerPool);
       }
+      if (restoredState.skipPoolPhase) setSkipPoolPhase(restoredState.skipPoolPhase);
     }
   }, [restoredState, isLoaded]);
 
@@ -348,6 +354,16 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     setCurrentPhase('ranking');
   };
 
+  const handleSkipToRanking = () => {
+    const checkedIn = getCheckedInFencers();
+    const initialRanking = generateInitialRanking(checkedIn);
+    setOverallRanking(initialRanking);
+    setSkipPoolPhase(true);
+    setPools([]);
+    setRankingValidated(false);
+    setCurrentPhase('ranking');
+  };
+
   const handleGoToTableau = () => {
     setRankingValidated(true);
     // Ne pas recalculer : overallRanking est déjà à jour
@@ -431,6 +447,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   };
 
   const handleGoBack = () => {
+    if (skipPoolPhase && currentPhase === 'ranking') {
+      setCurrentPhase('poolprep');
+      return;
+    }
     const phaseOrder: Phase[] = ['checkin', 'poolprep', 'pools', 'ranking', 'tableau', 'results'];
     const currentIndex = phaseOrder.indexOf(currentPhase);
     if (currentIndex > 0) {
@@ -439,7 +459,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   };
 
   // Phases dynamiques
-  const canAdvanceFromPools = pools.length > 0 && areAllPoolsComplete();
+  const canAdvanceFromPools = skipPoolPhase || (pools.length > 0 && areAllPoolsComplete());
   const isLastPoolRound = currentPoolRound >= poolRounds;
   const isResultsLocked = hasDirectElimination && finalResults.length === 0;
   const isTableauUnlocked = canAdvanceFromPools && rankingValidated;
@@ -468,10 +488,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     },
     {
       id: 'pools',
-      label: poolRounds > 1 ? `Poules (${currentPoolRound}/${poolRounds})` : 'Poules',
-      icon: '🎯',
-      disabled: false,
-      title: undefined as string | undefined,
+      label: skipPoolPhase ? 'Poules (saut)' : poolRounds > 1 ? `Poules (${currentPoolRound}/${poolRounds})` : 'Poules',
+      icon: skipPoolPhase ? '⏭' : '🎯',
+      disabled: skipPoolPhase,
+      title: skipPoolPhase ? 'Phase de poules ignorée (0 poules)' : (undefined as string | undefined),
     },
     {
       id: 'ranking',
@@ -770,8 +790,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             maxFencersPerPool={maxFencersPerPool}
             onPoolsConfirm={confirmedPools => {
               setPools(confirmedPools);
+              setSkipPoolPhase(false);
               setCurrentPhase('pools');
             }}
+            onSkipPools={handleSkipToRanking}
             onSettingsChange={(min, max) => {
               setMinFencersPerPool(min);
               setMaxFencersPerPool(max);
@@ -841,6 +863,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             ranking={overallRanking}
             weapon={competition.weapon}
             hasDirectElimination={hasDirectElimination}
+            isInitialRanking={skipPoolPhase}
             onGoToTableau={handleGoToTableau}
             onGoToResults={() => setCurrentPhase('results')}
             onPoolsChange={(updatedPools, hasRankingChanged) => {

--- a/src/renderer/components/PoolPrepView.tsx
+++ b/src/renderer/components/PoolPrepView.tsx
@@ -19,6 +19,7 @@ interface PoolPrepViewProps {
   minFencersPerPool?: number;
   maxFencersPerPool?: number;
   onPoolsConfirm: (pools: Pool[]) => void;
+  onSkipPools?: () => void;
   onSettingsChange?: (min: number, max: number) => void;
 }
 
@@ -37,6 +38,7 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
   minFencersPerPool: initialMin = 5,
   maxFencersPerPool: initialMax = 7,
   onPoolsConfirm,
+  onSkipPools,
   onSettingsChange,
 }) => {
   const [poolCount, setPoolCount] = useState<number>(0);
@@ -232,9 +234,10 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
   };
 
   const handlePoolCountChange = (newCount: number) => {
-    if (newCount >= 1 && newCount <= Math.ceil(fencers.length / 3)) {
+    if (newCount >= 0 && newCount <= Math.ceil(fencers.length / 3)) {
       saveToHistory();
       setPoolCount(newCount);
+      if (newCount === 0) setPools([]);
     }
   };
 
@@ -419,7 +422,7 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
             <button
               className="btn btn-secondary"
               onClick={() => handlePoolCountChange(poolCount - 1)}
-              disabled={poolCount <= 1}
+              disabled={poolCount <= 0}
               style={{ padding: '0.25rem 0.75rem' }}
             >
               -
@@ -540,12 +543,31 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
         style={{
           flex: 1,
           overflowY: 'auto',
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+          display: poolCount === 0 ? 'flex' : 'grid',
+          gridTemplateColumns: poolCount === 0 ? undefined : 'repeat(auto-fill, minmax(280px, 1fr))',
+          alignItems: poolCount === 0 ? 'center' : undefined,
+          justifyContent: poolCount === 0 ? 'center' : undefined,
           gap: '1rem',
           padding: '0.5rem',
         }}
       >
+        {poolCount === 0 ? (
+          <div
+            style={{
+              textAlign: 'center',
+              padding: '3rem',
+              color: '#6b7280',
+            }}
+          >
+            <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>⏭</div>
+            <div style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+              Aucune poule
+            </div>
+            <div style={{ fontSize: '0.9rem' }}>
+              Passage direct au classement initial des tireurs
+            </div>
+          </div>
+        ) : null}
         {pools.map((pool, poolIndex) => (
           <div
             key={pool.id}
@@ -769,11 +791,11 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
 
         <button
           className="btn btn-primary"
-          onClick={() => onPoolsConfirm(pools)}
-          disabled={pools.length === 0 || pools.some(p => p.fencers.length < 3)}
+          onClick={() => (poolCount === 0 ? onSkipPools?.() : onPoolsConfirm(pools))}
+          disabled={poolCount > 0 && (pools.length === 0 || pools.some(p => p.fencers.length < 3))}
           style={{ fontSize: '1rem', padding: '0.75rem 2rem' }}
         >
-          Lancer les poules →
+          {poolCount === 0 ? 'Passer au classement initial →' : 'Lancer les poules →'}
         </button>
       </div>
     </div>

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -21,6 +21,7 @@ interface PoolRankingViewProps {
   pools: Pool[];
   weapon?: Weapon;
   ranking?: PoolRanking[];
+  isInitialRanking?: boolean;
   onGoToTableau?: () => void;
   onGoToResults?: () => void;
   hasDirectElimination?: boolean;
@@ -33,6 +34,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   pools,
   weapon,
   ranking: externalRanking,
+  isInitialRanking = false,
   onGoToTableau,
   onGoToResults,
   hasDirectElimination = true,
@@ -256,21 +258,26 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
         }}
       >
         <div>
-          <h2 style={{ fontSize: '1.25rem', fontWeight: '600' }}>Classement après poules</h2>
+          <h2 style={{ fontSize: '1.25rem', fontWeight: '600' }}>
+            {isInitialRanking ? 'Classement initial' : 'Classement après poules'}
+          </h2>
           <p className="text-sm text-muted">
-            {pools.length} poule{pools.length > 1 ? 's' : ''} • {editedRanking.length} tireur
-            {editedRanking.length > 1 ? 's' : ''}
+            {isInitialRanking
+              ? `${editedRanking.length} tireur${editedRanking.length > 1 ? 's' : ''} • Classement de départ`
+              : `${pools.length} poule${pools.length > 1 ? 's' : ''} • ${editedRanking.length} tireur${editedRanking.length > 1 ? 's' : ''}`}
             {isEditing && ' (mode édition)'}
           </p>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <button
-            className="btn btn-secondary"
-            onClick={handleRecalculate}
-            title="Recalculer le classement"
-          >
-            🔄 Recalculer
-          </button>
+          {!isInitialRanking && (
+            <button
+              className="btn btn-secondary"
+              onClick={handleRecalculate}
+              title="Recalculer le classement"
+            >
+              🔄 Recalculer
+            </button>
+          )}
           <button
             className="btn btn-secondary"
             onClick={() => handleExport('csv')}

--- a/src/renderer/hooks/useCompetitionSession.ts
+++ b/src/renderer/hooks/useCompetitionSession.ts
@@ -19,6 +19,7 @@ interface SessionState {
   tableauMatches: TableauMatch[];
   finalResults: FinalResult[];
   currentPoolRound: number;
+  skipPoolPhase: boolean;
   poolPrepParams: {
     poolCount: number;
     minFencersPerPool: number;
@@ -40,6 +41,7 @@ interface UseCompetitionSessionProps {
   overallRanking: PoolRanking[];
   tableauMatches: TableauMatch[];
   finalResults: FinalResult[];
+  skipPoolPhase: boolean;
   poolPrepParams: {
     poolCount: number;
     minFencersPerPool: number;
@@ -84,6 +86,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
       tableauMatches: props.tableauMatches,
       finalResults: props.finalResults,
       currentPoolRound: props.currentPoolRound,
+      skipPoolPhase: props.skipPoolPhase,
       poolPrepParams: {
         poolCount: props.poolPrepParams?.poolCount || 0,
         minFencersPerPool: props.poolPrepParams?.minFencersPerPool || 5,
@@ -124,6 +127,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
           tableauMatches: typedState.tableauMatches || [],
           finalResults: typedState.finalResults || [],
           currentPoolRound: typedState.uiState?.currentPoolRound || 1,
+          skipPoolPhase: typedState.skipPoolPhase ?? false,
           poolPrepParams: typedState.poolPrepParams || {
             poolCount: 0,
             minFencersPerPool: 5,

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -1053,3 +1053,19 @@ export function calculateOverallRanking(pools: Pool[]): PoolRanking[] {
 
   return allRankings;
 }
+
+// Génère un classement initial depuis la liste des tireurs (sans données de poules)
+export function generateInitialRanking(fencers: Fencer[]): PoolRanking[] {
+  return fencers.map((fencer, index) => ({
+    fencer,
+    rank: index + 1,
+    victories: 0,
+    defeats: 0,
+    matchesPlayed: 0,
+    touchesScored: 0,
+    touchesReceived: 0,
+    index: 0,
+    ratio: 0,
+    questPoints: 0,
+  }));
+}


### PR DESCRIPTION
Permet de configurer 0 poules dans PoolPrepView pour passer
directement au classement initial des tireurs, puis au tableau
d'élimination directe, sans passer par la phase de poules.

- poolCalculations: ajoute generateInitialRanking()
- PoolPrepView: autorise poolCount à 0, affiche message, bouton adapté
- useCompetitionSession: persiste/restaure skipPoolPhase
- CompetitionView: handler handleSkipToRanking, logique canAdvanceFromPools,
  handleGoBack, phases nav, wiring PoolPrepView et PoolRankingView
- PoolRankingView: prop isInitialRanking pour titre et UX adaptés

https://claude.ai/code/session_01Xn1zjrPWrJVkFzSSHjhiG8