### PR TITLE
fix: permettre le remplacement de photo lors du ré-import de tireurs

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -782,7 +782,7 @@ export class DatabaseManager {
 
       if (existing) {
         const updates = { ...fencer };
-        if (existing.photo) delete updates.photo;
+        if (existing.photo && !updates.photo) delete updates.photo;
         this.updateFencer(existing.id, updates);
         updated++;
       } else {


### PR DESCRIPTION
upsertFencersByLicense supprimait inconditionnellement le champ photo
des mises à jour si le tireur possédait déjà une photo, empêchant tout
remplacement via import (XML, FFE, archive .bpf). La condition est
maintenant plus précise : la photo existante n'est préservée que si la
mise à jour ne fournit pas de nouvelle photo (formats sans photo comme
XML/FFE), mais une nouvelle photo explicite remplace bien l'ancienne.

https://claude.ai/code/session_0141SRzJaq3SZj8Cw2PGU3R7