### PR TITLE
feat: afficher le prochain combat avec photos quand un match est terminé

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1971,9 +1971,22 @@ export class RemoteScoreServer {
       );
     }
 
-    this.updateArena(arenaId, {
+    const nextMatch = this.peekNextMatch(arenaId);
+
+    // Mettre à jour l'état en mémoire sans broadcaster (on fait le broadcast manuellement
+    // pour pouvoir inclure nextMatch, absent de Arena)
+    const arenaRef = this.arenas.get(arenaId)!;
+    Object.assign(arenaRef, { status: 'finished', currentMatch: arena.currentMatch });
+
+    this.broadcastArenaUpdate(arenaId, {
+      arenaId,
+      match: arena.currentMatch,
+      scoreA: arena.currentMatch?.scoreA,
+      scoreB: arena.currentMatch?.scoreB,
       status: 'finished',
-      currentMatch: arena.currentMatch,
+      fencerA: arena.currentMatch?.fencerA,
+      fencerB: arena.currentMatch?.fencerB,
+      nextMatch,
     });
 
     // Émettre l'event pour le renderer (pour sauvegarder le score dans les pools)
@@ -1999,6 +2012,48 @@ export class RemoteScoreServer {
         this.loadNextMatch(arenaId);
       }
     }, 3000);
