### PR TITLE
fix(remote): inclure le thème dans l'état initial envoyé à la connexion de l'arène

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1331,9 +1331,10 @@ export class RemoteScoreServer {
         }
         socket.join(`arena:${data.arenaId}`);
 
-        // Envoyer l'état actuel de l'arène
+        // Envoyer l'état actuel de l'arène (thème inclus pour éviter le flash dark au chargement)
         const arena = this.getArena(data.arenaId);
         if (arena) {
+          const override = this.arenaThemeOverrides.get(data.arenaId);
           socket.emit(`arena:${data.arenaId}:update`, {
             arenaId: data.arenaId,
             match: arena.currentMatch,
@@ -1341,6 +1342,8 @@ export class RemoteScoreServer {
             scoreB: arena.currentMatch?.scoreB,
             status: arena.status,
             showPhotos: this.sessionShowPhotos,
+            theme: override?.theme ?? this.sessionTheme,
+            customTheme: override?.customTheme,
             fencerA: arena.currentMatch?.fencerA,
             fencerB: arena.currentMatch?.fencerB,
           });


### PR DESCRIPTION
Sans ce champ, arena.html ignorait le thème au join_arena (data.theme absent →
if (data.theme) falsy) et restait sur le localStorage ou 'dark' par défaut,
même si sessionTheme ou un override par arène était configuré.

Même logique que broadcastArenaUpdate : override?.theme ?? sessionTheme.

https://claude.ai/code/session_01Ewp8W5LkCdwBVwSTbHtrJC