### PR TITLE
fix: mise à jour automatique des matchs DE sans relancer la saisie distante

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1196,6 +1196,16 @@ ipcMain.handle(
   }
 );
 
+ipcMain.handle('remote:refreshDeMatches', async (_, matches: any[]) => {
+  try {
+    if (!remoteScoreServer) return { success: false, error: 'Serveur non démarré' };
+    remoteScoreServer.refreshDeMatches(matches);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+  }
+});
+
 ipcMain.handle('remote:stopSession', async () => {
   try {
     if (!remoteScoreServer) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -407,6 +407,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:updateMatchArena', matchId, fromArena, toArena),
     updatePoolFencers: (updates: Array<{ poolId: string; fencers: any[] }>) =>
       ipcRenderer.invoke('remote:updatePoolFencers', updates),
+    refreshDeMatches: (matches: any[]) =>
+      ipcRenderer.invoke('remote:refreshDeMatches', matches),
     setArenaPassword: (arenaId: string, password: string) =>
       ipcRenderer.invoke('remote:setArenaPassword', arenaId, password),
     setOrgNote: (note: any) => ipcRenderer.invoke('remote:setOrgNote', note),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2746,6 +2746,70 @@ export class RemoteScoreServer {
     }
   }
 
+  public refreshDeMatches(matchesFromRenderer: any[]): void {
+    if (!this.session) throw new Error('Aucune session active');
+
+    const strips = this.session.strips.length;
+
+    // Collect IDs of matches currently assigned to an arena (must not be disturbed)
+    const activeMatchIds = new Set<string>();
+    for (const arena of this.arenas.values()) {
+      if (arena.currentMatch) activeMatchIds.add(arena.currentMatch.id);
+    }
+
+    // Build the new DE match list, excluding already-active matches
+    const deMatches = matchesFromRenderer
+      .filter(m => !m.__poolFencers && m.isTableau && m.fencerA && m.fencerB)
+      .sort((a: any, b: any) => (a.round || 0) - (b.round || 0));
+
+    // Replace DE entries in sessionMatches (keep pool matches intact)
+    this.sessionMatches = this.sessionMatches.filter((m: any) => !m.isTableau);
+    for (const m of deMatches) this.sessionMatches.push(m);
+
+    // Rebuild DE queues (preserve any non-DE entries already queued)
+    for (const [arenaId, queue] of this.arenaMatchQueue.entries()) {
+      this.arenaMatchQueue.set(arenaId, queue.filter((m: ArenaMatch) => !m.isTableau));
+    }
+
+    const pending = deMatches.filter(m => !activeMatchIds.has(m.id));
+    let rrIndex = 0;
+    const queuesByArena = new Map<string, ArenaMatch[]>();
+    for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
+
+    for (const match of pending) {
+      const preferred = match.arena ? `arena${match.arena}` : `arena${(rrIndex % strips) + 1}`;
+      const targetId = this.arenas.has(preferred) ? preferred : `arena${(rrIndex % strips) + 1}`;
+      queuesByArena.get(targetId)!.push({
+        id: match.id,
+        fencerA: match.fencerA,
+        fencerB: match.fencerB,
+        scoreA: 0,
+        scoreB: 0,
+        status: 'not_started',
+        startTime: null,
+        endTime: null,
+        isTableau: true,
+      });
+      rrIndex++;
+    }
+
+    for (const [arenaId, queue] of queuesByArena) {
+      const arena = this.arenas.get(arenaId);
+      if (!arena) continue;
+      const existing = this.arenaMatchQueue.get(arenaId) || [];
+      if (!arena.currentMatch && queue.length > 0) {
+        this.assignMatchToArena(arenaId, queue[0]);
+        this.arenaMatchQueue.set(arenaId, [...existing, ...queue.slice(1)]);
+      } else {
+        this.arenaMatchQueue.set(arenaId, [...existing, ...queue]);
+      }
+    }
+
+    console.log(
+      `[RemoteScoreServer] refreshDeMatches: ${deMatches.length} matchs DE, ${pending.length} distribués`
+    );
+  }
+
   public getSession(): RemoteSession | null {
     return this.session;
   }

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import QRCode from 'qrcode';
 import { Competition, Pool } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
@@ -113,6 +113,24 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     const updates = pools.map(pool => ({ poolId: pool.id, fencers: pool.fencers ?? [] }));
     window.electronAPI.remote.updatePoolFencers(updates).catch(() => {});
   }, [pools, isRemoteActive, session]);
+
+  // Quand les matchs tableau changent pendant une session active, mettre à jour le serveur
+  // sans avoir à arrêter/relancer la saisie distante (transition poules → tableau).
+  const prevDeMatchesKeyRef = useRef<string>('');
+  const pendingDeMatches = useMemo(
+    () =>
+      (tableauMatches || [])
+        .filter(m => m.winner === null && m.fencerA && m.fencerB)
+        .map(m => ({ ...m, isTableau: true })),
+    [tableauMatches]
+  );
+  useEffect(() => {
+    const key = pendingDeMatches.map(m => m.id).join(',');
+    if (key === prevDeMatchesKeyRef.current) return;
+    prevDeMatchesKeyRef.current = key;
+    if (!isRemoteActive || !session || pendingDeMatches.length === 0) return;
+    window.electronAPI.remote.refreshDeMatches(pendingDeMatches).catch(() => {});
+  }, [pendingDeMatches, isRemoteActive, session]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -347,6 +347,7 @@ export interface RemoteServerAPI {
   updatePoolFencers: (
     updates: Array<{ poolId: string; fencers: any[] }>
   ) => Promise<{ success: boolean; error?: string }>;
+  refreshDeMatches: (matches: any[]) => Promise<{ success: boolean; error?: string }>;
   setArenaPassword: (
     arenaId: string,
     password: string


### PR DESCRIPTION
Quand la compétition passe des poules au tableau d'élimination directe,
les matchs DE sont maintenant poussés vers le serveur distant dès qu'ils
apparaissent dans tableauMatches, via refreshDeMatches(). Plus besoin
d'arrêter et de relancer la session entre les deux phases.

https://claude.ai/code/session_0152uHyNA9etjq4hSFKKW8gT