### PR TITLE
fix(remote): corriger l'affichage du prochain match sur l'arène

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -989,6 +989,22 @@ export class RemoteScoreServer {
             scoreB: scoreBObj,
             status: MatchStatus.FINISHED,
           });
+          // Synchroniser sessionMatchScores pour que peekNextMatch/loadNextMatch
+          // puisse filtrer ce match comme terminé (sinon il réapparaît comme "prochain")
+          this.sessionMatchScores.set(matchId, {
+            scoreA: scoreAObj,
+            scoreB: scoreBObj,
+            status: MatchStatus.FINISHED,
+          });
+          // Mettre à jour le score en mémoire de l'arène pour que le broadcast
+          // finishArenaMatch envoie le vrai score (pas 0-0) à l'affichage
+          for (const [, arena] of this.arenas) {
+            if (arena.currentMatch && arena.currentMatch.id === matchId) {
+              arena.currentMatch.scoreA = sA;
+              arena.currentMatch.scoreB = sB;
+              break;
+            }
+          }
         } else {
           // Match en mémoire uniquement (poule non persistée)
           // Synchroniser les scores dans l'arène et déclencher l'IPC vers le renderer
@@ -1425,6 +1441,9 @@ export class RemoteScoreServer {
             customTheme: override?.customTheme,
             fencerA: arena.currentMatch?.fencerA,
             fencerB: arena.currentMatch?.fencerB,
+            ...(arena.status === 'finished' && {
+              nextMatch: this.peekNextMatch(data.arenaId),
+            }),
           });
         }
       });


### PR DESCRIPTION
Trois bugs corrigés dans remoteScoreServer.ts :

1. sessionMatchScores non mis à jour pour les matchs DB : peekNextMatch
   filtre les matchs terminés via sessionMatchScores, mais pour les matchs
   persistés en DB (POST /api/matches/:matchId/finish), ce map n'était jamais
   alimenté → les matchs déjà joués réapparaissaient comme "prochain match"
   dès le 2e combat.

2. arena.currentMatch.scoreA/B non synchronisé pour les matchs DB : le
   broadcast de finishArenaMatch envoyait 0-0 à l'affichage au lieu du
   vrai score final (qui n'était mis à jour que pour les matchs in-memory).

3. join_arena ne transmettait pas nextMatch quand l'arène était déjà en
   statut 'finished' : un écran qui se reconnecte ratait le panneau
   "prochain combat".

https://claude.ai/code/session_01VfR7gaTBnhzzVb3TaCzWiD