### PR TITLE
feat: annonce visuelle carton sur affichages distants

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1546,6 +1546,14 @@ export class RemoteScoreServer {
       cardsA?: string[];
       cardsB?: string[];
       suddenDeath?: boolean;
+      announcement?: {
+        fencer: 'A' | 'B';
+        fencerName: string;
+        cardType: string;
+        isRevalorisation: boolean;
+        fromCard: string | null;
+        toCard: string | null;
+      };
     }
   ): void {
     const arena = this.getArena(data.arenaId);
@@ -1654,6 +1662,14 @@ export class RemoteScoreServer {
             suddenDeath: false,
             status: arena.status,
           });
+        }
+        break;
+      case 'card_announcement':
+        if (data.announcement) {
+          this.io.to(`arena:${data.arenaId}`).emit(
+            `arena:${data.arenaId}:card_announcement`,
+            data.announcement
+          );
         }
         break;
       case 'update_timer':

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -171,6 +171,50 @@
         padding-top: 52px;
       }
 
+      /* ── Bandeau annonce carton ── */
+      .card-announcement-banner {
+        position: fixed;
+        top: 52px;
+        left: 0;
+        right: 0;
+        z-index: 300;
+        padding: 1rem 2rem;
+        text-align: center;
+        font-size: clamp(1.4rem, 3.5vw, 2.4rem);
+        font-weight: 900;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        animation: banner-slide-in 0.35s ease-out;
+        display: none;
+      }
+      .card-announcement-banner.visible {
+        display: block;
+      }
+      .card-announcement-banner.card-white {
+        background: #e5e7eb;
+        color: #111827;
+        border-bottom: 4px solid #9ca3af;
+      }
+      .card-announcement-banner.card-yellow {
+        background: #fbbf24;
+        color: #1c1917;
+        border-bottom: 4px solid #d97706;
+      }
+      .card-announcement-banner.card-red {
+        background: #dc2626;
+        color: #fff;
+        border-bottom: 4px solid #991b1b;
+      }
+      .card-announcement-banner.card-black {
+        background: #111827;
+        color: #f9fafb;
+        border-bottom: 4px solid #374151;
+      }
+      @keyframes banner-slide-in {
+        from { transform: translateY(-100%); opacity: 0; }
+        to   { transform: translateY(0);    opacity: 1; }
+      }
+
       /* ── Bandeau numéro d'arène permanent ── */
       .arena-number-strip {
         position: fixed;
@@ -867,6 +911,8 @@
     </style>
   </head>
   <body>
+    <div id="card-announcement-banner" class="card-announcement-banner"></div>
+
     <div class="arena-number-strip">
       Arène <span id="arena-strip-number">1</span>
     </div>
@@ -1169,6 +1215,33 @@
           this.socket.on(`arena:${this.arenaId}:update`, data => {
             this.handleArenaUpdate(data);
           });
+
+          this.socket.on(`arena:${this.arenaId}:card_announcement`, ann => {
+            this.showCardAnnouncement(ann);
+          });
+        }
+
+        showCardAnnouncement(ann) {
+          const banner = document.getElementById('card-announcement-banner');
+          if (!banner) return;
+
+          let msg;
+          if (ann.isRevalorisation) {
+            const fromLabel = ann.fromCard === 'white' ? 'blanc' : ann.fromCard === 'yellow' ? 'jaune' : ann.fromCard;
+            const toLabel = ann.toCard === 'yellow' ? 'JAUNE' : ann.toCard === 'red' ? 'ROUGE' : ann.toCard.toUpperCase();
+            msg = `⚠️ Revalorisation — 2ème ${fromLabel} → ${toLabel} · ${ann.fencerName}`;
+          } else {
+            const typeLabel = ann.cardType === 'white' ? 'BLANC' : ann.cardType === 'yellow' ? 'JAUNE' : ann.cardType === 'red' ? 'ROUGE' : 'NOIR';
+            msg = `Carton ${typeLabel} · ${ann.fencerName}`;
+          }
+
+          banner.textContent = msg;
+          banner.className = `card-announcement-banner visible card-${ann.cardType}`;
+
+          if (this._cardAnnouncementTimer) clearTimeout(this._cardAnnouncementTimer);
+          this._cardAnnouncementTimer = setTimeout(() => {
+            banner.className = 'card-announcement-banner';
+          }, 5000);
         }
 
         updateConnectionStatus(connected) {

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -31,6 +31,40 @@
         flex-direction: column;
       }
 
