### PR TITLE
feat: éditeur de modèles PDF avec drag-and-drop

### DIFF
--- a/src/features/pdfTemplates/hooks/usePdfTemplateStore.ts
+++ b/src/features/pdfTemplates/hooks/usePdfTemplateStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+import type { PdfDocType, PdfTemplate } from '../../../shared/types/pdfTemplate.types';
+import { buildDefaultTemplate } from '../../../shared/types/pdfTemplate.types';
+
+interface PdfTemplateState {
+  templates: Record<PdfDocType, PdfTemplate>;
+}
+
+interface PdfTemplateActions {
+  setTemplate: (docType: PdfDocType, template: PdfTemplate) => void;
+  resetTemplate: (docType: PdfDocType) => void;
+  importTemplate: (template: PdfTemplate) => void;
+}
+
+export const usePdfTemplateStore = create<PdfTemplateState & PdfTemplateActions>()(
+  devtools(
+    immer(
+      persist(
+        (set) => ({
+          templates: {
+            pool:    buildDefaultTemplate('pool'),
+            tableau: buildDefaultTemplate('tableau'),
+            ranking: buildDefaultTemplate('ranking'),
+          },
+
+          setTemplate: (docType, template) =>
+            set(s => { s.templates[docType] = template; }),
+
+          resetTemplate: (docType) =>
+            set(s => { s.templates[docType] = buildDefaultTemplate(docType); }),
+
+          importTemplate: (template) =>
+            set(s => { s.templates[template.docType] = template; }),
+        }),
+        { name: 'bellepoule-pdf-templates' }
+      )
+    ),
+    { name: 'PdfTemplateStore' }
+  )
+);

