### PR TITLE
feat: bouton export PDF sur la phase Résultats

### DIFF
--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -8,6 +8,8 @@ import React from 'react';
 import { Fencer, PoolRanking, Competition, FencerStatus } from '../../shared/types';
 import { useToast } from './Toast';
 import { exportResultsXMLFFE } from '../../shared/utils/multiFormatExport';
+import { exportResultsToPDF } from '../../shared/utils/pdfExport';
+import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 
 interface FinalResult {
   rank: number;
@@ -23,6 +25,7 @@ interface ResultsViewProps {
 
 const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, finalResults }) => {
   const { showToast } = useToast();
+  const rankingTemplate = usePdfTemplateStore(s => s.templates.ranking);
 
   const getMedalEmoji = (rank: number): string => {
     if (rank === 1) return '🥇';
@@ -83,6 +86,21 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
     link.download = `resultats_${competition.title.replace(/[^a-z0-9]/gi, '_')}.csv`;
     link.click();
     showToast('Export CSV réussi !', 'success');
+  };
+
+  // Export PDF
+  const exportPDF = async () => {
+    try {
+      const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+      await exportResultsToPDF(
+        resultsToDisplay,
+        `Résultats — ${competition.title}`,
+        logo,
+        rankingTemplate
+      );
+    } catch (e) {
+      showToast((e as Error).message, 'error');
+    }
   };
 
   // Export XML
@@ -361,6 +379,23 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
           }}
         >
           📝 XML
+        </button>
+        <button
+          onClick={exportPDF}
+          style={{
+            padding: '0.75rem 1.5rem',
+            background: '#ef4444',
+            color: 'white',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+          }}
+        >
+          📄 PDF
         </button>
       </div>
 

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -873,3 +873,111 @@ export async function exportRankingToPDF(
   await savePDF(html, 'classement-general.pdf');
 }
 
+// ─── Export Résultats Finaux ───────────────────────────────────────────────────
+
+interface FinalResultForPDF {
+  rank: number;
+  fencer: Fencer;
+  eliminatedAt?: string;
+}
+
+function generateResultsHTML(
+  results: FinalResultForPDF[],
+  title: string,
+  logoBase64?: string,
+  template?: PdfTemplate
+): string {
+  const now = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
+  const medals: Record<number, string> = { 1: '🥇', 2: '🥈', 3: '🥉' };
+
+  const rows = results.map(r => {
+    const medal = medals[r.rank] ?? '';
+    const status =
+      (r.fencer as any).status === 'ABANDONED' ? ' <span style="color:#ef4444;font-size:8pt">(A)</span>' :
+      (r.fencer as any).status === 'FORFAIT'   ? ' <span style="color:#ef4444;font-size:8pt">(F)</span>' :
+      (r.fencer as any).status === 'EXCLUDED'  ? ' <span style="color:#ef4444;font-size:8pt">(X)</span>' : '';
+    return `
+<tr>
+  <td style="text-align:center;font-weight:700;color:var(--navy)">${medal} ${r.rank}</td>
+  <td style="font-weight:600">${r.fencer.lastName.toUpperCase()}${status}</td>
+  <td>${r.fencer.firstName ?? ''}</td>
+  <td style="color:var(--gray-dark)">${r.fencer.club ?? ''}</td>
+  <td style="text-align:center;color:var(--gray-dark)">${r.eliminatedAt ?? '-'}</td>
+</tr>`;
+  }).join('');
+
+  const effectiveTitle = template?.customTitle?.trim() || title;
+  const cssOverrides = template ? buildCssOverrides(template) : '';
+
+  const sections: Record<string, string> = {
+    'header': `
+  <div class="doc-header">
+    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
+    <div class="doc-header-left">
+      <h1>${effectiveTitle}</h1>
+      <div class="subtitle">Classement final — ${results.length} tireur${results.length > 1 ? 's' : ''}</div>
+    </div>
+    <div class="doc-header-badge" style="font-size:11pt">RF</div>
+  </div>`,
+    'gold-bar': `  <div class="gold-bar"></div>`,
+    'results-table': `
+  <table>
+    <thead>
+      <tr>
+        <th style="width:10mm">Rg</th>
+        <th style="text-align:left">Nom</th>
+        <th style="text-align:left">Prénom</th>
+        <th style="text-align:left">Club</th>
+        <th>Éliminé en</th>
+      </tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>`,
+    'footer': `
+  <div class="doc-footer">
+    <span>BellePoule Modern</span>
+    <span>${now}</span>
+  </div>`,
+  };
+
+  const defaultOrder = ['header', 'gold-bar', 'results-table', 'footer'];
+  const body = assembleBody(sections, template, defaultOrder);
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>${effectiveTitle}</title>
+  <style>
+    ${cssOverrides}
+    ${BASE_CSS}
+    table { width: 100%; border-collapse: collapse; font-size: 9pt; }
+    th {
+      background: var(--navy); color: var(--white);
+      font-size: 8pt; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.8px; padding: 2.5mm 3mm; text-align: center;
+    }
+    td { padding: 2mm 3mm; border-bottom: 1px solid var(--gray-light); vertical-align: middle; }
+    tr:nth-child(even) td { background: var(--gray-xlight); }
+    tr:nth-child(1) td:first-child { color: #d97706; font-size: 11pt; }
+    tr:nth-child(2) td:first-child { color: #6b7280; font-size: 11pt; }
+    tr:nth-child(3) td:first-child { color: #92400e; font-size: 11pt; }
+  </style>
+</head>
+<body>
+${body}
+</body>
+</html>`;
+}
+
+export async function exportResultsToPDF(
+  results: FinalResultForPDF[],
+  title: string = 'Résultats Finaux',
+  logoBase64?: string,
+  template?: PdfTemplate
+): Promise<void> {
+  if (results.length === 0) throw new Error('Aucun résultat à exporter');
+  const html = generateResultsHTML(results, title, logoBase64, template);
+  await savePDF(html, 'resultats-finaux.pdf');
+}
+


### PR DESCRIPTION
## Summary

- Ajoute `exportResultsToPDF` dans `pdfExport.ts` : génère un PDF A4 avec rang (+ médaille), nom, prénom, club et colonne « Éliminé en »
- Utilise le template PDF existant (`ranking`) et le logo stocké en localStorage
- Ajoute le bouton 📄 PDF (rouge) dans `ResultsView.tsx` aux côtés des boutons Imprimer / Copier / CSV / XML

## Test plan

- [ ] Ouvrir une compétition avec des résultats finaux, aller sur l'onglet Résultats
- [ ] Cliquer sur 📄 PDF → dialogue de sauvegarde, vérifier le contenu du PDF
- [ ] Tester sans résultats DE (fallback classement poules) → PDF généré correctement
- [ ] Vérifier que les boutons CSV, XML et Imprimer existants ne sont pas affectés

🤖 Generated with [Claude Code](https://claude.com/claude-code)