### PR TITLE
Implement acceptRemoteVersion to update local cache on conflict resolution

### DIFF
--- a/src/renderer/services/offlineSync.ts
+++ b/src/renderer/services/offlineSync.ts
@@ -423,11 +423,23 @@ export class OfflineSyncManager {
   }
 
   private async acceptRemoteVersion(conflict: SyncConflict): Promise<void> {
-    // Update local cache with remote version
-    // Implementation depends on what needs to be updated
+    const { entityType, entityId, remoteVersion } = conflict;
+
+    switch (entityType) {
+      case 'match':
+        await offlineStorage.cacheMatches([remoteVersion]);
+        break;
+      case 'fencer':
+        await offlineStorage.cacheFencers([remoteVersion]);
+        break;
+      case 'pool':
+        await offlineStorage.cachePools([remoteVersion]);
+        break;
+    }
+
     logger.debug(
       LogCategory.NETWORK,
-      `[Sync] Accepting remote version for ${conflict.entityType} ${conflict.entityId}`
+      `[Sync] Accepted remote version for ${entityType} ${entityId}`
     );
   }
 }


### PR DESCRIPTION
When a sync conflict is resolved in favour of the remote version, overwrite
the corresponding IndexedDB cache entry (match, fencer, or pool) with the
remote data so the local state stays consistent.

https://claude.ai/code/session_01MNRfjrp9wepKWNuFSiYuSL