--- a/src/renderer/components/PdfTemplateEditor.tsx
+++ b/src/renderer/components/PdfTemplateEditor.tsx
@@ -1,0 +1,192 @@
+import React, { useState, useRef } from 'react';
+import { useTranslation } from '../hooks/useTranslation';
+import type { PdfTemplate, PdfElementConfig } from '../../shared/types/pdfTemplate.types';
+
+interface Props {
+  template: PdfTemplate;
+  onChange: (t: PdfTemplate) => void;
+  onReset: () => void;
+}
+
+const PdfTemplateEditor: React.FC<Props> = ({ template, onChange, onReset }) => {
+  const { t } = useTranslation();
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const sorted = [...template.elements].sort((a, b) => a.order - b.order);
+
+  const handleDragStart = (id: string) => setDraggedId(id);
+
+  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
+
+  const handleDrop = (e: React.DragEvent, targetId: string) => {
+    e.preventDefault();
+    if (!draggedId || draggedId === targetId) { setDraggedId(null); return; }
+    const fromEl = sorted.find(el => el.id === draggedId);
+    const toEl = sorted.find(el => el.id === targetId);
+    if (!fromEl || !toEl) { setDraggedId(null); return; }
+    onChange({
+      ...template,
+      elements: template.elements.map(el => {
+        if (el.id === draggedId) return { ...el, order: toEl.order };
+        if (el.id === targetId)  return { ...el, order: fromEl.order };
+        return el;
+      }),
+      updatedAt: new Date().toISOString(),
+    });
+    setDraggedId(null);
+  };
+
+  const toggleVisible = (id: string) => {
+    onChange({
+      ...template,
+      elements: template.elements.map((el: PdfElementConfig) =>
+        el.id === id ? { ...el, visible: !el.visible } : el
+      ),
+      updatedAt: new Date().toISOString(),
+    });
+  };
+
+  const handleColorChange = (key: keyof typeof template.colors, value: string) => {
+    onChange({ ...template, colors: { ...template.colors, [key]: value }, updatedAt: new Date().toISOString() });
+  };
+
+  const handleTitleChange = (value: string) => {
+    onChange({ ...template, customTitle: value, updatedAt: new Date().toISOString() });
+  };
+
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(template, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `pdf-template-${template.docType}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportClick = () => {
+    setImportError(null);
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = '';
+    try {
+      const raw = await file.text();
+      const parsed = JSON.parse(raw) as PdfTemplate;
+      if (!parsed.docType || !Array.isArray(parsed.elements)) throw new Error('invalid');
+      onChange(parsed);
+    } catch {
+      setImportError(t('pdfTemplate.importError'));
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+
+      {/* Titre personnalisé */}
+      <div className="form-group" style={{ marginBottom: 0 }}>
+        <label style={{ fontSize: '0.85rem', fontWeight: 600 }}>{t('pdfTemplate.customTitle')}</label>
+        <input
+          className="form-input"
+          type="text"
+          value={template.customTitle}
+          onChange={e => handleTitleChange(e.target.value)}
+          placeholder={t('pdfTemplate.customTitlePlaceholder')}
+          style={{ marginTop: '0.35rem' }}
+        />
+      </div>
+
+      {/* Couleurs */}
+      <div>
+        <div style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+          Couleurs
+        </div>
+        <div style={{ display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
+          {(['navy', 'gold', 'green'] as const).map(key => (
+            <label key={key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem', cursor: 'pointer' }}>
+              <input
+                type="color"
+                value={template.colors[key]}
+                onChange={e => handleColorChange(key, e.target.value)}
+                style={{ width: '32px', height: '32px', padding: '2px', border: '1px solid var(--color-border, #d1d5db)', borderRadius: '4px', cursor: 'pointer' }}
+              />
+              {t(`pdfTemplate.colors.${key}`)}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Ordre et visibilité des sections */}
+      <div>
+        <div style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+          Sections
+        </div>
+        <div style={{ border: '1px solid var(--color-border, #d1d5db)', borderRadius: '6px', overflow: 'hidden' }}>
+          {sorted.map((el, idx) => (
+            <div
+              key={el.id}
+              draggable
+              onDragStart={() => handleDragStart(el.id)}
+              onDragOver={handleDragOver}
+              onDrop={e => handleDrop(e, el.id)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.75rem',
+                padding: '0.6rem 0.75rem',
+                background: draggedId === el.id
+                  ? 'var(--color-primary-light, #eff6ff)'
+                  : idx % 2 === 0 ? 'var(--color-surface, #fff)' : 'var(--color-bg, #f9fafb)',
+                borderBottom: idx < sorted.length - 1 ? '1px solid var(--color-border, #e5e7eb)' : 'none',
+                opacity: draggedId === el.id ? 0.5 : 1,
+                cursor: 'grab',
+                transition: 'background 0.1s',
+              }}
+            >
+              <span style={{ color: 'var(--color-muted, #9ca3af)', fontSize: '1rem', userSelect: 'none' }}>⠿</span>
+              <input
+                type="checkbox"
+                checked={el.visible}
+                onChange={() => toggleVisible(el.id)}
+                style={{ cursor: 'pointer', width: '15px', height: '15px', flexShrink: 0 }}
+              />
+              <span style={{
+                fontSize: '0.85rem',
+                color: el.visible ? 'var(--color-text, #1e293b)' : 'var(--color-muted, #9ca3af)',
+                textDecoration: el.visible ? 'none' : 'line-through',
+                flex: 1,
+              }}>
+                {t(`pdfTemplate.elements.${el.id}`)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', paddingTop: '0.25rem' }}>
+        <button className="btn btn-secondary" style={{ fontSize: '0.8rem' }} onClick={onReset}>
+          {t('pdfTemplate.reset')}
+        </button>
+        <button className="btn btn-secondary" style={{ fontSize: '0.8rem' }} onClick={handleExport}>
+          {t('pdfTemplate.exportJson')}
+        </button>
+        <button className="btn btn-secondary" style={{ fontSize: '0.8rem' }} onClick={handleImportClick}>
+          {t('pdfTemplate.importJson')}
+        </button>
+        <input ref={fileInputRef} type="file" accept=".json" style={{ display: 'none' }} onChange={handleFileChange} />
+      </div>
+
+      {importError && (
+        <p style={{ fontSize: '0.8rem', color: 'var(--danger, #ef4444)', marginTop: '-0.5rem' }}>{importError}</p>
+      )}
+    </div>
+  );
+};
+
+export default PdfTemplateEditor;

--- a/src/renderer/components/PdfTemplateModal.tsx
+++ b/src/renderer/components/PdfTemplateModal.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { useTranslation } from '../hooks/useTranslation';
+import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
+import PdfTemplateEditor from './PdfTemplateEditor';
+import type { PdfDocType, PdfTemplate } from '../../shared/types/pdfTemplate.types';
+
+interface Props {
+  onClose: () => void;
+}
+
+const DOC_TYPES: PdfDocType[] = ['pool', 'tableau', 'ranking'];
+
+const PdfTemplateModal: React.FC<Props> = ({ onClose }) => {
+  const { t } = useTranslation();
+  const [activeType, setActiveType] = useState<PdfDocType>('pool');
+  const { templates, setTemplate, resetTemplate } = usePdfTemplateStore();
+
+  const current = templates[activeType];
+
+  const handleChange = (updated: PdfTemplate) => {
+    setTemplate(activeType, updated);
+  };
+
+  const handleReset = () => {
+    resetTemplate(activeType);
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal"
+        onClick={e => e.stopPropagation()}
+        style={{ maxWidth: '780px', width: '95%', maxHeight: '90vh', overflow: 'auto' }}
+      >
+        <div className="modal-header">
+          <h2 className="modal-title">{t('pdfTemplate.modalTitle')}</h2>
+          <button
+            className="btn btn-secondary"
+            style={{ fontSize: '0.8rem', padding: '0.25rem 0.6rem' }}
+            onClick={onClose}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="modal-body">
+          {/* Sélecteur de type */}
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.25rem' }}>
+            {DOC_TYPES.map(type => (
+              <button
+                key={type}
+                className={`btn ${activeType === type ? 'btn-primary' : 'btn-secondary'}`}
+                style={{ fontSize: '0.85rem' }}
+                onClick={() => setActiveType(type)}
+              >
+                {t(`pdfTemplate.docType.${type}`)}
+              </button>
+            ))}
+          </div>
+
+          <PdfTemplateEditor
+            template={current}
+            onChange={handleChange}
+            onReset={handleReset}
+          />
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn btn-primary" onClick={onClose}>
+            {t('actions.close') || 'Fermer'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PdfTemplateModal;

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -7,6 +7,7 @@
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { PoolRanking, Pool, Weapon, FencerStatus } from '../../shared/types';
 import { exportRankingToPDF } from '../../shared/utils/pdfExport';
+import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import {
   formatRatio,
   formatIndex,
@@ -45,6 +46,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
 }) => {
   const { showToast } = useToast();
   const { isColumnVisible, toggleColumn, getVisibleColumns } = useColumnVisibility();
+  const rankingTemplate = usePdfTemplateStore(s => s.templates.ranking);
   const isLaserSabre = weapon === 'L';
   const [recalcKey, setRecalcKey] = useState(0);
   const [isEditing, setIsEditing] = useState(false);
@@ -171,7 +173,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     try {
       const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
       const cols = getVisibleColumns('ranking').filter(col => col !== 'quest' || isLaserSabre);
-      await exportRankingToPDF(overallRanking, 'Classement Général', weapon, cols, logo);
+      await exportRankingToPDF(overallRanking, 'Classement Général', weapon, cols, logo, rankingTemplate);
     } catch (e) {
       showToast((e as Error).message, 'error');
     }

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -13,6 +13,7 @@ import { useToast } from './Toast';
 import { useConfirm } from './ConfirmDialog';
 import { exportPoolToPDF } from '../../shared/utils/pdfExport';
 import { useColumnVisibility, POOL_COLUMNS, ColumnId } from '../hooks/useColumnVisibility';
+import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import { useHistory } from '../hooks/useHistory';
 
 interface PoolViewProps {
@@ -43,6 +44,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const { showToast } = useToast();
   const { confirm } = useConfirm();
   const { isColumnVisible, toggleColumn, getVisibleColumns } = useColumnVisibility();
+  const poolTemplate = usePdfTemplateStore(s => s.templates.pool);
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [editingMatch, setEditingMatch] = useState<number | null>(null);
   const [showColumnMenu, setShowColumnMenu] = useState(false);
@@ -353,7 +355,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         includePoolStats: true,
         logoBase64: logo,
         visibleColumns: getVisibleColumns('pool'),
-      });
+      }, poolTemplate);
       showToast(`Export PDF de la poule ${pool.number} généré avec succès`, 'success');
     } catch (error) {
       logger.error(LogCategory.UI, "Erreur lors de l'export PDF", error as Error);

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from '../hooks/useTranslation';
 import type { Language } from '../contexts/TranslationContext';
 import LanguageSelector from './LanguageSelector';
+import PdfTemplateModal from './PdfTemplateModal';
 
 const LOGO_STORAGE_KEY = 'bellepoule-logo';
 const WEBHOOK_STORAGE_KEY = 'bellepoule-webhook-url';
@@ -65,6 +66,7 @@ interface SettingsModalProps {
 
 const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
   const { t, language, theme, changeLanguage, changeTheme } = useTranslation();
+  const [showPdfEditor, setShowPdfEditor] = useState(false);
   const [settings, setSettings] = useState({
     language: language,
     theme: theme,
@@ -199,6 +201,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
   };
 
   return (
+    <>
+    {showPdfEditor && <PdfTemplateModal onClose={() => setShowPdfEditor(false)} />}
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }}>
         <div className="modal-header">
@@ -283,6 +287,21 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
               </button>
             )}
           </div>
+          {/* PDF Templates */}
+          <div className="form-group" style={{ marginTop: '1rem', borderTop: '1px solid var(--border, #e5e7eb)', paddingTop: '1rem' }}>
+            <label style={{ fontWeight: 600 }}>Exports PDF</label>
+            <p style={{ fontSize: '0.8rem', color: 'var(--text-muted, #6b7280)', marginBottom: '0.5rem' }}>
+              Personnalisez l'apparence de chaque type d'export PDF.
+            </p>
+            <button
+              className="btn btn-secondary"
+              style={{ fontSize: '0.8rem', padding: '0.35rem 0.75rem' }}
+              onClick={() => setShowPdfEditor(true)}
+            >
+              {t('pdfTemplate.openButton')}
+            </button>
+          </div>
+
           {/* Notifications webhook */}
           <div className="form-group" style={{ marginTop: '1rem', borderTop: '1px solid var(--border, #e5e7eb)', paddingTop: '1rem' }}>
             <label style={{ fontWeight: 600 }}>Notifications webhook</label>
@@ -338,6 +357,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
         </div>
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -10,6 +10,7 @@ import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
 import Bracket from './Bracket';
 import { exportTableauToPDF, printTableauHTML, MAX_MATCHES_PER_PAGE_TABLEAU } from '../../shared/utils/pdfExport';
+import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 
 interface BracketMatch {
   id: string;
@@ -153,6 +154,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   onMatchArenaChange,
 }) => {
   const { showToast } = useToast();
+  const tableauTemplate = usePdfTemplateStore(s => s.templates.tableau);
   const [tableauSize, setTableauSize] = useState<number>(0);
   const [editingMatch, setEditingMatch] = useState<string | null>(null);
   const [showScoreModal, setShowScoreModal] = useState(false);
@@ -495,9 +497,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
     try {
       if (pdfMode === 'print') {
-        await printTableauHTML(matches, perPage, title, logo);
+        await printTableauHTML(matches, perPage, title, logo, tableauTemplate);
       } else {
-        await exportTableauToPDF(matches, perPage, title, logo);
+        await exportTableauToPDF(matches, perPage, title, logo, tableauTemplate);
       }
       setShowPdfModal(false);
     } catch (e) {

--- a/src/renderer/hooks/useExport.ts
+++ b/src/renderer/hooks/useExport.ts
@@ -10,6 +10,7 @@ import { logger, LogCategory } from '@shared/services/logger';
 import { FinalResult } from '../components/TableauView';
 import { exportFencersToTXT, exportFencersToFFF } from '../../shared/utils/fencerExport';
 import { exportMultiplePoolsToPDF } from '../../shared/utils/pdfExport';
+import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import { useToast } from '../components/Toast';
 import {
   exportResultsHTML,
@@ -24,6 +25,8 @@ interface UseExportProps {
 }
 
 export const useExport = ({ competition, showToast }: UseExportProps) => {
+  const poolTemplate = usePdfTemplateStore(s => s.templates.pool);
+
   // Helper pour télécharger un fichier
   const downloadFile = useCallback((content: string, filename: string, mimeType: string) => {
     const blob = new Blob([content], { type: mimeType });
@@ -215,7 +218,8 @@ export const useExport = ({ competition, showToast }: UseExportProps) => {
         await exportMultiplePoolsToPDF(
           pools,
           `Toutes les Poules - ${competition.title} - Tour ${currentPoolRound}`,
-          logo
+          logo,
+          poolTemplate
         );
         showToast(`Export PDF de ${pools.length} poules généré avec succès`, 'success');
       } catch (error) {
@@ -226,7 +230,7 @@ export const useExport = ({ competition, showToast }: UseExportProps) => {
         );
       }
     },
-    [competition.title, showToast]
+    [competition.title, showToast, poolTemplate]
   );
 
   // Export HTML des résultats

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -211,5 +211,20 @@
     "seconds": "eil",
     "hours": "eurvezh",
     "days": "deiz"
+  },
+  "pdfTemplate": {
+    "modalTitle": "Personelañ ezporzhioù PDF",
+    "openButton": "Personelañ PDF",
+    "docType": { "pool": "Poelloù", "tableau": "Taolenn", "ranking": "Renk" },
+    "customTitle": "Titl personelaet",
+    "customTitlePlaceholder": "Lezel goullo evit titl emgefreek",
+    "colors": { "navy": "Liv pennañ", "gold": "Liv mouezh", "green": "Liv trechañ" },
+    "elements": {
+      "header": "Penn-bann", "gold-bar": "Barenn aour", "meta-chips": "Chips titouroù",
+      "score-grid": "Reizh poentoù", "pending-matches": "Emgavioù o vont",
+      "finished-matches": "Disoc'hoù", "match-cards": "Kartennoù emgav",
+      "ranking-table": "Taolenn renk", "footer": "Troad-pajenn"
+    },
+    "reset": "Adderaouiñ", "exportJson": "Ezporzhiañ JSON", "importJson": "Enporzhiañ JSON", "importError": "Restr JSON fall"
   }
 }

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -211,5 +211,20 @@
     "seconds": "segons",
     "hours": "hores",
     "days": "dies"
+  },
+  "pdfTemplate": {
+    "modalTitle": "Personalitzar exportacions PDF",
+    "openButton": "Personalitzar PDFs",
+    "docType": { "pool": "Grups", "tableau": "Quadre", "ranking": "Classificació" },
+    "customTitle": "Títol personalitzat",
+    "customTitlePlaceholder": "Deixar buit per al títol automàtic",
+    "colors": { "navy": "Color principal", "gold": "Color d'accent", "green": "Color de victòria" },
+    "elements": {
+      "header": "Capçalera", "gold-bar": "Separador daurat", "meta-chips": "Xips d'info",
+      "score-grid": "Quadrícula de puntuació", "pending-matches": "Combats pendents",
+      "finished-matches": "Resultats", "match-cards": "Fitxes de combat",
+      "ranking-table": "Taula de classificació", "footer": "Peu de pàgina"
+    },
+    "reset": "Restablir", "exportJson": "Exportar JSON", "importJson": "Importar JSON", "importError": "Fitxer JSON no vàlid"
   }
 }

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -211,5 +211,20 @@
     "seconds": "Sekunden",
     "hours": "Stunden",
     "days": "Tage"
+  },
+  "pdfTemplate": {
+    "modalTitle": "PDF-Exporte anpassen",
+    "openButton": "PDFs anpassen",
+    "docType": { "pool": "Gruppen", "tableau": "Tableau", "ranking": "Rangliste" },
+    "customTitle": "Benutzerdefinierter Titel",
+    "customTitlePlaceholder": "Leer lassen für automatischen Titel",
+    "colors": { "navy": "Hauptfarbe", "gold": "Akzentfarbe", "green": "Siegesfarbe" },
+    "elements": {
+      "header": "Kopfzeile", "gold-bar": "Goldene Trennlinie", "meta-chips": "Info-Chips",
+      "score-grid": "Punkteraster", "pending-matches": "Ausstehende Kämpfe",
+      "finished-matches": "Ergebnisse", "match-cards": "Kampfblätter",
+      "ranking-table": "Rangtabelle", "footer": "Fußzeile"
+    },
+    "reset": "Zurücksetzen", "exportJson": "JSON exportieren", "importJson": "JSON importieren", "importError": "Ungültige JSON-Datei"
   }
 }

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -211,5 +211,20 @@
     "seconds": "seconds",
     "hours": "hours",
     "days": "days"
+  },
+  "pdfTemplate": {
+    "modalTitle": "Customize PDF Exports",
+    "openButton": "Customize PDFs",
+    "docType": { "pool": "Pools", "tableau": "Tableau", "ranking": "Ranking" },
+    "customTitle": "Custom title",
+    "customTitlePlaceholder": "Leave empty for automatic title",
+    "colors": { "navy": "Primary color", "gold": "Accent color", "green": "Victory color" },
+    "elements": {
+      "header": "Header", "gold-bar": "Gold separator", "meta-chips": "Info chips",
+      "score-grid": "Score grid", "pending-matches": "Pending matches",
+      "finished-matches": "Results", "match-cards": "Match cards",
+      "ranking-table": "Ranking table", "footer": "Footer"
+    },
+    "reset": "Reset", "exportJson": "Export JSON", "importJson": "Import JSON", "importError": "Invalid JSON file"
   }
 }

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -211,5 +211,20 @@
     "seconds": "segundos",
     "hours": "horas",
     "days": "días"
+  },
+  "pdfTemplate": {
+    "modalTitle": "Personalizar exportaciones PDF",
+    "openButton": "Personalizar PDFs",
+    "docType": { "pool": "Grupos", "tableau": "Cuadro", "ranking": "Clasificación" },
+    "customTitle": "Título personalizado",
+    "customTitlePlaceholder": "Dejar vacío para título automático",
+    "colors": { "navy": "Color principal", "gold": "Color de acento", "green": "Color de victoria" },
+    "elements": {
+      "header": "Encabezado", "gold-bar": "Separador dorado", "meta-chips": "Chips de info",
+      "score-grid": "Cuadrícula de puntuación", "pending-matches": "Combates pendientes",
+      "finished-matches": "Resultados", "match-cards": "Fichas de combate",
+      "ranking-table": "Tabla de clasificación", "footer": "Pie de página"
+    },
+    "reset": "Restablecer", "exportJson": "Exportar JSON", "importJson": "Importar JSON", "importError": "Archivo JSON inválido"
   }
 }

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -211,5 +211,36 @@
     "seconds": "secondes",
     "hours": "heures",
     "days": "jours"
+  },
+  "pdfTemplate": {
+    "modalTitle": "Personnaliser les exports PDF",
+    "openButton": "Personnaliser les PDF",
+    "docType": {
+      "pool": "Poules",
+      "tableau": "Tableau",
+      "ranking": "Classement"
+    },
+    "customTitle": "Titre personnalisé",
+    "customTitlePlaceholder": "Laisser vide pour le titre automatique",
+    "colors": {
+      "navy": "Couleur principale",
+      "gold": "Couleur accent",
+      "green": "Couleur victoire"
+    },
+    "elements": {
+      "header": "En-tête",
+      "gold-bar": "Séparateur doré",
+      "meta-chips": "Puces d'info",
+      "score-grid": "Grille des scores",
+      "pending-matches": "Matchs à jouer",
+      "finished-matches": "Résultats",
+      "match-cards": "Fiches de matchs",
+      "ranking-table": "Tableau du classement",
+      "footer": "Pied de page"
+    },
+    "reset": "Réinitialiser",
+    "exportJson": "Exporter JSON",
+    "importJson": "Importer JSON",
+    "importError": "Fichier JSON invalide"
   }
 }

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -211,5 +211,20 @@
     "seconds": "秒",
     "hours": "小時",
     "days": "天"
+  },
+  "pdfTemplate": {
+    "modalTitle": "自訂PDF匯出",
+    "openButton": "自訂PDF",
+    "docType": { "pool": "分組", "tableau": "淘汰賽", "ranking": "排名" },
+    "customTitle": "自訂標題",
+    "customTitlePlaceholder": "留空使用自動標題",
+    "colors": { "navy": "主色", "gold": "強調色", "green": "勝利色" },
+    "elements": {
+      "header": "頁首", "gold-bar": "金色分隔線", "meta-chips": "資訊標籤",
+      "score-grid": "分數表格", "pending-matches": "待打比賽",
+      "finished-matches": "結果", "match-cards": "比賽卡片",
+      "ranking-table": "排名表", "footer": "頁尾"
+    },
+    "reset": "重設", "exportJson": "匯出JSON", "importJson": "匯入JSON", "importError": "JSON檔案無效"
   }
 }

--- a/src/shared/types/pdfTemplate.types.ts
+++ b/src/shared/types/pdfTemplate.types.ts
@@ -1,0 +1,47 @@
+export type PdfDocType = 'pool' | 'tableau' | 'ranking';
+
+export interface PdfElementConfig {
+  id: string;
+  visible: boolean;
+  order: number;
+}
+
+export interface PdfColorScheme {
+  navy: string;
+  gold: string;
+  green: string;
+}
+
+export interface PdfTemplate {
+  id: string;
+  name: string;
+  docType: PdfDocType;
+  customTitle: string;
+  colors: PdfColorScheme;
+  elements: PdfElementConfig[];
+  updatedAt: string;
+}
+
+export const PDF_ELEMENT_IDS: Record<PdfDocType, string[]> = {
+  pool:    ['header', 'gold-bar', 'meta-chips', 'score-grid', 'pending-matches', 'finished-matches', 'footer'],
+  tableau: ['header', 'gold-bar', 'match-cards', 'footer'],
+  ranking: ['header', 'gold-bar', 'ranking-table', 'footer'],
+};
+
+export const DEFAULT_COLORS: PdfColorScheme = {
+  navy:  '#1a2e4a',
+  gold:  '#c9a227',
+  green: '#166534',
+};
+
+export function buildDefaultTemplate(docType: PdfDocType): PdfTemplate {
+  return {
+    id: `default-${docType}`,
+    name: '',
+    docType,
+    customTitle: '',
+    colors: { ...DEFAULT_COLORS },
+    elements: PDF_ELEMENT_IDS[docType].map((id, i) => ({ id, visible: true, order: i * 10 })),
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -5,6 +5,7 @@
  */
 
 import { Pool, Match, MatchStatus, Fencer, PoolRanking, Weapon } from '../types';
+import type { PdfTemplate } from '../types/pdfTemplate.types';
 
 interface PoolExportOptions {
   title?: string;
@@ -80,6 +81,28 @@ async function savePDF(html: string, defaultName: string): Promise<void> {
   if (!res.success) {
     throw new Error(res.error ?? 'Échec de la génération PDF');
   }
+}
+
+// ─── Template helpers ─────────────────────────────────────────────────────────
+
+function buildCssOverrides(t: PdfTemplate): string {
+  return `:root { --navy: ${t.colors.navy}; --gold: ${t.colors.gold}; --green: ${t.colors.green}; }`;
+}
+
+function isVisible(t: PdfTemplate | undefined, id: string): boolean {
+  if (!t) return true;
+  return t.elements.find(e => e.id === id)?.visible ?? true;
+}
+
+function assembleBody(
+  sections: Record<string, string>,
+  t: PdfTemplate | undefined,
+  defaultOrder: string[]
+): string {
+  const order = t
+    ? [...t.elements].sort((a, b) => a.order - b.order).map(e => e.id)
+    : defaultOrder;
+  return order.filter(id => isVisible(t, id)).map(id => sections[id] ?? '').join('\n');
 }
 
 // ─── CSS commun ───────────────────────────────────────────────────────────────
@@ -221,8 +244,10 @@ const STAT_COLS: { id: string; header: string; cls: string; render: (d: RankData
   { id: 'rank',      header: 'Rg',  cls: 'rank-cell', render: d => `${d.rank}` },
 ];
 
-function generatePoolHTML(pool: Pool, options: PoolExportOptions): string {
-  const { title = `Poule ${pool.number}`, competitionName = '', weapon = '', category = '', logoBase64 } = options;
+function generatePoolHTML(pool: Pool, options: PoolExportOptions, template?: PdfTemplate): string {
+  const runtimeTitle = `Poule ${pool.number}`;
+  const effectiveTitle = template?.customTitle?.trim() || options.title || runtimeTitle;
+  const { competitionName = '', weapon = '', category = '', logoBase64 } = options;
   const fencers = pool.fencers ?? [];
   const matches = pool.matches ?? [];
   const finishedCount = matches.filter(m => m.status === MatchStatus.FINISHED).length;
@@ -232,7 +257,6 @@ function generatePoolHTML(pool: Pool, options: PoolExportOptions): string {
     ? STAT_COLS.filter(c => options.visibleColumns!.includes(c.id))
     : STAT_COLS;
 
-  // Classement
   const rankings = fencers.map(f => ({
     fencer: f,
     stats: calculateFencerStats(f, matches),
@@ -246,7 +270,6 @@ function generatePoolHTML(pool: Pool, options: PoolExportOptions): string {
   rankings.forEach((r, i) => { r.rank = i + 1; });
   const rankMap = new Map(rankings.map(r => [r.fencer.id, r]));
 
-  // Grille scores
   const colHeaders = fencers.map((_, i) => `<th class="num-header">${i + 1}</th>`).join('');
   const rows = fencers.map((fencer, row) => {
     const data = rankMap.get(fencer.id)!;
@@ -267,20 +290,18 @@ function generatePoolHTML(pool: Pool, options: PoolExportOptions): string {
       </tr>`;
   }).join('');
 