+  }
+
+  private peekNextMatch(arenaId: string): ArenaMatch | null {
+    const arena = this.arenas.get(arenaId);
+    if (!arena || !this.session) return null;
+
+    const currentMatchId = arena.currentMatch?.id;
+    const currentPoolId = arena.currentMatch?.poolId;
+
+    if (currentPoolId && this.sessionMatches.length > 0) {
+      const rawPoolMatches = this.sessionMatches
+        .filter((m: any) => {
+          const matchPoolId = m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`;
+          return matchPoolId === currentPoolId;
+        })
+        .map((m: any) => {
+          const scoreUpdate = this.sessionMatchScores.get(m.id);
+          return scoreUpdate ? { ...m, ...scoreUpdate } : m;
+        });
+      const poolMatches = this.applySmartMatchOrder(rawPoolMatches as Match[]).filter(
+        m => m.status !== MatchStatus.FINISHED
+      );
+      const nextMatch = poolMatches.find(m => m.id !== currentMatchId);
+      if (nextMatch) {
+        return {
+          id: nextMatch.id,
+          poolId: currentPoolId,
+          fencerA: nextMatch.fencerA!,
+          fencerB: nextMatch.fencerB!,
+          scoreA: 0,
+          scoreB: 0,
+          status: 'not_started',
+          startTime: null,
+          endTime: null,
+        };
+      }
+    }
+
+    const deQueue = this.arenaMatchQueue.get(arenaId) || [];
+    if (deQueue.length > 0) return deQueue[0];
+
+    return null;
   }
 
   private loadNextMatch(arenaId: string): void {

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -688,6 +688,96 @@
         flex-shrink: 0;
       }
 
+      /* Panneau prochain combat */
+      .next-match-panel {
+        border-top: 2px solid rgba(245, 158, 11, 0.35);
+        padding: 0.45rem 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.9rem;
+        animation: fadeIn 0.4s ease-out;
+        flex-shrink: 0;
+      }
+
+      .next-match-panel.hidden { display: none; }
+
+      @keyframes fadeIn {
+        from { opacity: 0; transform: translateY(6px); }
+        to   { opacity: 1; transform: translateY(0); }
+      }
+
+      .next-match-label {
+        font-size: 0.8rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: #f59e0b;
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+
+      .next-match-fighters {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        flex: 1;
+        justify-content: center;
+        overflow: hidden;
+      }
+
+      .next-fighter {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-weight: 600;
+        font-size: clamp(0.75rem, 1.4vw, 1rem);
+        min-width: 0;
+      }
+
+      .next-fighter-a { color: #15803d; }
+      .next-fighter-b { color: #dc2626; }
+
+      .next-photo-wrap {
+        width: 2.4rem;
+        height: 2.4rem;
+        border-radius: 50%;
+        overflow: hidden;
+        border: 2px solid currentColor;
+        background: rgba(0, 0, 0, 0.1);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+      }
+
+      .next-photo-wrap img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: none;
+      }
+
+      .next-default-icon {
+        width: 58%;
+        height: 58%;
+        fill: currentColor;
+        opacity: 0.65;
+        display: block;
+      }
+
+      .next-fighter-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .next-vs {
+        font-size: 0.95rem;
+        font-weight: 900;
+        color: #f59e0b;
+        flex-shrink: 0;
+      }
+
       /* Responsive portrait/mobile */
       @media (max-width: 768px) {
         .fencers-row {
@@ -815,6 +905,36 @@
           <div class="sudden-death-banner" id="sudden-death-banner">⚡ MORT SUBITE</div>
           <div class="timer-label">Temps restant</div>
         </div>
+
+        <!-- Prochain combat (affiché quand status=finished et nextMatch disponible) -->
+        <div class="next-match-panel hidden" id="next-match-panel">
+          <div class="next-match-label">⚔ Prochain</div>
+          <div class="next-match-fighters">
+            <div class="next-fighter next-fighter-a">
+              <div class="next-photo-wrap">
+                <img id="next-photo-a" src="" alt="" />
+                <svg id="next-icon-a" class="next-default-icon" viewBox="0 0 100 120" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="50" cy="18" r="15"/>
+                  <path d="M33 38 Q50 34 67 38 L70 82 Q50 78 30 82 Z"/>
+                  <path d="M36 82 L28 118 M64 82 L72 118" stroke="currentColor" stroke-width="9" stroke-linecap="round" fill="none"/>
+                </svg>
+              </div>
+              <span class="next-fighter-name" id="next-name-a">-</span>
+            </div>
+            <span class="next-vs">VS</span>
+            <div class="next-fighter next-fighter-b">
+              <div class="next-photo-wrap">
+                <img id="next-photo-b" src="" alt="" />
+                <svg id="next-icon-b" class="next-default-icon" viewBox="0 0 100 120" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="50" cy="18" r="15"/>
+                  <path d="M33 38 Q50 34 67 38 L70 82 Q50 78 30 82 Z"/>
+                  <path d="M36 82 L28 118 M64 82 L72 118" stroke="currentColor" stroke-width="9" stroke-linecap="round" fill="none"/>
+                </svg>
+              </div>
+              <span class="next-fighter-name" id="next-name-b">-</span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -825,6 +945,7 @@
           this.arenaId = this.getArenaId();
           this.arenaNumber = this.arenaNumberFromId();
           this.currentMatch = null;
+          this.nextMatch = null;
           this.timerSeconds = 180;
           this.matchStatus = 'idle';
           this.cardsA = [];
@@ -986,6 +1107,11 @@
             }
           }
 
+          // Prochain combat
+          if ('nextMatch' in data) {
+            this.nextMatch = data.nextMatch || null;
+          }
+
           // Mise à jour des scores
           if (data.scoreA !== undefined) {
             document.getElementById('score-a').textContent = data.scoreA;
@@ -1120,27 +1246,69 @@
           const waitingScreen = document.getElementById('waiting-screen');
           const matchDisplay = document.getElementById('match-display');
           const photoIntro = document.getElementById('photo-intro');
+          const nextPanel = document.getElementById('next-match-panel');
 
           if (this.matchStatus === 'idle' || this.matchStatus === 'not_started') {
             waitingScreen.classList.remove('hidden');
             matchDisplay.classList.remove('active');
             photoIntro.classList.add('hidden');
+            nextPanel.classList.add('hidden');
             this.isSuddenDeath = false;
             this.updateSuddenDeathBanner();
           } else if (this.matchStatus === 'ready' && this.showPhotos && this.currentMatch) {
             waitingScreen.classList.add('hidden');
             matchDisplay.classList.remove('active');
             photoIntro.classList.remove('hidden');
+            nextPanel.classList.add('hidden');
             this.updatePhotoIntro();
-          } else if (this.matchStatus === 'in_progress' || this.matchStatus === 'finished') {
+          } else if (this.matchStatus === 'in_progress') {
             waitingScreen.classList.add('hidden');
             photoIntro.classList.add('hidden');
             matchDisplay.classList.add('active');
+            nextPanel.classList.add('hidden');
+          } else if (this.matchStatus === 'finished') {
+            waitingScreen.classList.add('hidden');
+            photoIntro.classList.add('hidden');
+            matchDisplay.classList.add('active');
+            if (this.nextMatch) {
+              this.updateNextMatchPanel();
+              nextPanel.classList.remove('hidden');
+            } else {
+              nextPanel.classList.add('hidden');
+            }
           } else {
             // 'ready' sans photos : écran d'attente (combat pas encore démarré)
             waitingScreen.classList.remove('hidden');
             matchDisplay.classList.remove('active');
             photoIntro.classList.add('hidden');
+            nextPanel.classList.add('hidden');
+          }
+        }
+
+        updateNextMatchPanel() {
+          if (!this.nextMatch) return;
+          const fA = this.nextMatch.fencerA || {};
+          const fB = this.nextMatch.fencerB || {};
+
+          document.getElementById('next-name-a').textContent =
+            `${fA.lastName || ''} ${fA.firstName || ''}`.trim() || '-';
+          document.getElementById('next-name-b').textContent =
+            `${fB.lastName || ''} ${fB.firstName || ''}`.trim() || '-';
+
+          this.setNextFencerPhoto('a', fA.photo);
+          this.setNextFencerPhoto('b', fB.photo);
+        }
+
+        setNextFencerPhoto(side, photoBase64) {
+          const img = document.getElementById(`next-photo-${side}`);
+          const icon = document.getElementById(`next-icon-${side}`);
+          if (photoBase64) {
+            img.src = photoBase64.startsWith('data:') ? photoBase64 : `data:image/jpeg;base64,${photoBase64}`;
+            img.style.display = 'block';
+            icon.style.display = 'none';
+          } else {
+            img.style.display = 'none';
+            icon.style.display = 'block';
           }
         }
 

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -152,6 +152,7 @@ export interface ArenaUpdate {
   showPhotos?: boolean; // afficher les photos avant le combat
   theme?: DisplayTheme; // thème visuel de l'affichage distant
   customTheme?: CustomTheme; // thème personnalisé (si theme === 'custom')
+  nextMatch?: ArenaMatch | null; // prochain combat (affiché quand status=finished)
 }
 
 export interface RefereeControl {


### PR DESCRIPTION
Quand un combat se termine sur l'affichage distant (arena.html), un
panneau "Prochain combat" apparaît en bas du tableau des scores avec
les noms et photos (si disponibles) des deux tireurs suivants.

- ArenaUpdate: ajout du champ `nextMatch?: ArenaMatch | null`
- RemoteScoreServer: ajout de `peekNextMatch()` qui consulte la file
  sans la consommer, appelé dans `finishArenaMatch()` pour broadcaster
  le prochain match sans attendre le délai de 3s
- arena.html: panneau next-match-panel (CSS + HTML + JS) avec photos
  circulaires et icônes de repli, visible uniquement quand finished+nextMatch

https://claude.ai/code/session_014NwJdLKr8XZMH4GUHP7BA7