### PR TITLE
fix: cardAnnounce manquant dans la chaîne IPC startSession

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1384,7 +1384,8 @@ ipcMain.handle(
     strips: number,
     matches?: any[],
     showPhotos?: boolean,
-    kioskViews?: { poules: boolean; classement: boolean; direct: boolean; suivants: boolean }
+    kioskViews?: { poules: boolean; classement: boolean; direct: boolean; suivants: boolean },
+    cardAnnounce?: boolean
   ) => {
     try {
       if (!remoteScoreServer) {
@@ -1396,7 +1397,8 @@ ipcMain.handle(
         strips,
         matches,
         showPhotos,
-        kioskViews
+        kioskViews,
+        cardAnnounce
       );
       return { success: true, session };
     } catch (error) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -413,7 +413,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       strips: number,
       matches?: any[],
       showPhotos?: boolean,
-      kioskViews?: { poules: boolean; classement: boolean; direct: boolean; suivants: boolean }
+      kioskViews?: { poules: boolean; classement: boolean; direct: boolean; suivants: boolean },
+      cardAnnounce?: boolean
     ) =>
       ipcRenderer.invoke(
         'remote:startSession',
@@ -421,7 +422,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         strips,
         matches,
         showPhotos,
-        kioskViews
+        kioskViews,
+        cardAnnounce
       ),
     stopSession: () => ipcRenderer.invoke('remote:stopSession'),
     getSession: () => ipcRenderer.invoke('remote:getSession'),

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -331,7 +331,8 @@ export interface RemoteServerAPI {
     strips: number,
     matches?: any[],
     showPhotos?: boolean,
-    kioskViews?: Record<string, boolean>
+    kioskViews?: Record<string, boolean>,
+    cardAnnounce?: boolean
   ) => Promise<{ success: boolean; session?: any; error?: string }>;
   stopSession: () => Promise<{ success: boolean; error?: string }>;
   getSession: () => Promise<{ success: boolean; session?: any; error?: string }>;


### PR DESCRIPTION
## Problème

Le build CI échouait avec une erreur TypeScript `TS2554` :

> Expected at most 5 arguments, but got 6.

`RemoteScoreManager.tsx` passait `cardAnnounce` comme 6ème argument à `startSession`, mais le type `RemoteServerAPI`, le bridge preload et le handler `main.ts` n'en déclaraient que 5 — le paramètre était silencieusement ignoré et TypeScript levait une erreur.

## Fix

Ajout de `cardAnnounce?: boolean` dans les 3 couches de la chaîne IPC :

- `src/shared/types/preload.ts` — interface `RemoteServerAPI.startSession`
- `src/main/preload.ts` — implémentation du bridge
- `src/main/main.ts` — handler `remote:startSession`

La valeur est maintenant correctement transmise à `remoteScoreServer.startSession()` dès le démarrage de session (et pas seulement via `updateCardAnnounce` après coup).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvxFxyR3TjjRQ1piCbR8nb)_