### PR TITLE
i18n: externaliser tous les textes hardcodés (7 langues)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -85,6 +85,38 @@ const MENU_LABELS: Record<MenuLang, Record<string, string>> = {
     updatesTitle: 'Mises à jour',
     docs: 'Documentation',
     reportBug: '📝 Signaler un bug / Suggestion',
+    remoteTitle: 'Saisie distante',
+    remoteAlreadyStarted: 'Le serveur de saisie distante est déjà démarré',
+    remoteStartedTitle: 'Saisie distante démarrée',
+    remoteStartedMsg: 'Les arbitres peuvent maintenant se connecter',
+    remoteDetailTemplate: 'Arène 1: {url}/arene1/arbitre\nArène 2: {url}/arene2/arbitre\nArène 3: {url}/arene3/arbitre\nArène 4: {url}/arene4/arbitre\n\nAffichage kiosk (grand écran public): {url}/kiosk\nClassement en direct: {url}/\n\nPartagez ces URLs avec les arbitres munis de tablettes.\nAssurez-vous que le pare-feu Windows autorise les connexions sur le port {port}.',
+    remoteNotStarted: "Le serveur de saisie distante n'est pas démarré",
+    remoteStoppedTitle: 'Saisie distante arrêtée',
+    remoteStoppedMsg: 'Le serveur de saisie distante a été arrêté',
+    errTitle: 'Erreur',
+    remoteErrStart: 'Impossible de démarrer le serveur distant:',
+    remoteErrStop: "Impossible d'arrêter le serveur distant:",
+    openTitle: 'Ouvrir une compétition',
+    filterBpm: 'BellePoule Modern',
+    filterClassic: 'BellePoule Classic',
+    filterAll: 'Tous les fichiers',
+    openErr: "Impossible d'ouvrir le fichier:",
+    saveTitle: 'Enregistrer la compétition',
+    saveErr: "Impossible d'enregistrer:",
+    importTitle: 'Importer',
+    importXmlTitle: 'Importer un fichier XML BellePoule',
+    importFffTitle: 'Importer une liste FFE',
+    importRankingTitle: 'Importer un classement FFE',
+    importBpfTitle: 'Importer tireurs + photos (.bpf)',
+    filterXmlBP: 'XML BellePoule',
+    filterFfe: 'Fichier FFE',
+    filterRanking: 'Fichier classement',
+    importReadErr: 'Impossible de lire le fichier:',
+    importErrTitle: "Erreur d'import",
+    aboutTitle: 'À propos de BellePoule Modern',
+    aboutSoftware: "Logiciel de gestion de compétitions d'escrime.",
+    aboutRewrite: 'Réécriture moderne du logiciel BellePoule original créé par Yann Deboeuf.',
+    aboutBugHint: 'Pour signaler un bug, mentionnez:',
   },
   en: {
     file: 'File',
@@ -135,6 +167,38 @@ const MENU_LABELS: Record<MenuLang, Record<string, string>> = {
     updatesTitle: 'Updates',
     docs: 'Documentation',
     reportBug: '📝 Report a Bug / Suggestion',
+    remoteTitle: 'Remote Scoring',
+    remoteAlreadyStarted: 'The remote scoring server is already started',
+    remoteStartedTitle: 'Remote scoring started',
+    remoteStartedMsg: 'Referees can now connect',
+    remoteDetailTemplate: 'Arena 1: {url}/arene1/arbitre\nArena 2: {url}/arene2/arbitre\nArena 3: {url}/arene3/arbitre\nArena 4: {url}/arene4/arbitre\n\nKiosk display (public screen): {url}/kiosk\nLive ranking: {url}/\n\nShare these URLs with referees using tablets.\nMake sure Windows firewall allows connections on port {port}.',
+    remoteNotStarted: 'The remote scoring server is not started',
+    remoteStoppedTitle: 'Remote scoring stopped',
+    remoteStoppedMsg: 'The remote scoring server has been stopped',
+    errTitle: 'Error',
+    remoteErrStart: 'Unable to start the remote server:',
+    remoteErrStop: 'Unable to stop the remote server:',
+    openTitle: 'Open Competition',
+    filterBpm: 'BellePoule Modern',
+    filterClassic: 'BellePoule Classic',
+    filterAll: 'All Files',
+    openErr: 'Unable to open file:',
+    saveTitle: 'Save Competition',
+    saveErr: 'Unable to save:',
+    importTitle: 'Import',
+    importXmlTitle: 'Import BellePoule XML file',
+    importFffTitle: 'Import FFE list',
+    importRankingTitle: 'Import FFE ranking',
+    importBpfTitle: 'Import fencers + photos (.bpf)',
+    filterXmlBP: 'XML BellePoule',
+    filterFfe: 'FFE File',
+    filterRanking: 'Ranking file',
+    importReadErr: 'Unable to read file:',
+    importErrTitle: 'Import Error',
+    aboutTitle: 'About BellePoule Modern',
+    aboutSoftware: 'Fencing competition management software.',
+    aboutRewrite: 'Modern rewrite of the original BellePoule software created by Yann Deboeuf.',
+    aboutBugHint: 'To report a bug, mention:',
   },
   de: {
     file: 'Datei',
@@ -185,6 +249,38 @@ const MENU_LABELS: Record<MenuLang, Record<string, string>> = {
     updatesTitle: 'Updates',
     docs: 'Dokumentation',
     reportBug: '📝 Bug melden / Vorschlag',
+    remoteTitle: 'Fernpunkteingabe',
+    remoteAlreadyStarted: 'Der Fernpunkteingabe-Server ist bereits gestartet',
+    remoteStartedTitle: 'Fernpunkteingabe gestartet',
+    remoteStartedMsg: 'Schiedsrichter können sich jetzt verbinden',
+    remoteDetailTemplate: 'Arena 1: {url}/arene1/arbitre\nArena 2: {url}/arene2/arbitre\nArena 3: {url}/arene3/arbitre\nArena 4: {url}/arene4/arbitre\n\nKiosk-Anzeige (öffentlicher Bildschirm): {url}/kiosk\nLive-Rangliste: {url}/\n\nTeilen Sie diese URLs mit Schiedsrichtern mit Tablets.\nStellen Sie sicher, dass die Windows-Firewall Verbindungen auf Port {port} zulässt.',
+    remoteNotStarted: 'Der Fernpunkteingabe-Server ist nicht gestartet',
+    remoteStoppedTitle: 'Fernpunkteingabe gestoppt',
+    remoteStoppedMsg: 'Der Fernpunkteingabe-Server wurde gestoppt',
+    errTitle: 'Fehler',
+    remoteErrStart: 'Fernserver konnte nicht gestartet werden:',
+    remoteErrStop: 'Fernserver konnte nicht gestoppt werden:',
+    openTitle: 'Wettkampf öffnen',
+    filterBpm: 'BellePoule Modern',
+    filterClassic: 'BellePoule Classic',
+    filterAll: 'Alle Dateien',
+    openErr: 'Datei konnte nicht geöffnet werden:',
+    saveTitle: 'Wettkampf speichern',
+    saveErr: 'Speichern nicht möglich:',
+    importTitle: 'Importieren',
+    importXmlTitle: 'BellePoule XML-Datei importieren',
+    importFffTitle: 'FFE-Liste importieren',
+    importRankingTitle: 'FFE-Rangliste importieren',
+    importBpfTitle: 'Fechter + Fotos importieren (.bpf)',
+    filterXmlBP: 'XML BellePoule',
+    filterFfe: 'FFE-Datei',
+    filterRanking: 'Ranglistendatei',
+    importReadErr: 'Datei konnte nicht gelesen werden:',
+    importErrTitle: 'Importfehler',
+    aboutTitle: 'Über BellePoule Modern',
+    aboutSoftware: 'Fechtwettkampf-Verwaltungssoftware.',
+    aboutRewrite: 'Moderne Neuentwicklung der originalen BellePoule-Software erstellt von Yann Deboeuf.',
+    aboutBugHint: 'Zum Melden eines Fehlers bitte angeben:',
   },
   'zh-HK': {
     file: '檔案',
@@ -235,8 +331,49 @@ const MENU_LABELS: Record<MenuLang, Record<string, string>> = {
     updatesTitle: '更新',
     docs: '文件',
     reportBug: '📝 回報錯誤 / 建議',
+    remoteTitle: '遠程計分',
+    remoteAlreadyStarted: '遠程計分伺服器已啟動',
+    remoteStartedTitle: '遠程計分已啟動',
+    remoteStartedMsg: '裁判現在可以連線',
+    remoteDetailTemplate: '賽場 1: {url}/arene1/arbitre\n賽場 2: {url}/arene2/arbitre\n賽場 3: {url}/arene3/arbitre\n賽場 4: {url}/arene4/arbitre\n\nKiosk 顯示（公開大螢幕）: {url}/kiosk\n即時排名: {url}/\n\n請將這些網址分享給使用平板電腦的裁判。\n請確保 Windows 防火牆允許連接埠 {port} 上的連線。',
+    remoteNotStarted: '遠程計分伺服器尚未啟動',
+    remoteStoppedTitle: '遠程計分已停止',
+    remoteStoppedMsg: '遠程計分伺服器已停止',
+    errTitle: '錯誤',
+    remoteErrStart: '無法啟動遠程伺服器:',
+    remoteErrStop: '無法停止遠程伺服器:',
+    openTitle: '開啟比賽',
+    filterBpm: 'BellePoule Modern',
+    filterClassic: 'BellePoule Classic',
+    filterAll: '所有檔案',
+    openErr: '無法開啟檔案:',
+    saveTitle: '儲存比賽',
+    saveErr: '無法儲存:',
+    importTitle: '匯入',
+    importXmlTitle: '匯入 BellePoule XML 檔案',
+    importFffTitle: '匯入 FFE 名單',
+    importRankingTitle: '匯入 FFE 排名',
+    importBpfTitle: '匯入劍手 + 照片 (.bpf)',
+    filterXmlBP: 'XML BellePoule',
+    filterFfe: 'FFE 檔案',
+    filterRanking: '排名檔案',
+    importReadErr: '無法讀取檔案:',
+    importErrTitle: '匯入錯誤',
+    aboutTitle: '關於 BellePoule Modern',
+    aboutSoftware: '劍擊比賽管理軟件。',
+    aboutRewrite: '由 Yann Deboeuf 創建的 BellePoule 原版軟件的現代重寫版本。',
+    aboutBugHint: '回報錯誤時請提及:',
   },
 };
+
+// ============================================================================
+// Localized Label Helper
+// ============================================================================
+
+function getL(): Record<string, string> {
+  const lang = (MENU_LABELS[currentMenuLanguage as MenuLang] ? currentMenuLanguage : 'fr') as MenuLang;
+  return MENU_LABELS[lang];
+}
 
 // ============================================================================
 // Version Information
@@ -563,11 +700,12 @@ function createMenu(language?: string): void {
 // ============================================================================
 
 function startRemoteScoreServer(port: number = 8066): void {
+  const L = getL();
   if (remoteScoreServer) {
     dialog.showMessageBox(mainWindow!, {
       type: 'info',
-      title: 'Saisie distante',
-      message: 'Le serveur de saisie distante est déjà démarré',
+      title: L.remoteTitle,
+      message: L.remoteAlreadyStarted,
       buttons: ['OK'],
     });
     return;
@@ -579,27 +717,31 @@ function startRemoteScoreServer(port: number = 8066): void {
     remoteScoreServer.start();
 
     const serverUrl = remoteScoreServer.getServerUrl();
+    const detail = L.remoteDetailTemplate
+      .replace(/{url}/g, serverUrl)
+      .replace('{port}', String(port));
     dialog.showMessageBox(mainWindow!, {
       type: 'info',
-      title: 'Saisie distante démarrée',
-      message: `Les arbitres peuvent maintenant se connecter`,
-      detail: `Arène 1: ${serverUrl}/arene1/arbitre\nArène 2: ${serverUrl}/arene2/arbitre\nArène 3: ${serverUrl}/arene3/arbitre\nArène 4: ${serverUrl}/arene4/arbitre\n\nAffichage kiosk (grand écran public): ${serverUrl}/kiosk\nClassement en direct: ${serverUrl}/\n\nPartagez ces URLs avec les arbitres munis de tablettes.\nAssurez-vous que le pare-feu Windows autorise les connexions sur le port ${port}.`,
+      title: L.remoteStartedTitle,
+      message: L.remoteStartedMsg,
+      detail,
       buttons: ['OK'],
     });
 
     // Stocker la référence globale pour le serveur distant
     (global as any).mainWindow = mainWindow;
   } catch (error) {
-    dialog.showErrorBox('Erreur', `Impossible de démarrer le serveur distant: ${error}`);
+    dialog.showErrorBox(L.errTitle, `${L.remoteErrStart} ${error}`);
   }
 }
 
 function stopRemoteScoreServer(): void {
+  const L = getL();
   if (!remoteScoreServer) {
     dialog.showMessageBox(mainWindow!, {
       type: 'info',
-      title: 'Saisie distante',
-      message: "Le serveur de saisie distante n'est pas démarré",
+      title: L.remoteTitle,
+      message: L.remoteNotStarted,
       buttons: ['OK'],
     });
     return;
@@ -611,12 +753,12 @@ function stopRemoteScoreServer(): void {
 
     dialog.showMessageBox(mainWindow!, {
       type: 'info',
-      title: 'Saisie distante arrêtée',
-      message: 'Le serveur de saisie distante a été arrêté',
+      title: L.remoteStoppedTitle,
+      message: L.remoteStoppedMsg,
       buttons: ['OK'],
     });
   } catch (error) {
-    dialog.showErrorBox('Erreur', `Impossible d'arrêter le serveur distant: ${error}`);
+    dialog.showErrorBox(L.errTitle, `${L.remoteErrStop} ${error}`);
   }
 }
 
@@ -625,12 +767,13 @@ function stopRemoteScoreServer(): void {
 // ============================================================================
 
 async function handleOpenFile(): Promise<void> {
+  const L = getL();
   const result = await dialog.showOpenDialog(mainWindow!, {
-    title: 'Ouvrir une compétition',
+    title: L.openTitle,
     filters: [
-      { name: 'BellePoule Modern', extensions: ['bpm', 'db'] },
-      { name: 'BellePoule Classic', extensions: ['cotcot', 'cocot'] },
-      { name: 'Tous les fichiers', extensions: ['*'] },
+      { name: L.filterBpm, extensions: ['bpm', 'db'] },
+      { name: L.filterClassic, extensions: ['cotcot', 'cocot'] },
+      { name: L.filterAll, extensions: ['*'] },
     ],
     properties: ['openFile'],
   });
@@ -641,16 +784,17 @@ async function handleOpenFile(): Promise<void> {
       db.importFromFile(filepath);
       mainWindow?.webContents.send('file:opened', filepath);
     } catch (error) {
-      dialog.showErrorBox('Erreur', `Impossible d'ouvrir le fichier: ${error}`);
+      dialog.showErrorBox(L.errTitle, `${L.openErr} ${error}`);
     }
   }
 }
 
 async function handleSaveAs(): Promise<void> {
+  const L = getL();
   const result = await dialog.showSaveDialog(mainWindow!, {
-    title: 'Enregistrer la compétition',
+    title: L.saveTitle,
     defaultPath: 'competition.bpm',
-    filters: [{ name: 'BellePoule Modern', extensions: ['bpm'] }],
+    filters: [{ name: L.filterBpm, extensions: ['bpm'] }],
   });
 
   if (!result.canceled && result.filePath) {
@@ -658,7 +802,7 @@ async function handleSaveAs(): Promise<void> {
       db.exportToFile(result.filePath);
       mainWindow?.webContents.send('file:saved', result.filePath);
     } catch (error) {
-      dialog.showErrorBox('Erreur', `Impossible d'enregistrer: ${error}`);
+      dialog.showErrorBox(L.errTitle, `${L.saveErr} ${error}`);
     }
   }
 }
@@ -668,28 +812,29 @@ async function handleExport(format: string): Promise<void> {
 }
 
 async function handleImport(format: string): Promise<void> {
+  const L = getL();
   let filters: Electron.FileFilter[] = [];
-  let title = 'Importer';
+  let title = L.importTitle;
 
   switch (format) {
     case 'xml':
-      title = 'Importer un fichier XML BellePoule';
-      filters = [{ name: 'XML BellePoule', extensions: ['xml', 'cotcot'] }];
+      title = L.importXmlTitle;
+      filters = [{ name: L.filterXmlBP, extensions: ['xml', 'cotcot'] }];
       break;
     case 'fff':
-      title = 'Importer une liste FFE';
-      filters = [{ name: 'Fichier FFE', extensions: ['fff', 'csv', 'txt'] }];
+      title = L.importFffTitle;
+      filters = [{ name: L.filterFfe, extensions: ['fff', 'csv', 'txt'] }];
       break;
     case 'ranking':
-      title = 'Importer un classement FFE';
-      filters = [{ name: 'Fichier classement', extensions: ['fff', 'csv', 'txt', 'xlsx'] }];
+      title = L.importRankingTitle;
+      filters = [{ name: L.filterRanking, extensions: ['fff', 'csv', 'txt', 'xlsx'] }];
       break;
     case 'fencers-bpf':
-      title = 'Importer tireurs + photos (.bpf)';
+      title = L.importBpfTitle;
       filters = [{ name: 'BellePoule Fencers', extensions: ['bpf'] }];
       break;
     default:
-      filters = [{ name: 'Tous les fichiers', extensions: ['*'] }];
+      filters = [{ name: L.filterAll, extensions: ['*'] }];
   }
 
   const result = await dialog.showOpenDialog(mainWindow!, {
@@ -709,14 +854,16 @@ async function handleImport(format: string): Promise<void> {
         mainWindow?.webContents.send('menu:import', format, filepath, content);
       }
     } catch (error) {
-      dialog.showErrorBox("Erreur d'import", `Impossible de lire le fichier: ${error}`);
+      dialog.showErrorBox(L.importErrTitle, `${L.importReadErr} ${error}`);
     }
   }
 }
 
 function showAbout(): void {
+  const L = getL();
   const versionInfo = getVersionInfo();
-  const buildDate = new Date(versionInfo.date).toLocaleDateString('fr-FR', {
+  const locale = currentMenuLanguage === 'zh-HK' ? 'zh-HK' : currentMenuLanguage === 'de' ? 'de-DE' : currentMenuLanguage === 'en' ? 'en-GB' : 'fr-FR';
+  const buildDate = new Date(versionInfo.date).toLocaleDateString(locale, {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
@@ -726,19 +873,19 @@ function showAbout(): void {
 
   dialog.showMessageBox(mainWindow!, {
     type: 'info',
-    title: 'À propos de BellePoule Modern',
+    title: L.aboutTitle,
     message: `BellePoule Modern v${versionInfo.version}`,
     detail: `Build #${versionInfo.build}
 Date: ${buildDate}
 
-Logiciel de gestion de compétitions d'escrime.
+${L.aboutSoftware}
 
-Réécriture moderne du logiciel BellePoule original créé par Yann Deboeuf.
+${L.aboutRewrite}
 
 Licence: GPL-3.0
 © 2024-2026 BellePoule Modern Contributors
 
-Pour signaler un bug, mentionnez:
+${L.aboutBugHint}
   Version: ${versionInfo.version}
   Build: #${versionInfo.build}`,
   });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -308,9 +308,9 @@ const AppContent: React.FC = () => {
                   setView('home');
                   setActiveTabId(null);
                 }}
-                title="Revenir à la liste des compétitions"
+                title={t('app.back_to_list')}
               >
-                🏠 Général
+                🏠 {t('app.home')}
               </button>
             )}
             <button className="btn btn-primary" onClick={() => setShowNewCompetitionModal(true)}>
@@ -384,7 +384,7 @@ const AppContent: React.FC = () => {
                   gap: '0.5rem',
                 }}
               >
-                🏠 Général
+                🏠 {t('app.home')}
               </span>
             </div>
 
@@ -461,7 +461,7 @@ const AppContent: React.FC = () => {
                     e.currentTarget.style.background = 'none';
                     e.currentTarget.style.color = '#6b7280';
                   }}
-                  title="Fermer l'onglet"
+                  title={t('app.close_tab')}
                 >
                   ×
                 </button>
@@ -475,9 +475,9 @@ const AppContent: React.FC = () => {
             <ErrorBoundary
               fallback={
                 <div style={{ padding: '20px', textAlign: 'center' }}>
-                  <h3>🏠 Erreur de chargement</h3>
-                  <p>Une erreur est survenue lors du chargement de la liste des compétitions.</p>
-                  <button onClick={() => window.location.reload()}>Recharger l'application</button>
+                  <h3>🏠 {t('app.load_error_title')}</h3>
+                  <p>{t('app.load_error_message')}</p>
+                  <button onClick={() => window.location.reload()}>{t('app.reload')}</button>
                 </div>
               }
             >

--- a/src/renderer/components/AddFencerModal.tsx
+++ b/src/renderer/components/AddFencerModal.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { Fencer, Gender, FencerStatus } from '../../shared/types';
 import { useToast } from './Toast';
 import FencerPhoto from './FencerPhoto';
+import { useTranslation } from '../contexts/TranslationContext';
 
 interface AddFencerModalProps {
   onClose: () => void;
@@ -15,6 +16,7 @@ interface AddFencerModalProps {
 
 const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
   const { showToast } = useToast();
+  const { t } = useTranslation();
   const [lastName, setLastName] = useState('');
   const [firstName, setFirstName] = useState('');
   const [club, setClub] = useState('');
@@ -29,7 +31,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
     e.preventDefault();
 
     if (!lastName.trim() || !firstName.trim()) {
-      showToast('Le nom et le prénom sont obligatoires', 'warning');
+      showToast(t('messages.name_required'), 'warning');
       return;
     }
 
@@ -51,7 +53,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()}>
         <div className="modal-header">
-          <h2 className="modal-title">Ajouter un tireur</h2>
+          <h2 className="modal-title">{t('fencer.add')}</h2>
           <button
             className="btn btn-icon btn-secondary"
             onClick={onClose}
@@ -76,7 +78,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
 
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
               <div className="form-group">
-                <label className="form-label">Nom *</label>
+                <label className="form-label">{t('fencer.last_name')} *</label>
                 <input
                   type="text"
                   className="form-input"
@@ -88,7 +90,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
                 />
               </div>
               <div className="form-group">
-                <label className="form-label">Prénom *</label>
+                <label className="form-label">{t('fencer.first_name')} *</label>
                 <input
                   type="text"
                   className="form-input"
@@ -102,18 +104,18 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
 
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
               <div className="form-group">
-                <label className="form-label">Sexe</label>
+                <label className="form-label">{t('fencer.gender')}</label>
                 <select
                   className="form-input form-select"
                   value={gender}
                   onChange={e => setGender(e.target.value as Gender)}
                 >
-                  <option value={Gender.MALE}>Masculin</option>
-                  <option value={Gender.FEMALE}>Féminin</option>
+                  <option value={Gender.MALE}>{t('genders.male')}</option>
+                  <option value={Gender.FEMALE}>{t('genders.female')}</option>
                 </select>
               </div>
               <div className="form-group">
-                <label className="form-label">Nationalité</label>
+                <label className="form-label">{t('fencer.nationality')}</label>
                 <input
                   type="text"
                   className="form-input"
@@ -126,7 +128,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
             </div>
 
             <div className="form-group">
-              <label className="form-label">Club</label>
+              <label className="form-label">{t('fencer.club')}</label>
               <input
                 type="text"
                 className="form-input"
@@ -138,7 +140,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
 
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
               <div className="form-group">
-                <label className="form-label">Région</label>
+                <label className="form-label">{t('fencer.league')}</label>
                 <input
                   type="text"
                   className="form-input"
@@ -148,7 +150,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
                 />
               </div>
               <div className="form-group">
-                <label className="form-label">Licence</label>
+                <label className="form-label">{t('fencer.license')}</label>
                 <input
                   type="text"
                   className="form-input"
@@ -160,7 +162,7 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
             </div>
 
             <div className="form-group">
-              <label className="form-label">Classement</label>
+              <label className="form-label">{t('fencer.ranking')}</label>
               <input
                 type="number"
                 className="form-input"
@@ -174,10 +176,10 @@ const AddFencerModal: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
 
           <div className="modal-footer">
             <button type="button" className="btn btn-secondary" onClick={onClose}>
-              Annuler
+              {t('actions.cancel')}
             </button>
             <button type="submit" className="btn btn-primary">
-              Ajouter le tireur
+              {t('fencer.add')}
             </button>
           </div>
         </form>

--- a/src/renderer/components/KeyboardShortcutsHelp.tsx
+++ b/src/renderer/components/KeyboardShortcutsHelp.tsx
@@ -5,39 +5,41 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from '../contexts/TranslationContext';
 
 interface Shortcut {
   key: string;
-  description: string;
+  descriptionKey: string;
   category: 'navigation' | 'actions' | 'competition' | 'global';
 }
 
 const SHORTCUTS: Shortcut[] = [
   // Global
-  { key: '?', description: "Afficher l'aide des raccourcis", category: 'global' },
-  { key: 'Ctrl + K', description: 'Recherche rapide', category: 'global' },
-  { key: 'Esc', description: 'Fermer la modale / Annuler', category: 'global' },
+  { key: '?', descriptionKey: 'shortcuts.show_help', category: 'global' },
+  { key: 'Ctrl + K', descriptionKey: 'shortcuts.quick_search', category: 'global' },
+  { key: 'Esc', descriptionKey: 'shortcuts.close_modal', category: 'global' },
 
   // Navigation
-  { key: 'Ctrl + 1', description: 'Aller aux poules', category: 'navigation' },
-  { key: 'Ctrl + 2', description: 'Aller au tableau', category: 'navigation' },
-  { key: 'Ctrl + 3', description: 'Aller aux résultats', category: 'navigation' },
-  { key: 'Tab', description: 'Navigation entre champs', category: 'navigation' },
+  { key: 'Ctrl + 1', descriptionKey: 'shortcuts.go_pools', category: 'navigation' },
+  { key: 'Ctrl + 2', descriptionKey: 'shortcuts.go_tableau', category: 'navigation' },
+  { key: 'Ctrl + 3', descriptionKey: 'shortcuts.go_results', category: 'navigation' },
+  { key: 'Tab', descriptionKey: 'shortcuts.nav_fields', category: 'navigation' },
 
   // Actions
-  { key: 'Ctrl + S', description: 'Sauvegarder', category: 'actions' },
-  { key: 'Ctrl + Z', description: 'Annuler (Undo)', category: 'actions' },
-  { key: 'Ctrl + Y', description: 'Refaire (Redo)', category: 'actions' },
-  { key: 'Ctrl + N', description: 'Nouvelle compétition', category: 'actions' },
+  { key: 'Ctrl + S', descriptionKey: 'shortcuts.save', category: 'actions' },
+  { key: 'Ctrl + Z', descriptionKey: 'shortcuts.undo', category: 'actions' },
+  { key: 'Ctrl + Y', descriptionKey: 'shortcuts.redo', category: 'actions' },
+  { key: 'Ctrl + N', descriptionKey: 'shortcuts.new_competition', category: 'actions' },
 
   // Competition
-  { key: 'F5', description: 'Rafraîchir les données', category: 'competition' },
-  { key: 'Space', description: 'Démarrer/Pause le chronomètre', category: 'competition' },
-  { key: '↑ ↓', description: 'Naviguer dans la liste', category: 'competition' },
-  { key: 'Enter', description: 'Valider / Ouvrir', category: 'competition' },
+  { key: 'F5', descriptionKey: 'shortcuts.refresh_data', category: 'competition' },
+  { key: 'Space', descriptionKey: 'shortcuts.timer', category: 'competition' },
+  { key: '↑ ↓', descriptionKey: 'shortcuts.nav_list', category: 'competition' },
+  { key: 'Enter', descriptionKey: 'shortcuts.validate', category: 'competition' },
 ];
 
 export const KeyboardShortcutsHelp: React.FC = () => {
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [activeCategory, setActiveCategory] = useState<string>('all');
 
@@ -59,11 +61,11 @@ export const KeyboardShortcutsHelp: React.FC = () => {
   if (!isOpen) return null;
 
   const categories = [
-    { id: 'all', label: 'Tous', icon: '⌨️' },
-    { id: 'global', label: 'Globaux', icon: '🌍' },
-    { id: 'navigation', label: 'Navigation', icon: '🧭' },
-    { id: 'actions', label: 'Actions', icon: '⚡' },
-    { id: 'competition', label: 'Compétition', icon: '🤺' },
+    { id: 'all', label: t('shortcuts.category_all'), icon: '⌨️' },
+    { id: 'global', label: t('shortcuts.category_global'), icon: '🌍' },
+    { id: 'navigation', label: t('shortcuts.category_navigation'), icon: '🧭' },
+    { id: 'actions', label: t('shortcuts.category_actions'), icon: '⚡' },
+    { id: 'competition', label: t('shortcuts.category_competition'), icon: '🤺' },
   ];
 
   const filteredShortcuts =
@@ -104,9 +106,9 @@ export const KeyboardShortcutsHelp: React.FC = () => {
           }}
         >
           <div>
-            <h2 style={{ margin: 0, fontSize: '24px', color: '#111827' }}>⌨️ Raccourcis Clavier</h2>
+            <h2 style={{ margin: 0, fontSize: '24px', color: '#111827' }}>⌨️ {t('shortcuts.title')}</h2>
             <p style={{ margin: '4px 0 0 0', color: '#6b7280', fontSize: '14px' }}>
-              Maîtrisez BellePoule comme un pro
+              {t('shortcuts.subtitle')}
             </p>
           </div>
           <button
@@ -200,7 +202,7 @@ export const KeyboardShortcutsHelp: React.FC = () => {
                     paddingLeft: '8px',
                   }}
                 >
-                  {shortcut.description}
+                  {t(shortcut.descriptionKey)}
                 </span>
               </React.Fragment>
             ))}
@@ -218,7 +220,7 @@ export const KeyboardShortcutsHelp: React.FC = () => {
             textAlign: 'center',
           }}
         >
-          Appuyez sur{' '}
+          {t('shortcuts.footer').split('?')[0]}
           <kbd
             style={{
               padding: '2px 6px',
@@ -229,8 +231,8 @@ export const KeyboardShortcutsHelp: React.FC = () => {
             }}
           >
             ?
-          </kbd>{' '}
-          pour afficher cette aide à tout moment
+          </kbd>
+          {t('shortcuts.footer').split('?')[1]}
         </div>
       </div>
     </div>

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -1,6 +1,12 @@
 {
   "app": {
-    "title": "BellePoule Modern"
+    "title": "BellePoule Modern",
+    "home": "Broadel",
+    "back_to_list": "Distro d'al roll kenstrivadegoù",
+    "close_tab": "Serriñ an ivinell",
+    "load_error_title": "Fazi kargañ",
+    "load_error_message": "Ur fazi zo chegnet en ur gargañ al roll kenstrivadegoù.",
+    "reload": "Adkargañ an arlivañ"
   },
   "menu": {
     "new_competition": "Nevezompetañ",
@@ -215,7 +221,8 @@
     "warning": "Diwallit",
     "info": "Stlenn",
     "connection_lost": "Kevreadur kolletet",
-    "connection_restored": "Kevreadur az adsavet"
+    "connection_restored": "Kevreadur az adsavet",
+    "name_required": "Ret eo an anv-tiezh hag an anv-bihan"
   },
   "time": {
     "minutes": "munutennoù",
@@ -237,5 +244,30 @@
       "ranking-table": "Taolenn renk", "footer": "Troad-pajenn"
     },
     "reset": "Adderaouiñ", "exportJson": "Ezporzhiañ JSON", "importJson": "Enporzhiañ JSON", "importError": "Restr JSON fall"
+  },
+  "shortcuts": {
+    "title": "Birvikerezh Klavier",
+    "subtitle": "Mestrañ BellePoule evel ur prof",
+    "footer": "Stailhit ? evit diskouez an sikour-mañ",
+    "category_all": "Holl",
+    "category_global": "Hollvedel",
+    "category_navigation": "Levenez",
+    "category_actions": "Oberoù",
+    "category_competition": "Kenstrivadeg",
+    "show_help": "Diskouez sikour birvikerezh",
+    "quick_search": "Klask tost",
+    "close_modal": "Serriñ / Nullañ",
+    "go_pools": "Mont d'ar poellou",
+    "go_tableau": "Mont d'an daolenn",
+    "go_results": "Mont d'an disoc'hoù",
+    "nav_fields": "Levenez etre maezioù",
+    "save": "Enrollañ",
+    "undo": "Diret",
+    "redo": "Adober",
+    "new_competition": "Kenstrivadeg nevez",
+    "refresh_data": "Hizivaat roadennoù",
+    "timer": "Krogañ/Paouez kronometr",
+    "nav_list": "Levenez en rol",
+    "validate": "Gwiriañ / Digeriñ"
   }
 }

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -1,6 +1,12 @@
 {
   "app": {
-    "title": "BellePoule Modern"
+    "title": "BellePoule Modern",
+    "home": "General",
+    "back_to_list": "Tornar a la llista de competicions",
+    "close_tab": "Tancar la pestanya",
+    "load_error_title": "Error de càrrega",
+    "load_error_message": "S'ha produït un error en carregar la llista de competicions.",
+    "reload": "Recarregar l'aplicació"
   },
   "menu": {
     "new_competition": "Nova Competició",
@@ -215,7 +221,8 @@
     "warning": "Avís",
     "info": "Informació",
     "connection_lost": "Connexió perduda",
-    "connection_restored": "Connexió restablerta"
+    "connection_restored": "Connexió restablerta",
+    "name_required": "El cognom i el nom són obligatoris"
   },
   "time": {
     "minutes": "minuts",
@@ -237,5 +244,30 @@
       "ranking-table": "Taula de classificació", "footer": "Peu de pàgina"
     },
     "reset": "Restablir", "exportJson": "Exportar JSON", "importJson": "Importar JSON", "importError": "Fitxer JSON no vàlid"
+  },
+  "shortcuts": {
+    "title": "Dreceres de Teclat",
+    "subtitle": "Domina BellePoule com un professional",
+    "footer": "Premeu ? per mostrar aquesta ajuda en qualsevol moment",
+    "category_all": "Tots",
+    "category_global": "Global",
+    "category_navigation": "Navegació",
+    "category_actions": "Accions",
+    "category_competition": "Competició",
+    "show_help": "Mostrar ajuda de dreceres",
+    "quick_search": "Cerca ràpida",
+    "close_modal": "Tancar modal / Cancel·lar",
+    "go_pools": "Anar a poules",
+    "go_tableau": "Anar al quadre",
+    "go_results": "Anar als resultats",
+    "nav_fields": "Navegar entre camps",
+    "save": "Desar",
+    "undo": "Desfer",
+    "redo": "Refer",
+    "new_competition": "Nova competició",
+    "refresh_data": "Actualitzar dades",
+    "timer": "Iniciar/Pausar cronòmetre",
+    "nav_list": "Navegar a la llista",
+    "validate": "Validar / Obrir"
   }
 }

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -1,6 +1,12 @@
 {
   "app": {
-    "title": "BellePoule Modern"
+    "title": "BellePoule Modern",
+    "home": "Allgemein",
+    "back_to_list": "Zurück zur Wettbewerbliste",
+    "close_tab": "Tab schließen",
+    "load_error_title": "Ladefehler",
+    "load_error_message": "Beim Laden der Wettbewerbliste ist ein Fehler aufgetreten.",
+    "reload": "Anwendung neu laden"
   },
   "menu": {
     "new_competition": "Neuer Wettbewerb",
@@ -215,7 +221,8 @@
     "warning": "Warnung",
     "info": "Information",
     "connection_lost": "Verbindung verloren",
-    "connection_restored": "Verbindung wiederhergestellt"
+    "connection_restored": "Verbindung wiederhergestellt",
+    "name_required": "Nachname und Vorname sind erforderlich"
   },
   "time": {
     "minutes": "Minuten",
@@ -237,5 +244,30 @@
       "ranking-table": "Rangtabelle", "footer": "Fußzeile"
     },
     "reset": "Zurücksetzen", "exportJson": "JSON exportieren", "importJson": "JSON importieren", "importError": "Ungültige JSON-Datei"
+  },
+  "shortcuts": {
+    "title": "Tastaturkürzel",
+    "subtitle": "BellePoule wie ein Profi meistern",
+    "footer": "Drücken Sie ? um diese Hilfe jederzeit anzuzeigen",
+    "category_all": "Alle",
+    "category_global": "Global",
+    "category_navigation": "Navigation",
+    "category_actions": "Aktionen",
+    "category_competition": "Wettkampf",
+    "show_help": "Hilfe für Tastaturkürzel anzeigen",
+    "quick_search": "Schnellsuche",
+    "close_modal": "Modal schließen / Abbrechen",
+    "go_pools": "Zu den Poules",
+    "go_tableau": "Zum Tableau",
+    "go_results": "Zu den Ergebnissen",
+    "nav_fields": "Zwischen Feldern navigieren",
+    "save": "Speichern",
+    "undo": "Rückgängig",
+    "redo": "Wiederholen",
+    "new_competition": "Neuer Wettkampf",
+    "refresh_data": "Daten aktualisieren",
+    "timer": "Stoppuhr starten/pausieren",
+    "nav_list": "In der Liste navigieren",
+    "validate": "Bestätigen / Öffnen"
   }
 }

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -1,6 +1,12 @@
 {
   "app": {
-    "title": "BellePoule Modern"
+    "title": "BellePoule Modern",
+    "home": "General",
+    "back_to_list": "Back to competition list",
+    "close_tab": "Close tab",
+    "load_error_title": "Loading Error",
+    "load_error_message": "An error occurred while loading the competition list.",
+    "reload": "Reload Application"
   },
   "menu": {
     "new_competition": "New Competition",
@@ -215,7 +221,8 @@
     "warning": "Warning",
     "info": "Information",
     "connection_lost": "Connection lost",
-    "connection_restored": "Connection restored"
+    "connection_restored": "Connection restored",
+    "name_required": "Last name and first name are required"
   },
   "time": {
     "minutes": "minutes",
@@ -237,5 +244,30 @@
       "ranking-table": "Ranking table", "footer": "Footer"
     },
     "reset": "Reset", "exportJson": "Export JSON", "importJson": "Import JSON", "importError": "Invalid JSON file"
+  },
+  "shortcuts": {
+    "title": "Keyboard Shortcuts",
+    "subtitle": "Master BellePoule like a pro",
+    "footer": "Press ? to show this help at any time",
+    "category_all": "All",
+    "category_global": "Global",
+    "category_navigation": "Navigation",
+    "category_actions": "Actions",
+    "category_competition": "Competition",
+    "show_help": "Show shortcuts help",
+    "quick_search": "Quick search",
+    "close_modal": "Close modal / Cancel",
+    "go_pools": "Go to pools",
+    "go_tableau": "Go to tableau",
+    "go_results": "Go to results",
+    "nav_fields": "Navigate between fields",
+    "save": "Save",
+    "undo": "Undo",
+    "redo": "Redo",
+    "new_competition": "New competition",
+    "refresh_data": "Refresh data",
+    "timer": "Start/Pause timer",
+    "nav_list": "Navigate in list",
+    "validate": "Validate / Open"
   }
 }

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -1,6 +1,12 @@
 {
   "app": {
-    "title": "BellePoule Modern"
+    "title": "BellePoule Modern",
+    "home": "General",
+    "back_to_list": "Volver a la lista de competiciones",
+    "close_tab": "Cerrar pestaña",
+    "load_error_title": "Error de carga",
+    "load_error_message": "Ocurrió un error al cargar la lista de competiciones.",
+    "reload": "Recargar la aplicación"
   },
   "menu": {
     "new_competition": "Nueva Competición",
@@ -215,7 +221,8 @@
     "warning": "Advertencia",
     "info": "Información",
     "connection_lost": "Conexión perdida",
-    "connection_restored": "Conexión restaurada"
+    "connection_restored": "Conexión restaurada",
+    "name_required": "El apellido y el nombre son obligatorios"
   },
   "time": {
     "minutes": "minutos",
@@ -237,5 +244,30 @@
       "ranking-table": "Tabla de clasificación", "footer": "Pie de página"
     },
     "reset": "Restablecer", "exportJson": "Exportar JSON", "importJson": "Importar JSON", "importError": "Archivo JSON inválido"
+  },
+  "shortcuts": {
+    "title": "Atajos de Teclado",
+    "subtitle": "Domina BellePoule como un profesional",
+    "footer": "Presiona ? para mostrar esta ayuda en cualquier momento",
+    "category_all": "Todos",
+    "category_global": "Global",
+    "category_navigation": "Navegación",
+    "category_actions": "Acciones",
+    "category_competition": "Competición",
+    "show_help": "Mostrar ayuda de atajos",
+    "quick_search": "Búsqueda rápida",
+    "close_modal": "Cerrar modal / Cancelar",
+    "go_pools": "Ir a grupos",
+    "go_tableau": "Ir al cuadro",
+    "go_results": "Ir a resultados",
+    "nav_fields": "Navegar entre campos",
+    "save": "Guardar",
+    "undo": "Deshacer",
+    "redo": "Rehacer",
+    "new_competition": "Nueva competición",
+    "refresh_data": "Actualizar datos",
+    "timer": "Iniciar/Pausar cronómetro",
+    "nav_list": "Navegar en la lista",
+    "validate": "Validar / Abrir"
   }
 }

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -1,6 +1,12 @@
 {
   "app": {
-    "title": "BellePoule Modern"
+    "title": "BellePoule Modern",
+    "home": "Général",
+    "back_to_list": "Revenir à la liste des compétitions",
+    "close_tab": "Fermer l'onglet",
+    "load_error_title": "Erreur de chargement",
+    "load_error_message": "Une erreur est survenue lors du chargement de la liste des compétitions.",
+    "reload": "Recharger l'application"
   },
   "menu": {
     "new_competition": "Nouvelle compétition",
@@ -215,7 +221,8 @@
     "warning": "Avertissement",
     "info": "Information",
     "connection_lost": "Connexion perdue",
-    "connection_restored": "Connexion rétablie"
+    "connection_restored": "Connexion rétablie",
+    "name_required": "Le nom et le prénom sont obligatoires"
   },
   "time": {
     "minutes": "minutes",
@@ -253,5 +260,30 @@
     "exportJson": "Exporter JSON",
     "importJson": "Importer JSON",
     "importError": "Fichier JSON invalide"
+  },
+  "shortcuts": {
+    "title": "Raccourcis Clavier",
+    "subtitle": "Maîtrisez BellePoule comme un pro",
+    "footer": "Appuyez sur ? pour afficher cette aide à tout moment",
+    "category_all": "Tous",
+    "category_global": "Globaux",
+    "category_navigation": "Navigation",
+    "category_actions": "Actions",
+    "category_competition": "Compétition",
+    "show_help": "Afficher l'aide des raccourcis",
+    "quick_search": "Recherche rapide",
+    "close_modal": "Fermer la modale / Annuler",
+    "go_pools": "Aller aux poules",
+    "go_tableau": "Aller au tableau",
+    "go_results": "Aller aux résultats",
+    "nav_fields": "Navigation entre champs",
+    "save": "Sauvegarder",
+    "undo": "Annuler (Undo)",
+    "redo": "Refaire (Redo)",
+    "new_competition": "Nouvelle compétition",
+    "refresh_data": "Rafraîchir les données",
+    "timer": "Démarrer/Pause le chronomètre",
+    "nav_list": "Naviguer dans la liste",
+    "validate": "Valider / Ouvrir"
   }
 }

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -1,6 +1,12 @@
 {
   "app": {
-    "title": "BellePoule Modern"
+    "title": "BellePoule Modern",
+    "home": "主頁",
+    "back_to_list": "返回比賽列表",
+    "close_tab": "關閉標籤",
+    "load_error_title": "載入錯誤",
+    "load_error_message": "載入比賽列表時發生錯誤。",
+    "reload": "重新載入應用程式"
   },
   "menu": {
     "new_competition": "新增比賽",
@@ -215,7 +221,8 @@
     "warning": "警告",
     "info": "資訊",
     "connection_lost": "連線中斷",
-    "connection_restored": "連線已恢復"
+    "connection_restored": "連線已恢復",
+    "name_required": "姓和名為必填欄位"
   },
   "time": {
     "minutes": "分鐘",
@@ -237,5 +244,30 @@
       "ranking-table": "排名表", "footer": "頁尾"
     },
     "reset": "重設", "exportJson": "匯出JSON", "importJson": "匯入JSON", "importError": "JSON檔案無效"
+  },
+  "shortcuts": {
+    "title": "鍵盤快捷鍵",
+    "subtitle": "像專業人士一樣掌握 BellePoule",
+    "footer": "隨時按 ? 顯示此說明",
+    "category_all": "全部",
+    "category_global": "全域",
+    "category_navigation": "導航",
+    "category_actions": "操作",
+    "category_competition": "比賽",
+    "show_help": "顯示快捷鍵說明",
+    "quick_search": "快速搜尋",
+    "close_modal": "關閉視窗 / 取消",
+    "go_pools": "前往分組賽",
+    "go_tableau": "前往淘汰賽",
+    "go_results": "前往成績",
+    "nav_fields": "欄位間導航",
+    "save": "儲存",
+    "undo": "復原",
+    "redo": "重做",
+    "new_competition": "新增比賽",
+    "refresh_data": "重新整理資料",
+    "timer": "開始/暫停計時器",
+    "nav_list": "在列表中導航",
+    "validate": "確認 / 開啟"
   }
 }


