### PR TITLE
feat: items critiques et importants de la todo

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -25,6 +25,8 @@ import {
   Referee,
 } from '../shared/types';
 import { validateId, validateSessionState, sanitizeId } from './validation';
+import { MigrationManager } from './migrations';
+import { ALL_MIGRATIONS } from './migrations/migrations';
 
 let SQL: any = null;
 
@@ -57,7 +59,7 @@ export class DatabaseManager {
       this.db = new SQL.Database();
     }
 
-    this.initializeTables();
+    this.runMigrations();
     this.save();
   }
 
@@ -127,223 +129,9 @@ export class DatabaseManager {
     return this.db !== null;
   }
 
-  private initializeTables(): void {
+  private runMigrations(): void {
     if (!this.db) throw new Error('Database not open');
-
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS competitions (
-        id TEXT PRIMARY KEY, title TEXT NOT NULL, short_title TEXT,
-        date TEXT NOT NULL, location TEXT, organizer TEXT,
-        weapon TEXT NOT NULL, gender TEXT NOT NULL, category TEXT NOT NULL,
-        championship TEXT, color TEXT DEFAULT '#3B82F6',
-        current_phase_index INTEGER DEFAULT 0, is_team_event INTEGER DEFAULT 0,
-        status TEXT DEFAULT 'draft', settings TEXT,
-        created_at TEXT NOT NULL, updated_at TEXT NOT NULL
-      )
-    `);
-
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS phases (
-        id TEXT PRIMARY KEY,
-        competition_id TEXT NOT NULL,
-        name TEXT NOT NULL,
-        type TEXT NOT NULL,
-        order_index INTEGER NOT NULL,
-        status TEXT DEFAULT 'pending',
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        FOREIGN KEY (competition_id) REFERENCES competitions(id) ON DELETE CASCADE
-      )
-    `);
-
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS fencers (
-        id TEXT PRIMARY KEY, competition_id TEXT NOT NULL,
-        ref INTEGER NOT NULL, last_name TEXT NOT NULL, first_name TEXT NOT NULL,
-        birth_date TEXT, gender TEXT NOT NULL, nationality TEXT DEFAULT 'FRA',
-        region TEXT, club TEXT, license TEXT, ranking INTEGER,
-        status TEXT DEFAULT 'N', seed_number INTEGER, final_ranking INTEGER,
-        pool_stats TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
-      )
-    `);
-
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS matches (
-        id TEXT PRIMARY KEY, number INTEGER NOT NULL,
-        pool_id TEXT, table_id TEXT,
-        fencer_a_id TEXT, fencer_b_id TEXT,
-        score_a TEXT, score_b TEXT, max_score INTEGER NOT NULL,
-        status TEXT DEFAULT 'not_started', referee_id TEXT,
-        strip INTEGER, round INTEGER, position INTEGER,
-        created_at TEXT NOT NULL, updated_at TEXT NOT NULL
-      )
-    `);
-
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS pools (
-        id TEXT PRIMARY KEY, phase_id TEXT NOT NULL,
-        number INTEGER NOT NULL, strip INTEGER, start_time TEXT,
-        is_complete INTEGER DEFAULT 0, has_error INTEGER DEFAULT 0,
-        created_at TEXT NOT NULL, updated_at TEXT NOT NULL
-      )
-    `);
-
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS pool_fencers (
-        pool_id TEXT NOT NULL, fencer_id TEXT NOT NULL, position INTEGER NOT NULL,
-        PRIMARY KEY (pool_id, fencer_id)
-      )
-    `);
-
-    // Table pour stocker l'état de session (persistance au refresh)
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS session_state (
-        competition_id TEXT PRIMARY KEY,
-        state_json TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      )
-    `);
-
-    // Table pour les touches (points marqués avec horodatage)
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS match_touches (
-        id TEXT PRIMARY KEY,
-        match_id TEXT NOT NULL,
-        fencer_id TEXT NOT NULL,
-        zone TEXT NOT NULL,
-        points INTEGER NOT NULL,
-        timestamp TEXT NOT NULL,
-        is_valid_in_sudden_death INTEGER DEFAULT 0,
-        is_reversed INTEGER DEFAULT 0,
-        FOREIGN KEY (match_id) REFERENCES matches(id) ON DELETE CASCADE
-      )
-    `);
-
-    // Table pour les cartons (avec horodatage)
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS match_cards (
-        id TEXT PRIMARY KEY,
-        match_id TEXT NOT NULL,
-        fencer_id TEXT NOT NULL,
-        card_type TEXT NOT NULL,
-        reason TEXT NOT NULL,
-        card_group INTEGER NOT NULL DEFAULT 1,
-        timestamp TEXT NOT NULL,
-        points_awarded INTEGER NOT NULL DEFAULT 0,
-        resulting_exclusion INTEGER DEFAULT 0,
-        FOREIGN KEY (match_id) REFERENCES matches(id) ON DELETE CASCADE
-      )
-    `);
-
-    // Table des arbitres
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS referees (
-        id TEXT PRIMARY KEY,
-        competition_id TEXT NOT NULL,
-        ref INTEGER NOT NULL,
-        name TEXT NOT NULL,
-        gender TEXT,
-        nationality TEXT DEFAULT 'FRA',
-        club TEXT,
-        license TEXT,
-        category TEXT,
-        status TEXT DEFAULT 'active',
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        FOREIGN KEY (competition_id) REFERENCES competitions(id) ON DELETE CASCADE
-      )
-    `);
-
-    // Table pour les snapshots d'abandon (annulation d'abandon)
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS fencer_abandons (
-        id TEXT PRIMARY KEY,
-        fencer_id TEXT NOT NULL,
-        competition_id TEXT NOT NULL,
-        previous_status TEXT NOT NULL,
-        abandon_type TEXT NOT NULL,
-        match_snapshots TEXT NOT NULL,
-        created_at TEXT NOT NULL
-      )
-    `);
-
-    // Colonnes de timing sur les matchs (migration idempotente)
-    try {
-      this.db.run(`ALTER TABLE matches ADD COLUMN start_time TEXT`);
-    } catch {
-      /* colonne déjà présente */
-    }
-    try {
-      this.db.run(`ALTER TABLE matches ADD COLUMN end_time TEXT`);
-    } catch {
-      /* colonne déjà présente */
-    }
-    try {
-      this.db.run(`ALTER TABLE matches ADD COLUMN duration INTEGER`);
-    } catch {
-      /* colonne déjà présente */
-    }
-
-    // Photo des tireurs (migration idempotente)
-    try {
-      this.db.run(`ALTER TABLE fencers ADD COLUMN photo TEXT`);
-    } catch {
-      /* colonne déjà présente */
-    }
-
-    // Renommage league → region (migration idempotente)
-    try {
-      this.db.run(`ALTER TABLE fencers RENAME COLUMN league TO region`);
-    } catch {
-      /* colonne déjà renommée */
-    }
-
-    // Création des index pour optimiser les performances
-    this.createIndexes();
-  }
-
-  private createIndexes(): void {
-    if (!this.db) return;
-
-    // Index pour les recherches par date de compétition
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_competitions_date ON competitions(date)`);
-
-    // Index pour les recherches par statut
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_competitions_status ON competitions(status)`);
-
-    // Index pour les phases par compétition
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_phases_competition ON phases(competition_id)`);
-
-    // Index pour les tireurs par compétition (très fréquemment utilisé)
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_fencers_competition ON fencers(competition_id)`);
-
-    // Index pour les recherches de tireurs par nom
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_fencers_name ON fencers(last_name, first_name)`);
-
-    // Index pour les recherches par club
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_fencers_club ON fencers(club)`);
-
-    // Index pour les matchs par pool
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_matches_pool ON matches(pool_id)`);
-
-    // Index pour les matchs par tableau
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_matches_table ON matches(table_id)`);
-
-    // Index pour les matchs par statut
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_matches_status ON matches(status)`);
-
-    // Index pour les poules par phase
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_pools_phase ON pools(phase_id)`);
-
-    // Index pour les associations pool/tireur
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_pool_fencers_pool ON pool_fencers(pool_id)`);
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_pool_fencers_fencer ON pool_fencers(fencer_id)`);
-
-    // Index pour les statistiques par combattant
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_touches_match ON match_touches(match_id)`);
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_touches_fencer ON match_touches(fencer_id)`);
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_cards_match ON match_cards(match_id)`);
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_cards_fencer ON match_cards(fencer_id)`);
+    new MigrationManager(this.db).run(ALL_MIGRATIONS);
   }
 
   // Session State Management
@@ -926,6 +714,61 @@ export class DatabaseManager {
     return this.getMatch(id)!;
   }
 
+  public upsertTableauMatch(params: {
+    competitionId: string;
+    matchId: string; // ex: '3-0', '2-0', '4-1'
+    round: number;
+    position: number;
+    fencerAId?: string | null;
+    fencerBId?: string | null;
+    scoreA?: any | null;
+    scoreB?: any | null;
+    status?: string;
+    maxScore?: number;
+    isBye?: boolean;
+  }): void {
+    if (!this.db) throw new Error('Database not open');
+    const now = new Date().toISOString();
+    const dbId = `${params.competitionId}-${params.matchId}`;
+    const status = params.status ?? 'not_started';
+    const exists = !!this.getMatch(dbId);
+    if (!exists) {
+      this.db.run(
+        `INSERT INTO matches (id, number, table_id, fencer_a_id, fencer_b_id, max_score, status, round, position, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          dbId,
+          parseInt(params.matchId.replace('-', '')) || 0,
+          params.competitionId,
+          params.fencerAId ?? null,
+          params.fencerBId ?? null,
+          params.maxScore ?? 15,
+          status,
+          params.round,
+          params.position,
+          now,
+          now,
+        ]
+      );
+    } else {
+      this.db.run(
+        `UPDATE matches SET fencer_a_id=?, fencer_b_id=?, score_a=?, score_b=?, status=?, round=?, position=?, updated_at=? WHERE id=?`,
+        [
+          params.fencerAId ?? null,
+          params.fencerBId ?? null,
+          params.scoreA != null ? JSON.stringify(params.scoreA) : null,
+          params.scoreB != null ? JSON.stringify(params.scoreB) : null,
+          status,
+          params.round,
+          params.position,
+          now,
+          dbId,
+        ]
+      );
+    }
+    this.save();
+  }
+
   public getMatch(id: string): Match | null {
     if (!this.db) throw new Error('Database not open');
     const stmt = this.db.prepare('SELECT * FROM matches WHERE id = ?');
@@ -1244,6 +1087,12 @@ export class DatabaseManager {
     if (updates.status !== undefined)
       this.db.run('UPDATE matches SET status = ?, updated_at = ? WHERE id = ?', [
         updates.status,
+        now,
+        id,
+      ]);
+    if (updates.refereeId !== undefined)
+      this.db.run('UPDATE matches SET referee_id = ?, updated_at = ? WHERE id = ?', [
+        updates.refereeId,
         now,
         id,
       ]);
@@ -1899,6 +1748,190 @@ export class DatabaseManager {
     this.close();
     this.dbPath = filepath;
     await this.open();
+  }
+
+  // ─── Bracket nodes (élimination directe) ────────────────────────────────────
+
+  public upsertBracketNode(node: {
+    id: string;
+    competitionId: string;
+    phaseId: string;
+    round: number;
+    position: number;
+    fencerId?: string | null;
+    matchId?: string | null;
+    isBye?: boolean;
+    isThirdPlace?: boolean;
+    parentNodeId?: string | null;
+  }): void {
+    if (!this.db) throw new Error('Database not open');
+    const now = new Date().toISOString();
+    this.db.run(
+      `INSERT OR REPLACE INTO bracket_nodes
+        (id, competition_id, phase_id, round, position, fencer_id, match_id, is_bye, is_third_place, parent_node_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE((SELECT created_at FROM bracket_nodes WHERE id=?), ?), ?)`,
+      [
+        node.id, node.competitionId, node.phaseId, node.round, node.position,
+        node.fencerId ?? null, node.matchId ?? null,
+        node.isBye ? 1 : 0, node.isThirdPlace ? 1 : 0, node.parentNodeId ?? null,
+        node.id, now, now,
+      ]
+    );
+    this.save();
+  }
+
+  public getBracketNodes(competitionId: string, phaseId: string): any[] {
+    if (!this.db) throw new Error('Database not open');
+    const stmt = this.db.prepare(
+      `SELECT * FROM bracket_nodes WHERE competition_id=? AND phase_id=? ORDER BY round, position`
+    );
+    stmt.bind([competitionId, phaseId]);
+    const rows: any[] = [];
+    while (stmt.step()) rows.push(stmt.getAsObject());
+    stmt.free();
+    return rows.map(r => ({
+      ...r,
+      isBye: r.is_bye === 1,
+      isThirdPlace: r.is_third_place === 1,
+    }));
+  }
+
+  public clearBracket(competitionId: string, phaseId: string): void {
+    if (!this.db) throw new Error('Database not open');
+    this.db.run(
+      `DELETE FROM bracket_nodes WHERE competition_id=? AND phase_id=?`,
+      [competitionId, phaseId]
+    );
+    this.save();
+  }
+
+  // ─── Score audit log ─────────────────────────────────────────────────────────
+
+  public logScoreChange(entry: {
+    matchId: string;
+    arenaId?: string;
+    previousScoreA?: any;
+    previousScoreB?: any;
+    newScoreA: any;
+    newScoreB: any;
+    changedBy: string;
+    reason?: string;
+  }): void {
+    if (!this.db) throw new Error('Database not open');
+    const { v4: uuidv4gen } = require('uuid');
+    this.db.run(
+      `INSERT INTO score_audit_log
+        (id, match_id, arena_id, previous_score_a, previous_score_b, new_score_a, new_score_b, changed_by, changed_at, reason)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        uuidv4gen(),
+        entry.matchId,
+        entry.arenaId ?? null,
+        entry.previousScoreA != null ? JSON.stringify(entry.previousScoreA) : null,
+        entry.previousScoreB != null ? JSON.stringify(entry.previousScoreB) : null,
+        JSON.stringify(entry.newScoreA),
+        JSON.stringify(entry.newScoreB),
+        entry.changedBy,
+        new Date().toISOString(),
+        entry.reason ?? null,
+      ]
+    );
+    this.save();
+  }
+
+  public getScoreAuditLog(matchId: string): any[] {
+    if (!this.db) throw new Error('Database not open');
+    const stmt = this.db.prepare(
+      `SELECT * FROM score_audit_log WHERE match_id=? ORDER BY changed_at ASC`
+    );
+    stmt.bind([matchId]);
+    const rows: any[] = [];
+    while (stmt.step()) {
+      const r = stmt.getAsObject();
+      rows.push({
+        id: r.id,
+        matchId: r.match_id,
+        arenaId: r.arena_id,
+        previousScoreA: r.previous_score_a ? JSON.parse(r.previous_score_a as string) : null,
+        previousScoreB: r.previous_score_b ? JSON.parse(r.previous_score_b as string) : null,
+        newScoreA: JSON.parse(r.new_score_a as string),
+        newScoreB: JSON.parse(r.new_score_b as string),
+        changedBy: r.changed_by,
+        changedAt: r.changed_at,
+        reason: r.reason,
+      });
+    }
+    stmt.free();
+    return rows;
+  }
+
+  // ─── Arena state persistence ─────────────────────────────────────────────────
+
+  public saveArenaState(arenaId: string, state: {
+    competitionId: string;
+    currentMatch: any | null;
+    matchQueue: any[];
+    settings: any;
+    status: string;
+  }): void {
+    if (!this.db) throw new Error('Database not open');
+    this.db.run(
+      `INSERT OR REPLACE INTO arena_state
+        (arena_id, competition_id, current_match, match_queue, settings, status, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        arenaId,
+        state.competitionId,
+        state.currentMatch != null ? JSON.stringify(state.currentMatch) : null,
+        JSON.stringify(state.matchQueue),
+        state.settings != null ? JSON.stringify(state.settings) : null,
+        state.status,
+        new Date().toISOString(),
+      ]
+    );
+    this.save();
+  }
+
+  public getArenaState(arenaId: string): {
+    arenaId: string;
+    competitionId: string;
+    currentMatch: any | null;
+    matchQueue: any[];
+    settings: any | null;
+    status: string;
+    updatedAt: string;
+  } | null {
+    if (!this.db) throw new Error('Database not open');
+    const stmt = this.db.prepare(`SELECT * FROM arena_state WHERE arena_id=?`);
+    stmt.bind([arenaId]);
+    if (!stmt.step()) { stmt.free(); return null; }
+    const r = stmt.getAsObject();
+    stmt.free();
+    return {
+      arenaId: r.arena_id as string,
+      competitionId: r.competition_id as string,
+      currentMatch: r.current_match ? JSON.parse(r.current_match as string) : null,
+      matchQueue: r.match_queue ? JSON.parse(r.match_queue as string) : [],
+      settings: r.settings ? JSON.parse(r.settings as string) : null,
+      status: r.status as string,
+      updatedAt: r.updated_at as string,
+    };
+  }
+
+  public getArenaStatesByCompetition(competitionId: string): ReturnType<DatabaseManager['getArenaState']>[] {
+    if (!this.db) throw new Error('Database not open');
+    const stmt = this.db.prepare(`SELECT arena_id FROM arena_state WHERE competition_id=?`);
+    stmt.bind([competitionId]);
+    const ids: string[] = [];
+    while (stmt.step()) ids.push(stmt.getAsObject().arena_id as string);
+    stmt.free();
+    return ids.map(id => this.getArenaState(id)).filter(Boolean) as any;
+  }
+
+  public clearArenaStates(competitionId: string): void {
+    if (!this.db) throw new Error('Database not open');
+    this.db.run(`DELETE FROM arena_state WHERE competition_id=?`, [competitionId]);
+    this.save();
   }
 }
 

--- a/src/database/migrations/index.ts
+++ b/src/database/migrations/index.ts
@@ -1,0 +1,59 @@
+/**
+ * BellePoule Modern - Système de migrations DB versionnées
+ * Chaque migration est appliquée une seule fois, dans l'ordre croissant.
+ */
+
+export interface Migration {
+  version: number;
+  description: string;
+  up(db: any): void;
+}
+
+export class MigrationManager {
+  constructor(private db: any) {}
+
+  run(migrations: Migration[]): void {
+    this.ensureMigrationsTable();
+    const applied = this.getAppliedVersions();
+    const pending = migrations
+      .filter(m => !applied.has(m.version))
+      .sort((a, b) => a.version - b.version);
+
+    for (const migration of pending) {
+      console.log(`[DB] Migration v${migration.version}: ${migration.description}`);
+      migration.up(this.db);
+      this.recordMigration(migration.version, migration.description);
+    }
+
+    if (pending.length > 0) {
+      console.log(`[DB] ${pending.length} migration(s) appliquée(s)`);
+    }
+  }
+
+  private ensureMigrationsTable(): void {
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version INTEGER PRIMARY KEY,
+        description TEXT NOT NULL,
+        applied_at TEXT NOT NULL
+      )
+    `);
+  }
+
+  private getAppliedVersions(): Set<number> {
+    const applied = new Set<number>();
+    const stmt = this.db.prepare('SELECT version FROM schema_migrations');
+    while (stmt.step()) {
+      applied.add(stmt.getAsObject().version as number);
+    }
+    stmt.free();
+    return applied;
+  }
+
+  private recordMigration(version: number, description: string): void {
+    this.db.run(
+      'INSERT OR IGNORE INTO schema_migrations (version, description, applied_at) VALUES (?, ?, ?)',
+      [version, description, new Date().toISOString()]
+    );
+  }
+}

--- a/src/database/migrations/migrations.ts
+++ b/src/database/migrations/migrations.ts
@@ -1,0 +1,231 @@
+/**
+ * BellePoule Modern - Liste des migrations DB
+ * Ajouter ici chaque nouvelle migration avec un numéro de version croissant.
+ */
+
+import { Migration } from './index';
+
+export const ALL_MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    description: 'Tables initiales (baseline)',
+    up(db) {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS competitions (
+          id TEXT PRIMARY KEY, title TEXT NOT NULL, short_title TEXT,
+          date TEXT NOT NULL, location TEXT, organizer TEXT,
+          weapon TEXT NOT NULL, gender TEXT NOT NULL, category TEXT NOT NULL,
+          championship TEXT, color TEXT DEFAULT '#3B82F6',
+          current_phase_index INTEGER DEFAULT 0, is_team_event INTEGER DEFAULT 0,
+          status TEXT DEFAULT 'draft', settings TEXT,
+          created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS phases (
+          id TEXT PRIMARY KEY,
+          competition_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          type TEXT NOT NULL,
+          order_index INTEGER NOT NULL,
+          status TEXT DEFAULT 'pending',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          FOREIGN KEY (competition_id) REFERENCES competitions(id) ON DELETE CASCADE
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS fencers (
+          id TEXT PRIMARY KEY, competition_id TEXT NOT NULL,
+          ref INTEGER NOT NULL, last_name TEXT NOT NULL, first_name TEXT NOT NULL,
+          birth_date TEXT, gender TEXT NOT NULL, nationality TEXT DEFAULT 'FRA',
+          region TEXT, club TEXT, license TEXT, ranking INTEGER,
+          status TEXT DEFAULT 'N', seed_number INTEGER, final_ranking INTEGER,
+          pool_stats TEXT, photo TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS matches (
+          id TEXT PRIMARY KEY, number INTEGER NOT NULL,
+          pool_id TEXT, table_id TEXT,
+          fencer_a_id TEXT, fencer_b_id TEXT,
+          score_a TEXT, score_b TEXT, max_score INTEGER NOT NULL,
+          status TEXT DEFAULT 'not_started', referee_id TEXT,
+          strip INTEGER, round INTEGER, position INTEGER,
+          start_time TEXT, end_time TEXT, duration INTEGER,
+          created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS pools (
+          id TEXT PRIMARY KEY, phase_id TEXT NOT NULL,
+          number INTEGER NOT NULL, strip INTEGER, start_time TEXT,
+          is_complete INTEGER DEFAULT 0, has_error INTEGER DEFAULT 0,
+          created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS pool_fencers (
+          pool_id TEXT NOT NULL, fencer_id TEXT NOT NULL, position INTEGER NOT NULL,
+          PRIMARY KEY (pool_id, fencer_id)
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS session_state (
+          competition_id TEXT PRIMARY KEY,
+          state_json TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS match_touches (
+          id TEXT PRIMARY KEY,
+          match_id TEXT NOT NULL,
+          fencer_id TEXT NOT NULL,
+          zone TEXT NOT NULL,
+          points INTEGER NOT NULL,
+          timestamp TEXT NOT NULL,
+          is_valid_in_sudden_death INTEGER DEFAULT 0,
+          is_reversed INTEGER DEFAULT 0,
+          FOREIGN KEY (match_id) REFERENCES matches(id) ON DELETE CASCADE
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS match_cards (
+          id TEXT PRIMARY KEY,
+          match_id TEXT NOT NULL,
+          fencer_id TEXT NOT NULL,
+          card_type TEXT NOT NULL,
+          reason TEXT NOT NULL,
+          card_group INTEGER NOT NULL DEFAULT 1,
+          timestamp TEXT NOT NULL,
+          points_awarded INTEGER NOT NULL DEFAULT 0,
+          resulting_exclusion INTEGER DEFAULT 0,
+          FOREIGN KEY (match_id) REFERENCES matches(id) ON DELETE CASCADE
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS referees (
+          id TEXT PRIMARY KEY,
+          competition_id TEXT NOT NULL,
+          ref INTEGER NOT NULL,
+          name TEXT NOT NULL,
+          gender TEXT,
+          nationality TEXT DEFAULT 'FRA',
+          club TEXT,
+          license TEXT,
+          category TEXT,
+          status TEXT DEFAULT 'active',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          FOREIGN KEY (competition_id) REFERENCES competitions(id) ON DELETE CASCADE
+        )
+      `);
+      db.run(`
+        CREATE TABLE IF NOT EXISTS fencer_abandons (
+          id TEXT PRIMARY KEY,
+          fencer_id TEXT NOT NULL,
+          competition_id TEXT NOT NULL,
+          previous_status TEXT NOT NULL,
+          abandon_type TEXT NOT NULL,
+          match_snapshots TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        )
+      `);
+      // Colonnes ajoutées progressivement (compat ascendante pour DBs existantes)
+      try { db.run(`ALTER TABLE matches ADD COLUMN start_time TEXT`); } catch { /* */ }
+      try { db.run(`ALTER TABLE matches ADD COLUMN end_time TEXT`); } catch { /* */ }
+      try { db.run(`ALTER TABLE matches ADD COLUMN duration INTEGER`); } catch { /* */ }
+      try { db.run(`ALTER TABLE fencers ADD COLUMN photo TEXT`); } catch { /* */ }
+      try { db.run(`ALTER TABLE fencers RENAME COLUMN league TO region`); } catch { /* */ }
+
+      // Index de performance
+      db.run(`CREATE INDEX IF NOT EXISTS idx_competitions_date ON competitions(date)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_competitions_status ON competitions(status)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_phases_competition ON phases(competition_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_fencers_competition ON fencers(competition_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_fencers_name ON fencers(last_name, first_name)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_fencers_club ON fencers(club)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_matches_pool ON matches(pool_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_matches_table ON matches(table_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_matches_status ON matches(status)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_pools_phase ON pools(phase_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_pool_fencers_pool ON pool_fencers(pool_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_pool_fencers_fencer ON pool_fencers(fencer_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_touches_match ON match_touches(match_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_touches_fencer ON match_touches(fencer_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_cards_match ON match_cards(match_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_cards_fencer ON match_cards(fencer_id)`);
+    },
+  },
+
+  {
+    version: 2,
+    description: 'Table bracket_nodes pour l\'élimination directe',
+    up(db) {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS bracket_nodes (
+          id TEXT PRIMARY KEY,
+          competition_id TEXT NOT NULL,
+          phase_id TEXT NOT NULL,
+          round INTEGER NOT NULL,
+          position INTEGER NOT NULL,
+          fencer_id TEXT,
+          match_id TEXT,
+          is_bye INTEGER DEFAULT 0,
+          is_third_place INTEGER DEFAULT 0,
+          parent_node_id TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          FOREIGN KEY (competition_id) REFERENCES competitions(id) ON DELETE CASCADE
+        )
+      `);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_bracket_competition ON bracket_nodes(competition_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_bracket_phase ON bracket_nodes(phase_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_bracket_round_pos ON bracket_nodes(round, position)`);
+    },
+  },
+
+  {
+    version: 3,
+    description: 'Table score_audit_log pour la traçabilité des scores',
+    up(db) {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS score_audit_log (
+          id TEXT PRIMARY KEY,
+          match_id TEXT NOT NULL,
+          arena_id TEXT,
+          previous_score_a TEXT,
+          previous_score_b TEXT,
+          new_score_a TEXT NOT NULL,
+          new_score_b TEXT NOT NULL,
+          changed_by TEXT NOT NULL,
+          changed_at TEXT NOT NULL,
+          reason TEXT,
+          FOREIGN KEY (match_id) REFERENCES matches(id) ON DELETE CASCADE
+        )
+      `);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_audit_match ON score_audit_log(match_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_audit_changed_at ON score_audit_log(changed_at)`);
+    },
+  },
+
+  {
+    version: 4,
+    description: 'Table arena_state pour la persistance des arènes',
+    up(db) {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS arena_state (
+          arena_id TEXT PRIMARY KEY,
+          competition_id TEXT NOT NULL,
+          current_match TEXT,
+          match_queue TEXT DEFAULT '[]',
+          settings TEXT,
+          status TEXT DEFAULT 'idle',
+          updated_at TEXT NOT NULL
+        )
+      `);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_arena_state_competition ON arena_state(competition_id)`);
+    },
+  },
+];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -759,6 +759,10 @@ ipcMain.handle('db:updateMatch', async (_, id, updates) => {
   return db.updateMatch(id, updates);
 });
 
