### PR TITLE
fix: corrige la webcam qui n'affiche pas le flux vidéo (PhotoBooth)

### DIFF
--- a/src/renderer/components/PhotoBooth.tsx
+++ b/src/renderer/components/PhotoBooth.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { logger, LogCategory } from '@shared/services/logger';
 
 interface PhotoBoothProps {
@@ -19,6 +19,21 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ onConfirm, onClose }) =>
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (isCapturing && videoRef.current && streamRef.current) {
+      videoRef.current.srcObject = streamRef.current;
+    }
+  }, [isCapturing]);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
 
   const startCamera = useCallback(async () => {
     try {
@@ -47,17 +62,16 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ onConfirm, onClose }) =>
   }, []);
 
   const capturePhoto = useCallback(() => {
-    setCountdown(3);
-
-    const countdownInterval = setInterval(() => {
-      setCountdown(prev => {
-        if (prev <= 1) {
-          clearInterval(countdownInterval);
-          takePhoto();
-          return 0;
-        }
-        return prev - 1;
-      });
+    let count = 3;
+    setCountdown(count);
+    intervalRef.current = setInterval(() => {
+      count -= 1;
+      setCountdown(count);
+      if (count <= 0) {
+        clearInterval(intervalRef.current!);
+        intervalRef.current = null;
+        takePhoto();
+      }
     }, 1000);
   }, []);
 


### PR DESCRIPTION
- Bug 1 (critique) : le stream getUserMedia n'était jamais assigné à <video>
  car videoRef.current est null quand isCapturing=false. Ajout d'un useEffect
  sur [isCapturing] qui assigne srcObject après le montage du <video>.
- Bug 2 (moyen) : takePhoto() appelé dans un updater React (setCountdown),
  causant une double exécution en Strict Mode. Remplacé par une variable
  locale `count` avec setCountdown(count) impératif.
- Bug 3 (faible) : l'intervalle de décompte n'était pas nettoyé au démontage.
  Stockage dans intervalRef + useEffect de cleanup.

https://claude.ai/code/session_01KqBNMj8WtuZXqPkiL5ebyy