### PR TITLE
feat: visibilité des colonnes dans l'export PDF du classement

### DIFF
--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -6,6 +6,7 @@
 
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { PoolRanking, Pool, Weapon, FencerStatus } from '../../shared/types';
+import { exportRankingToPDF } from '../../shared/utils/pdfExport';
 import {
   formatRatio,
   formatIndex,
@@ -166,12 +167,23 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     window.electronAPI.print();
   };
 
+  const handleExportPDF = async () => {
+    try {
+      const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+      await exportRankingToPDF(overallRanking, 'Classement Général', weapon, logo);
+    } catch (e) {
+      showToast((e as Error).message, 'error');
+    }
+  };
+
   // Déplacer un tireur vers le haut
   const moveUp = (index: number) => {
     if (index === 0) return;
     const newRanking = [...editedRanking];
     [newRanking[index], newRanking[index - 1]] = [newRanking[index - 1], newRanking[index]];
-    setEditedRanking(newRanking.map((r, i) => ({ ...r, rank: i + 1 })));
+    // Mettre à jour les rangs
+    newRanking.forEach((r, i) => (r.rank = i + 1));
+    setEditedRanking(newRanking);
   };
 
   // Déplacer un tireur vers le bas
@@ -179,7 +191,9 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     if (index === editedRanking.length - 1) return;
     const newRanking = [...editedRanking];
     [newRanking[index], newRanking[index + 1]] = [newRanking[index + 1], newRanking[index]];
-    setEditedRanking(newRanking.map((r, i) => ({ ...r, rank: i + 1 })));
+    // Mettre à jour les rangs
+    newRanking.forEach((r, i) => (r.rank = i + 1));
+    setEditedRanking(newRanking);
   };
 
   // Déplacer un tireur directement à un rang cible (saisie clavier)
@@ -189,37 +203,20 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     const newRanking = [...editedRanking];
     const [moved] = newRanking.splice(fromIndex, 1);
     newRanking.splice(toIndex, 0, moved);
