### PR TITLE
feat: bandeau sortie d'arène en mode carton avancer

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1481,6 +1481,7 @@ export class RemoteScoreServer {
             scoreB: arena.currentMatch?.scoreB,
             status: arena.status,
             showPhotos: this.sessionShowPhotos,
+            cardAnnounce: this.sessionCardAnnounce,
             theme: override?.theme ?? this.sessionTheme,
             customTheme: override?.customTheme,
             fencerA: arena.currentMatch?.fencerA,


### PR DESCRIPTION
## Résumé

- En mode **carton avancer**, les sorties d'arène (boutons "Sortie rouge/verte") affichent désormais un bandeau orange sur les écrans d'arène pendant 5 s : `🚪 SORTIE D'ARÈNE — [Nom]` / `+3 pts pour l'adversaire`
- Correction d'un bug existant : le message de connexion initiale de l'arbitre n'incluait pas `cardAnnounce`, donc `cardAnnounceEnabled` restait `false` jusqu'au premier broadcast — rendant la fonctionnalité inopérante si la sortie était la première action du match

## Changements

- `src/remote/referee.html` — émet `exit_announcement` via socket si `cardAnnounceEnabled`
- `src/main/remoteScoreServer.ts` — relaye `exit_announcement` vers la room de l'arène + ajoute `cardAnnounce` dans la réponse initiale `join_arena`
- `src/remote/arena.html` — listener `exit_announcement`, méthode `showExitAnnouncement()`, CSS `.card-exit` (orange)

## Plan de test

- [ ] Démarrer une session avec "mode carton avancer" coché
- [ ] Sur la tablette arbitre, appuyer sur "Sortie rouge" ou "Sortie verte"
- [ ] Vérifier que le bandeau orange apparaît sur l'écran d'arène pendant 5 s
- [ ] Vérifier qu'**sans** mode carton avancer, aucun bandeau n'apparaît
- [ ] Vérifier que les bandeaux cartons (jaune/rouge/noir) fonctionnent toujours normalement

https://claude.ai/code/session_01LmRmVpMLH9gbeznQzBs7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmRmVpMLH9gbeznQzBs7h4)_