### PR TITLE
fix: modale PDF s'affiche par-dessus les paramètres

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -202,7 +202,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
 
   return (
     <>
-    {showPdfEditor && <PdfTemplateModal onClose={() => setShowPdfEditor(false)} />}
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }}>
         <div className="modal-header">
@@ -357,6 +356,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
         </div>
       </div>
     </div>
+    {showPdfEditor && <PdfTemplateModal onClose={() => setShowPdfEditor(false)} />}
     </>
   );
 };


### PR DESCRIPTION
## Summary
- Correction de l'ordre de rendu dans `SettingsModal` : `PdfTemplateModal` était rendu **avant** l'overlay des paramètres, ce qui lui donnait une priorité DOM inférieure à z-index égal (1000)
- Déplacement du `PdfTemplateModal` **après** la div `modal-overlay` des paramètres pour qu'il s'affiche toujours par-dessus

## Test plan
- [ ] Ouvrir les paramètres
- [ ] Cliquer sur "Modèles PDF"
- [ ] Vérifier que la modale PDF s'affiche bien par-dessus la fenêtre des paramètres

🤖 Generated with [Claude Code](https://claude.ai/claude-code)