### PR TITLE
fix: corriger les crashs de la fonctionnalité Analytics

### DIFF
--- a/src/features/analytics/hooks/useAnalyticsStore.ts
+++ b/src/features/analytics/hooks/useAnalyticsStore.ts
@@ -2,8 +2,26 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { useShallow } from 'zustand/shallow';
-import { AnalyticsState, AnalyticsActions } from '../types/analytics.types';
 import { AnalyticsService } from '../services/analyticsService';
+
+interface FencerStats { [key: string]: unknown }
+interface CompetitionMetrics { [key: string]: unknown }
+interface PredictionResult { [key: string]: unknown }
+
+interface AnalyticsState {
+  fencerStats: FencerStats[];
+  competitionMetrics: CompetitionMetrics | null;
+  predictions: PredictionResult[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface AnalyticsActions {
+  loadFencerStats: (competitionId: string) => Promise<void>;
+  loadCompetitionMetrics: (competitionId: string) => Promise<void>;
+  predictMatch: (fencerAId: string, fencerBId: string) => Promise<PredictionResult>;
+  clearError: () => void;
+}
 
 const service = new AnalyticsService();
 

--- a/src/features/analytics/index.ts
+++ b/src/features/analytics/index.ts
@@ -1,33 +1,3 @@
-/**
- * BellePoule Modern - Analytics Feature
- * Main entry point for analytics functionality
- * Licensed under GPL-3.0
- */
-
-// Components
-export { AnalyticsDashboard } from './components/AnalyticsDashboard';
-export { StatsChart } from './components/StatsChart';
-export { PerformanceGraph } from './components/PerformanceGraph';
-
-// Hooks
-export { useAnalytics } from './hooks/useAnalytics';
 export { useAnalyticsStore } from './hooks/useAnalyticsStore';
-
-// Services
 export { AnalyticsService } from './services/analyticsService';
-
-// Types
-export type {
-  AnalyticsState,
-  AnalyticsActions,
-  FencerStats,
-  CompetitionMetrics,
-  PredictionResult,
-} from './types/analytics.types';
-
-// Utils
-export {
-  calculateWinProbability,
-  predictMatchDuration,
-  analyzeFencerPerformance,
-} from './utils/analyticsCalculations';
+export type { CompetitionStats } from './services/analyticsService';

--- a/src/renderer/components/AnalyticsDashboard.tsx
+++ b/src/renderer/components/AnalyticsDashboard.tsx
@@ -44,7 +44,7 @@ interface PoolProgress {
   projectedFinishTime: Date;
 }
 
-interface AnalyticsDashboardProps {
+export interface AnalyticsDashboardProps {
   competition: Competition;
   pools: Pool[];
   matches: Match[];
@@ -52,6 +52,214 @@ interface AnalyticsDashboardProps {
   className?: string;
   onClose?: () => void;
 }
+
+// ── Pure helper functions (defined outside component to avoid TDZ and re-creation) ──
+
+function filterMatchesByTimeframe(matchList: Match[], timeframe: string): Match[] {
+  if (timeframe === 'all') return matchList;
+
+  const now = new Date();
+  const cutoffTime = new Date(now.getTime() - (timeframe === 'last30min' ? 30 : 5) * 60 * 1000);
+
+  return matchList.filter(match => {
+    if (!match.updatedAt) return false;
+    return new Date(match.updatedAt) >= cutoffTime;
+  });
+}
+
+function calculateAverageMatchDuration(matches: Match[]): number {
+  if (matches.length === 0) return 0;
+
+  const durations = matches
+    .map(match => {
+      if (!match.createdAt || !match.updatedAt) return 0;
+      return new Date(match.updatedAt).getTime() - new Date(match.createdAt).getTime();
+    })
+    .filter(d => d > 0);
+
+  return durations.length > 0 ? durations.reduce((a, b) => a + b, 0) / durations.length : 0;
+}
+
+function calculateCurrentStreak(fencer: Fencer, matches: Match[]): number {
+  const fencerMatches = matches
+    .filter(m => m.fencerA?.id === fencer.id || m.fencerB?.id === fencer.id)
+    .sort((a, b) => new Date(b.updatedAt || 0).getTime() - new Date(a.updatedAt || 0).getTime());
+
+  let streak = 0;
+  for (const match of fencerMatches) {
+    const isA = match.fencerA?.id === fencer.id;
+    const score = isA ? match.scoreA : match.scoreB;
+
+    if (score?.isVictory) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+function calculateBestStreak(_fencer: Fencer, _matches: Match[]): number {
+  return 0;
+}
+
+function calculateRecentForm(
+  fencer: Fencer,
+  matches: Match[]
+): 'excellent' | 'good' | 'average' | 'poor' {
+  const recentMatches = matches
+    .filter(m => m.fencerA?.id === fencer.id || m.fencerB?.id === fencer.id)
+    .slice(-5);
+
+  if (recentMatches.length === 0) return 'average';
+
+  const victories = recentMatches.filter(m => {
+    const isA = m.fencerA?.id === fencer.id;
+    const score = isA ? m.scoreA : m.scoreB;
+    return score?.isVictory;
+  }).length;
+
+  const winRate = victories / recentMatches.length;
+
+  if (winRate >= 0.8) return 'excellent';
+  if (winRate >= 0.6) return 'good';
+  if (winRate >= 0.4) return 'average';
+  return 'poor';
+}
+
+function calculateFencerPerformance(
+  fencerList: Fencer[],
+  matches: Match[]
+): FencerPerformance[] {
+  return fencerList
+    .map(fencer => {
+      const fencerMatches = matches.filter(
+        m =>
+          (m.fencerA?.id === fencer.id || m.fencerB?.id === fencer.id) &&
+          m.status === MatchStatus.FINISHED
+      );
+
+      const victories = fencerMatches.filter(m => {
+        const isA = m.fencerA?.id === fencer.id;
+        const score = isA ? m.scoreA : m.scoreB;
+        return score?.isVictory;
+      }).length;
+
+      const totalScored = fencerMatches.reduce((total, match) => {
+        const isA = match.fencerA?.id === fencer.id;
+        const score = isA ? match.scoreA : match.scoreB;
+        return total + (score?.value || 0);
+      }, 0);
+
+      const totalReceived = fencerMatches.reduce((total, match) => {
+        const isA = match.fencerA?.id === fencer.id;
+        const score = isA ? match.scoreB : match.scoreA;
+        return total + (score?.value || 0);
+      }, 0);
+
+      const currentStreak = calculateCurrentStreak(fencer, matches);
+      const bestStreak = calculateBestStreak(fencer, matches);
+      const recentForm = calculateRecentForm(fencer, matches);
+
+      return {
+        fencer,
+        victoryRate: fencerMatches.length > 0 ? victories / fencerMatches.length : 0,
+        averageScore: fencerMatches.length > 0 ? totalScored / fencerMatches.length : 0,
+        touchesScoredPerMatch: fencerMatches.length > 0 ? totalScored / fencerMatches.length : 0,
+        touchesReceivedPerMatch:
+          fencerMatches.length > 0 ? totalReceived / fencerMatches.length : 0,
+        currentStreak,
+        bestStreak,
+        recentForm,
+      };
+    })
+    .sort((a, b) => b.victoryRate - a.victoryRate);
+}
+
+function calculateWeaponStats(matches: Match[]): WeaponStats {
+  const margins = matches
+    .map(m => {
+      if (m.status !== MatchStatus.FINISHED) return 0;
+      return Math.abs((m.scoreA?.value || 0) - (m.scoreB?.value || 0));
+    })
+    .filter(m => m > 0);
+
+  const totalTouches = matches.map(m => (m.scoreA?.value || 0) + (m.scoreB?.value || 0));
+  const mostTouchingMatch = totalTouches.length > 0 ? Math.max(...totalTouches) : 0;
+
+  return {
+    totalMatches: matches.length,
+    averageVictoryMargin:
+      margins.length > 0 ? margins.reduce((a, b) => a + b, 0) / margins.length : 0,
+    longestMatch: 0,
+    shortestMatch: 0,
+    mostTouchingMatch,
+  };
+}
+
+function calculatePoolProgress(pools: Pool[], matches: Match[]): PoolProgress[] {
+  return pools.map(pool => {
+    const poolMatches = matches.filter(m =>
+      (pool.matches ?? []).some(pm => pm.id === m.id)
+    );
+
+    const completed = poolMatches.filter(m => m.status === MatchStatus.FINISHED).length;
+    const completionPercentage =
+      poolMatches.length > 0 ? (completed / poolMatches.length) * 100 : 0;
+
+    return {
+      poolId: pool.id,
+      poolNumber: pool.number || 0,
+      completionPercentage,
+      averageTimeRemaining: 0,
+      projectedFinishTime: new Date(),
+    };
+  });
+}
+
+function calculateAnalytics(
+  _comp: Competition,
+  poolList: Pool[],
+  matchList: Match[],
+  fencerList: Fencer[],
+  timeframe: string
+): AnalyticsData {
+  const filteredMatches = filterMatchesByTimeframe(matchList, timeframe);
+  const completedMatches = filteredMatches.filter(match => match.status === MatchStatus.FINISHED);
+
+  return {
+    totalFencers: fencerList.length,
+    completedMatches: completedMatches.length,
+    totalMatches: filteredMatches.length,
+    averageMatchDuration: calculateAverageMatchDuration(completedMatches),
+    fencerPerformance: calculateFencerPerformance(fencerList, completedMatches),
+    weaponStats: calculateWeaponStats(completedMatches),
+    poolProgress: calculatePoolProgress(poolList, filteredMatches),
+  };
+}
+
+function formatTime(milliseconds: number): string {
+  const minutes = Math.floor(milliseconds / 60000);
+  const seconds = Math.floor((milliseconds % 60000) / 1000);
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function getFormColor(form: string): string {
+  switch (form) {
+    case 'excellent':
+      return 'text-green-600 bg-green-100';
+    case 'good':
+      return 'text-blue-600 bg-blue-100';
+    case 'average':
+      return 'text-yellow-600 bg-yellow-100';
+    case 'poor':
+      return 'text-red-600 bg-red-100';
+    default:
+      return 'text-gray-600 bg-gray-100';
+  }
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
 
 export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
   competition,
@@ -65,227 +273,20 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [lastUpdate, setLastUpdate] = useState(new Date());
 
-  const analyticsData = useMemo(() => {
-    return calculateAnalytics(competition, pools, matches, fencers, selectedTimeframe);
-  }, [competition, pools, matches, fencers, selectedTimeframe]);
+  const analyticsData = useMemo(
+    () => calculateAnalytics(competition, pools, matches, fencers, selectedTimeframe),
+    [competition, pools, matches, fencers, selectedTimeframe]
+  );
 
-  // Auto-refresh for live data
   useEffect(() => {
     if (!autoRefresh || selectedTimeframe !== 'live') return;
 
     const interval = setInterval(() => {
       setLastUpdate(new Date());
-    }, 5000); // Update every 5 seconds
+    }, 5000);
 
     return () => clearInterval(interval);
   }, [autoRefresh, selectedTimeframe]);
-
-  const filterMatchesByTimeframe = (matchList: Match[], timeframe: string): Match[] => {
-    if (timeframe === 'all') return matchList;
-
-    const now = new Date();
-    const cutoffTime = new Date(now.getTime() - (timeframe === 'last30min' ? 30 : 5) * 60 * 1000);
-
-    return matchList.filter(match => {
-      if (!match.updatedAt) return false;
-      return new Date(match.updatedAt) >= cutoffTime;
-    });
-  };
-
-  const calculateAnalytics = (
-    comp: Competition,
-    poolList: Pool[],
-    matchList: Match[],
-    fencerList: Fencer[],
-    timeframe: string
-  ): AnalyticsData => {
-    const filteredMatches = filterMatchesByTimeframe(matchList, timeframe);
-    const completedMatches = filteredMatches.filter(match => match.status === MatchStatus.FINISHED);
-
-    return {
-      totalFencers: fencerList.length,
-      completedMatches: completedMatches.length,
-      totalMatches: filteredMatches.length,
-      averageMatchDuration: calculateAverageMatchDuration(completedMatches),
-      fencerPerformance: calculateFencerPerformance(fencerList, completedMatches),
-      weaponStats: calculateWeaponStats(completedMatches),
-      poolProgress: calculatePoolProgress(poolList, filteredMatches),
-    };
-  };
-
-  const calculateAverageMatchDuration = (matches: Match[]): number => {
-    if (matches.length === 0) return 0;
-
-    const durations = matches
-      .map(match => {
-        if (!match.createdAt || !match.updatedAt) return 0;
-        return new Date(match.updatedAt).getTime() - new Date(match.createdAt).getTime();
-      })
-      .filter(d => d > 0);
-
-    return durations.length > 0 ? durations.reduce((a, b) => a + b, 0) / durations.length : 0;
-  };
-
-  const calculateFencerPerformance = (
-    fencerList: Fencer[],
-    matches: Match[]
-  ): FencerPerformance[] => {
-    return fencerList
-      .map(fencer => {
-        const fencerMatches = matches.filter(
-          m =>
-            (m.fencerA?.id === fencer.id || m.fencerB?.id === fencer.id) &&
-            m.status === MatchStatus.FINISHED
-        );
-
-        const victories = fencerMatches.filter(m => {
-          const isA = m.fencerA?.id === fencer.id;
-          const score = isA ? m.scoreA : m.scoreB;
-          return score?.isVictory;
-        }).length;
-
-        const totalScored = fencerMatches.reduce((total, match) => {
-          const isA = match.fencerA?.id === fencer.id;
-          const score = isA ? match.scoreA : match.scoreB;
-          return total + (score?.value || 0);
-        }, 0);
-
-        const totalReceived = fencerMatches.reduce((total, match) => {
-          const isA = match.fencerA?.id === fencer.id;
-          const score = isA ? match.scoreB : match.scoreA;
-          return total + (score?.value || 0);
-        }, 0);
-
-        const currentStreak = calculateCurrentStreak(fencer, matches);
-        const bestStreak = calculateBestStreak(fencer, matches);
-        const recentForm = calculateRecentForm(fencer, matches);
-
-        return {
-          fencer,
-          victoryRate: fencerMatches.length > 0 ? victories / fencerMatches.length : 0,
-          averageScore: fencerMatches.length > 0 ? totalScored / fencerMatches.length : 0,
-          touchesScoredPerMatch: fencerMatches.length > 0 ? totalScored / fencerMatches.length : 0,
-          touchesReceivedPerMatch:
-            fencerMatches.length > 0 ? totalReceived / fencerMatches.length : 0,
-          currentStreak,
-          bestStreak,
-          recentForm,
-        };
-      })
-      .sort((a, b) => b.victoryRate - a.victoryRate);
-  };
-
-  const calculateCurrentStreak = (fencer: Fencer, matches: Match[]): number => {
-    const fencerMatches = matches
-      .filter(m => m.fencerA?.id === fencer.id || m.fencerB?.id === fencer.id)
-      .sort((a, b) => new Date(b.updatedAt || 0).getTime() - new Date(a.updatedAt || 0).getTime());
-
-    let streak = 0;
-    for (const match of fencerMatches) {
-      const isA = match.fencerA?.id === fencer.id;
-      const score = isA ? match.scoreA : match.scoreB;
-
-      if (score?.isVictory) {
-        streak++;
-      } else {
-        break;
-      }
-    }
-    return streak;
-  };
-
-  const calculateBestStreak = (fencer: Fencer, matches: Match[]): number => {
-    // Implementation for calculating historical best streak
-    // This would require more complex analysis of match history
-    return 0; // Placeholder
-  };
-
-  const calculateRecentForm = (
-    fencer: Fencer,
-    matches: Match[]
-  ): 'excellent' | 'good' | 'average' | 'poor' => {
-    const recentMatches = matches
-      .filter(m => m.fencerA?.id === fencer.id || m.fencerB?.id === fencer.id)
-      .slice(-5); // Last 5 matches
-
-    if (recentMatches.length === 0) return 'average';
-
-    const victories = recentMatches.filter(m => {
-      const isA = m.fencerA?.id === fencer.id;
-      const score = isA ? m.scoreA : m.scoreB;
-      return score?.isVictory;
-    }).length;
-
-    const winRate = victories / recentMatches.length;
-
-    if (winRate >= 0.8) return 'excellent';
-    if (winRate >= 0.6) return 'good';
-    if (winRate >= 0.4) return 'average';
-    return 'poor';
-  };
-
-  const calculateWeaponStats = (matches: Match[]): WeaponStats => {
-    const margins = matches
-      .map(m => {
-        if (m.status !== MatchStatus.FINISHED) return 0;
-        const margin = Math.abs((m.scoreA?.value || 0) - (m.scoreB?.value || 0));
-        return margin;
-      })
-      .filter(m => m > 0);
-
-    const totalTouches = matches.map(m => (m.scoreA?.value || 0) + (m.scoreB?.value || 0));
-    const mostTouchingMatch = totalTouches.length > 0 ? Math.max(...totalTouches) : 0;
-
-    return {
-      totalMatches: matches.length,
-      averageVictoryMargin:
-        margins.length > 0 ? margins.reduce((a, b) => a + b, 0) / margins.length : 0,
-      longestMatch: 0, // Would need duration data
-      shortestMatch: 0, // Would need duration data
-      mostTouchingMatch,
-    };
-  };
-
-  const calculatePoolProgress = (pools: Pool[], matches: Match[]): PoolProgress[] => {
-    return pools.map(pool => {
-      const poolMatches = matches.filter(m =>
-        pools.some(p => p.matches.some(pm => pm.id === m.id))
-      );
-
-      const completed = poolMatches.filter(m => m.status === MatchStatus.FINISHED).length;
-      const completionPercentage =
-        poolMatches.length > 0 ? (completed / poolMatches.length) * 100 : 0;
-
-      return {
-        poolId: pool.id,
-        poolNumber: pool.number || 0,
-        completionPercentage,
-        averageTimeRemaining: 0, // Complex calculation based on remaining matches
-        projectedFinishTime: new Date(),
-      };
-    });
-  };
-
-  const formatTime = (milliseconds: number): string => {
-    const minutes = Math.floor(milliseconds / 60000);
-    const seconds = Math.floor((milliseconds % 60000) / 1000);
-    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-  };
-
-  const getFormColor = (form: string): string => {
-    switch (form) {
-      case 'excellent':
-        return 'text-green-600 bg-green-100';
-      case 'good':
-        return 'text-blue-600 bg-blue-100';
-      case 'average':
-        return 'text-yellow-600 bg-yellow-100';
-      case 'poor':
-        return 'text-red-600 bg-red-100';
-      default:
-        return 'text-gray-600 bg-gray-100';
-    }
-  };
 
   return (
     <div className={`analytics-dashboard bg-white rounded-lg shadow-lg p-6 ${className}`}>
@@ -310,13 +311,18 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
           </div>
           <select
             value={selectedTimeframe}
-            onChange={e => setSelectedTimeframe(e.target.value as any)}
+            onChange={e => setSelectedTimeframe(e.target.value as 'live' | 'last30min' | 'all')}
             className="px-3 py-2 border border-gray-300 rounded-md"
           >
             <option value="live">Live</option>
             <option value="last30min">Last 30 min</option>
             <option value="all">All time</option>
           </select>
+          {onClose && (
+            <button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-xl font-bold">
+              ×
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1070,7 +1070,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         <AnalyticsDashboard
           competition={competition}
           pools={pools}
-          matches={pools.flatMap(p => p.matches)}
+          matches={pools.flatMap(p => p.matches ?? [])}
           fencers={fencers}
           onClose={() => setShowAnalytics(false)}
         />


### PR DESCRIPTION
## Summary

- **TDZ ReferenceError (crash principal)** : les fonctions `calculateAnalytics`, `filterMatchesByTimeframe` et autres helpers étaient déclarées avec `const` *après* le `useMemo` qui les appelait dans `AnalyticsDashboard.tsx`. JavaScript ne hisse pas les `const`/`let`, donc React crashait à chaque rendu avec `ReferenceError: Cannot access 'calculateAnalytics' before initialization`. Toutes les fonctions ont été extraites hors du composant.
- **Bug logique `calculatePoolProgress`** : utilisait `pools.some(p => p.matches.some(...))` (toutes les pools) au lieu de `pool.matches.some(...)` (la pool courante). Corrigé avec guard `?? []`.
- **Guard null** : `pools.flatMap(p => p.matches ?? [])` dans `CompetitionView.tsx`.
- **Barrel file cassé** : `src/features/analytics/index.ts` exportait 6 fichiers inexistants (composants, hook, types, utils). Nettoyé pour n'exporter que ce qui existe. `useAnalyticsStore.ts` : types `AnalyticsState`/`AnalyticsActions` définis inline (le fichier `analytics.types.ts` n'existe pas).

## Test plan

- [ ] Ouvrir une compétition avec des poules
- [ ] Cliquer sur "📊 Analytics" → la modale s'affiche sans crash
- [ ] Tester avec pools sans matchs (null guard)
- [ ] Vérifier que la progression des pools s'affiche correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)