### PR TITLE
fix(remote): garantir Poule N → Arène N lors du démarrage de session

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -871,7 +871,7 @@ export class DatabaseManager {
 
     try {
       const poolsStmt = this.db.prepare(
-        'SELECT id FROM pools WHERE phase_id IN (SELECT id FROM phases WHERE competition_id = ?)'
+        'SELECT id FROM pools WHERE phase_id IN (SELECT id FROM phases WHERE competition_id = ?) ORDER BY number'
       );
       poolsStmt.bind([competitionId]);
 
@@ -903,11 +903,11 @@ export class DatabaseManager {
       }
     }
 
-    // Then get pending matches from those pools
+    // Then get pending matches from those pools, ordered by pool number then match number
     if (poolIds.length > 0) {
       const placeholders = poolIds.map(() => '?').join(',');
       const matchesStmt = this.db.prepare(
-        `SELECT id FROM matches WHERE pool_id IN (${placeholders}) AND status IN ('not_started', 'in_progress') ORDER BY pool_id, number`
+        `SELECT m.id FROM matches m JOIN pools p ON m.pool_id = p.id WHERE m.pool_id IN (${placeholders}) AND m.status IN ('not_started', 'in_progress') ORDER BY p.number, m.number`
       );
       matchesStmt.bind(poolIds);
 
@@ -933,6 +933,7 @@ export class DatabaseManager {
         INNER JOIN pool_fencers pf ON p.id = pf.pool_id
         INNER JOIN fencers f ON pf.fencer_id = f.id
         WHERE f.competition_id = ?
+        ORDER BY p.number
       `);
       poolsStmt.bind([competitionId]);
 
@@ -945,11 +946,11 @@ export class DatabaseManager {
       return results;
     }
 
-    // Get pending matches from those pools
+    // Get pending matches from those pools, ordered by pool number then match number
     if (poolIds.length > 0) {
       const placeholders = poolIds.map(() => '?').join(',');
       const matchesStmt = this.db.prepare(
-        `SELECT id FROM matches WHERE pool_id IN (${placeholders}) AND status IN ('not_started', 'in_progress') ORDER BY pool_id, number`
+        `SELECT m.id FROM matches m JOIN pools p ON m.pool_id = p.id WHERE m.pool_id IN (${placeholders}) AND m.status IN ('not_started', 'in_progress') ORDER BY p.number, m.number`
       );
       matchesStmt.bind(poolIds);
 
@@ -971,11 +972,12 @@ export class DatabaseManager {
     try {
       const matchesStmt = this.db.prepare(`
         SELECT DISTINCT m.id FROM matches m
+        LEFT JOIN pools p ON m.pool_id = p.id
         INNER JOIN fencers fA ON m.fencer_a_id = fA.id
         INNER JOIN fencers fB ON m.fencer_b_id = fB.id
         WHERE (fA.competition_id = ? OR fB.competition_id = ?)
         AND m.status IN ('not_started', 'in_progress')
-        ORDER BY m.pool_id, m.number
+        ORDER BY p.number, m.number
       `);
       matchesStmt.bind([competitionId, competitionId]);
 

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2615,6 +2615,7 @@ export class RemoteScoreServer {
 
     // Utiliser les matches passés depuis le renderer si disponibles, sinon chercher dans la DB
     let allMatches: any[] = [];
+    const poolNumberMap = new Map<string, number>();
     if (matchesFromRenderer && matchesFromRenderer.length > 0) {
       console.log(`[RemoteScoreServer] ${matchesFromRenderer.length} matchs reçus du renderer`);
 
@@ -2626,6 +2627,7 @@ export class RemoteScoreServer {
       for (const m of matchesFromRenderer) {
         if ((m as any).__poolFencers) {
           fencerOrderMap.set(m.poolId, m.fencers);
+          if ((m as any).poolNumber != null) poolNumberMap.set(m.poolId, (m as any).poolNumber);
         } else {
           realMatches.push(m);
         }
@@ -2713,8 +2715,17 @@ export class RemoteScoreServer {
     // Assigner les matchs aux arènes par pool (Pool 1 -> Arena 1, Pool 2 -> Arena 2, etc.)
     console.log(`[RemoteScoreServer] Assignation des matches par pool aux ${strips} arènes`);
 
+    // Trier les poules par numéro pour garantir Poule 1 → Arène 1, Poule 2 → Arène 2, etc.
+    // poolNumberMap est peuplé par les marqueurs __poolFencers du renderer ;
+    // le fallback extrait les chiffres du poolId (ex: "pool-0" → 0, "pool-1" → 1).
+    const sortedPoolEntries = Array.from(matchesByPool.entries()).sort((a, b) => {
+      const numA = poolNumberMap.get(a[0]) ?? parseInt(a[0].replace(/\D/g, '') || '999', 10);
+      const numB = poolNumberMap.get(b[0]) ?? parseInt(b[0].replace(/\D/g, '') || '999', 10);
+      return numA - numB;
+    });
+
     let poolIndex = 0;
-    for (const [poolId, poolMatches] of matchesByPool) {
+    for (const [poolId, poolMatches] of sortedPoolEntries) {
       if (poolIndex >= strips) break;
 
       const arenaId = `arena${poolIndex + 1}`;

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -176,8 +176,9 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       // Prepend fencer-order markers so the server can rebuild poolFencersCache correctly.
       // The FIE match order for 4-fencer pools starts with [1,4] not [1,2], so naively
       // extracting fencers from match pairs produces the wrong order.
-      const poolMatches = pools.flatMap(pool => [
-        { __poolFencers: true, poolId: pool.id, fencers: pool.fencers || [] },
+      const sortedPools = [...pools].sort((a, b) => (a.number ?? 0) - (b.number ?? 0));
+      const poolMatches = sortedPools.flatMap(pool => [
+        { __poolFencers: true, poolId: pool.id, poolNumber: pool.number, fencers: pool.fencers || [] },
         ...(pool.matches || []),
       ]);
       const deMatches = (tableauMatches || [])


### PR DESCRIPTION
La Map matchesByPool était construite dans l'ordre d'insertion des matches.
Si les matches de la poule 2 arrivaient avant ceux de la poule 1 (ordre UUID
en DB ou ordre non déterministe), la poule 2 héritait de l'arène 1.

- RemoteScoreManager: trier pools par number avant flatMap et ajouter
  poolNumber au marqueur __poolFencers
- remoteScoreServer: déclarer poolNumberMap hors du bloc if-renderer,
  l'alimenter depuis les marqueurs, puis trier sortedPoolEntries par
  pool number avant l'assignation aux arènes
- database: ORDER BY p.number dans getPendingMatches,
  getAllPendingMatchesFromPools et getPendingMatchesDirectly pour que
  le chemin DB-only soit également correct

https://claude.ai/code/session_019wFfY2SAKxN842pdxzDNzk