### PR TITLE
fix(i18n): use bundled imports for locales (Electron file:// fix)

### DIFF
--- a/src/renderer/contexts/TranslationContext.tsx
+++ b/src/renderer/contexts/TranslationContext.tsx
@@ -6,6 +6,13 @@
 
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { logger, LogCategory } from '@shared/services/logger';
+import frTranslations from '../locales/fr.json';
+import enTranslations from '../locales/en.json';
+import deTranslations from '../locales/de.json';
+import esTranslations from '../locales/es.json';
+import brTranslations from '../locales/br.json';
+import caTranslations from '../locales/ca.json';
+import zhHKTranslations from '../locales/zh-HK.json';
 
 export type Language = 'fr' | 'en' | 'br' | 'ca' | 'de' | 'es' | 'zh-HK';
 export type TranslationKey = string;
@@ -100,16 +107,18 @@ const getFallbackTranslations = (language: Language): Translations => {
   return fallbackTranslations[language] || fallbackTranslations.fr;
 };
 
-const loadTranslations = async (language: Language): Promise<Translations> => {
-  try {
-    const response = await fetch(`./locales/${language}.json`);
-    if (response.ok) {
-      return await response.json();
-    }
-  } catch {
-    logger.warn(LogCategory.UI, `Failed to load translations for ${language}`);
-  }
-  return getFallbackTranslations(language);
+const bundledTranslations: Record<Language, Translations> = {
+  fr: frTranslations as Translations,
+  en: enTranslations as Translations,
+  de: deTranslations as Translations,
+  es: esTranslations as Translations,
+  br: brTranslations as Translations,
+  ca: caTranslations as Translations,
+  'zh-HK': zhHKTranslations as Translations,
+};
+
+const loadTranslations = (language: Language): Translations => {
+  return bundledTranslations[language] || getFallbackTranslations(language);
 };
 
 const applyTheme = (theme: Theme): void => {
@@ -131,18 +140,12 @@ export const TranslationProvider: React.FC<TranslationProviderProps> = ({ childr
 
   const changeLanguage = useCallback(async (newLanguage: Language) => {
     setIsLoading(true);
-    try {
-      const loadedTranslations = await loadTranslations(newLanguage);
-      setLanguage(newLanguage);
-      setTranslations(loadedTranslations);
-      localStorage.setItem('bellepoule-language', newLanguage);
-      // Rebuild native Electron menu in the new language
-      window.electronAPI?.notifyLanguageChanged?.(newLanguage);
-    } catch (error) {
-      logger.error(LogCategory.UI, 'Failed to change language', error as Error);
-    } finally {
-      setIsLoading(false);
-    }
+    const loadedTranslations = loadTranslations(newLanguage);
+    setLanguage(newLanguage);
+    setTranslations(loadedTranslations);
+    localStorage.setItem('bellepoule-language', newLanguage);
+    window.electronAPI?.notifyLanguageChanged?.(newLanguage);
+    setIsLoading(false);
   }, []);
 
   const changeTheme = useCallback((newTheme: Theme) => {
@@ -157,7 +160,7 @@ export const TranslationProvider: React.FC<TranslationProviderProps> = ({ childr
       const savedTheme = (localStorage.getItem('bellepoule-theme') as Theme) || 'default';
 
       applyTheme(savedTheme);
-      const loadedTranslations = await loadTranslations(savedLanguage);
+      const loadedTranslations = loadTranslations(savedLanguage);
 
       setLanguage(savedLanguage);
       setTheme(savedTheme);


### PR DESCRIPTION
## Problem

`fetch('./locales/xx.json')` fails silently in Electron when the renderer runs on a `file://` origin. The app loads but falls back to the hardcoded fallback translations — language switching appears broken.

## Fix

Replace the async `fetch()` call in `TranslationContext.tsx` with direct TypeScript imports bundled at build time. A `bundledTranslations` lookup replaces the async loader, so `loadTranslations` becomes synchronous.

## Impact

- Language switching works correctly in the packaged Electron app
- No change to the locale files or translation keys
- `changeLanguage` stays `async` for API compatibility but no longer needs `await`

Tested on Linux with `npm start`.