+ipcMain.handle('db:upsertTableauMatch', async (_, params) => {
+  return db.upsertTableauMatch(params);
+});
+
 // Session State handlers
 ipcMain.handle('db:saveSessionState', async (_, competitionId, state) => {
   return db.saveSessionState(competitionId, state);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -154,6 +154,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return ipcRenderer.invoke('db:updateMatch', id, updates);
     },
 
+    upsertTableauMatch: (params: any) =>
+      ipcRenderer.invoke('db:upsertTableauMatch', params),
+
     // Pools
     createPool: (phaseId: string, number: number) => {
       if (!phaseId || typeof phaseId !== 'string') {

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -60,6 +60,13 @@ export class RemoteScoreServer {
 
   // Rate limiting pour le login : { ip → { count, resetAt } }
   private loginAttempts: Map<string, { count: number; resetAt: number }> = new Map();
+  // Rate limiting pour les soumissions de score : { ip → { count, resetAt } }
+  private scoreRateLimiter: Map<string, { count: number; resetAt: number }> = new Map();
+  private readonly SCORE_RATE_LIMIT = 30; // soumissions par minute par IP
+  // Buffer d'événements par arène pour la reconnexion WebSocket (replay)
+  private arenaEventBuffer: Map<string, Array<{ event: ArenaUpdate; timestamp: number }>> = new Map();
+  private readonly EVENT_BUFFER_MAX = 50;
+  private readonly EVENT_BUFFER_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
   constructor(db: DatabaseManager, port: number = 8066) {
     console.log('[RemoteScoreServer] Initialisation du serveur de saisie distante...');
@@ -757,6 +764,10 @@ export class RemoteScoreServer {
       if (!this.hasAnyValidToken(req.headers.cookie)) {
         return res.status(401).json({ error: 'Non authentifié' });
       }
+      const clientIp = (req.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ?? req.socket.remoteAddress ?? 'unknown';
+      if (!this.checkScoreRateLimit(clientIp)) {
+        return res.status(429).json({ error: 'Trop de soumissions, réessayez dans une minute' });
+      }
       const { poolId, matchId } = req.params;
       if (!/^[0-9a-f-]{36}$/i.test(matchId) && !/^[0-9a-f-]{36}$/i.test(poolId)) {
         // Accepter aussi des IDs non-UUID (matchs en mémoire) - on valide le format souple
@@ -788,11 +799,24 @@ export class RemoteScoreServer {
           isExclusion: specialStatus === 'exclusion_B',
           isForfait: specialStatus === 'forfait_B',
         };
+        const previousMatch = this.db.getMatch(matchId);
         this.db.updateMatch(matchId, {
           scoreA: scoreAObj,
           scoreB: scoreBObj,
           status: MatchStatus.FINISHED,
         });
+
+        try {
+          this.db.logScoreChange({
+            matchId,
+            previousScoreA: previousMatch?.scoreA ?? null,
+            previousScoreB: previousMatch?.scoreB ?? null,
+            newScoreA: scoreAObj,
+            newScoreB: scoreBObj,
+            changedBy: 'referee',
+            reason: 'pool_remote_entry',
+          });
+        } catch { /* non bloquant */ }
 
         // Mettre à jour le score en mémoire (pour les matchs du renderer non persistés en DB)
         this.sessionMatchScores.set(matchId, {
@@ -837,6 +861,7 @@ export class RemoteScoreServer {
           });
         }
 
+        this.broadcastDashboardUpdate();
         res.json({ success: true, isComplete });
       } catch (err) {
         console.error('[RemoteScoreServer] Erreur score poule:', err);
@@ -1413,7 +1438,7 @@ export class RemoteScoreServer {
       console.log('Client connected:', socket.id);
 
       // Gestion des arènes
-      socket.on('join_arena', (data: { arenaId: string; role?: string }) => {
+      socket.on('join_arena', (data: { arenaId: string; role?: string; lastSeen?: number }) => {
         console.log(
           `Client ${socket.id} joining arena ${data.arenaId} as ${data.role || 'spectator'}`
         );
@@ -1426,10 +1451,23 @@ export class RemoteScoreServer {
         }
         socket.join(`arena:${data.arenaId}`);
 
-        // Envoyer l'état actuel de l'arène (thème inclus pour éviter le flash dark au chargement)
         const arena = this.getArena(data.arenaId);
         if (arena) {
           const override = this.arenaThemeOverrides.get(data.arenaId);
+
+          // Replay des événements manqués si lastSeen fourni
+          if (data.lastSeen && data.lastSeen > 0) {
+            const buf = this.arenaEventBuffer.get(data.arenaId) ?? [];
+            const missed = buf.filter(e => e.timestamp > data.lastSeen!);
+            if (missed.length > 0) {
+              socket.emit(`arena:${data.arenaId}:replay`, {
+                events: missed.map(e => e.event),
+              });
+              return; // pas besoin d'envoyer l'état courant séparément
+            }
+          }
+
+          // Sinon : état courant complet
           socket.emit(`arena:${data.arenaId}:update`, {
             arenaId: data.arenaId,
             match: arena.currentMatch,
@@ -1450,6 +1488,17 @@ export class RemoteScoreServer {
 
       socket.on('join_pool', (data: { arenaId: string }) => {
         socket.join(`pool:${data.arenaId}`);
+      });
+
+      socket.on('dashboard:subscribe', () => {
+        socket.join('dashboard');
+        // Envoyer l'état courant immédiatement
+        const snapshot = this.buildDashboardSnapshot();
+        if (snapshot) {
+          socket.emit('rankings:update', { rankings: snapshot.rankings });
+          socket.emit('pools:update', { pools: snapshot.pools });
+          socket.emit('matches:update', { matches: snapshot.liveMatches });
+        }
       });
 
       socket.on(
@@ -1860,6 +1909,7 @@ export class RemoteScoreServer {
       currentMatch: match,
     });
 
+    this.persistArenaState(arenaId);
     console.log(`[RemoteScoreServer] Match assigné avec succès à l'arène ${arenaId}`);
   }
 
@@ -1985,6 +2035,7 @@ export class RemoteScoreServer {
       startTime: arena.startTime,
       currentMatch: arena.currentMatch,
     });
+    this.persistArenaState(arenaId);
   }
 
   public pauseArenaMatch(arenaId: string): void {
@@ -2013,6 +2064,23 @@ export class RemoteScoreServer {
 
     arena.currentMatch.scoreA = scoreA;
     arena.currentMatch.scoreB = scoreB;
+
+    // Audit trail si le match est en DB
+    try {
+      const matchId = arena.currentMatch.id;
+      if (this.db.getMatch(matchId)) {
+        this.db.logScoreChange({
+          matchId,
+          arenaId,
+          previousScoreA: { value: previousScoreA },
+          previousScoreB: { value: previousScoreB },
+          newScoreA: { value: scoreA },
+          newScoreB: { value: scoreB },
+          changedBy: 'referee',
+          reason: 'remote_entry',
+        });
+      }
+    } catch { /* non bloquant */ }
 
     // Envoyer la mise à jour via WebSocket
     this.broadcastArenaUpdate(arenaId, {
@@ -2101,6 +2169,9 @@ export class RemoteScoreServer {
         `[RemoteScoreServer] Émission match:finished pour ${finishedMatch.id}: ${finishedMatch.scoreA}-${finishedMatch.scoreB}`
       );
     }
+
+    this.persistArenaState(arenaId);
+    this.broadcastDashboardUpdate();
 
     // Charger automatiquement le prochain match après un délai
     // (loadNextMatch gère aussi le cas "plus de matchs" → arène idle)
@@ -2253,11 +2324,84 @@ export class RemoteScoreServer {
       status: 'idle',
       startTime: null,
     });
+    this.persistArenaState(arenaId);
     console.log(`[RemoteScoreServer] Arène ${arenaId} marquée comme vide`);
   }
 
+  private buildDashboardSnapshot(): { rankings: any[]; pools: any[]; liveMatches: any[] } | null {
+    if (!this.session) return null;
+    const { competitionId } = this.session;
+
+    // Classement global (depuis les poules terminées)
+    let rankings: any[] = [];
+    try {
+      const fencers = this.db.getFencersByCompetition(competitionId);
+      rankings = fencers
+        .filter((f: any) => f.poolStats)
+        .map((f: any) => {
+          const stats = typeof f.poolStats === 'string' ? JSON.parse(f.poolStats) : f.poolStats;
+          return {
+            lastName: f.lastName,
+            firstName: f.firstName,
+            club: f.club || '',
+            victories: stats?.victories ?? 0,
+            quest: stats?.questPoints ?? stats?.touchesScored ?? 0,
+          };
+        })
+        .sort((a: any, b: any) => b.victories - a.victories || b.quest - a.quest);
+    } catch { /* */ }
+
+    // État des poules
+    const pools: any[] = [];
+    try {
+      const matchesByPool = new Map<string, any[]>();
+      for (const m of this.sessionMatches) {
+        const pid = m.poolId || m.pool?.id;
+        if (!pid) continue;
+        if (!matchesByPool.has(pid)) matchesByPool.set(pid, []);
+        matchesByPool.get(pid)!.push(m);
+      }
+      let poolNum = 1;
+      for (const [pid, pMatches] of matchesByPool) {
+        const isComplete = pMatches.every((m: any) => {
+          const u = this.sessionMatchScores.get(m.id);
+          return u ? u.status === 'finished' : m.status === 'finished';
+        });
+        pools.push({ id: pid, number: poolNum++, isComplete, ranking: [] });
+      }
+    } catch { /* */ }
+
+    // Matchs en direct (arènes actives)
+    const liveMatches: any[] = [];
+    for (const arena of this.arenas.values()) {
+      if (arena.currentMatch && arena.status === 'in_progress') {
+        const m = arena.currentMatch;
+        liveMatches.push({
+          number: arena.number,
+          poolNumber: m.poolId || null,
+          fencerA: `${m.fencerA?.lastName ?? ''} ${m.fencerA?.firstName ?? ''}`.trim(),
+          fencerB: `${m.fencerB?.lastName ?? ''} ${m.fencerB?.firstName ?? ''}`.trim(),
+          clubA: m.fencerA?.club || '',
+          clubB: m.fencerB?.club || '',
+          scoreA: m.scoreA,
+          scoreB: m.scoreB,
+          winner: m.status === 'finished' ? (m.scoreA > m.scoreB ? 'A' : 'B') : null,
+        });
+      }
+    }
+
+    return { rankings, pools, liveMatches };
+  }
+
+  public broadcastDashboardUpdate(): void {
+    const snapshot = this.buildDashboardSnapshot();
+    if (!snapshot) return;
+    this.io.to('dashboard').emit('rankings:update', { rankings: snapshot.rankings });
+    this.io.to('dashboard').emit('pools:update', { pools: snapshot.pools });
+    this.io.to('dashboard').emit('matches:update', { matches: snapshot.liveMatches });
+  }
+
   private broadcastArenaUpdate(arenaId: string, update: ArenaUpdate): void {
-    // Injecter showPhotos + thème (par arène si override, sinon thème global de session)
     const override = this.arenaThemeOverrides.get(arenaId);
     const updateWithPhotos: ArenaUpdate = {
       ...update,
@@ -2265,16 +2409,52 @@ export class RemoteScoreServer {
       theme: override?.theme ?? this.sessionTheme,
       customTheme: override?.customTheme,
     };
-    // Envoyer via Socket.IO aux clients connectés aux arènes
+
+    // Stocker dans le buffer de replay (TTL + max size)
+    const now = Date.now();
+    let buf = this.arenaEventBuffer.get(arenaId) ?? [];
+    buf = buf.filter(e => now - e.timestamp < this.EVENT_BUFFER_TTL_MS);
+    buf.push({ event: updateWithPhotos, timestamp: now });
+    if (buf.length > this.EVENT_BUFFER_MAX) buf = buf.slice(-this.EVENT_BUFFER_MAX);
+    this.arenaEventBuffer.set(arenaId, buf);
+
     this.io.emit(`arena:${arenaId}:update`, updateWithPhotos);
 
-    // Envoyer aussi à la fenêtre principale
     if ((global as any).mainWindow) {
       (global as any).mainWindow.webContents.send('arena:update', {
         arenaId,
         update: updateWithPhotos,
       });
     }
+  }
+
+  private persistArenaState(arenaId: string): void {
+    if (!this.session) return;
+    try {
+      const arena = this.arenas.get(arenaId);
+      if (!arena) return;
+      this.db.saveArenaState(arenaId, {
+        competitionId: this.session.competitionId,
+        currentMatch: arena.currentMatch,
+        matchQueue: this.arenaMatchQueue.get(arenaId) ?? [],
+        settings: arena.settings,
+        status: arena.status,
+      });
+    } catch (err) {
+      console.error(`[RemoteScoreServer] Erreur persistance arène ${arenaId}:`, err);
+    }
+  }
+
+  private checkScoreRateLimit(ip: string): boolean {
+    const now = Date.now();
+    const entry = this.scoreRateLimiter.get(ip);
+    if (!entry || now > entry.resetAt) {
+      this.scoreRateLimiter.set(ip, { count: 1, resetAt: now + 60_000 });
+      return true;
+    }
+    if (entry.count >= this.SCORE_RATE_LIMIT) return false;
+    entry.count++;
+    return true;
   }
 
   public getLocalIPAddress(): string {

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -233,6 +233,27 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     };
   }, [updateMatchFromRemote]);
 
+  // Sync matchs tableau vers DB (persistence individuelle, inclut la 3e place)
+  useEffect(() => {
+    if (!competition?.id || tableauMatches.length === 0) return;
+    const maxScore = competition.settings?.defaultTableMaxScore ?? 15;
+    tableauMatches.forEach(m => {
+      window.electronAPI.db.upsertTableauMatch({
+        competitionId: competition.id,
+        matchId: m.id,
+        round: m.round,
+        position: m.position,
+        fencerAId: m.fencerA?.id ?? null,
+        fencerBId: m.fencerB?.id ?? null,
+        scoreA: m.scoreA != null ? { value: m.scoreA, isVictory: m.winner?.id === m.fencerA?.id } : null,
+        scoreB: m.scoreB != null ? { value: m.scoreB, isVictory: m.winner?.id === m.fencerB?.id } : null,
+        status: m.winner ? 'finished' : m.isBye ? 'finished' : 'not_started',
+        maxScore,
+        isBye: m.isBye,
+      }).catch(() => {});
+    });
+  }, [tableauMatches, competition?.id]);
+
   // Menu events
   useMenuEvents({
     currentPhase,

--- a/src/renderer/components/RefereeManager.tsx
+++ b/src/renderer/components/RefereeManager.tsx
@@ -36,10 +36,19 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
 
   const manager = useMemo(() => new RefereeManager(referees, config), [referees, config]);
 
+  const persistAssignments = async (map: Map<string, Referee>) => {
+    for (const [matchId, referee] of map.entries()) {
+      try {
+        await window.electronAPI.db.updateMatch(matchId, { refereeId: referee.id });
+      } catch { /* non bloquant */ }
+    }
+  };
+
   const handleAutoAssign = () => {
     const newAssignments = manager.assignRefereesToMatches(matches, pools);
     setAssignments(newAssignments);
     onAssignmentsChange(newAssignments);
+    persistAssignments(newAssignments);
   };
 
   const handleManualAssign = (matchId: string, refereeId: string) => {
@@ -49,6 +58,7 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
       newAssignments.set(matchId, referee);
       setAssignments(newAssignments);
       onAssignmentsChange(newAssignments);
+      window.electronAPI.db.updateMatch(matchId, { refereeId: referee.id }).catch(() => {});
     }
   };
 

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -101,6 +101,7 @@ export interface MatchUpdateData {
   startTime?: Date;
   endTime?: Date;
   duration?: number;
+  refereeId?: string;
 }
 
 // ============================================================================
@@ -392,6 +393,19 @@ export interface DatabaseAPI {
   getMatch: (id: string) => Promise<Match | null>;
   getMatchesByPool: (poolId: string) => Promise<Match[]>;
   updateMatch: (id: string, updates: MatchUpdateData) => Promise<void>;
+  upsertTableauMatch: (params: {
+    competitionId: string;
+    matchId: string;
+    round: number;
+    position: number;
+    fencerAId?: string | null;
+    fencerBId?: string | null;
+    scoreA?: any | null;
+    scoreB?: any | null;
+    status?: string;
+    maxScore?: number;
+    isBye?: boolean;
+  }) => Promise<void>;
 
   // Pools
   createPool: (phaseId: string, number: number) => Promise<Pool>;


### PR DESCRIPTION
Migrations DB versionnées :
- MigrationManager avec suivi schema_migrations
- 4 migrations : baseline, bracket_nodes, score_audit_log, arena_state

Remote scoring :
- Persistance état arène en DB (saveArenaState) à chaque transition
- Rate limiting 30 req/min sur les soumissions de score
- Buffer d'événements WS par arène + replay sur reconnexion (lastSeen)
- Audit trail score_audit_log pour chaque changement de score
- Dashboard live data via socket dashboard:subscribe + broadcastDashboardUpdate

DB + types :
- upsertTableauMatch : persistance individuelle des matchs DE (y compris 3e place)
- updateMatch supporte refereeId
- MatchUpdateData + IPC upsertTableauMatch exposés

RefereeManager :
- persistAssignments : chaque attribution sauvegardée en DB via IPC

https://claude.ai/code/session_01YAxQE2UiCF5w1sJq4i4VZU