### PR TITLE
fix: kiosk - inversion couleurs combattant A (vert) et B (rouge)

### DIFF
--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -415,8 +415,8 @@
         text-align: center;
       }
 
-      .score-a { color: #ef4444; }
-      .score-b { color: #10b981; }
+      .score-a { color: #10b981; }
+      .score-b { color: #ef4444; }
 
       .arena-vs {
         font-size: 1rem;


### PR DESCRIPTION
score-a était affiché en rouge (#ef4444) alors que le combattant A est
le côté vert dans referee.html. Correction des couleurs CSS pour aligner
kiosk.html avec la convention des autres vues.

https://claude.ai/code/session_01CAmZdXAHWtbZEpEr2k4bxh