### PR TITLE
i18n: traduire les onglets de navigation hardcodés en français

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -45,7 +45,7 @@ interface CompetitionViewProps {
 
 const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate }) => {
   const { showToast } = useToast();
-  const { t } = useTranslation();
+  const { t, language } = useTranslation();
 
   // Settings avec valeurs par défaut
   const poolRounds = competition.settings?.poolRounds ?? 1;
@@ -519,28 +519,32 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const phases = [
     {
       id: 'checkin',
-      label: 'Appel',
+      label: t('phases.checkin'),
       icon: '📋',
       disabled: false,
       title: undefined as string | undefined,
     },
     {
       id: 'poolprep',
-      label: 'Préparation',
+      label: t('phases.poolprep'),
       icon: '⚙️',
       disabled: false,
       title: undefined as string | undefined,
     },
     {
       id: 'pools',
-      label: skipPoolPhase ? 'Poules (saut)' : poolRounds > 1 ? `Poules (${currentPoolRound}/${poolRounds})` : 'Poules',
+      label: skipPoolPhase
+        ? t('phases.pools_skip')
+        : poolRounds > 1
+          ? t('phases.pools_round', { current: currentPoolRound, total: poolRounds })
+          : t('phases.pools'),
       icon: skipPoolPhase ? '⏭' : '🎯',
       disabled: skipPoolPhase,
-      title: skipPoolPhase ? 'Phase de poules ignorée (0 poules)' : (undefined as string | undefined),
+      title: skipPoolPhase ? t('phases.pools_skip_tooltip') : (undefined as string | undefined),
     },
     {
       id: 'ranking',
-      label: 'Classement',
+      label: t('phases.ranking'),
       icon: '📊',
       disabled: false,
       title: undefined as string | undefined,
@@ -549,25 +553,25 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       ? [
           {
             id: 'tableau',
-            label: 'Tableau',
+            label: t('phases.tableau'),
             icon: '🏆',
             disabled: !isTableauUnlocked,
             title: !isTableauUnlocked
-              ? 'Terminez toutes les poules et validez le classement pour accéder au tableau'
+              ? t('phases.tableau_locked_tooltip')
               : (undefined as string | undefined),
           },
         ]
       : []),
     {
       id: 'results',
-      label: 'Résultats',
+      label: t('phases.results'),
       icon: '🏁',
       disabled: isResultsLocked,
       title: undefined as string | undefined,
     },
     {
       id: 'remote',
-      label: '📡 Saisie distante',
+      label: `📡 ${t('phases.remote')}`,
       icon: '📡',
       disabled: false,
       title: undefined as string | undefined,
@@ -579,13 +583,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
     if (!isLastPoolRound) {
       return {
-        label: `Tour ${currentPoolRound + 1} de poules →`,
+        label: t('pools.next_round_n', { n: currentPoolRound + 1 }),
         action: handleNextPoolRound,
       };
     }
 
     return {
-      label: 'Voir le classement →',
+      label: t('pools.view_ranking_action'),
       action: handleGoToRanking,
     };
   };
@@ -610,7 +614,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             {competition.title}
           </h1>
           <p style={{ opacity: 0.9, fontSize: '0.875rem' }}>
-            {new Date(competition.date).toLocaleDateString('fr-FR', {
+            {new Date(competition.date).toLocaleDateString(language === 'zh-HK' ? 'zh-HK' : language, {
               weekday: 'long',
               day: 'numeric',
               month: 'long',
@@ -621,10 +625,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         </div>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <span className="badge" style={{ background: 'rgba(255,255,255,0.2)' }}>
-            {fencers.length} tireurs
+            {fencers.length} {t('fencer.label')}
           </span>
           <span className="badge" style={{ background: 'rgba(255,255,255,0.2)' }}>
-            {getCheckedInFencers().length} pointés
+            {getCheckedInFencers().length} {t('fencer.present_label')}
           </span>
           <button
             onClick={() => setCurrentPhase('remote')}
@@ -638,7 +642,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               fontSize: '0.875rem',
             }}
           >
-            📡 Saisie distante
+            📡 {t('phases.remote')}
           </button>
           <button
             onClick={() => setShowFencerComparison(true)}
@@ -652,7 +656,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               fontSize: '0.875rem',
             }}
           >
-            ⚔️ Comparaisons
+            ⚔️ {t('competition.comparisons')}
           </button>
           <button
             onClick={() => setShowAnalytics(true)}
@@ -666,7 +670,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               fontSize: '0.875rem',
             }}
           >
-            📊 Analytics
+            📊 {t('competition.analytics')}
           </button>
           <button
             onClick={() => setShowQRCode(true)}

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -24,7 +24,9 @@
     "third_place_match_ok": "Klikit war OK evit ouzhpennañ ar bras bihan",
     "third_place_match_cancel": "Klikit war Nullañ evit echuiñ goude an hanter gourfenn",
     "third_place_match_label": "Bras bihan (match evit an 3de plas)",
-    "third_place_match_description": "Aoz ur match ouzhpenn etre an daou c'hoarzer a yaouank en hanter gourfenn evit derminiñ an 3de ha 4de plas"
+    "third_place_match_description": "Aoz ur match ouzhpenn etre an daou c'hoarzer a yaouank en hanter gourfenn evit derminiñ an 3de ha 4de plas",
+    "comparisons": "Kenstrivañ",
+    "analytics": "Analiz"
   },
   "weapons": {
     "epee": "Spes",
@@ -63,7 +65,9 @@
     "abandon": "Dilez",
     "forfait": "Dilez",
     "reactivate": "Adilhañ",
-    "points": "Poentoù"
+    "points": "Poentoù",
+    "label": "klezeourion",
+    "present_label": "enrollet"
   },
   "status": {
     "checked_in": "Enrollañet",
@@ -79,7 +83,12 @@
   },
   "phases": {
     "checkin": "Enrollañ",
+    "poolprep": "Hentez",
     "pools": "Poullou",
+    "pools_skip": "Poullou (treuzet)",
+    "pools_round": "Poullou ({{current}}/{{total}})",
+    "pools_skip_tooltip": "Talbenn poulloù trespasset (0 poullou)",
+    "tableau_locked_tooltip": "Echuiit an holl poullou ha validait ar renk evit mont d'ar daolenn",
     "ranking": "Renk",
     "tableau": "Taolenn",
     "results": "Disoc'hoùezioù",
@@ -98,7 +107,9 @@
     "no_pools": "Poull ebet ebet",
     "return_to_checkin": "Distro d'an enrollañ",
     "pool_number": "Poull",
-    "change_pool": "Kemmañ ar poullou"
+    "change_pool": "Kemmañ ar poullou",
+    "next_round_n": "Tro {{n}} →",
+    "view_ranking_action": "Gwelet ar renk →"
   },
   "ranking": {
     "rank": "Renk",

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -24,7 +24,9 @@
     "third_place_match_ok": "Feu clic a D'acord per afegir la petita final",
     "third_place_match_cancel": "Feu clic a Cancel·lar per acabar després de les semifinals",
     "third_place_match_label": "Petita final (combat pel 3r lloc)",
-    "third_place_match_description": "Organitza un combat addicional entre els dos semifinalistes perdedors per determinar el 3r i 4t lloc"
+    "third_place_match_description": "Organitza un combat addicional entre els dos semifinalistes perdedors per determinar el 3r i 4t lloc",
+    "comparisons": "Comparacions",
+    "analytics": "Analytics"
   },
   "weapons": {
     "epee": "Espasa",
@@ -63,7 +65,9 @@
     "abandon": "Abandonar",
     "forfait": "No Presentar-se",
     "reactivate": "Reactivar",
-    "points": "Punts"
+    "points": "Punts",
+    "label": "tiradors",
+    "present_label": "registrats"
   },
   "status": {
     "checked_in": "Registrat",
@@ -79,7 +83,12 @@
   },
   "phases": {
     "checkin": "Registre",
+    "poolprep": "Preparació",
     "pools": "Poules",
+    "pools_skip": "Poules (saltades)",
+    "pools_round": "Poules ({{current}}/{{total}})",
+    "pools_skip_tooltip": "Fase de poules ignorada (0 poules)",
+    "tableau_locked_tooltip": "Completeu totes les poules i valideu la classificació per accedir al quadre",
     "ranking": "Classificació",
     "tableau": "Quadre",
     "results": "Resultats",
@@ -98,7 +107,9 @@
     "no_pools": "Sense Poules",
     "return_to_checkin": "Tornar al Registre",
     "pool_number": "Poule",
-    "change_pool": "Canviar de Poule"
+    "change_pool": "Canviar de Poule",
+    "next_round_n": "Ronda {{n}} →",
+    "view_ranking_action": "Veure classificació →"
   },
   "ranking": {
     "rank": "Pos",

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -24,7 +24,9 @@
     "third_place_match_ok": "Klicken Sie auf OK, um das kleine Finale hinzuzufügen",
     "third_place_match_cancel": "Klicken Sie auf Abbrechen, um nach den Halbfinals zu beenden",
     "third_place_match_label": "Kleines Finale (Spiel um den 3. Platz)",
-    "third_place_match_description": "Organisiert ein zusätzliches Spiel zwischen den beiden verlierenden Halbfinalisten, um den 3. und 4. Platz zu bestimmen"
+    "third_place_match_description": "Organisiert ein zusätzliches Spiel zwischen den beiden verlierenden Halbfinalisten, um den 3. und 4. Platz zu bestimmen",
+    "comparisons": "Vergleiche",
+    "analytics": "Analytics"
   },
   "weapons": {
     "epee": "Degen",
@@ -63,7 +65,9 @@
     "abandon": "Aufgeben",
     "forfait": "Nicht Antreten",
     "reactivate": "Reaktivieren",
-    "points": "Punkte"
+    "points": "Punkte",
+    "label": "Fechter",
+    "present_label": "angemeldet"
   },
   "status": {
     "checked_in": "Eingecheckt",
@@ -79,7 +83,12 @@
   },
   "phases": {
     "checkin": "Anmeldung",
+    "poolprep": "Vorbereitung",
     "pools": "Pools",
+    "pools_skip": "Pools (übersprungen)",
+    "pools_round": "Pools ({{current}}/{{total}})",
+    "pools_skip_tooltip": "Poolphase übersprungen (0 Pools)",
+    "tableau_locked_tooltip": "Beenden Sie alle Pools und validieren Sie das Ranking, um auf die Tabelle zuzugreifen",
     "ranking": "Rangliste",
     "tableau": "Tabelle",
     "results": "Ergebnisse",
@@ -98,7 +107,9 @@
     "no_pools": "Keine Pools",
     "return_to_checkin": "Zurück zur Anmeldung",
     "pool_number": "Pool",
-    "change_pool": "Pool Wechseln"
+    "change_pool": "Pool Wechseln",
+    "next_round_n": "Runde {{n}} →",
+    "view_ranking_action": "Rangliste anzeigen →"
   },
   "ranking": {
     "rank": "Rg",

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -24,7 +24,9 @@
     "third_place_match_ok": "Click OK to add the bronze medal match",
     "third_place_match_cancel": "Click Cancel to finish after the semi-finals",
     "third_place_match_label": "Bronze medal match (3rd place match)",
-    "third_place_match_description": "Organizes an additional match between the two losing semi-finalists to determine 3rd and 4th place"
+    "third_place_match_description": "Organizes an additional match between the two losing semi-finalists to determine 3rd and 4th place",
+    "comparisons": "Comparisons",
+    "analytics": "Analytics"
   },
   "weapons": {
     "epee": "Epee",
@@ -63,7 +65,9 @@
     "abandon": "Abandon",
     "forfait": "Withdraw",
     "reactivate": "Reactivate",
-    "points": "Points"
+    "points": "Points",
+    "label": "fencers",
+    "present_label": "checked in"
   },
   "status": {
     "checked_in": "Present",
@@ -79,7 +83,12 @@
   },
   "phases": {
     "checkin": "Check-in",
+    "poolprep": "Preparation",
     "pools": "Pools",
+    "pools_skip": "Pools (skipped)",
+    "pools_round": "Pools ({{current}}/{{total}})",
+    "pools_skip_tooltip": "Pool phase skipped (0 pools)",
+    "tableau_locked_tooltip": "Complete all pools and validate ranking to access the table",
     "ranking": "Ranking",
     "tableau": "Table",
     "results": "Results",
@@ -98,7 +107,9 @@
     "no_pools": "No Pools",
     "return_to_checkin": "Return to Check-in",
     "pool_number": "Pool",
-    "change_pool": "Change Pool"
+    "change_pool": "Change Pool",
+    "next_round_n": "Pool round {{n}} →",
+    "view_ranking_action": "View ranking →"
   },
   "ranking": {
     "rank": "Rank",

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -24,7 +24,9 @@
     "third_place_match_ok": "Haga clic en OK para agregar la pequeña final",
     "third_place_match_cancel": "Haga clic en Cancelar para terminar después de las semifinales",
     "third_place_match_label": "Pequeña final (partido por el 3er lugar)",
-    "third_place_match_description": "Organiza un partido adicional entre los dos semifinalistas perdedores para determinar el 3er y 4to lugar"
+    "third_place_match_description": "Organiza un partido adicional entre los dos semifinalistas perdedores para determinar el 3er y 4to lugar",
+    "comparisons": "Comparaciones",
+    "analytics": "Analytics"
   },
   "weapons": {
     "epee": "Espada",
@@ -63,7 +65,9 @@
     "abandon": "Abandonar",
     "forfait": "No Presentarse",
     "reactivate": "Reactivar",
-    "points": "Puntos"
+    "points": "Puntos",
+    "label": "tiradores",
+    "present_label": "registrados"
   },
   "status": {
     "checked_in": "Registrado",
@@ -79,7 +83,12 @@
   },
   "phases": {
     "checkin": "Registro",
+    "poolprep": "Preparación",
     "pools": "Poules",
+    "pools_skip": "Poules (saltadas)",
+    "pools_round": "Poules ({{current}}/{{total}})",
+    "pools_skip_tooltip": "Fase de poules ignorada (0 poules)",
+    "tableau_locked_tooltip": "Complete todas las poules y valide la clasificación para acceder al cuadro",
     "ranking": "Clasificación",
     "tableau": "Cuadro",
     "results": "Resultados",
@@ -98,7 +107,9 @@
     "no_pools": "Sin Poules",
     "return_to_checkin": "Volver al Registro",
     "pool_number": "Poule",
-    "change_pool": "Cambiar Poule"
+    "change_pool": "Cambiar Poule",
+    "next_round_n": "Ronda {{n}} →",
+    "view_ranking_action": "Ver clasificación →"
   },
   "ranking": {
     "rank": "Pos",

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -24,7 +24,9 @@
     "third_place_match_ok": "Cliquez sur OK pour ajouter la petite finale",
     "third_place_match_cancel": "Cliquez sur Annuler pour terminer après les demi-finales",
     "third_place_match_label": "Petite finale (match pour la 3ème place)",
-    "third_place_match_description": "Organise un match supplémentaire entre les deux demi-finalistes perdants pour déterminer la 3ème et 4ème place"
+    "third_place_match_description": "Organise un match supplémentaire entre les deux demi-finalistes perdants pour déterminer la 3ème et 4ème place",
+    "comparisons": "Comparaisons",
+    "analytics": "Analytics"
   },
   "weapons": {
     "epee": "Épée",
@@ -63,7 +65,9 @@
     "abandon": "Abandonner",
     "forfait": "Forfait",
     "reactivate": "Réactiver",
-    "points": "Points"
+    "points": "Points",
+    "label": "tireurs",
+    "present_label": "pointés"
   },
   "status": {
     "checked_in": "Présent",
@@ -79,7 +83,12 @@
   },
   "phases": {
     "checkin": "Appel",
+    "poolprep": "Préparation",
     "pools": "Poules",
+    "pools_skip": "Poules (saut)",
+    "pools_round": "Poules ({{current}}/{{total}})",
+    "pools_skip_tooltip": "Phase de poules ignorée (0 poules)",
+    "tableau_locked_tooltip": "Terminez toutes les poules et validez le classement pour accéder au tableau",
     "ranking": "Classement",
     "tableau": "Tableau",
     "results": "Résultats",
@@ -98,7 +107,9 @@
     "no_pools": "Pas de poules",
     "return_to_checkin": "Retour à l'appel",
     "pool_number": "Poule",
-    "change_pool": "Changer de poule"
+    "change_pool": "Changer de poule",
+    "next_round_n": "Tour {{n}} de poules →",
+    "view_ranking_action": "Voir le classement →"
   },
   "ranking": {
     "rank": "Rg",

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -24,7 +24,9 @@
     "third_place_match_ok": "點擊確定以加入銅牌賽",
     "third_place_match_cancel": "點擊取消以於半準決賽後結束",
     "third_place_match_label": "銅牌賽（季軍賽）",
-    "third_place_match_description": "為兩位落敗半準決賽選手安排額外比賽，以決定第三及第四名"
+    "third_place_match_description": "為兩位落敗半準決賽選手安排額外比賽，以決定第三及第四名",
+    "comparisons": "比較",
+    "analytics": "分析"
   },
   "weapons": {
     "epee": "重劍",
@@ -63,7 +65,9 @@
     "abandon": "棄賽",
     "forfait": "放棄資格",
     "reactivate": "重新啟用",
-    "points": "分數"
+    "points": "分數",
+    "label": "劍手",
+    "present_label": "已報到"
   },
   "status": {
     "checked_in": "已報到",
@@ -79,7 +83,12 @@
   },
   "phases": {
     "checkin": "報到",
+    "poolprep": "準備",
     "pools": "分組賽",
+    "pools_skip": "分組賽（跳過）",
+    "pools_round": "分組賽（{{current}}/{{total}}）",
+    "pools_skip_tooltip": "分組賽階段已跳過（0 組）",
+    "tableau_locked_tooltip": "完成所有分組賽並驗證排名後方可進入淘汰賽",
     "ranking": "排名",
     "tableau": "淘汰賽",
     "results": "成績",
@@ -98,7 +107,9 @@
     "no_pools": "無分組",
     "return_to_checkin": "返回報到",
     "pool_number": "分組",
-    "change_pool": "更改分組"
+    "change_pool": "更改分組",
+    "next_round_n": "第 {{n}} 輪分組賽 →",
+    "view_ranking_action": "查看排名 →"
   },
   "ranking": {
     "rank": "排名",


### PR DESCRIPTION
## Summary

- Remplace tous les textes hardcodés en français dans `CompetitionView.tsx` par des appels `t()` : onglets Appel / Préparation / Poules / Classement / Tableau / Résultats / Saisie distante, tooltips, badges du header, boutons d'action
- Ajoute les clés manquantes dans les 7 locales (fr, en, de, es, br, ca, zh-HK) : `phases.poolprep`, `phases.pools_skip`, `phases.pools_round`, tooltips, `pools.next_round_n`, `fencer.label/present_label`, `competition.comparisons/analytics`
- La date de compétition est désormais formatée dans la langue de l'interface (plus hardcodée en `fr-FR`)

## Test plan

- [ ] Changer la langue en Cantonais (zh-HK) — vérifier que les onglets affichent 報到 / 準備 / 分組賽 / 排名 / 淘汰賽 / 成績 / 遠程輸入
- [ ] Tester avec plusieurs langues (en, de, es) — vérifier les onglets de navigation
- [ ] Vérifier l'onglet Poules avec plusieurs tours : label dynamique `分組賽（1/2）`
- [ ] Vérifier le tooltip de l'onglet Tableau quand il est désactivé

🤖 Generated with [Claude Code](https://claude.com/claude-code)