### PR TITLE
feat: menu Importer déroulant sur la page appel

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -315,13 +315,25 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     setImportData(null);
   };
 
-  const handleOpenImportDialog = async () => {
+  const handleOpenImportDialog = async (type: 'xml' | 'fff' | 'ranking' = 'fff') => {
+    const configs = {
+      xml: {
+        title: 'Importer un fichier XML BellePoule',
+        filters: [{ name: 'XML BellePoule', extensions: ['xml', 'cotcot'] }],
+      },
+      fff: {
+        title: 'Importer une liste FFE',
+        filters: [{ name: 'Fichiers FFE', extensions: ['fff', 'csv', 'txt'] }],
+      },
+      ranking: {
+        title: 'Importer un classement FFE',
+        filters: [{ name: 'Fichier classement', extensions: ['fff', 'csv', 'txt', 'xlsx'] }],
+      },
+    };
+    const cfg = configs[type];
     const result = await window.electronAPI.dialog.openFile({
-      title: 'Importer des tireurs',
-      filters: [
-        { name: 'Fichiers FFE', extensions: ['fff', 'csv', 'txt'] },
-        { name: 'Tous les fichiers', extensions: ['*'] },
-      ],
+      title: cfg.title,
+      filters: [...cfg.filters, { name: 'Tous les fichiers', extensions: ['*'] }],
       properties: ['openFile'],
     });
 
@@ -330,8 +342,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       const content = result.content || '';
       const extension = filepath.split('.').pop()?.toLowerCase();
 
-      let format = 'fff';
-      if (extension === 'csv' || extension === 'txt') {
+      let format: string = type;
+      if (type === 'fff' && (extension === 'csv' || extension === 'txt')) {
         format = 'txt';
       }
 
@@ -767,7 +779,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onDeleteAllFencers={deleteAllFencers}
             onCheckInAll={checkInAll}
             onUncheckAll={uncheckAll}
-            onImport={handleOpenImportDialog}
+            onImport={(type) => handleOpenImportDialog(type)}
             onFencersImported={loadFencers}
             onSetFencerStatus={(id, status) => {
               // Si forfait, abandon ou exclusion, mettre à jour tous les matchs du tireur

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -21,7 +21,7 @@ interface FencerListProps {
   onCheckInAll?: () => void;
   onUncheckAll?: () => void;
   onSetFencerStatus?: (id: string, status: FencerStatus) => void;
-  onImport?: () => void;
+  onImport?: (type: 'xml' | 'fff' | 'ranking') => void;
   onFencersImported?: () => void;
 }
 
@@ -58,11 +58,16 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const [editingFencer, setEditingFencer] = useState<Fencer | null>(null);
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
+  const [importMenuOpen, setImportMenuOpen] = useState(false);
+  const importMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
         setExportMenuOpen(false);
+      }
+      if (importMenuRef.current && !importMenuRef.current.contains(e.target as Node)) {
+        setImportMenuOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -121,9 +126,9 @@ const FencerListComponent: React.FC<FencerListProps> = ({
     }
   };
 
-  const handleImportFencers = () => {
+  const handleImportFencers = (type: 'xml' | 'fff' | 'ranking') => {
     if (onImport) {
-      onImport();
+      onImport(type);
     }
   };
 
@@ -288,13 +293,69 @@ const FencerListComponent: React.FC<FencerListProps> = ({
             </button>
           )}
           {onImport && (
-            <button
-              className="btn btn-secondary"
-              onClick={handleImportFencers}
-              title="Importer depuis un fichier (.ffe, .csv, .txt)"
-            >
-              📥 Importer
-            </button>
+            <div ref={importMenuRef} style={{ position: 'relative', display: 'inline-block' }}>
+              <button
+                className="btn btn-secondary"
+                onClick={() => setImportMenuOpen(o => !o)}
+                title="Importer"
+              >
+                📥 Importer ▾
+              </button>
+              {importMenuOpen && (
+                <div style={{
+                  position: 'absolute',
+                  top: '100%',
+                  left: 0,
+                  zIndex: 1000,
+                  background: 'var(--bg-secondary, #2a2a3e)',
+                  border: '1px solid var(--border-color, #444)',
+                  borderRadius: '6px',
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+                  minWidth: '230px',
+                  padding: '4px 0',
+                }}>
+                  <button
+                    className="btn btn-ghost"
+                    style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 16px', borderRadius: 0 }}
+                    onClick={() => { handleImportFencers('xml'); setImportMenuOpen(false); }}
+                  >
+                    Importer XML (BellePoule)
+                  </button>
+                  <button
+                    className="btn btn-ghost"
+                    style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 16px', borderRadius: 0 }}
+                    onClick={() => { handleImportFencers('fff'); setImportMenuOpen(false); }}
+                  >
+                    Importer liste FFE (.fff)
+                  </button>
+                  <button
+                    className="btn btn-ghost"
+                    style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 16px', borderRadius: 0 }}
+                    onClick={() => { handleImportFencers('ranking'); setImportMenuOpen(false); }}
+                  >
+                    Importer classement FFE
+                  </button>
+                  {competitionId && (
+                    <>
+                      <button
+                        className="btn btn-ghost"
+                        style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 16px', borderRadius: 0 }}
+                        onClick={() => { handleImportFencersArchive(); setImportMenuOpen(false); }}
+                      >
+                        Importer tireurs + photos (.bpf)
+                      </button>
+                      <button
+                        className="btn btn-ghost"
+                        style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 16px', borderRadius: 0 }}
+                        onClick={() => { handleImportPhotos(); setImportMenuOpen(false); }}
+                      >
+                        Importer photos (.zip)
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
           )}
           <div ref={exportMenuRef} style={{ position: 'relative', display: 'inline-block' }}>
             <button
@@ -334,24 +395,6 @@ const FencerListComponent: React.FC<FencerListProps> = ({
               </div>
             )}
           </div>
-          {competitionId && (
-            <>
-              <button
-                className="btn btn-secondary"
-                onClick={handleImportPhotos}
-                title="Importer des photos depuis un .zip (matching par licence)"
-              >
-                📥 Import Photos
-              </button>
-              <button
-                className="btn btn-secondary"
-                onClick={handleImportFencersArchive}
-                title="Importer tireurs + photos depuis un fichier .bpf"
-              >
-                📦 .bpf
-              </button>
-            </>
-          )}
           <button className="btn btn-primary" onClick={onAddFencer}>
             + {t('fencer.add')}
           </button>


### PR DESCRIPTION
## Summary
- Remplace les 3 boutons séparés (Importer / Import Photos / .bpf) par un menu déroulant **📥 Importer ▾**
- 5 entrées : XML (BellePoule), liste FFE (.fff), classement FFE, tireurs+photos (.bpf), photos (.zip)
- `handleOpenImportDialog` dans CompetitionView accepte maintenant un `type: 'xml' | 'fff' | 'ranking'` avec filtres et titres adaptés

## Test plan
- [ ] Cliquer "Importer ▾" sur la page Appel → menu s'ouvre
- [ ] Chaque entrée ouvre le bon dialogue de fichier
- [ ] Import XML, FFE, classement, .bpf et photos fonctionnent correctement
- [ ] Clic en dehors ferme le menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)