### PR TITLE
feat: items critiques et importants de la todo + fix CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.2-build.524",
+  "version": "1.0.2-build.608",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.2-build.524",
+      "version": "1.0.2-build.608",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",
@@ -33,6 +33,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.49.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@vitest/coverage-v8": "^4.0.18",
@@ -1897,6 +1898,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -10005,6 +10022,53 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1069,7 +1069,7 @@ export class DatabaseManager {
     return count;
   }
 
-  public updateMatch(id: string, updates: Partial<Match>): void {
+  public updateMatch(id: string, updates: Partial<Match> & { refereeId?: string }): void {
     if (!this.db) throw new Error('Database not open');
     const now = new Date().toISOString();
     if (updates.scoreA !== undefined)


### PR DESCRIPTION
## Migrations DB versionnées

- `MigrationManager` : suivi via table `schema_migrations`, applique les migrations dans l'ordre croissant
- 4 migrations : baseline (toutes les tables existantes), `bracket_nodes` (élimination directe), `score_audit_log`, `arena_state`
- `initializeTables()` supprimé, remplacé par `runMigrations()` — rétrocompatible avec les DBs existantes

## Remote scoring — 5 améliorations

- **Persistance arène** : `persistArenaState()` appelé sur assign, start, finish, loadNext → survit au redémarrage
- **Rate limiting scores** : 30 req/min par IP sur `/api/pools/.../score` (HTTP 429 sinon)
- **Replay WebSocket** : buffer de 50 événements par arène (TTL 5 min) — `join_arena` avec `lastSeen` rejoue les événements manqués à la reconnexion
- **Audit trail** : `logScoreChange()` à chaque mise à jour de score (arène ou REST pool)
- **Dashboard live** : handler `dashboard:subscribe` + `broadcastDashboardUpdate()` après chaque fin de match — rankings, pools, matchs en direct

## Matchs tableau en DB

- `upsertTableauMatch` : chaque match DE (y compris la 3e place, `round === 3`) persisté individuellement via `useEffect` dans `CompetitionView`

## RefereeManager branché DB

- `handleAutoAssign` et `handleManualAssign` persistent chaque attribution via `db.updateMatch(matchId, { refereeId })`

## Fix CI

- `updateMatch` étendu à `Partial<Match> & { refereeId?: string }` — corrige l'erreur TS `Property 'refereeId' does not exist on Partial<Match>`
- `package-lock.json` synchronisé — `@playwright/test` manquait, `npm ci` échouait en fallback `npm install`

https://claude.ai/code/session_01YAxQE2UiCF5w1sJq4i4VZU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAxQE2UiCF5w1sJq4i4VZU)_