+      /* ── Bandeau annonce carton ── */
+      .card-announcement-banner {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 300;
+        padding: 1rem 2rem;
+        text-align: center;
+        font-size: clamp(1.4rem, 3.5vw, 2.4rem);
+        font-weight: 900;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        animation: banner-slide-in 0.35s ease-out;
+        display: none;
+      }
+      .card-announcement-banner.visible { display: block; }
+      .card-announcement-banner.card-white {
+        background: #e5e7eb; color: #111827; border-bottom: 4px solid #9ca3af;
+      }
+      .card-announcement-banner.card-yellow {
+        background: #fbbf24; color: #1c1917; border-bottom: 4px solid #d97706;
+      }
+      .card-announcement-banner.card-red {
+        background: #dc2626; color: #fff; border-bottom: 4px solid #991b1b;
+      }
+      .card-announcement-banner.card-black {
+        background: #111827; color: #f9fafb; border-bottom: 4px solid #374151;
+      }
+      @keyframes banner-slide-in {
+        from { transform: translateY(-100%); opacity: 0; }
+        to   { transform: translateY(0);    opacity: 1; }
+      }
+
       .header {
         background: rgba(0, 0, 0, 0.4);
         padding: 0.4rem 1rem;
@@ -558,6 +592,8 @@
     </style>
   </head>
   <body>
+    <div id="card-announcement-banner" class="card-announcement-banner"></div>
+
     <div class="header">
       <div class="arena-title">
         <span>⚔️</span>
@@ -729,6 +765,33 @@
           this.socket.on(`arena:${this.arenaId}:update`, data => {
             this.handleArenaUpdate(data);
           });
+
+          this.socket.on(`arena:${this.arenaId}:card_announcement`, ann => {
+            this.showCardAnnouncement(ann);
+          });
+        }
+
+        showCardAnnouncement(ann) {
+          const banner = document.getElementById('card-announcement-banner');
+          if (!banner) return;
+
+          let msg;
+          if (ann.isRevalorisation) {
+            const fromLabel = ann.fromCard === 'white' ? 'blanc' : ann.fromCard === 'yellow' ? 'jaune' : ann.fromCard;
+            const toLabel = ann.toCard === 'yellow' ? 'JAUNE' : ann.toCard === 'red' ? 'ROUGE' : ann.toCard.toUpperCase();
+            msg = `⚠️ Revalorisation — 2ème ${fromLabel} → ${toLabel} · ${ann.fencerName}`;
+          } else {
+            const typeLabel = ann.cardType === 'white' ? 'BLANC' : ann.cardType === 'yellow' ? 'JAUNE' : ann.cardType === 'red' ? 'ROUGE' : 'NOIR';
+            msg = `Carton ${typeLabel} · ${ann.fencerName}`;
+          }
+
+          banner.textContent = msg;
+          banner.className = `card-announcement-banner visible card-${ann.cardType}`;
+
+          if (this._cardAnnouncementTimer) clearTimeout(this._cardAnnouncementTimer);
+          this._cardAnnouncementTimer = setTimeout(() => {
+            banner.className = 'card-announcement-banner';
+          }, 5000);
         }
 
         updateConnectionStatus(connected) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -301,6 +301,39 @@
         color: #ef4444;
       }
 
+      /* Toggle annonce carton */
+      .card-announce-bar {
+        display: flex;
+        justify-content: center;
+        margin: 0.4rem 0 0.2rem;
+      }
+      .card-announce-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-radius: 2rem;
+        border: 2px solid #4b5563;
+        background: rgba(255,255,255,0.05);
+        color: #d1d5db;
+        font-size: 0.85rem;
+        font-weight: 600;
+        cursor: pointer;
+        user-select: none;
+        transition: all 0.2s;
+      }
+      .card-announce-toggle:has(input:checked) {
+        border-color: #f59e0b;
+        background: rgba(245,158,11,0.15);
+        color: #fbbf24;
+      }
+      .card-announce-toggle input {
+        accent-color: #f59e0b;
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+      }
+
       /* Chronomètre */
       .timer-section {
         background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
@@ -807,6 +840,14 @@
               </button>
             </div>
           </div>
+        </div>
+
+        <!-- Toggle annonce carton -->
+        <div class="card-announce-bar">
+          <label class="card-announce-toggle">
+            <input type="checkbox" id="carton-avancer-toggle">
+            📣 Carton avancer
+          </label>
         </div>
 
         <!-- Chronomètre -->
@@ -1452,11 +1493,17 @@
           const cards = fencer === 'A' ? this.cardsA : this.cardsB;
           const otherFencer = fencer === 'A' ? 'B' : 'A';
 
+          // Détecter la revalorisation avant conversion
+          let isRevalorisation = false;
+          let fromCard = null;
+
           // Logique des cartons
           if (cardType === 'white') {
             const whiteCount = cards.filter(c => c === 'white').length;
             if (whiteCount >= 1) {
               // Deuxième blanc = jaune automatique
+              isRevalorisation = true;
+              fromCard = 'white';
               cardType = 'yellow';
               this.showNotification('⚠️ 2ème blanc = Jaune automatique');
             }
@@ -1487,6 +1534,25 @@
           this.updateCardsDisplay();
           this.broadcastUpdate();
           this.saveScore();
+
+          // Annonce carton si case cochée
+          const toggle = document.getElementById('carton-avancer-toggle');
+          if (toggle && toggle.checked) {
+            const nameEl = document.getElementById(`fencer-${fencer.toLowerCase()}-name`);
+            const fencerName = nameEl ? nameEl.textContent.trim() : `Tireur ${fencer}`;
+            this.socket.emit('arena_control', {
+              arenaId: this.arenaId,
+              action: 'card_announcement',
+              announcement: {
+                fencer,
+                fencerName,
+                cardType,
+                isRevalorisation,
+                fromCard: isRevalorisation ? fromCard : null,
+                toCard: isRevalorisation ? cardType : null,
+              },
+            });
+          }
         }
 
         // ── Historique / Undo ─────────────────────────────────────────────────


### PR DESCRIPTION
Ajoute une case à cocher "📣 Carton avancer" dans l'interface arbitre.
Quand elle est cochée, un bandeau coloré plein-écran s'affiche 5 secondes
sur arena.html et public.html en indiquant le carton donné et, le cas
échéant, la revalorisation (ex. 2ème blanc → JAUNE).

- referee.html : toggle CSS + HTML + logique dans addCard() + émission
  socket `card_announcement`
- remoteScoreServer.ts : nouveau case `card_announcement` qui relay
  l'annonce aux clients de l'arène
- arena.html / public.html : CSS bandeau + div#card-announcement-banner +
  listener socket + méthode showCardAnnouncement()

https://claude.ai/code/session_01HvxFxyR3TjjRQ1piCbR8nb