### PR TITLE
fix: bump ignoreDeprecations to 6.0 pour TypeScript 5.9

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "baseUrl": ".",


### PR DESCRIPTION
TypeScript 5.9.3 (dans package-lock.json) introduit TS5107 et TS5101
pour les options dépréciées moduleResolution=node et baseUrl.
ignoreDeprecations "5.0" ne les supprimait plus, bloquant tsc dans CI.

https://claude.ai/code/session_016iRY6Qh7YS3wBXBJCvUu6S