### PR TITLE
feat(infra): add type-check, test:e2e, e2e:debug scripts + cleanup TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,8 +9,6 @@
 
 ### Services qui retournent des tableaux vides / valeurs hardcodées
 - [ ] **`cloudSyncService` providers** — `uploadToDropbox/GoogleDrive/OneDrive/Custom()` tous stubs non implémentés
-- [x] **Late fencers** — `updateDelays()` sort prématurément à la ligne 150, logique auto-forfeit absente
-
 ### Base de données
 - [ ] **DirectElimination en DB** — types `DirectEliminationTable`, `TableNode` définis mais aucune table SQL ni opération DB
 - [ ] **Système de migrations DB** — actuellement `ALTER TABLE` avec try-catch ad-hoc ; implémenter migrations versionnées dans `src/database/migrations/`
@@ -102,9 +100,7 @@
 - [ ] **Voice scoring i18n** — `VoiceScoreController.tsx` : vérifier support multilingue Web Speech API
 
 ### Infrastructure
-- [ ] **`npm run type-check`** — `tsc --noEmit` pour validation CI sans compilation
 - [ ] **`npm run analyze`** — bundle Webpack avec webpack-bundle-analyzer
-- [ ] **`npm run test:e2e`** et **`npm run e2e:debug`** — scripts Playwright manquants dans `package.json`
 - [ ] **`npm run db:migrate`** — une fois le système de migration implémenté
 - [ ] **Documentation API IPC** — TypeDoc ou manuel des handlers IPC
 - [ ] **i18n complète** — vérifier que les 7 locales (fr/en/br/ca/de/es/zh-HK) couvrent tous les nouveaux textes

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
+    "type-check": "tsc --noEmit",
+    "test:e2e": "playwright test",
+    "e2e:debug": "playwright test --debug"
   },
   "keywords": [
     "fencing",
@@ -143,6 +146,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "@vitest/coverage-v8": "^4.0.18",


### PR DESCRIPTION
- Ajoute `npm run type-check` (tsc --noEmit) pour validation CI sans compilation
- Ajoute `npm run test:e2e` et `npm run e2e:debug` (Playwright)
- Ajoute @playwright/test ^1.49.0 en devDependencies
- Supprime les lignes traitées du TODO.md ([x] late fencers, scripts infra)

https://claude.ai/code/session_0185fLQkkc7m8mC53B2tHizX