### PR DESCRIPTION
## Summary

- Nouvelles clés \`app.*\` (home, back_to_list, close_tab, erreurs de chargement) dans les 7 langues (fr, en, de, es, br, ca, zh-HK)
- Nouvelle section \`shortcuts.*\` (25 clés) pour le composant d'aide aux raccourcis clavier
- \`messages.name_required\` pour la validation du formulaire d'ajout de tireur
- \`main.ts\` : dialogs **saisie distante** (démarrer/arrêter/kiosk/partager), **fichiers** (ouvrir/enregistrer/importer), **à propos** — traduits en fr/en/de/zh-HK via \`MENU_LABELS\` + helper \`getL()\`
- \`App.tsx\` : 6 strings hardcodées remplacées par \`t()\`
- \`AddFencerModal.tsx\` : 12 labels/boutons traduits + import \`useTranslation\`
- \`KeyboardShortcutsHelp.tsx\` : refactoring complet — toutes les descriptions et catégories passent par \`t()\`

## Test plan

- [ ] Changer la langue en cantonais (zh-HK) et vérifier : menu saisie distante, dialogs démarrer/arrêter, dialog à propos, modale ajout tireur, aide raccourcis clavier
- [ ] Vérifier que le menu "Compétition > Propriétés" s'affiche correctement en toutes les langues
- [ ] Lancer la saisie distante et vérifier que le dialog affiche les URLs arènes + kiosk + instruction partage dans la bonne langue
- [ ] Vérifier que l'aide raccourcis (touche ?) affiche correctement toutes les catégories et descriptions traduites
- [ ] Tester l'import/export de fichiers — titres de dialogs traduits

🤖 Generated with [Claude Code](https://claude.com/claude-code)