### PR TITLE
fix: bouton webcam soumet le formulaire au lieu d'ouvrir la caméra

### DIFF
--- a/src/renderer/components/FencerPhoto.tsx
+++ b/src/renderer/components/FencerPhoto.tsx
@@ -196,6 +196,7 @@ export const FencerPhoto: React.FC<FencerPhotoProps> = ({
 
       {editable && photo && (
         <button
+          type="button"
           onClick={e => {
             e.stopPropagation();
             handleRemovePhoto();
@@ -209,6 +210,7 @@ export const FencerPhoto: React.FC<FencerPhotoProps> = ({
 
       {editable && (
         <button
+          type="button"
           onClick={e => {
             e.stopPropagation();
             setShowWebcam(true);
@@ -273,6 +275,7 @@ export const FencerPhoto: React.FC<FencerPhotoProps> = ({
                 Prendre une photo
               </h3>
               <button
+                type="button"
                 className="btn btn-icon btn-secondary"
                 onClick={() => setShowWebcam(false)}
                 style={{ padding: '0.25rem' }}

--- a/src/renderer/components/PhotoBooth.tsx
+++ b/src/renderer/components/PhotoBooth.tsx
@@ -191,10 +191,10 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ onConfirm, onClose }) =>
             📷
           </div>
           <div style={{ display: 'flex', gap: '12px', justifyContent: 'center' }}>
-            <button className="btn btn-secondary" onClick={onClose}>
+            <button type="button" className="btn btn-secondary" onClick={onClose}>
               Annuler
             </button>
-            <button className="btn btn-primary" onClick={startCamera}>
+            <button type="button" className="btn btn-primary" onClick={startCamera}>
               Démarrer la caméra
             </button>
           </div>
@@ -234,6 +234,7 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ onConfirm, onClose }) =>
 
           <div style={{ display: 'flex', gap: '12px', marginTop: '12px' }}>
             <button
+              type="button"
               onClick={capturePhoto}
               disabled={countdown > 0}
               className="btn btn-primary"
@@ -242,6 +243,7 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ onConfirm, onClose }) =>
               {countdown > 0 ? `${countdown}…` : '📸 Capturer'}
             </button>
             <button
+              type="button"
               onClick={() => { stopCamera(); onClose(); }}
               className="btn btn-secondary"
             >
@@ -263,10 +265,10 @@ export const PhotoBooth: React.FC<PhotoBoothProps> = ({ onConfirm, onClose }) =>
             }}
           />
           <div style={{ display: 'flex', gap: '12px', justifyContent: 'center' }}>
-            <button onClick={retake} className="btn btn-secondary">
+            <button type="button" onClick={retake} className="btn btn-secondary">
               Recommencer
             </button>
-            <button onClick={() => onConfirm(photo)} className="btn btn-primary">
+            <button type="button" onClick={() => onConfirm(photo)} className="btn btn-primary">
               Utiliser cette photo
             </button>
           </div>


### PR DESCRIPTION
Ajouter type="button" sur tous les <button> de FencerPhoto et PhotoBooth.
Sans cet attribut, les boutons dans un <form> ont type="submit" par défaut,
ce qui provoque la sauvegarde du tireur au lieu d'ouvrir la webcam.

https://claude.ai/code/session_0179ooBghEVJ5ift8yADyux2