### PR TITLE
feat: séparer Imprimer et Export PDF pour le tableau

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -964,6 +964,42 @@ ipcMain.handle('window:print', () => {
   });
 });
 
+// Print via hidden BrowserWindow — opens system print dialog on clean HTML
+ipcMain.handle('file:printHtml', async (_, html: string) => {
+  return new Promise<{ success: boolean; error?: string }>((resolve) => {
+    const tmpFile = path.join(os.tmpdir(), `bp-print-${Date.now()}.html`);
+    try {
+      fs.writeFileSync(tmpFile, html, 'utf-8');
+    } catch (e) {
+      resolve({ success: false, error: `Impossible de créer le fichier temporaire: ${e}` });
+      return;
+    }
+
+    const printWin = new BrowserWindow({
+      show: false,
+      width: 1200,
+      height: 1600,
+      webPreferences: { contextIsolation: true, nodeIntegration: false, javascript: false },
+    });
+    printWin.setMenu(null);
+    printWin.loadFile(tmpFile);
+
+    printWin.webContents.once('did-finish-load', () => {
+      printWin.webContents.print({ silent: false, printBackground: true }, (success) => {
+        try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+        printWin.destroy();
+        resolve({ success });
+      });
+    });
+
+    printWin.webContents.once('did-fail-load', () => {
+      try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+      printWin.destroy();
+      resolve({ success: false, error: 'Chargement HTML échoué' });
+    });
+  });
+});
+
 // PDF generation via hidden BrowserWindow (propre, sans menus d'application)
 ipcMain.handle('file:printHtmlToPDF', async (_, html: string, outputPath: string) => {
   return new Promise<{ success: boolean; path?: string; error?: string }>((resolve) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -264,6 +264,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       }
       return ipcRenderer.invoke('file:writeContent', filepath, content);
     },
+    printHtml: (html: string) => {
+      if (!html || typeof html !== 'string') {
+        throw new Error('HTML content is required');
+      }
+      return ipcRenderer.invoke('file:printHtml', html);
+    },
     printHtmlToPDF: (html: string, outputPath: string) => {
       if (!html || typeof html !== 'string') {
         throw new Error('HTML content is required');

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -9,7 +9,7 @@ import { Fencer, PoolRanking } from '../../shared/types';
 import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
 import Bracket from './Bracket';
-import { exportTableauToPDF, MAX_MATCHES_PER_PAGE_TABLEAU } from '../../shared/utils/pdfExport';
+import { exportTableauToPDF, printTableauHTML, MAX_MATCHES_PER_PAGE_TABLEAU } from '../../shared/utils/pdfExport';
 
 interface BracketMatch {
   id: string;
@@ -167,6 +167,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const [selectedMatchForArena, setSelectedMatchForArena] = useState<string | null>(null);
   const [pyramidViewMode, setPyramidViewMode] = useState<boolean>(false);
   const [showPdfModal, setShowPdfModal] = useState(false);
+  const [pdfMode, setPdfMode] = useState<'print' | 'pdf'>('pdf');
   const [pdfMatchesPerPage, setPdfMatchesPerPage] = useState<number>(MAX_MATCHES_PER_PAGE_TABLEAU);
   const isUnlimitedScore = maxScore === 999;
 
@@ -491,9 +492,13 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const handleExportPDF = async () => {
     const perPage = Math.max(1, Math.min(pdfMatchesPerPage, MAX_MATCHES_PER_PAGE_TABLEAU));
     const title = `Tableau de ${tableauSize}`;
+    const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
     try {
-      const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
-      await exportTableauToPDF(matches, perPage, title, logo);
+      if (pdfMode === 'print') {
+        await printTableauHTML(matches, perPage, title, logo);
+      } else {
+        await exportTableauToPDF(matches, perPage, title, logo);
+      }
       setShowPdfModal(false);
     } catch (e) {
       showToast((e as Error).message, 'error');
@@ -1129,7 +1134,26 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
             {pyramidViewMode ? '🔲 Tableau' : '🔺 Pyramide'}
           </button>
           <button
-            onClick={() => setShowPdfModal(true)}
+            onClick={() => { setPdfMode('print'); setShowPdfModal(true); }}
+            style={{
+              background: '#6366f1',
+              color: 'white',
+              border: 'none',
+              padding: '0.5rem 0.75rem',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontSize: '0.875rem',
+              fontWeight: '500',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem',
+            }}
+            title="Imprimer les feuilles de match"
+          >
+            🖨️ Imprimer
+          </button>
+          <button
+            onClick={() => { setPdfMode('pdf'); setShowPdfModal(true); }}
             style={{
               background: '#10b981',
               color: 'white',
@@ -1527,7 +1551,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         <div className="modal-overlay" onClick={() => setShowPdfModal(false)}>
           <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '400px' }}>
             <div className="modal-header">
-              <h3 className="modal-title">Export PDF – Feuilles de match</h3>
+              <h3 className="modal-title">{pdfMode === 'print' ? 'Imprimer' : 'Export PDF'} – Feuilles de match</h3>
               <button className="btn-close" onClick={() => setShowPdfModal(false)}>
                 &times;
               </button>
@@ -1585,7 +1609,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 Annuler
               </button>
               <button className="btn btn-primary" onClick={handleExportPDF}>
-                Générer PDF
+                {pdfMode === 'print' ? '🖨️ Imprimer' : '📄 Générer PDF'}
               </button>
             </div>
           </div>

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -423,6 +423,7 @@ export interface FileAPI {
   export: (filepath: string) => Promise<FileSaveResult>;
   import: (filepath: string) => Promise<FileOpenResult>;
   writeContent: (filepath: string, content: string) => Promise<void>;
+  printHtml: (html: string) => Promise<{ success: boolean; error?: string }>;
   printHtmlToPDF: (html: string, outputPath: string) => Promise<{ success: boolean; path?: string; error?: string }>;
   exportPhotos: (competitionId: string, filepath: string) => Promise<{ count: number }>;
   importPhotos: (

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -692,8 +692,28 @@ export async function exportTableauToPDF(
   if (real.length === 0) {
     throw new Error('Aucun match à exporter (tous sont des exempts ou sans tireurs assignés)');
   }
-
   const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64);
   await savePDF(html, `tableau-elimination.pdf`);
+}
+
+export async function printTableauHTML(
+  matches: TableauMatchForPDF[],
+  matchesPerPage: number,
+  title: string = 'Tableau Élimination Directe',
+  logoBase64?: string
+): Promise<void> {
+  const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
+  if (real.length === 0) {
+    throw new Error('Aucun match à imprimer (tous sont des exempts ou sans tireurs assignés)');
+  }
+  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64);
+  const api = (window as any).electronAPI;
+  if (!api?.file?.printHtml) {
+    throw new Error('API Electron non disponible');
+  }
+  const res = await api.file.printHtml(html);
+  if (!res?.success) {
+    throw new Error(res?.error ?? "Échec de l'impression");
+  }
 }
 


### PR DESCRIPTION
## Summary
- Nouveau IPC `file:printHtml` : ouvre une fenêtre cachée avec le HTML propre + dialogue d'impression système (sans menus React ni menus app)
- `printTableauHTML` dans `pdfExport.ts` : même template HTML que l'Export PDF (logo, en-tête, barre dorée)
- **Deux boutons** dans TableauView : 🖨️ Imprimer (violet) et 📄 Export PDF (vert)
- Le modal de configuration (matchs/feuille) est partagé — titre et bouton de confirmation s'adaptent selon le mode
- Logo inclus via `localStorage.getItem('bellepoule-logo')` dans les deux cas

## Test plan
- [ ] Cliquer "🖨️ Imprimer" → modal s'ouvre avec titre "Imprimer – Feuilles de match"
- [ ] Confirmer → dialogue d'impression système s'ouvre sur contenu propre (sans menus app)
- [ ] Cliquer "📄 Export PDF" → modal s'ouvre avec titre "Export PDF – Feuilles de match"
- [ ] Confirmer → dialogue de sauvegarde fichier puis PDF généré
- [ ] Vérifier logo présent dans les deux sorties si configuré dans Paramètres

🤖 Generated with [Claude Code](https://claude.com/claude-code)