### PR TITLE
fix(latefencers): correct auto-forfeit logic in updateDelays

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@
 
 ### Services qui retournent des tableaux vides / valeurs hardcodées
 - [ ] **`cloudSyncService` providers** — `uploadToDropbox/GoogleDrive/OneDrive/Custom()` tous stubs non implémentés
-- [ ] **Late fencers** — `updateDelays()` sort prématurément à la ligne 150, logique auto-forfeit absente
+- [x] **Late fencers** — `updateDelays()` sort prématurément à la ligne 150, logique auto-forfeit absente
 
 ### Base de données
 - [ ] **DirectElimination en DB** — types `DirectEliminationTable`, `TableNode` définis mais aucune table SQL ni opération DB

--- a/src/features/latefencers/hooks/useLateFencerStore.ts
+++ b/src/features/latefencers/hooks/useLateFencerStore.ts
@@ -146,21 +146,25 @@ export const useLateFencerStore = create<LateFencerState & LateFencerActions>()(
 
             set(state => {
               state.lateFencers.forEach(lf => {
+                if (lf.status === 'forfeit') return;
+
                 const delayMs = now.getTime() - lf.scheduledMatchTime.getTime();
                 lf.delayMinutes = Math.floor(delayMs / 60000);
 
                 // Update status based on thresholds
                 if (lf.delayMinutes >= config.forfeitThresholdMinutes) {
-                  lf.status = 'forfeit';
-                  if (config.autoForfeit && lf.status !== 'forfeit') {
-                    // Trigger auto-forfeit
+                  if (config.autoForfeit) {
                     lf.status = 'forfeit';
+                  } else {
+                    lf.status = 'critical';
                   }
                 } else if (lf.delayMinutes >= config.criticalThresholdMinutes) {
                   lf.status = 'critical';
                 } else if (lf.delayMinutes >= config.warningThresholdMinutes) {
                   lf.status = 'warned';
                 }
+
+                if (lf.status === 'forfeit') return;
 
                 // Check if notification needed
                 const timeSinceLastNotification = lf.lastNotificationTime
@@ -169,10 +173,8 @@ export const useLateFencerStore = create<LateFencerState & LateFencerActions>()(
 
                 if (
                   lf.notificationsSent < config.maxNotifications &&
-                  timeSinceLastNotification >= config.notificationIntervalMinutes &&
-                  lf.status !== 'forfeit'
+                  timeSinceLastNotification >= config.notificationIntervalMinutes
                 ) {
-                  // Send notification
                   lf.notificationsSent += 1;
                   lf.lastNotificationTime = now;
                 }


### PR DESCRIPTION
- Remove dead-code branch that checked `lf.status !== 'forfeit'` immediately
  after setting it to 'forfeit' (condition was always false)
- Only auto-set status to 'forfeit' when config.autoForfeit is true; fall
  back to 'critical' so manual forfeit workflows still work
- Skip fencers already marked 'forfeit' at the top of the loop to avoid
  recalculating their delay on every tick

https://claude.ai/code/session_01Mfyy7zi4T9bAov1oPey7U9