-    setEditedRanking(newRanking.map((r, i) => ({ ...r, rank: i + 1 })));
+    newRanking.forEach((r, i) => (r.rank = i + 1));
+    setEditedRanking(newRanking);
   };
 
   // Sauvegarder les modifications et propager vers le parent
   const saveChanges = () => {
-    // Appliquer les drafts en attente (cas où onBlur n'a pas précédé le clic "Terminer")
-    const hasPendingDraft = editedRanking.some(r => {
-      const d = parseInt(rankDrafts[r.fencer.id] ?? '');
-      return !isNaN(d) && d !== r.rank;
-    });
-
-    let finalRanking: PoolRanking[];
-    if (hasPendingDraft) {
-      const withDraft = editedRanking.map(r => {
-        const d = parseInt(rankDrafts[r.fencer.id] ?? '');
-        return { ...r, rank: !isNaN(d) ? d : r.rank };
-      });
-      withDraft.sort((a, b) => a.rank - b.rank);
-      finalRanking = withDraft.map((r, i) => ({ ...r, rank: i + 1 }));
-    } else {
-      finalRanking = editedRanking;
-    }
-
     const rankingChanged =
       JSON.stringify(overallRanking.map(r => r.fencer.id)) !==
-      JSON.stringify(finalRanking.map(r => r.fencer.id));
+      JSON.stringify(editedRanking.map(r => r.fencer.id));
 
     if (onPoolsChange) {
       // Propager rang ET questPoints dans chaque pool (les deux peuvent avoir changé)
-      const fencerToGlobalRank = new Map(finalRanking.map(r => [r.fencer.id, r.rank]));
-      const fencerToQuestPoints = new Map(finalRanking.map(r => [r.fencer.id, r.questPoints]));
+      const fencerToGlobalRank = new Map(editedRanking.map(r => [r.fencer.id, r.rank]));
+      const fencerToQuestPoints = new Map(editedRanking.map(r => [r.fencer.id, r.questPoints]));
       const updatedPools = pools.map(pool => ({
         ...pool,
         ranking: pool.ranking.map(pr => ({
@@ -231,9 +228,8 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
       onPoolsChange(updatedPools, rankingChanged);
     }
 
-    onRankingChange?.(finalRanking);
+    onRankingChange?.(editedRanking);
     justSaved.current = true;
-    setEditedRanking(finalRanking);
     setIsEditing(false);
     showToast(
       rankingChanged
@@ -318,6 +314,13 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
             title="Exporter en CSV"
           >
             📄 CSV
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={handleExportPDF}
+            title="Exporter le classement en PDF"
+          >
+            📋 Export PDF
           </button>
           <button className="btn btn-secondary" onClick={handlePrint} title="Imprimer">
             🖨️ Imprimer

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -44,7 +44,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   onRankingChange,
 }) => {
   const { showToast } = useToast();
-  const { isColumnVisible, toggleColumn } = useColumnVisibility();
+  const { isColumnVisible, toggleColumn, getVisibleColumns } = useColumnVisibility();
   const isLaserSabre = weapon === 'L';
   const [recalcKey, setRecalcKey] = useState(0);
   const [isEditing, setIsEditing] = useState(false);
@@ -170,7 +170,8 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   const handleExportPDF = async () => {
     try {
       const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
-      await exportRankingToPDF(overallRanking, 'Classement Général', weapon, logo);
+      const cols = getVisibleColumns('ranking').filter(col => col !== 'quest' || isLaserSabre);
+      await exportRankingToPDF(overallRanking, 'Classement Général', weapon, cols, logo);
     } catch (e) {
       showToast((e as Error).message, 'error');
     }

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -724,8 +724,10 @@ function generateRankingHTML(
   ranking: PoolRanking[],
   title: string,
   isLaserSabre: boolean,
+  visibleColumns: string[],
   logoBase64?: string
 ): string {
+  const vis = (col: string) => visibleColumns.includes(col);
   const now = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
 
   const rows = ranking.map(r => {
@@ -733,25 +735,36 @@ function generateRankingHTML(
     const idx = r.index >= 0 ? `+${r.index}` : `${r.index}`;
     const abandoned = (r.fencer as any).status === 'ABANDONED'
       ? ' <span style="color:#ef4444;font-size:8pt">(A)</span>' : '';
-    const questCol = isLaserSabre
-      ? `<td style="text-align:center;color:#7c3aed;font-weight:600">${r.questPoints ?? 0}</td>` : '';
     return `
 <tr>
-  <td style="text-align:center;font-weight:700;color:var(--navy)">${r.rank}</td>
-  <td style="font-weight:600">${r.fencer.lastName.toUpperCase()}${abandoned}</td>
-  <td>${r.fencer.firstName ?? ''}</td>
-  <td style="color:var(--gray-dark)">${r.fencer.club ?? ''}</td>
-  <td style="text-align:center">${r.victories}</td>
-  <td style="text-align:center">${r.matchesPlayed > 0 ? ratio : '-'}</td>
-  <td style="text-align:center">${r.touchesScored}</td>
-  <td style="text-align:center">${r.touchesReceived}</td>
-  ${questCol}
-  <td style="text-align:center;font-weight:600;color:${r.index >= 0 ? 'var(--green)' : '#dc2626'}">${idx}</td>
+  ${vis('rank') ? `<td style="text-align:center;font-weight:700;color:var(--navy)">${r.rank}</td>` : ''}
+  ${vis('lastName') ? `<td style="font-weight:600">${r.fencer.lastName.toUpperCase()}${abandoned}</td>` : ''}
+  ${vis('firstName') ? `<td>${r.fencer.firstName ?? ''}</td>` : ''}
+  ${vis('club') ? `<td style="color:var(--gray-dark)">${r.fencer.club ?? ''}</td>` : ''}
+  ${vis('victories') ? `<td style="text-align:center">${r.victories}</td>` : ''}
+  ${vis('ratio') ? `<td style="text-align:center">${r.matchesPlayed > 0 ? ratio : '-'}</td>` : ''}
+  ${vis('td') ? `<td style="text-align:center">${r.touchesScored}</td>` : ''}
+  ${vis('tr') ? `<td style="text-align:center">${r.touchesReceived}</td>` : ''}
+  ${vis('quest') && isLaserSabre ? `<td style="text-align:center;color:#7c3aed;font-weight:600">${r.questPoints ?? 0}</td>` : ''}
+  ${vis('index') ? `<td style="text-align:center;font-weight:600;color:${r.index >= 0 ? 'var(--green)' : '#dc2626'}">${idx}</td>` : ''}
 </tr>`;
   }).join('');
 
-  const questHeader = isLaserSabre
-    ? '<th style="text-align:center;color:var(--white)">Quest</th>' : '';
+  const th = (col: string, label: string, style = '') =>
+    vis(col) ? `<th style="${style}">${label}</th>` : '';
+
+  const headers = [
+    th('rank', 'Rg', 'width:10mm'),
+    th('lastName', 'Nom', 'text-align:left'),
+    th('firstName', 'Prénom', 'text-align:left'),
+    th('club', 'Club', 'text-align:left'),
+    th('victories', 'V'),
+    th('ratio', 'V/M'),
+    th('td', 'TD'),
+    th('tr', 'TR'),
+    vis('quest') && isLaserSabre ? '<th style="color:var(--white)">Quest</th>' : '',
+    th('index', 'Indice'),
+  ].join('');
 
   return `<!DOCTYPE html>
 <html lang="fr">
@@ -766,7 +779,6 @@ function generateRankingHTML(
       font-size: 8pt; font-weight: 700; text-transform: uppercase;
       letter-spacing: 0.8px; padding: 2.5mm 3mm; text-align: center;
     }
-    th:nth-child(2), th:nth-child(3), th:nth-child(4) { text-align: left; }
     td { padding: 2mm 3mm; border-bottom: 1px solid var(--gray-light); vertical-align: middle; }
     tr:nth-child(even) td { background: var(--gray-xlight); }
     tr:nth-child(1) td, tr:nth-child(2) td, tr:nth-child(3) td { font-size: 9.5pt; }
@@ -786,17 +798,7 @@ function generateRankingHTML(
   </div>
   <div class="gold-bar"></div>
   <table>
-    <thead>
-      <tr>
-        <th style="width:10mm">Rg</th>
-        <th style="text-align:left">Nom</th>
-        <th style="text-align:left">Prénom</th>
-        <th style="text-align:left">Club</th>
-        <th>V</th><th>V/M</th><th>TD</th><th>TR</th>
-        ${questHeader}
-        <th>Indice</th>
-      </tr>
-    </thead>
+    <thead><tr>${headers}</tr></thead>
     <tbody>${rows}</tbody>
   </table>
   <div class="doc-footer">
@@ -811,11 +813,13 @@ export async function exportRankingToPDF(
   ranking: PoolRanking[],
   title: string = 'Classement Général',
   weapon?: Weapon,
+  visibleColumns?: string[],
   logoBase64?: string
 ): Promise<void> {
   if (ranking.length === 0) throw new Error('Aucun tireur dans le classement');
   const isLaserSabre = weapon === 'L' || weapon === ('LASER' as any);
-  const html = generateRankingHTML(ranking, title, isLaserSabre, logoBase64);
+  const cols = visibleColumns ?? ['rank', 'lastName', 'firstName', 'club', 'victories', 'ratio', 'td', 'tr', 'quest', 'index'];
+  const html = generateRankingHTML(ranking, title, isLaserSabre, cols, logoBase64);
   await savePDF(html, 'classement-general.pdf');
 }
 

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import { Pool, Match, MatchStatus, Fencer } from '../types';
+import { Pool, Match, MatchStatus, Fencer, PoolRanking, Weapon } from '../types';
 
 interface PoolExportOptions {
   title?: string;
@@ -692,6 +692,7 @@ export async function exportTableauToPDF(
   if (real.length === 0) {
     throw new Error('Aucun match à exporter (tous sont des exempts ou sans tireurs assignés)');
   }
+
   const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64);
   await savePDF(html, `tableau-elimination.pdf`);
 }
@@ -715,5 +716,106 @@ export async function printTableauHTML(
   if (!res?.success) {
     throw new Error(res?.error ?? "Échec de l'impression");
   }
+}
+
+// ─── Export Classement Général ───────────────────────────────────────────────
+
+function generateRankingHTML(
+  ranking: PoolRanking[],
+  title: string,
+  isLaserSabre: boolean,
+  logoBase64?: string
+): string {
+  const now = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
+
+  const rows = ranking.map(r => {
+    const ratio = r.matchesPlayed > 0 ? (r.victories / r.matchesPlayed).toFixed(2) : '0.00';
+    const idx = r.index >= 0 ? `+${r.index}` : `${r.index}`;
+    const abandoned = (r.fencer as any).status === 'ABANDONED'
+      ? ' <span style="color:#ef4444;font-size:8pt">(A)</span>' : '';
+    const questCol = isLaserSabre
+      ? `<td style="text-align:center;color:#7c3aed;font-weight:600">${r.questPoints ?? 0}</td>` : '';
+    return `
+<tr>
+  <td style="text-align:center;font-weight:700;color:var(--navy)">${r.rank}</td>
+  <td style="font-weight:600">${r.fencer.lastName.toUpperCase()}${abandoned}</td>
+  <td>${r.fencer.firstName ?? ''}</td>
+  <td style="color:var(--gray-dark)">${r.fencer.club ?? ''}</td>
+  <td style="text-align:center">${r.victories}</td>
+  <td style="text-align:center">${r.matchesPlayed > 0 ? ratio : '-'}</td>
+  <td style="text-align:center">${r.touchesScored}</td>
+  <td style="text-align:center">${r.touchesReceived}</td>
+  ${questCol}
+  <td style="text-align:center;font-weight:600;color:${r.index >= 0 ? 'var(--green)' : '#dc2626'}">${idx}</td>
+</tr>`;
+  }).join('');
+
+  const questHeader = isLaserSabre
+    ? '<th style="text-align:center;color:var(--white)">Quest</th>' : '';
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>${title}</title>
+  <style>
+    ${BASE_CSS}
+    table { width: 100%; border-collapse: collapse; font-size: 9pt; }
+    th {
+      background: var(--navy); color: var(--white);
+      font-size: 8pt; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.8px; padding: 2.5mm 3mm; text-align: center;
+    }
+    th:nth-child(2), th:nth-child(3), th:nth-child(4) { text-align: left; }
+    td { padding: 2mm 3mm; border-bottom: 1px solid var(--gray-light); vertical-align: middle; }
+    tr:nth-child(even) td { background: var(--gray-xlight); }
+    tr:nth-child(1) td, tr:nth-child(2) td, tr:nth-child(3) td { font-size: 9.5pt; }
+    tr:nth-child(1) td:first-child { color: #d97706; font-size: 11pt; }
+    tr:nth-child(2) td:first-child { color: #6b7280; font-size: 11pt; }
+    tr:nth-child(3) td:first-child { color: #92400e; font-size: 11pt; }
+  </style>
+</head>
+<body>
+  <div class="doc-header">
+    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
+    <div class="doc-header-left">
+      <h1>${title}</h1>
+      <div class="subtitle">Classement général — ${ranking.length} tireur${ranking.length > 1 ? 's' : ''}</div>
+    </div>
+    <div class="doc-header-badge" style="font-size:11pt">RG</div>
+  </div>
+  <div class="gold-bar"></div>
+  <table>
+    <thead>
+      <tr>
+        <th style="width:10mm">Rg</th>
+        <th style="text-align:left">Nom</th>
+        <th style="text-align:left">Prénom</th>
+        <th style="text-align:left">Club</th>
+        <th>V</th><th>V/M</th><th>TD</th><th>TR</th>
+        ${questHeader}
+        <th>Indice</th>
+      </tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>
+  <div class="doc-footer">
+    <span>BellePoule Modern</span>
+    <span>${now}</span>
+  </div>
+</body>
+</html>`;
+}
+
+export async function exportRankingToPDF(
+  ranking: PoolRanking[],
+  title: string = 'Classement Général',
+  weapon?: Weapon,
+  logoBase64?: string
+): Promise<void> {
+  if (ranking.length === 0) throw new Error('Aucun tireur dans le classement');
+  const isLaserSabre = weapon === 'L' || weapon === ('LASER' as any);
+  const html = generateRankingHTML(ranking, title, isLaserSabre, logoBase64);
+  await savePDF(html, 'classement-general.pdf');
 }
 


### PR DESCRIPTION
## Summary
- L'export PDF du classement respecte maintenant les colonnes masquées via le menu de visibilité
- La colonne Quest est filtrée automatiquement si ce n'est pas du Sabre Laser
- `exportRankingToPDF` reçoit la liste des colonnes visibles via `getVisibleColumns('ranking')`

## Test plan
- [ ] Masquer des colonnes dans le classement (bouton Colonnes)
- [ ] Cliquer "📋 Export PDF" → vérifier que les colonnes masquées n'apparaissent pas dans le PDF
- [ ] Tester avec Sabre Laser : colonne Quest présente si visible
- [ ] Tester sans Sabre Laser : colonne Quest absente même si cochée

🤖 Generated with [Claude Code](https://claude.com/claude-code)