### PR TITLE
fix: Analytics modale + CI Node.js 24

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -5,6 +5,9 @@ on:
     branches: [dev]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   increment-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   increment-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,9 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   claude:
     if: |

--- a/src/renderer/components/AnalyticsDashboard.tsx
+++ b/src/renderer/components/AnalyticsDashboard.tsx
@@ -289,7 +289,8 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
   }, [autoRefresh, selectedTimeframe]);
 
   return (
-    <div className={`analytics-dashboard bg-white rounded-lg shadow-lg p-6 ${className}`}>
+    <div className="modal-overlay" onClick={onClose}>
+    <div className={`modal modal--lg analytics-dashboard ${className}`} onClick={e => e.stopPropagation()}>
       {/* Header */}
       <div className="flex justify-between items-center mb-6">
         <div>
@@ -432,6 +433,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
           </div>
         </div>
       </div>
+    </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Correction du bouton Analytics qui ne faisait rien : le composant `AnalyticsDashboard` s'affichait en ligne hors écran au lieu d'une modale — enveloppé dans `modal-overlay` + `modal modal--lg` comme les autres modales
- CI : ajout de `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` dans les 4 workflows GitHub Actions pour supprimer le warning de dépréciation Node.js 20

## Test plan
- [ ] Cliquer sur le bouton 📊 Analytics dans une compétition → la modale s'ouvre en plein écran
- [ ] Cliquer en dehors de la modale ou sur × → la modale se ferme
- [ ] Vérifier que les autres modales (Comparaisons, QR Code) fonctionnent toujours

🤖 Generated with [Claude Code](https://claude.com/claude-code)