-  // Matchs restants
   const pending = matches.filter(m => m.status !== MatchStatus.FINISHED);
-  const pendingHTML = pending.length === 0 ? '' : `
+  const pendingSection = pending.length === 0 ? '' : `
     <div class="section-label">Matchs à jouer (${pending.length})</div>
     <div class="match-grid">
-      ${pending.map((m, i) => {
+      ${pending.map(m => {
         const idx = matches.indexOf(m) + 1;
         return `<div class="match-item match-pending">${idx}. ${m.fencerA?.lastName ?? '?'} — ${m.fencerB?.lastName ?? '?'}</div>`;
       }).join('')}
     </div>`;
 
-  // Matchs terminés
   const finished = matches.filter(m => m.status === MatchStatus.FINISHED);
-  const finishedHTML = finished.length === 0 ? '' : `
+  const finishedSection = finished.length === 0 ? '' : `
     <div class="section-label" style="margin-top:4mm">Résultats (${finished.length})</div>
     <div class="match-grid match-grid-2col">
       ${finished.map(m => {
@@ -295,12 +316,57 @@ function generatePoolHTML(pool: Pool, options: PoolExportOptions): string {
   const catLabel = category ? `<span class="chip"><strong>Catégorie</strong> ${category}</span>` : '';
   const compLabel = competitionName ? `<span class="chip gold"><strong>${competitionName}</strong></span>` : '';
 
+  const sections: Record<string, string> = {
+    'header': `
+  <div class="doc-header">
+    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
+    <div class="doc-header-left">
+      <h1>${effectiveTitle}</h1>
+      <div class="subtitle">Grille de poule • ${finishedCount}/${matches.length} matchs joués</div>
+    </div>
+    <div class="doc-header-badge">P${pool.number}</div>
+  </div>`,
+    'gold-bar': `  <div class="gold-bar"></div>`,
+    'meta-chips': `
+  <div class="meta-row">
+    ${compLabel}${weaponLabel}${catLabel}
+    <span class="chip"><strong>Tireurs</strong> ${fencers.length}</span>
+    <span class="chip"><strong>Matchs</strong> ${finishedCount}/${matches.length}</span>
+  </div>`,
+    'score-grid': `
+  <div class="section-label">Grille des scores</div>
+  <table class="score-grid">
+    <thead>
+      <tr>
+        <th class="num-header">#</th>
+        <th class="name-header">Tireur</th>
+        ${colHeaders}
+        ${activeCols.map(c => `<th class="${c.cls === 'rank-cell' ? 'rank-header' : 'stat-header'}">${c.header}</th>`).join('')}
+        <th class="sig-header">Signature</th>
+      </tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>`,
+    'pending-matches': pendingSection,
+    'finished-matches': finishedSection,
+    'footer': `
+  <div class="doc-footer">
+    <span>BellePoule Modern</span>
+    <span>${now}</span>
+  </div>`,
+  };
+
+  const defaultOrder = ['header', 'gold-bar', 'meta-chips', 'score-grid', 'pending-matches', 'finished-matches', 'footer'];
+  const body = assembleBody(sections, template, defaultOrder);
+  const cssOverrides = template ? buildCssOverrides(template) : '';
+
   return `<!DOCTYPE html>
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <title>${title}</title>
+  <title>${effectiveTitle}</title>
   <style>
+    ${cssOverrides}
     ${BASE_CSS}
 
     /* Grille scores */
@@ -394,68 +460,31 @@ function generatePoolHTML(pool: Pool, options: PoolExportOptions): string {
   </style>
 </head>
 <body>
-  <div class="doc-header">
-    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
-    <div class="doc-header-left">
-      <h1>${title}</h1>
-      <div class="subtitle">Grille de poule • ${finishedCount}/${matches.length} matchs joués</div>
-    </div>
-    <div class="doc-header-badge">P${pool.number}</div>
-  </div>
-  <div class="gold-bar"></div>
-
-  <div class="meta-row">
-    ${compLabel}
-    ${weaponLabel}
-    ${catLabel}
-    <span class="chip"><strong>Tireurs</strong> ${fencers.length}</span>
-    <span class="chip"><strong>Matchs</strong> ${finishedCount}/${matches.length}</span>
-  </div>
-
-  <div class="section-label">Grille des scores</div>
-  <table class="score-grid">
-    <thead>
-      <tr>
-        <th class="num-header">#</th>
-        <th class="name-header">Tireur</th>
-        ${colHeaders}
-        ${activeCols.map(c => `<th class="${c.cls === 'rank-cell' ? 'rank-header' : 'stat-header'}">${c.header}</th>`).join('')}
-        <th class="sig-header">Signature</th>
-      </tr>
-    </thead>
-    <tbody>${rows}</tbody>
-  </table>
-
-  ${pendingHTML}
-  ${finishedHTML}
-
-  <div class="doc-footer">
-    <span>BellePoule Modern</span>
-    <span>${now}</span>
-  </div>
+${body}
 </body>
 </html>`;
 }
 
 // ─── Export Poule ─────────────────────────────────────────────────────────────
 
-export async function exportPoolToPDF(pool: Pool, options: PoolExportOptions = {}): Promise<void> {
+export async function exportPoolToPDF(pool: Pool, options: PoolExportOptions = {}, template?: PdfTemplate): Promise<void> {
   if (!pool.fencers || pool.fencers.length === 0) throw new Error('La poule ne contient aucun tireur');
   if (!pool.matches || pool.matches.length === 0) throw new Error('La poule ne contient aucun match');
 
   const title = options.title ?? `Poule ${pool.number}`;
-  const html = generatePoolHTML(pool, { ...options, title });
+  const html = generatePoolHTML(pool, { ...options, title }, template);
   await savePDF(html, `poule-${pool.number}.pdf`);
 }
 
 export async function exportMultiplePoolsToPDF(
   pools: Pool[],
   title: string = 'Export des Poules',
-  logoBase64?: string
+  logoBase64?: string,
+  template?: PdfTemplate
 ): Promise<void> {
   if (pools.length === 0) throw new Error('Aucune poule à exporter');
   for (const pool of pools) {
-    await exportPoolToPDF(pool, { title: `${title} - Poule ${pool.number}`, logoBase64 });
+    await exportPoolToPDF(pool, { title: `${title} - Poule ${pool.number}`, logoBase64 }, template);
   }
 }
 
@@ -495,7 +524,8 @@ function generateTableauHTML(
   matches: TableauMatchForPDF[],
   matchesPerPage: number,
   title: string,
-  logoBase64?: string
+  logoBase64?: string,
+  template?: PdfTemplate
 ): string {
   const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
   const sorted = [...real].sort((a, b) => b.round - a.round || a.position - b.position);
@@ -560,24 +590,41 @@ function generateTableauHTML(
     return `<div class="page${isLast ? '' : ' page-break'}">${cards}</div>`;
   }).join('');
 
+  const effectiveTitle = template?.customTitle?.trim() || title;
+  const cssOverrides = template ? buildCssOverrides(template) : '';
+
+  const sections: Record<string, string> = {
+    'header': `
+  <div class="doc-header">
+    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
+    <div class="doc-header-left">
+      <h1>${effectiveTitle}</h1>
+      <div class="subtitle">Feuilles d'arbitrage — Élimination directe</div>
+    </div>
+    <div class="doc-header-badge" style="font-size:11pt">ED</div>
+  </div>`,
+    'gold-bar': `  <div class="gold-bar"></div>`,
+    'match-cards': `  ${pagesHTML}`,
+    'footer': `
+  <div class="doc-footer">
+    <span>BellePoule Modern</span>
+    <span>${now}</span>
+  </div>`,
+  };
+
+  const defaultOrder = ['header', 'gold-bar', 'match-cards', 'footer'];
+  const body = assembleBody(sections, template, defaultOrder);
+
   return `<!DOCTYPE html>
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <title>${title}</title>
+  <title>${effectiveTitle}</title>
   <style>
+    ${cssOverrides}
     ${BASE_CSS}
     @page { size: A4; margin: 12mm 10mm; }
 
-    .page-title {
-      text-align: center;
-      font-size: 13pt;
-      font-weight: 700;
-      color: var(--navy);
-      margin-bottom: 5mm;
-      padding-bottom: 3mm;
-      border-bottom: 2px solid var(--gold);
-    }
     .page-break { page-break-after: always; }
 
     .match-card {
@@ -662,22 +709,7 @@ function generateTableauHTML(
   </style>
 </head>
 <body>
-  <div class="doc-header">
-    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
-    <div class="doc-header-left">
-      <h1>${title}</h1>
-      <div class="subtitle">Feuilles d'arbitrage — Élimination directe</div>
-    </div>
-    <div class="doc-header-badge" style="font-size:11pt">ED</div>
-  </div>
-  <div class="gold-bar"></div>
-
-  ${pagesHTML}
-
-  <div class="doc-footer">
-    <span>BellePoule Modern</span>
-    <span>${now}</span>
-  </div>
+${body}
 </body>
 </html>`;
 }
@@ -686,14 +718,15 @@ export async function exportTableauToPDF(
   matches: TableauMatchForPDF[],
   matchesPerPage: number,
   title: string = 'Tableau Élimination Directe',
-  logoBase64?: string
+  logoBase64?: string,
+  template?: PdfTemplate
 ): Promise<void> {
   const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
   if (real.length === 0) {
     throw new Error('Aucun match à exporter (tous sont des exempts ou sans tireurs assignés)');
   }
 
-  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64);
+  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64, template);
   await savePDF(html, `tableau-elimination.pdf`);
 }
 
@@ -701,13 +734,14 @@ export async function printTableauHTML(
   matches: TableauMatchForPDF[],
   matchesPerPage: number,
   title: string = 'Tableau Élimination Directe',
-  logoBase64?: string
+  logoBase64?: string,
+  template?: PdfTemplate
 ): Promise<void> {
   const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
   if (real.length === 0) {
     throw new Error('Aucun match à imprimer (tous sont des exempts ou sans tireurs assignés)');
   }
-  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64);
+  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64, template);
   const api = (window as any).electronAPI;
   if (!api?.file?.printHtml) {
     throw new Error('API Electron non disponible');
@@ -725,7 +759,8 @@ function generateRankingHTML(
   title: string,
   isLaserSabre: boolean,
   visibleColumns: string[],
-  logoBase64?: string
+  logoBase64?: string,
+  template?: PdfTemplate
 ): string {
   const vis = (col: string) => visibleColumns.includes(col);
   const now = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
@@ -766,12 +801,42 @@ function generateRankingHTML(
     th('index', 'Indice'),
   ].join('');
 
+  const effectiveTitle = template?.customTitle?.trim() || title;
+  const cssOverrides = template ? buildCssOverrides(template) : '';
+
+  const sections: Record<string, string> = {
+    'header': `
+  <div class="doc-header">
+    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
+    <div class="doc-header-left">
+      <h1>${effectiveTitle}</h1>
+      <div class="subtitle">Classement général — ${ranking.length} tireur${ranking.length > 1 ? 's' : ''}</div>
+    </div>
+    <div class="doc-header-badge" style="font-size:11pt">RG</div>
+  </div>`,
+    'gold-bar': `  <div class="gold-bar"></div>`,
+    'ranking-table': `
+  <table>
+    <thead><tr>${headers}</tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`,
+    'footer': `
+  <div class="doc-footer">
+    <span>BellePoule Modern</span>
+    <span>${now}</span>
+  </div>`,
+  };
+
+  const defaultOrder = ['header', 'gold-bar', 'ranking-table', 'footer'];
+  const body = assembleBody(sections, template, defaultOrder);
+
   return `<!DOCTYPE html>
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <title>${title}</title>
+  <title>${effectiveTitle}</title>
   <style>
+    ${cssOverrides}
     ${BASE_CSS}
     table { width: 100%; border-collapse: collapse; font-size: 9pt; }
     th {
@@ -788,23 +853,7 @@ function generateRankingHTML(
   </style>
 </head>
 <body>
-  <div class="doc-header">
-    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
-    <div class="doc-header-left">
-      <h1>${title}</h1>
-      <div class="subtitle">Classement général — ${ranking.length} tireur${ranking.length > 1 ? 's' : ''}</div>
-    </div>
-    <div class="doc-header-badge" style="font-size:11pt">RG</div>
-  </div>
-  <div class="gold-bar"></div>
-  <table>
-    <thead><tr>${headers}</tr></thead>
-    <tbody>${rows}</tbody>
-  </table>
-  <div class="doc-footer">
-    <span>BellePoule Modern</span>
-    <span>${now}</span>
-  </div>
+${body}
 </body>
 </html>`;
 }
@@ -814,12 +863,13 @@ export async function exportRankingToPDF(
   title: string = 'Classement Général',
   weapon?: Weapon,
   visibleColumns?: string[],
-  logoBase64?: string
+  logoBase64?: string,
+  template?: PdfTemplate
 ): Promise<void> {
   if (ranking.length === 0) throw new Error('Aucun tireur dans le classement');
   const isLaserSabre = weapon === 'L' || weapon === ('LASER' as any);
   const cols = visibleColumns ?? ['rank', 'lastName', 'firstName', 'club', 'victories', 'ratio', 'td', 'tr', 'quest', 'index'];
-  const html = generateRankingHTML(ranking, title, isLaserSabre, cols, logoBase64);
+  const html = generateRankingHTML(ranking, title, isLaserSabre, cols, logoBase64, template);
   await savePDF(html, 'classement-general.pdf');
 }
 


### PR DESCRIPTION
## Résumé

- **Nouvel éditeur PDF** accessible depuis Paramètres → "Personnaliser les PDF" (modale 780px)
- **3 types de templates** : Poules, Tableau DE, Classement — un template par type, persisté en localStorage
- **Drag-and-drop natif** (HTML5, aucun package) pour réordonner les sections de chaque PDF
- Chaque section peut être **cachée/affichée** individuellement (checkbox)
- **3 couleurs personnalisables** (principale, accent, victoire) via `<input type="color">` — appliquées en override CSS `:root`
- **Titre custom** par type (vide = titre automatique)
- **Export/import JSON** du template (Blob + FileReader, sans IPC supplémentaire)
- **Réinitialisation** aux valeurs par défaut

## Fichiers créés

- `src/shared/types/pdfTemplate.types.ts` — Types + `buildDefaultTemplate()`
- `src/features/pdfTemplates/hooks/usePdfTemplateStore.ts` — Store Zustand (devtools + immer + persist)
- `src/renderer/components/PdfTemplateEditor.tsx` — Éditeur contrôlé (DnD + couleurs + titre + actions)
- `src/renderer/components/PdfTemplateModal.tsx` — Modale principale avec sélecteur de type

## Changements non-breaking

Les fonctions `exportPoolToPDF`, `exportTableauToPDF`, `exportRankingToPDF` et `exportMultiplePoolsToPDF` acceptent un `template?: PdfTemplate` en paramètre trailing optionnel. Les appelants sans template continuent de fonctionner identiquement.

## Test plan

- [ ] Paramètres → "Personnaliser les PDF" → la modale s'ouvre
- [ ] Changer la couleur navy → exporter une poule → le PDF reflète la couleur
- [ ] Masquer "Puces d'info" → la section n'apparaît plus dans le PDF
- [ ] Réordonner "Résultats" avant "Grille des scores" → ordre respecté dans le PDF
- [ ] Exporter JSON → fichier valide téléchargé ; importer le JSON → paramètres restaurés
- [ ] Réinitialiser → valeurs par défaut (`#1a2e4a`, `#c9a227`, `#166534`)
- [ ] Exports existants sans modification de template : comportement inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)