### PR TITLE
fix(cards): corriger la progression des fautes groupes 1 et 2

### DIFF
--- a/src/shared/utils/cardSystem.test.ts
+++ b/src/shared/utils/cardSystem.test.ts
@@ -41,7 +41,7 @@ const createMockCard = (
 // ============================================================================
 
 describe("determineCardType - Système d'escalade FFE", () => {
-  describe('Groupe 1: Blanc → Jaune → Rouge → Exclusion', () => {
+  describe('Groupe 1: Blanc → Jaune → Jaune', () => {
     it('1ère faute Groupe 1 = Carton BLANC (0 point)', () => {
       const result = determineCardType(CardReason.EARLY_START, []);
 
@@ -60,7 +60,7 @@ describe("determineCardType - Système d'escalade FFE", () => {
       expect(result.shouldExclude).toBe(false);
     });
 
-    it('3ème faute Groupe 1 = Carton ROUGE (+1 point)', () => {
+    it('3ème faute Groupe 1 = Carton JAUNE (+1 point)', () => {
       const previousCards = [
         createMockCard(CardGroup.GROUP_1, CardType.WHITE),
         createMockCard(CardGroup.GROUP_1, CardType.YELLOW),
@@ -68,37 +68,37 @@ describe("determineCardType - Système d'escalade FFE", () => {
 
       const result = determineCardType(CardReason.BODY_CONTACT, previousCards);
 
-      expect(result.type).toBe(CardType.RED);
+      expect(result.type).toBe(CardType.YELLOW);
       expect(result.points).toBe(1);
       expect(result.shouldExclude).toBe(false);
     });
 
-    it('4ème faute Groupe 1 = Carton NOIR (exclusion)', () => {
+    it('4ème faute Groupe 1 = Carton JAUNE (+1 point, pas de Noir)', () => {
       const previousCards = [
         createMockCard(CardGroup.GROUP_1, CardType.WHITE),
         createMockCard(CardGroup.GROUP_1, CardType.YELLOW),
-        createMockCard(CardGroup.GROUP_1, CardType.RED),
+        createMockCard(CardGroup.GROUP_1, CardType.YELLOW),
       ];
 
       const result = determineCardType(CardReason.COUNTER_ATTACK, previousCards);
 
-      expect(result.type).toBe(CardType.BLACK);
-      expect(result.points).toBe(0);
-      expect(result.shouldExclude).toBe(true);
+      expect(result.type).toBe(CardType.YELLOW);
+      expect(result.points).toBe(1);
+      expect(result.shouldExclude).toBe(false);
     });
   });
 
-  describe('Groupe 2: Rouge → Rouge → Exclusion', () => {
-    it('1ère faute Groupe 2 = Carton ROUGE (+1 point)', () => {
+  describe('Groupe 2: Jaune → Rouge → Rouge', () => {
+    it('1ère faute Groupe 2 = Carton JAUNE (+1 point)', () => {
       const result = determineCardType(CardReason.ESTOC, []);
 
-      expect(result.type).toBe(CardType.RED);
+      expect(result.type).toBe(CardType.YELLOW);
       expect(result.points).toBe(1);
       expect(result.shouldExclude).toBe(false);
     });
 
     it('2ème faute Groupe 2 = Carton ROUGE (+1 point)', () => {
-      const previousCards = [createMockCard(CardGroup.GROUP_2, CardType.RED)];
+      const previousCards = [createMockCard(CardGroup.GROUP_2, CardType.YELLOW)];
 
       const result = determineCardType(CardReason.VOLUNTARY_EXIT, previousCards);
 
@@ -107,16 +107,17 @@ describe("determineCardType - Système d'escalade FFE", () => {
       expect(result.shouldExclude).toBe(false);
     });
 
-    it('3ème faute Groupe 2 = Carton NOIR (exclusion)', () => {
+    it('3ème faute Groupe 2 = Carton ROUGE (+1 point, pas de Noir)', () => {
       const previousCards = [
-        createMockCard(CardGroup.GROUP_2, CardType.RED),
+        createMockCard(CardGroup.GROUP_2, CardType.YELLOW),
         createMockCard(CardGroup.GROUP_2, CardType.RED),
       ];
 
       const result = determineCardType(CardReason.HEAVY_HIT, previousCards);
 
-      expect(result.type).toBe(CardType.BLACK);
-      expect(result.shouldExclude).toBe(true);
+      expect(result.type).toBe(CardType.RED);
+      expect(result.points).toBe(1);
+      expect(result.shouldExclude).toBe(false);
     });
   });
 
@@ -172,10 +173,10 @@ describe("determineCardType - Système d'escalade FFE", () => {
         createMockCard(CardGroup.GROUP_1, CardType.RED),
       ];
 
-      // Faute Groupe 2 = Rouge (pas noir)
+      // Faute Groupe 2 = Jaune (pas noir, pas rouge)
       const result = determineCardType(CardReason.ESTOC, previousCards);
 
-      expect(result.type).toBe(CardType.RED);
+      expect(result.type).toBe(CardType.YELLOW);
       expect(result.shouldExclude).toBe(false);
     });
   });

--- a/src/shared/utils/cardSystem.ts
+++ b/src/shared/utils/cardSystem.ts
@@ -49,8 +49,8 @@ export const CARD_REASON_LABELS: Record<CardReason, string> = {
 };
 
 export const CARD_GROUP_LABELS: Record<CardGroup, string> = {
-  [CardGroup.GROUP_1]: 'Groupe 1 (Blanc → Jaune → Rouge → Exclusion)',
-  [CardGroup.GROUP_2]: 'Groupe 2 (Rouge direct)',
+  [CardGroup.GROUP_1]: 'Groupe 1 (Blanc → Jaune → Jaune)',
+  [CardGroup.GROUP_2]: 'Groupe 2 (Jaune → Rouge → Rouge)',
   [CardGroup.GROUP_3]: 'Groupe 3 (Rouge → Exclusion)',
   [CardGroup.GROUP_4]: 'Groupe 4 (Exclusion immédiate)',
 };
@@ -69,13 +69,11 @@ export function determineCardType(reason: CardReason, previousCards: Card[]): Ca
   switch (group) {
     case CardGroup.GROUP_1:
       if (count === 0) return { type: CardType.WHITE,  shouldExclude: false, points: 0 };
-      if (count === 1) return { type: CardType.YELLOW, shouldExclude: false, points: 1 };
-      if (count === 2) return { type: CardType.RED,    shouldExclude: false, points: 1 };
-      return { type: CardType.BLACK, shouldExclude: true, points: 0 };
+      return { type: CardType.YELLOW, shouldExclude: false, points: 1 };
 
     case CardGroup.GROUP_2:
-      if (count <= 1) return { type: CardType.RED, shouldExclude: false, points: 1 };
-      return { type: CardType.BLACK, shouldExclude: true, points: 0 };
+      if (count === 0) return { type: CardType.YELLOW, shouldExclude: false, points: 1 };
+      return { type: CardType.RED, shouldExclude: false, points: 1 };
 
     case CardGroup.GROUP_3:
       if (count === 0) return { type: CardType.RED, shouldExclude: false, points: 1 };


### PR DESCRIPTION
Groupe 1 : Blanc → Jaune → Jaune (répétition = Jaune, pas Rouge ni Noir)
Groupe 2 : Jaune → Rouge → Rouge (répétition = Rouge, pas Noir direct)

Le Noir ne peut pas être déclenché par simple répétition de faute.

https://claude.ai/code/session_013BVpumLKCxft5oH1jUEFJ9