### PR TITLE
feat: bandeau sortie d'arène en mode carton avancer

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1673,6 +1673,14 @@ export class RemoteScoreServer {
           );
         }
         break;
+      case 'exit_announcement':
+        if (data.announcement && this.sessionCardAnnounce) {
+          this.io.to(`arena:${data.arenaId}`).emit(
+            `arena:${data.arenaId}:exit_announcement`,
+            data.announcement
+          );
+        }
+        break;
       case 'update_timer':
       case 'pause_timer':
       case 'reset_timer':

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -210,6 +210,11 @@
         color: #f9fafb;
         border-bottom: 4px solid #374151;
       }
+      .card-announcement-banner.card-exit {
+        background: #ea580c;
+        color: #fff;
+        border-bottom: 4px solid #9a3412;
+      }
       @keyframes banner-slide-in {
         from { transform: translateY(-100%); opacity: 0; }
         to   { transform: translateY(0);    opacity: 1; }
@@ -1219,6 +1224,23 @@
           this.socket.on(`arena:${this.arenaId}:card_announcement`, ann => {
             this.showCardAnnouncement(ann);
           });
+
+          this.socket.on(`arena:${this.arenaId}:exit_announcement`, ann => {
+            this.showExitAnnouncement(ann);
+          });
+        }
+
+        showExitAnnouncement(ann) {
+          const banner = document.getElementById('card-announcement-banner');
+          if (!banner) return;
+          const line1 = `🚪 Sortie d'arène — ${ann.fencerName}`;
+          const line2 = `+${ann.points} pts pour l'adversaire`;
+          banner.innerHTML = `<div>${line1}</div><div style="font-size:0.65em;font-weight:600;margin-top:0.25em;opacity:0.9;">${line2}</div>`;
+          banner.className = 'card-announcement-banner visible card-exit';
+          if (this._cardAnnouncementTimer) clearTimeout(this._cardAnnouncementTimer);
+          this._cardAnnouncementTimer = setTimeout(() => {
+            banner.className = 'card-announcement-banner';
+          }, 5000);
         }
 
         showCardAnnouncement(ann) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1789,6 +1789,15 @@
           this.saveScore();
           const label = fencer === 'A' ? 'Rouge' : 'Vert';
           this.showNotification(window.T('referee.arena_exit_notif', { label, points }));
+          if (this.cardAnnounceEnabled) {
+            const nameEl = document.getElementById(`fencer-${fencer.toLowerCase()}-name`);
+            const fencerName = nameEl ? nameEl.textContent.trim() : label;
+            this.socket.emit('arena_control', {
+              arenaId: this.arenaId,
+              action: 'exit_announcement',
+              announcement: { fencer, fencerName, points },
+            });
+          }
         }
 
         // Retirer des points (appui long)


### PR DESCRIPTION
Quand le mode carton avancer est actif, les sorties d'arène (boutons
Sortie rouge/verte) déclenchent maintenant un bandeau orange sur les
écrans d'arène pendant 5 s, avec le nom du tireur et les points accordés.

https://claude.ai/code/session_01LmRmVpMLH9gbeznQzBs7h4