### PR TITLE
audit: ajout APIs dépréciées + optimisations performance dans TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,31 @@
 
 > Analyse complète du codebase (avril 2026). Aucun TODO/FIXME existant — code propre.  
 > Objectif : combler les lacunes fonctionnelles, structurelles et qualitatives pour atteindre un niveau production robuste.
-> Dernière mise à jour : 1er mai 2026 (v1.0.3)
+> Dernière mise à jour : 2 mai 2026 (v1.0.3) — ajout audit APIs dépréciées + optimisations performance
+
+---
+
+## ⚠️ AUDIT — APIs dépréciées à corriger
+
+### Electron
+
+- [ ] **[DEPR-1] `webContents.print()` callback déprécié** — `src/main/main.ts:1236` et `1263`  
+  Remplacer le troisième argument callback par la version Promise disponible depuis Electron 29 :
+  ```ts
+  // Avant
+  webContents.print({ silent: false, printBackground: true }, () => resolve());
+  // Après
+  const success = await webContents.print({ silent: false, printBackground: true });
+  ```
+
+- [ ] **[DEPR-2] `setPermissionCheckHandler` déprécié (Electron 25+)** — `src/main/main.ts:458-460`  
+  Supprimer l'appel : `setPermissionRequestHandler` seul suffit pour contrôler les permissions caméra/micro.
+
+### TypeScript
+
+- [ ] **[DEPR-3] `ignoreDeprecations: "5.0"` dans tsconfig.json:16**  
+  La clé masque des warnings liés à `moduleResolution: "node"` (déprécié TS 5.0).  
+  Fix : passer à `"moduleResolution": "bundler"` ou `"node16"`, corriger les erreurs remontées, puis supprimer `ignoreDeprecations`.
 
 ---
 
@@ -65,6 +89,80 @@
 - [x] **Flow complet compétition** — `e2e/competition-full.spec.ts` : création → ajout tireur → vérification
 - [x] **Flow remote scoring** — `e2e/remote-scoring.spec.ts` : démarrage serveur → URL affichée → arrêt
 - [x] **Flow import/export** — `e2e/import-export.spec.ts` : modal import → export
+
+---
+
+## 🟡 PERFORMANCE — Optimisations identifiées
+
+### Base de données — Requêtes N+1
+
+- [ ] **[PERF-1] Spin loop CPU dans la sauvegarde BDD** — `src/database/index.ts:104-108`  
+  La boucle `while (Date.now() - start < waitMs)` bloque le thread et peut geler l'UI lors de retries (verrouillage antivirus Windows).  
+  Fix : `await new Promise(r => setTimeout(r, waitMs));`
+
+- [ ] **[PERF-2] Requêtes N+1 — `getFencersByCompetition`** — `src/database/index.ts:471-482`  
+  SELECT des IDs → N appels individuels à `getFencer()`.  
+  Fix : `SELECT * FROM fencers WHERE competition_id = ? ORDER BY ref` + `parseFencerRow()` direct.
+
+- [ ] **[PERF-3] Requêtes N+1 — `getPoolFencers` + `getMatchesByPool`** — `src/database/index.ts:798-824`  
+  Même anti-pattern SELECT id → N × getRow().  
+  Fix : requêtes complètes avec tous les champs.
+
+- [ ] **[PERF-4] Requêtes N+1 critique — `getPoolsByPhase`** — `src/database/index.ts:1162-1188`  
+  Pour chaque pool : appelle `getPoolFencers()` + `getMatchesByPool()`, chacune faisant elle-même N requêtes.  
+  Complexité totale : **O(pools × (fencers + matches))**.  
+  Fix : requête JOIN unique ou batch SELECT + regroupement côté applicatif.
+
+- [ ] **[PERF-5] `updateFencerPhotosByLicense` — prepare() dans une boucle for** — `src/database/index.ts:507-514`  
+  N requêtes préparées individuellement pour N photos.  
+  Fix : préparer le statement **une fois** hors de la boucle, exécuter N fois.
+
+### React
+
+- [ ] **[PERF-6] `CompetitionView.tsx` non mémoïsé** — `src/renderer/components/CompetitionView.tsx`  
+  Composant de 1303 lignes se re-rend à chaque changement du parent.  
+  Fix : `export default React.memo(CompetitionView)`
+
+- [ ] **[PERF-7] Handlers sans `useCallback` dans App.tsx** — `src/renderer/App.tsx:145-184`  
+  `handleSelectCompetition` et consorts recréés à chaque render, propagent des re-renders aux enfants.  
+  Fix : `useCallback(fn, [deps])` sur les handlers passés comme props.
+
+### Webpack
+
+- [ ] **[PERF-8] Pas de code splitting** — `webpack.renderer.config.js`  
+  `TableauView` (1507 l.), `PoolView` (1424 l.), `CompetitionView` (1303 l.) tous chargés au démarrage.  
+  Fix :
+  ```ts
+  const TableauView = React.lazy(() => import('./components/TableauView'));
+  // Entourer de <Suspense fallback={<Spinner />}>
+  ```
+
+---
+
+## 🟡 QUALITÉ — Issues de code
+
+- [ ] **[QUAL-1] `console.log/error` dans le code de production**  
+  `drop_console` webpack ne couvre que le bundle renderer, pas le process main.  
+  Remplacer par `logger.error()` / `logger.warn()` de `src/shared/services/logger.ts` dans :
+  - `src/database/index.ts:111`
+  - `src/shared/services/cloudSyncService.ts:105, 134, 135`
+  - `src/shared/services/notificationService.ts:302, 326, 333`
+  - `src/shared/utils/fileParser.ts:48, 67, 77, 90, 162, 168`
+  - `src/shared/utils/tournamentTemplates.ts` (4 appels)
+
+- [ ] **[QUAL-2] Gestion d'erreurs silencieuse (`.catch(() => {})`)**  
+  Au minimum logger.warn dans chaque catch vide :
+  - `src/renderer/App.tsx:106`
+  - `src/renderer/components/SettingsModal.tsx:134, 157`
+  - `src/renderer/components/RemoteScoreManager.tsx:127, 145`
+
+- [ ] **[QUAL-3] Fuite potentielle d'intervalle — `CloudSyncService`** — `src/shared/services/cloudSyncService.ts:191`  
+  Si `startAutoSync()` est appelé deux fois, deux intervalles coexistent.  
+  Fix :
+  ```ts
+  if (this.syncIntervalId) clearInterval(this.syncIntervalId);
+  this.syncIntervalId = window.setInterval(...);
+  ```
 
 ---
 


### PR DESCRIPTION
Audit du code source (Electron 40 / React 19 / TS 5.8) :
- [DEPR] webContents.print() callback, setPermissionCheckHandler (Electron 25+), ignoreDeprecations TS 5.0
- [PERF] spin loop BDD, requêtes N+1 (getFencersByCompetition, getPoolsByPhase), code splitting absent
- [QUAL] console.* hors logger, silent catches, fuite intervalle CloudSyncService

https://claude.ai/code/session_01QbxTXPxUqicNZuSJtkCnDh