### PR TITLE
fix(CardModal): add Card and CardGroup to imports

### DIFF
--- a/src/renderer/components/CardModal.tsx
+++ b/src/renderer/components/CardModal.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useMemo } from 'react';
-import { CardReason, Fencer } from '../../shared/types';
+import { CardReason, CardGroup, Card, Fencer } from '../../shared/types';
 import { CardType } from '../../features/penalties/types/penalty.types';
 import {
   determineCardType,


### PR DESCRIPTION
## Résumé

`Card` et `CardGroup` avaient été retirés des imports de `CardModal.tsx` lors du passage à `createCard()`, mais les deux sont encore nécessaires :

- `Card` — utilisé dans `CardModalProps` (`onConfirm` callback et `previousCards`)
- `CardGroup` — utilisé dans le JSX : `group as unknown as CardGroup`

Leur absence provoque une erreur TypeScript au build (`tsc`).

## Test

```bash
npm run build:ci   # tsc doit passer sans erreur
```

https://claude.ai/code/session_01VEH2RiFPVKJ6XWJKgVsJEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEH2RiFPVKJ6XWJKgVsJEs)_