### PR TITLE
fix: sync logo to localStorage at startup so all PDF exports include it

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -84,6 +84,21 @@ const AppContent: React.FC = () => {
     };
   }, []);
 
+  // Sync logo from disk to localStorage so PDF exports always find it
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api) return;
+    api.getLogo?.().then((logo: string | null) => {
+      if (logo) localStorage.setItem('bellepoule-logo', logo);
+      else localStorage.removeItem('bellepoule-logo');
+    }).catch(() => {});
+    const unsub = api.onLogoLoaded?.((logo: string | null) => {
+      if (logo) localStorage.setItem('bellepoule-logo', logo);
+      else localStorage.removeItem('bellepoule-logo');
+    });
+    return () => { if (typeof unsub === 'function') unsub(); };
+  }, []);
+
   const loadCompetitions = useCallback(async () => {
     setIsLoading(true);
     try {

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -476,6 +476,8 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   onRemoteMatchFinished: (callback: (data: any) => void) => void;
   onKioskNoteUpdate: (callback: (note: import('../types/remote').OrgNote | null) => void) => () => void;
   notifyLanguageChanged: (lang: string) => void;
+  getLogo: () => Promise<string | null>;
+  onLogoLoaded: (callback: (logo: string | null) => void) => () => void;
 }
 
 


### PR DESCRIPTION
Le logo n'était chargé en localStorage que quand SettingsModal était monté.
App.tsx charge maintenant le logo depuis le processus principal dès le
démarrage, garantissant sa présence dans tous les exports PDF (poules,
tableau, classement).

https://claude.ai/code/session_01AJLtkcC6X2V5NUwy2ZJtAp