### PR TITLE
fix(cards): add WHITE card to GROUP_1 and fix hardcoded group in CardModal

### DIFF
--- a/src/features/penalties/hooks/usePenaltyStore.ts
+++ b/src/features/penalties/hooks/usePenaltyStore.ts
@@ -107,6 +107,7 @@ export const usePenaltyStore = create<PenaltyState & PenaltyActions>()(
             const state = get();
             const fencerPenalties = state.penalties.filter(p => p.fencerId === fencerId);
 
+            const whiteCards = fencerPenalties.filter(p => p.cardType === CardType.WHITE).length;
             const yellowCards = fencerPenalties.filter(p => p.cardType === CardType.YELLOW).length;
             const redCards = fencerPenalties.filter(p => p.cardType === CardType.RED).length;
             const blackCards = fencerPenalties.filter(p => p.cardType === CardType.BLACK).length;
@@ -114,6 +115,7 @@ export const usePenaltyStore = create<PenaltyState & PenaltyActions>()(
             return {
               fencer: { id: fencerId } as any, // Would fetch actual fencer
               penalties: fencerPenalties,
+              whiteCards,
               yellowCards,
               redCards,
               blackCards,
@@ -127,6 +129,7 @@ export const usePenaltyStore = create<PenaltyState & PenaltyActions>()(
             const penalties = state.penalties;
 
             const byType = {
+              [CardType.WHITE]: penalties.filter(p => p.cardType === CardType.WHITE).length,
               [CardType.YELLOW]: penalties.filter(p => p.cardType === CardType.YELLOW).length,
               [CardType.RED]: penalties.filter(p => p.cardType === CardType.RED).length,
               [CardType.BLACK]: penalties.filter(p => p.cardType === CardType.BLACK).length,

--- a/src/features/penalties/types/penalty.types.ts
+++ b/src/features/penalties/types/penalty.types.ts
@@ -7,6 +7,7 @@
 import { Fencer, Match } from '../../../shared/types';
 
 export enum CardType {
+  WHITE = 'WHITE',
   YELLOW = 'YELLOW',
   RED = 'RED',
   BLACK = 'BLACK',
@@ -41,6 +42,7 @@ export interface Penalty {
 export interface PenaltyHistory {
   fencer: Fencer;
   penalties: Penalty[];
+  whiteCards: number;
   yellowCards: number;
   redCards: number;
   blackCards: number;
@@ -71,6 +73,7 @@ export interface CreatePenaltyDTO {
 }
 
 export interface PenaltyConfig {
+  whiteCardTouches: number; // Touches to deduct for white (warning, 0)
   yellowCardTouches: number; // Touches to deduct for yellow
   redCardTouches: number; // Touches to deduct for red
   blackCardTouches: number; // Touches to deduct for black (usually match loss)
@@ -79,7 +82,8 @@ export interface PenaltyConfig {
 }
 
 export const DEFAULT_PENALTY_CONFIG: PenaltyConfig = {
-  yellowCardTouches: 0, // Yellow is warning only
+  whiteCardTouches: 0, // White is warning only
+  yellowCardTouches: 1, // Yellow = +1 touch for opponent
   redCardTouches: 1, // Red = -1 touch
   blackCardTouches: 999, // Black = match lost
   maxYellowBeforeRed: 2, // 2nd yellow = red

--- a/src/features/penalties/utils/penaltyUtils.ts
+++ b/src/features/penalties/utils/penaltyUtils.ts
@@ -22,6 +22,7 @@ export function getPenaltyDescription(reason: PenaltyReason): string {
 
 export function getPenaltyColor(cardType: CardType): string {
   const colors: Record<CardType, string> = {
+    [CardType.WHITE]: '#ffffff', // white
     [CardType.YELLOW]: '#fbbf24', // amber-400
     [CardType.RED]: '#ef4444', // red-500
     [CardType.BLACK]: '#000000', // black
@@ -57,6 +58,7 @@ export function validatePenalty(penalty: Partial<Penalty>): { valid: boolean; er
 
 export function getCardTypeLabel(cardType: CardType): string {
   const labels: Record<CardType, string> = {
+    [CardType.WHITE]: 'Carton Blanc',
     [CardType.YELLOW]: 'Carton Jaune',
     [CardType.RED]: 'Carton Rouge',
     [CardType.BLACK]: 'Carton Noir',
@@ -66,6 +68,8 @@ export function getCardTypeLabel(cardType: CardType): string {
 
 export function getImpactDescription(cardType: CardType, touches: number): string {
   switch (cardType) {
+    case CardType.WHITE:
+      return 'Avertissement (carton blanc)';
     case CardType.YELLOW:
       return 'Avertissement';
     case CardType.RED:

--- a/src/renderer/components/CardModal.tsx
+++ b/src/renderer/components/CardModal.tsx
@@ -5,10 +5,11 @@
  */
 
 import React, { useState, useMemo } from 'react';
-import { CardReason, CardGroup, Card, Fencer } from '../../shared/types';
+import { CardReason, Fencer } from '../../shared/types';
 import { CardType } from '../../features/penalties/types/penalty.types';
 import {
   determineCardType,
+  createCard,
   getReasonsByGroup,
   CARD_REASON_LABELS,
   CARD_GROUP_LABELS,
@@ -44,17 +45,7 @@ export const CardModal: React.FC<CardModalProps> = ({
 
   const handleConfirm = () => {
     if (selectedReason && preview) {
-      const card: Card = {
-        id: crypto.randomUUID(),
-        matchId: '',
-        fencerId: fencer.id,
-        type: preview.type,
-        reason: selectedReason,
-        group: CardGroup.GROUP_1,
-        timestamp: new Date(),
-        pointsAwarded: preview.points,
-        resultingExclusion: preview.shouldExclude,
-      };
+      const card = createCard('', fencer.id, selectedReason, previousCards);
       onConfirm(selectedReason, card);
       setSelectedReason(null);
       onClose();
@@ -64,6 +55,8 @@ export const CardModal: React.FC<CardModalProps> = ({
   const getCardBgColor = (cardType: CardType | undefined) => {
     if (!cardType) return 'bg-gray-100';
     switch (cardType) {
+      case CardType.WHITE:
+        return 'bg-white border-gray-400';
       case CardType.YELLOW:
         return 'bg-yellow-100 border-yellow-400';
       case CardType.RED:
@@ -78,6 +71,8 @@ export const CardModal: React.FC<CardModalProps> = ({
   const getButtonColor = (cardType: CardType | undefined) => {
     if (!cardType) return 'bg-gray-300';
     switch (cardType) {
+      case CardType.WHITE:
+        return 'bg-gray-400 hover:bg-gray-500';
       case CardType.YELLOW:
         return 'bg-yellow-500 hover:bg-yellow-600';
       case CardType.RED:
@@ -104,14 +99,22 @@ export const CardModal: React.FC<CardModalProps> = ({
                 <span
                   key={card.id}
                   className={`px-2 py-1 rounded text-xs font-bold ${
-                    card.type === CardType.YELLOW
-                      ? 'bg-yellow-400 text-black'
-                      : card.type === CardType.RED
-                        ? 'bg-red-500 text-white'
-                        : 'bg-black text-white'
+                    card.type === CardType.WHITE
+                      ? 'bg-white border border-gray-400 text-black'
+                      : card.type === CardType.YELLOW
+                        ? 'bg-yellow-400 text-black'
+                        : card.type === CardType.RED
+                          ? 'bg-red-500 text-white'
+                          : 'bg-black text-white'
                   }`}
                 >
-                  {card.type === CardType.YELLOW ? 'J' : card.type === CardType.RED ? 'R' : 'N'}
+                  {card.type === CardType.WHITE
+                    ? 'B'
+                    : card.type === CardType.YELLOW
+                      ? 'J'
+                      : card.type === CardType.RED
+                        ? 'R'
+                        : 'N'}
                 </span>
               ))}
             </div>
@@ -146,11 +149,13 @@ export const CardModal: React.FC<CardModalProps> = ({
         {preview && (
           <div className={`mt-4 p-4 rounded-lg border-2 ${getCardBgColor(preview.type)}`}>
             <p className="font-bold text-lg">
-              {preview.type === CardType.YELLOW
-                ? '🟨 CARTON JAUNE'
-                : preview.type === CardType.RED
-                  ? '🟥 CARTON ROUGE'
-                  : '⬛ CARTON NOIR'}
+              {preview.type === CardType.WHITE
+                ? '⬜ CARTON BLANC'
+                : preview.type === CardType.YELLOW
+                  ? '🟨 CARTON JAUNE'
+                  : preview.type === CardType.RED
+                    ? '🟥 CARTON ROUGE'
+                    : '⬛ CARTON NOIR'}
             </p>
             {preview.points > 0 && (
               <p className="text-sm mt-1">

--- a/src/shared/utils/cardSystem.test.ts
+++ b/src/shared/utils/cardSystem.test.ts
@@ -41,29 +41,29 @@ const createMockCard = (
 // ============================================================================
 
 describe("determineCardType - Système d'escalade FFE", () => {
-  describe('Groupe 1: Jaune → Rouge → Rouge → Exclusion', () => {
-    it('1ère faute Groupe 1 = Carton JAUNE (0 point)', () => {
+  describe('Groupe 1: Blanc → Jaune → Rouge → Exclusion', () => {
+    it('1ère faute Groupe 1 = Carton BLANC (0 point)', () => {
       const result = determineCardType(CardReason.EARLY_START, []);
 
-      expect(result.type).toBe(CardType.YELLOW);
+      expect(result.type).toBe(CardType.WHITE);
       expect(result.points).toBe(0);
       expect(result.shouldExclude).toBe(false);
     });
 
-    it('2ème faute Groupe 1 = Carton ROUGE (+1 point)', () => {
-      const previousCards = [createMockCard(CardGroup.GROUP_1, CardType.YELLOW)];
+    it('2ème faute Groupe 1 = Carton JAUNE (+1 point)', () => {
+      const previousCards = [createMockCard(CardGroup.GROUP_1, CardType.WHITE)];
 
       const result = determineCardType(CardReason.LATE_STOP, previousCards);
 
-      expect(result.type).toBe(CardType.RED);
+      expect(result.type).toBe(CardType.YELLOW);
       expect(result.points).toBe(1);
       expect(result.shouldExclude).toBe(false);
     });
 
     it('3ème faute Groupe 1 = Carton ROUGE (+1 point)', () => {
       const previousCards = [
+        createMockCard(CardGroup.GROUP_1, CardType.WHITE),
         createMockCard(CardGroup.GROUP_1, CardType.YELLOW),
-        createMockCard(CardGroup.GROUP_1, CardType.RED),
       ];
 
       const result = determineCardType(CardReason.BODY_CONTACT, previousCards);
@@ -75,8 +75,8 @@ describe("determineCardType - Système d'escalade FFE", () => {
 
     it('4ème faute Groupe 1 = Carton NOIR (exclusion)', () => {
       const previousCards = [
+        createMockCard(CardGroup.GROUP_1, CardType.WHITE),
         createMockCard(CardGroup.GROUP_1, CardType.YELLOW),
-        createMockCard(CardGroup.GROUP_1, CardType.RED),
         createMockCard(CardGroup.GROUP_1, CardType.RED),
       ];
 
@@ -165,10 +165,10 @@ describe("determineCardType - Système d'escalade FFE", () => {
 
   describe('Isolation entre groupes', () => {
     it("Les cartons d'un groupe n'affectent pas les autres groupes", () => {
-      // 3 cartons Groupe 1
+      // 3 cartons Groupe 1 (séquence complète B→J→R)
       const previousCards = [
+        createMockCard(CardGroup.GROUP_1, CardType.WHITE),
         createMockCard(CardGroup.GROUP_1, CardType.YELLOW),
-        createMockCard(CardGroup.GROUP_1, CardType.RED),
         createMockCard(CardGroup.GROUP_1, CardType.RED),
       ];
 

--- a/src/shared/utils/cardSystem.ts
+++ b/src/shared/utils/cardSystem.ts
@@ -49,7 +49,7 @@ export const CARD_REASON_LABELS: Record<CardReason, string> = {
 };
 
 export const CARD_GROUP_LABELS: Record<CardGroup, string> = {
-  [CardGroup.GROUP_1]: 'Groupe 1 (Jaune → Rouge)',
+  [CardGroup.GROUP_1]: 'Groupe 1 (Blanc → Jaune → Rouge → Exclusion)',
   [CardGroup.GROUP_2]: 'Groupe 2 (Rouge direct)',
   [CardGroup.GROUP_3]: 'Groupe 3 (Rouge → Exclusion)',
   [CardGroup.GROUP_4]: 'Groupe 4 (Exclusion immédiate)',
@@ -68,8 +68,9 @@ export function determineCardType(reason: CardReason, previousCards: Card[]): Ca
 
   switch (group) {
     case CardGroup.GROUP_1:
-      if (count === 0) return { type: CardType.YELLOW, shouldExclude: false, points: 0 };
-      if (count <= 2) return { type: CardType.RED, shouldExclude: false, points: 1 };
+      if (count === 0) return { type: CardType.WHITE,  shouldExclude: false, points: 0 };
+      if (count === 1) return { type: CardType.YELLOW, shouldExclude: false, points: 1 };
+      if (count === 2) return { type: CardType.RED,    shouldExclude: false, points: 1 };
       return { type: CardType.BLACK, shouldExclude: true, points: 0 };
 
     case CardGroup.GROUP_2:
@@ -84,7 +85,7 @@ export function determineCardType(reason: CardReason, previousCards: Card[]): Ca
       return { type: CardType.BLACK, shouldExclude: true, points: 0 };
 
     default:
-      return { type: CardType.YELLOW, shouldExclude: false, points: 0 };
+      return { type: CardType.WHITE, shouldExclude: false, points: 0 };
   }
 }
 


### PR DESCRIPTION
- Add CardType.WHITE to the enum; GROUP_1 now escalates Blanc→Jaune→Rouge→Noir
  conformément au règlement FFE (1ère faute = carton blanc, 0 point)
- Fix CardModal.tsx: replace hardcoded `group: CardGroup.GROUP_1` with
  createCard() so the saved card always carries the correct group, ensuring
  group independence is preserved for future escalation lookups
- Update penaltyUtils, usePenaltyStore and tests accordingly

https://claude.ai/code/session_01VEH2RiFPVKJ6XWJKgVsJEs