### PR TITLE
feat: annonce visuelle de carton avec sélection de raison

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1508,6 +1508,19 @@ ipcMain.handle('remote:updateShowPhotos', async (_, value: boolean) => {
   }
 });
 
+ipcMain.handle('remote:updateCardAnnounce', async (_, value: boolean) => {
+  try {
+    if (!remoteScoreServer) {
+      return { success: false, error: 'Le serveur distant n est pas démarré' };
+    }
+    remoteScoreServer.updateCardAnnounce(value);
+    return { success: true };
+  } catch (error) {
+    console.error('Error updating cardAnnounce:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle('remote:updateTheme', async (_, theme: string) => {
   try {
     if (!remoteScoreServer) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -428,6 +428,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getArenas: () => ipcRenderer.invoke('remote:getArenas'),
     updateStripCount: (count: number) => ipcRenderer.invoke('remote:updateStripCount', count),
     updateShowPhotos: (value: boolean) => ipcRenderer.invoke('remote:updateShowPhotos', value),
+    updateCardAnnounce: (value: boolean) => ipcRenderer.invoke('remote:updateCardAnnounce', value),
     updateTheme: (theme: string) => ipcRenderer.invoke('remote:updateTheme', theme),
     updateKioskViews: (views: { poules: boolean; classement: boolean; direct: boolean; suivants: boolean }) =>
       ipcRenderer.invoke('remote:updateKioskViews', views),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -41,6 +41,7 @@ export class RemoteScoreServer {
   private poolFencersCache: Map<string, any[]> = new Map(); // Tireurs par poolId (depuis le renderer)
   private sessionMatchScores: Map<string, { scoreA: any; scoreB: any; status: string }> = new Map(); // Scores en mémoire
   private sessionShowPhotos: boolean = false; // Afficher les photos des combattants avant le combat
+  private sessionCardAnnounce: boolean = false; // Annoncer les cartons avec raison sur les affichages
   private sessionTheme: DisplayTheme = 'dark'; // Thème visuel de l'affichage distant (global)
   private arenaThemeOverrides: Map<string, { theme: DisplayTheme; customTheme?: CustomTheme }> = new Map();
   private orgNote: OrgNote | null = null; // Note d'organisation affichée sur le kiosk
@@ -2438,6 +2439,7 @@ export class RemoteScoreServer {
     const updateWithPhotos: ArenaUpdate = {
       ...update,
       showPhotos: this.sessionShowPhotos,
+      cardAnnounce: this.sessionCardAnnounce,
       theme: override?.theme ?? this.sessionTheme,
       customTheme: override?.customTheme,
     };
@@ -2570,7 +2572,8 @@ export class RemoteScoreServer {
     strips: number,
     matchesFromRenderer?: any[],
     showPhotos?: boolean,
-    kioskViews?: { poules: boolean; classement: boolean; direct: boolean; suivants: boolean }
+    kioskViews?: { poules: boolean; classement: boolean; direct: boolean; suivants: boolean },
+    cardAnnounce?: boolean
   ): Promise<RemoteSession> {
     if (this.session) {
       throw new Error('Session déjà active');
@@ -2583,6 +2586,9 @@ export class RemoteScoreServer {
 
     // Stocker le réglage d'affichage des photos
     this.sessionShowPhotos = showPhotos ?? false;
+
+    // Stocker le réglage d'annonce de carton
+    this.sessionCardAnnounce = cardAnnounce ?? false;
 
     // Stocker les vues kiosk activées
     this.sessionKioskViews = kioskViews ?? { poules: true, classement: true, direct: true, suivants: true };
@@ -2904,6 +2910,20 @@ export class RemoteScoreServer {
         status: arena.status,
         fencerA: arena.currentMatch?.fencerA,
         fencerB: arena.currentMatch?.fencerB,
+      });
+    }
+  }
+
+  public updateCardAnnounce(value: boolean): void {
+    if (!this.session) throw new Error('Aucune session active');
+    this.sessionCardAnnounce = value;
+    for (const [arenaId, arena] of this.arenas.entries()) {
+      this.broadcastArenaUpdate(arenaId, {
+        arenaId,
+        match: arena.currentMatch,
+        scoreA: arena.currentMatch?.scoreA,
+        scoreB: arena.currentMatch?.scoreB,
+        status: arena.status,
       });
     }
   }

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -302,6 +302,7 @@
       }
 
       /* ── Modal sélecteur de raison ── */
+      /* (le toggle "Carton avancer" est géré dans les paramètres de saisie distante) */
       .reason-selector-overlay {
         display: none;
         position: fixed;
@@ -389,39 +390,6 @@
         touch-action: manipulation;
       }
       .reason-cancel-btn:hover { background: #374151; }
-
-      /* Toggle annonce carton */
-      .card-announce-bar {
-        display: flex;
-        justify-content: center;
-        margin: 0.4rem 0 0.2rem;
-      }
-      .card-announce-toggle {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.5rem 1rem;
-        border-radius: 2rem;
-        border: 2px solid #4b5563;
-        background: rgba(255,255,255,0.05);
-        color: #d1d5db;
-        font-size: 0.85rem;
-        font-weight: 600;
-        cursor: pointer;
-        user-select: none;
-        transition: all 0.2s;
-      }
-      .card-announce-toggle:has(input:checked) {
-        border-color: #f59e0b;
-        background: rgba(245,158,11,0.15);
-        color: #fbbf24;
-      }
-      .card-announce-toggle input {
-        accent-color: #f59e0b;
-        width: 16px;
-        height: 16px;
-        cursor: pointer;
-      }
 
       /* Chronomètre */
       .timer-section {
@@ -931,14 +899,6 @@
           </div>
         </div>
 
-        <!-- Toggle annonce carton -->
-        <div class="card-announce-bar">
-          <label class="card-announce-toggle">
-            <input type="checkbox" id="carton-avancer-toggle">
-            📣 Carton avancer
-          </label>
-        </div>
-
         <!-- Chronomètre -->
         <div class="timer-section">
           <div class="timer-display" id="timer-display">03:00</div>
@@ -1214,6 +1174,7 @@
           this.isLaserSabre = false;
           this.isSuddenDeath = false;
           this.actionHistory = []; // Historique pour undo (max 10)
+          this.cardAnnounceEnabled = false; // Réglé depuis les paramètres de saisie distante
           this.offlineQueue = new OfflineQueueInline();
 
           this.init();
@@ -1660,8 +1621,7 @@
         // ── Gestion carton avec sélecteur de raison ──────────────────────────
 
         handleCardButtonPress(fencer, cardType) {
-          const toggle = document.getElementById('carton-avancer-toggle');
-          if (toggle && toggle.checked) {
+          if (this.cardAnnounceEnabled) {
             this.openReasonSelector(fencer, cardType);
           } else {
             this.addCard(fencer, cardType);
@@ -2205,6 +2165,10 @@
         }
 
         handleArenaUpdate(data) {
+          if (data.cardAnnounce !== undefined) {
+            this.cardAnnounceEnabled = data.cardAnnounce;
+          }
+
           // Nouveau match prêt côté serveur (chargement automatique après fin de match)
           if (data.status === 'ready' && data.match && data.match.id) {
             // Ignorer si c'est déjà notre match actuel

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -63,6 +63,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const [arenaPasswords, setArenaPasswords] = useState<Record<string, string>>({});
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [showPhotos, setShowPhotos] = useState(false);
+  const [cardAnnounce, setCardAnnounce] = useState(false);
   const [displayTheme, setDisplayTheme] = useState<'dark' | 'light' | 'neon'>('dark');
   const [kioskViews, setKioskViews] = useState({ poules: true, classement: true, direct: true, suivants: true });
   const [orgNoteType, setOrgNoteType] = useState<'free' | 'target_time'>('free');
@@ -193,7 +194,8 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         count,
         allMatches,
         showPhotos,
-        kioskViews
+        kioskViews,
+        cardAnnounce
       );
       if (result.success && result.session) {
         setSession(result.session);
@@ -366,6 +368,14 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             />
             Afficher les photos des combattants avant le combat
           </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.5rem 0', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={cardAnnounce}
+              onChange={e => setCardAnnounce(e.target.checked)}
+            />
+            📣 Carton avancer (afficher bandeau + raison sur les écrans)
+          </label>
           <div style={{ margin: '0.5rem 0' }}>
             <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem', color: 'inherit' }}>
               Vues kiosk :
@@ -452,6 +462,17 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             }}
           />
           Afficher les photos des combattants avant le combat
+        </label>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.5rem 0', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={cardAnnounce}
+            onChange={async e => {
+              setCardAnnounce(e.target.checked);
+              await window.electronAPI.remote.updateCardAnnounce(e.target.checked);
+            }}
+          />
+          📣 Carton avancer (afficher bandeau + raison sur les écrans)
         </label>
         <div style={{ margin: '0.5rem 0' }}>
           <div style={{ fontSize: '0.875rem', marginBottom: '0.4rem', color: 'inherit' }}>

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -338,6 +338,7 @@ export interface RemoteServerAPI {
   getArenas: () => Promise<{ success: boolean; arenas?: any[]; error?: string }>;
   updateStripCount: (count: number) => Promise<{ success: boolean; session?: any; error?: string }>;
   updateShowPhotos: (value: boolean) => Promise<{ success: boolean; error?: string }>;
+  updateCardAnnounce: (value: boolean) => Promise<{ success: boolean; error?: string }>;
   updateMatchArena: (
     matchId: string,
     fromArena: number | null,

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -118,6 +118,7 @@ export interface ArenaSettings {
   breakDuration: number; // between matches
   autoAdvance: boolean; // automatically load next match
   showPhotos?: boolean; // afficher les photos avant le combat
+  cardAnnounce?: boolean; // annoncer les cartons avec raison sur les affichages
   theme?: DisplayTheme; // thème visuel de l'affichage distant
   customTheme?: CustomTheme; // thème personnalisé (si theme === 'custom')
 }
@@ -150,6 +151,7 @@ export interface ArenaUpdate {
   cardsB?: string[];
   suddenDeath?: boolean;
   showPhotos?: boolean; // afficher les photos avant le combat
+  cardAnnounce?: boolean; // annoncer les cartons avec raison sur les affichages
   theme?: DisplayTheme; // thème visuel de l'affichage distant
   customTheme?: CustomTheme; // thème personnalisé (si theme === 'custom')
   nextMatch?: ArenaMatch | null; // prochain combat (affiché quand status=finished)


### PR DESCRIPTION
## Résumé

- Case à cocher **📣 Carton avancer** ajoutée dans les **paramètres de saisie distante** (même section que "Afficher les photos"), active avant et après le démarrage de la session
- Quand activée, appuyer sur un bouton carton sur la tablette arbitre ouvre un **sélecteur de raison** plein-écran listant les 25 fautes en 3 groupes (règlement FFE combat sportif)
- La couleur du carton est déterminée automatiquement par le groupe et l'historique des fautes du tireur (Groupe 1 : blanc→jaune→rouge ; Groupes 2 & 3 : rouge direct)
- Un **bandeau coloré** (5 secondes) s'affiche sur `arena.html` et `public.html` avec la couleur, le nom du tireur, la raison, et la revalorisation si applicable (ex. 2ème blanc → JAUNE)
- Annuler le sélecteur donne le carton sans annonce publique

## Fichiers modifiés

- `src/renderer/components/RemoteScoreManager.tsx` — état `cardAnnounce` + checkbox × 2 (avant/après démarrage session)
- `src/main/remoteScoreServer.ts` — `sessionCardAnnounce`, `updateCardAnnounce()`, injection dans `broadcastArenaUpdate` et `startSession`
- `src/main/main.ts` — handler IPC `remote:updateCardAnnounce`
- `src/main/preload.ts` + `src/shared/types/preload.ts` — `updateCardAnnounce` exposé dans l'API Electron
- `src/shared/types/remote.ts` — `cardAnnounce?: boolean` dans `ArenaUpdate`
- `src/remote/referee.html` — sélecteur de raison plein-écran, logique groupe/historique, `this.cardAnnounceEnabled` reçu via socket
- `src/remote/arena.html` + `src/remote/public.html` — bandeau CSS + HTML + listener `card_announcement`

## Plan de test

- [ ] Ouvrir les paramètres de saisie distante → vérifier la présence de "📣 Carton avancer"
- [ ] Cocher la case, démarrer une session, ouvrir `arena.html` et `referee.html` dans deux onglets
- [ ] Appuyer sur un bouton carton → vérifier que le sélecteur de raison s'ouvre
- [ ] Sélectionner une faute Groupe 1 (1ère fois) → bandeau BLANC + raison sur arena/public
- [ ] Sélectionner une faute Groupe 1 (2ème fois) → bandeau JAUNE + "Revalorisation 2ème blanc → JAUNE"
- [ ] Sélectionner une faute Groupe 2 → bandeau ROUGE direct
- [ ] Annuler le sélecteur → carton attribué sans bandeau
- [ ] Décocher "Carton avancer" dans les paramètres → tablette arbitre revient au comportement normal sans sélecteur
- [ ] Vérifier que le bandeau disparaît après 5 secondes

https://claude.ai/code/session_01HvxFxyR3TjjRQ1piCbR8nb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvxFxyR3TjjRQ1piCbR8nb)_