### PR TITLE
feat: inversion rouge/vert synchronisée arbitrage + écrans d'affichage

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1535,6 +1535,7 @@ export class RemoteScoreServer {
             scoreA: arena.currentMatch?.scoreA,
             scoreB: arena.currentMatch?.scoreB,
             status: arena.status,
+            swapped: arena.swapped ?? false,
             showPhotos: this.sessionShowPhotos,
             cardAnnounce: this.sessionCardAnnounce,
             theme: override?.theme ?? this.sessionTheme,
@@ -1746,6 +1747,21 @@ export class RemoteScoreServer {
           });
         }
         break;
+      case 'toggle_swap': {
+        arena.swapped = !(arena.swapped ?? false);
+        const cards = this.arenaCards.get(data.arenaId) || { cardsA: [], cardsB: [] };
+        this.broadcastArenaUpdate(data.arenaId, {
+          arenaId: data.arenaId,
+          match: arena.currentMatch,
+          scoreA: arena.currentMatch?.scoreA,
+          scoreB: arena.currentMatch?.scoreB,
+          cardsA: cards.cardsA,
+          cardsB: cards.cardsB,
+          suddenDeath: this.arenaSuddenDeath.get(data.arenaId) ?? false,
+          status: arena.status,
+        });
+        break;
+      }
       case 'card_announcement':
         if (data.announcement) {
           this.io
@@ -2602,9 +2618,11 @@ export class RemoteScoreServer {
   }
 
   private broadcastArenaUpdate(arenaId: string, update: ArenaUpdate): void {
+    const arena = this.getArena(arenaId);
     const override = this.arenaThemeOverrides.get(arenaId);
     const updateWithPhotos: ArenaUpdate = {
       ...update,
+      swapped: arena?.swapped ?? false,
       showPhotos: this.sessionShowPhotos,
       cardAnnounce: this.sessionCardAnnounce,
       theme: override?.theme ?? this.sessionTheme,

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -422,14 +422,6 @@
         flex: 1;
       }
 
-      .fencers-row.reversed {
-        grid-template-columns: 1fr auto 1fr;
-        direction: rtl;
-      }
-
-      .fencers-row.reversed > * {
-        direction: ltr;
-      }
 
       .fencer-display {
         text-align: center;
@@ -1192,19 +1184,8 @@
           const checkbox = document.getElementById('inversion-checkbox');
           checkbox.checked = this.inversionEnabled;
           checkbox.addEventListener('change', () => {
-            this.inversionEnabled = checkbox.checked;
-            localStorage.setItem('inversionEnabled', this.inversionEnabled);
-            this.applyInversionState();
+            this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'toggle_swap' });
           });
-        }
-
-        applyInversionState() {
-          const fencersRow = document.querySelector('.fencers-row');
-          if (this.inversionEnabled) {
-            fencersRow.classList.add('reversed');
-          } else {
-            fencersRow.classList.remove('reversed');
-          }
         }
 
         setupSocketListeners() {
@@ -1315,6 +1296,14 @@
             this.showPhotos = data.showPhotos;
           }
 
+          // Mise à jour état d'inversion (synchronisé avec le serveur)
+          if (data.swapped !== undefined) {
+            this.inversionEnabled = data.swapped;
+            const cb = document.getElementById('inversion-checkbox');
+            if (cb) cb.checked = data.swapped;
+            localStorage.setItem('inversionEnabled', data.swapped);
+          }
+
           // Mise à jour du statut
           if (data.status) {
             this.matchStatus = data.status;
@@ -1339,12 +1328,12 @@
             }
           }
 
-          // Mise à jour des scores
+          // Mise à jour des scores (respecte l'inversion)
           if (data.scoreA !== undefined) {
-            document.getElementById('score-a').textContent = data.scoreA;
+            document.getElementById(this.inversionEnabled ? 'score-b' : 'score-a').textContent = data.scoreA;
           }
           if (data.scoreB !== undefined) {
-            document.getElementById('score-b').textContent = data.scoreB;
+            document.getElementById(this.inversionEnabled ? 'score-a' : 'score-b').textContent = data.scoreB;
           }
 
           // Mise à jour des cartons
@@ -1401,23 +1390,25 @@
         updateMatchDisplay() {
           if (!this.currentMatch) return;
 
-          const fencerA = this.currentMatch.fencerA || {};
-          const fencerB = this.currentMatch.fencerB || {};
+          const fA = this.currentMatch.fencerA || {};
+          const fB = this.currentMatch.fencerB || {};
+          const left  = this.inversionEnabled ? fB : fA;
+          const right = this.inversionEnabled ? fA : fB;
 
           document.getElementById('fencer-a-name').textContent =
-            `${fencerA.lastName || ''} ${fencerA.firstName || ''}`.trim() || '-';
-          document.getElementById('fencer-a-club').textContent = fencerA.club || '';
+            `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
+          document.getElementById('fencer-a-club').textContent = left.club || '';
 
           document.getElementById('fencer-b-name').textContent =
-            `${fencerB.lastName || ''} ${fencerB.firstName || ''}`.trim() || '-';
-          document.getElementById('fencer-b-club').textContent = fencerB.club || '';
+            `${right.lastName || ''} ${right.firstName || ''}`.trim() || '-';
+          document.getElementById('fencer-b-club').textContent = right.club || '';
 
           const sA = this.currentMatch.scoreA;
           const sB = this.currentMatch.scoreB;
-          document.getElementById('score-a').textContent =
-            (typeof sA === 'object' ? (sA?.value ?? 0) : sA) ?? 0;
-          document.getElementById('score-b').textContent =
-            (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
+          const valA = (typeof sA === 'object' ? (sA?.value ?? 0) : sA) ?? 0;
+          const valB = (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
+          document.getElementById('score-a').textContent = this.inversionEnabled ? valB : valA;
+          document.getElementById('score-b').textContent = this.inversionEnabled ? valA : valB;
         }
 
         updateCardsDisplay() {
@@ -1429,8 +1420,8 @@
               )
               .join('');
 
-          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.cardsA);
-          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.cardsB);
+          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsB : this.cardsA);
+          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsA : this.cardsB);
         }
 
         updateTimerDisplay(timerStatus) {

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -219,12 +219,7 @@
       }
 
       .fencers-row.reversed {
-        grid-template-columns: 1fr auto 1fr;
-        direction: rtl;
-      }
-
-      .fencers-row.reversed > * {
-        direction: ltr;
+        /* inversion via échange de contenu JS — voir handleArenaUpdate */
       }
 
       .fencer-display {
@@ -728,7 +723,6 @@
           document.getElementById('arena-number').textContent = this.arenaNumber;
           document.getElementById('arena-idle-number').textContent = this.arenaNumber;
           this.setupInversionToggle();
-          this.applyInversionState();
           this.setupSocketListeners();
         }
 
@@ -736,20 +730,8 @@
           const checkbox = document.getElementById('inversion-checkbox');
           checkbox.checked = this.inversionEnabled;
           checkbox.addEventListener('change', () => {
-            this.inversionEnabled = checkbox.checked;
-            // Clé indépendante de celle de l'écran arène
-            localStorage.setItem('publicInversionEnabled', this.inversionEnabled);
-            this.applyInversionState();
+            this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'toggle_swap' });
           });
-        }
-
-        applyInversionState() {
-          const fencersRow = document.querySelector('.fencers-row');
-          if (this.inversionEnabled) {
-            fencersRow.classList.add('reversed');
-          } else {
-            fencersRow.classList.remove('reversed');
-          }
         }
 
         setupSocketListeners() {
@@ -815,6 +797,14 @@
             this.showPhotos = data.showPhotos;
           }
 
+          // Mise à jour état d'inversion (synchronisé avec le serveur)
+          if (data.swapped !== undefined) {
+            this.inversionEnabled = data.swapped;
+            const cb = document.getElementById('inversion-checkbox');
+            if (cb) cb.checked = data.swapped;
+            localStorage.setItem('publicInversionEnabled', data.swapped);
+          }
+
           if (data.status) {
             this.matchStatus = data.status;
             this.updateStatusBadge();
@@ -829,10 +819,10 @@
           }
 
           if (data.scoreA !== undefined) {
-            document.getElementById('score-a').textContent = data.scoreA;
+            document.getElementById(this.inversionEnabled ? 'score-b' : 'score-a').textContent = data.scoreA;
           }
           if (data.scoreB !== undefined) {
-            document.getElementById('score-b').textContent = data.scoreB;
+            document.getElementById(this.inversionEnabled ? 'score-a' : 'score-b').textContent = data.scoreB;
           }
 
           if (data.cardsA) {
@@ -882,23 +872,25 @@
         updateMatchDisplay() {
           if (!this.currentMatch) return;
 
-          const fencerA = this.currentMatch.fencerA || {};
-          const fencerB = this.currentMatch.fencerB || {};
+          const fA = this.currentMatch.fencerA || {};
+          const fB = this.currentMatch.fencerB || {};
+          const left  = this.inversionEnabled ? fB : fA;
+          const right = this.inversionEnabled ? fA : fB;
 
           document.getElementById('fencer-a-name').textContent =
-            `${fencerA.lastName || ''} ${fencerA.firstName || ''}`.trim() || '-';
-          document.getElementById('fencer-a-club').textContent = fencerA.club || '';
+            `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
+          document.getElementById('fencer-a-club').textContent = left.club || '';
 
           document.getElementById('fencer-b-name').textContent =
-            `${fencerB.lastName || ''} ${fencerB.firstName || ''}`.trim() || '-';
-          document.getElementById('fencer-b-club').textContent = fencerB.club || '';
+            `${right.lastName || ''} ${right.firstName || ''}`.trim() || '-';
+          document.getElementById('fencer-b-club').textContent = right.club || '';
 
           const sA = this.currentMatch.scoreA;
           const sB = this.currentMatch.scoreB;
-          document.getElementById('score-a').textContent =
-            (typeof sA === 'object' ? (sA?.value ?? 0) : sA) ?? 0;
-          document.getElementById('score-b').textContent =
-            (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
+          const valA = (typeof sA === 'object' ? (sA?.value ?? 0) : sA) ?? 0;
+          const valB = (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
+          document.getElementById('score-a').textContent = this.inversionEnabled ? valB : valA;
+          document.getElementById('score-b').textContent = this.inversionEnabled ? valA : valB;
         }
 
         updateCardsDisplay() {
@@ -910,8 +902,8 @@
               )
               .join('');
 
-          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.cardsA);
-          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.cardsB);
+          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsB : this.cardsA);
+          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsA : this.cardsB);
         }
 
         updateTimerDisplay(timerStatus) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -783,6 +783,23 @@
           min-height: 52px;
         }
       }
+
+      .swap-btn {
+        background: #374151;
+        color: #e5e7eb;
+        border: 1px solid #4b5563;
+        border-radius: 0.4rem;
+        padding: 0.25rem 0.65rem;
+        font-size: 1rem;
+        cursor: pointer;
+        line-height: 1;
+        transition: background 0.15s, border-color 0.15s;
+      }
+      .swap-btn.active {
+        background: #5b21b6;
+        border-color: #7c3aed;
+        color: #fff;
+      }
     </style>
   </head>
   <body>
@@ -792,6 +809,7 @@
         <span>Arène <span id="arena-number">1</span></span>
       </h1>
       <div class="connection-status">
+        <button id="btn-swap" class="swap-btn" onclick="refereeApp.toggleSwap()" data-i18n-title="referee.swap_colors" title="Inverser rouge/vert">⇄</button>
         <div id="status-dot" class="status-dot"></div>
         <span id="connection-text" data-i18n="remote.connecting">Connexion...</span>
         <span
@@ -1214,6 +1232,7 @@
           this.isSuddenDeath = false;
           this.actionHistory = []; // Historique pour undo (max 10)
           this.cardAnnounceEnabled = false; // Réglé depuis les paramètres de saisie distante
+          this.swapped = false;
           this.offlineQueue = new OfflineQueueInline();
 
           this.init();
@@ -1562,21 +1581,13 @@
           this.timerSeconds = 180;
           this.isSuddenDeath = false;
           this.actionHistory = [];
+          this.swapped = false;
           this.stopTimer();
           const undoBtn = document.getElementById('btn-undo');
           if (undoBtn) undoBtn.disabled = true;
 
           // Charger les infos du match
-          document.getElementById('fencer-a-name').textContent =
-            `${match.fencerA?.lastName || ''} ${match.fencerA?.firstName || ''}`.trim();
-          document.getElementById('fencer-a-club').textContent = match.fencerA?.club || '';
-
-          document.getElementById('fencer-b-name').textContent =
-            `${match.fencerB?.lastName || ''} ${match.fencerB?.firstName || ''}`.trim();
-          document.getElementById('fencer-b-club').textContent = match.fencerB?.club || '';
-
-          this.updateScores();
-          this.updateCardsDisplay();
+          this.applySwapState();
           this.updateTimerDisplay();
           this.updateMatchStatus();
           this.updateControlButtons();
@@ -1608,8 +1619,9 @@
 
           this.pushHistory('score');
 
+          const ef = this._effectiveFencer(fencer);
           const zone = points === 1 ? 'A' : points === 3 ? 'B' : 'C';
-          if (fencer === 'A') {
+          if (ef === 'A') {
             this.scoreA = Math.max(0, this.scoreA + points);
             this.touchesA.push(zone);
           } else {
@@ -1637,7 +1649,8 @@
 
           this.pushHistory('card');
 
-          const cards = fencer === 'A' ? this.cardsA : this.cardsB;
+          const ef = this._effectiveFencer(fencer);
+          const cards = ef === 'A' ? this.cardsA : this.cardsB;
 
           // Conversion 2ème blanc → jaune (chemin sans sélecteur de raison)
           if (cardType === 'white') {
@@ -1651,11 +1664,11 @@
           cards.push(cardType);
 
           if (cardType === 'yellow') {
-            if (fencer === 'A') this.scoreB += 3;
+            if (ef === 'A') this.scoreB += 3;
             else this.scoreA += 3;
             this.showNotification("🟨 +3 points pour l'adversaire");
           } else if (cardType === 'red') {
-            if (fencer === 'A') this.scoreB += 5;
+            if (ef === 'A') this.scoreB += 5;
             else this.scoreA += 5;
             this.showNotification("🟥 +5 points pour l'adversaire");
           }
@@ -1669,10 +1682,11 @@
         // ── Gestion carton avec sélecteur de raison ──────────────────────────
 
         handleCardButtonPress(fencer, cardType) {
+          const ef = this._effectiveFencer(fencer);
           if (this.cardAnnounceEnabled) {
-            this.openReasonSelector(fencer, cardType);
+            this.openReasonSelector(ef, cardType);
           } else {
-            this.addCard(fencer, cardType);
+            this.addCard(ef, cardType);
           }
         }
 
@@ -1837,8 +1851,9 @@
           if (this.matchStatus === 'finished') return;
 
           this.pushHistory('arena_exit');
+          const ef = this._effectiveFencer(fencer);
           const points = 3;
-          if (fencer === 'A') {
+          if (ef === 'A') {
             this.scoreB += points;
           } else {
             this.scoreA += points;
@@ -1849,18 +1864,21 @@
           this.socket.emit('arena_control', {
             arenaId: this.arenaId,
             action: 'arena_exit',
-            fencer,
+            fencer: ef,
             isVoluntary: false,
           });
-          const label = fencer === 'A' ? 'Rouge' : 'Vert';
-          this.showNotification(window.T('referee.arena_exit_notif', { label, points }));
+          // label = couleur affichée pour le tireur qui a quitté la piste
+          const exitColor = fencer === 'A'
+            ? (this.swapped ? 'Rouge' : 'Vert')
+            : (this.swapped ? 'Vert' : 'Rouge');
+          this.showNotification(window.T('referee.arena_exit_notif', { label: exitColor, points }));
           if (this.cardAnnounceEnabled) {
             const nameEl = document.getElementById(`fencer-${fencer.toLowerCase()}-name`);
-            const fencerName = nameEl ? nameEl.textContent.trim() : label;
+            const fencerName = nameEl ? nameEl.textContent.trim() : exitColor;
             this.socket.emit('arena_control', {
               arenaId: this.arenaId,
               action: 'exit_announcement',
-              announcement: { fencer, fencerName, points },
+              announcement: { fencer: ef, fencerName, points },
             });
           }
         }
@@ -1870,8 +1888,9 @@
           if (!this.currentMatch) return;
           if (this.matchStatus === 'finished') return;
 
+          const ef = this._effectiveFencer(fencer);
           const zone = points === 1 ? 'A' : points === 3 ? 'B' : 'C';
-          if (fencer === 'A') {
+          if (ef === 'A') {
             this.scoreA = Math.max(0, this.scoreA - points);
             const idx = this.touchesA.lastIndexOf(zone);
             if (idx !== -1) this.touchesA.splice(idx, 1);
@@ -1900,8 +1919,9 @@
           if (!this.currentMatch) return;
           if (this.matchStatus === 'finished') return;
 
-          const cards = fencer === 'A' ? this.cardsA : this.cardsB;
-          const history = fencer === 'A' ? this.faultHistoryA : this.faultHistoryB;
+          const ef = this._effectiveFencer(fencer);
+          const cards = ef === 'A' ? this.cardsA : this.cardsB;
+          const history = ef === 'A' ? this.faultHistoryA : this.faultHistoryB;
 
           if (cards.length === 0) {
             this.showNotification('Aucun carton à retirer');
@@ -1912,10 +1932,10 @@
 
           // Restituer les points accordés à l'adversaire
           if (lastCard === 'yellow') {
-            if (fencer === 'A') this.scoreB = Math.max(0, this.scoreB - 3);
+            if (ef === 'A') this.scoreB = Math.max(0, this.scoreB - 3);
             else this.scoreA = Math.max(0, this.scoreA - 3);
           } else if (lastCard === 'red') {
-            if (fencer === 'A') this.scoreB = Math.max(0, this.scoreB - 5);
+            if (ef === 'A') this.scoreB = Math.max(0, this.scoreB - 5);
             else this.scoreA = Math.max(0, this.scoreA - 5);
           }
 
@@ -1946,6 +1966,40 @@
           this.showNotification(`↩ Dernier carton ${label} annulé`);
         }
 
+        toggleSwap() {
+          this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'toggle_swap' });
+        }
+
+        _effectiveFencer(configFencer) {
+          return this.swapped ? (configFencer === 'A' ? 'B' : 'A') : configFencer;
+        }
+
+        applySwapState() {
+          const boxA = document.getElementById('fencer-a-box');
+          const boxB = document.getElementById('fencer-b-box');
+          if (boxA) boxA.className = `fencer-box ${this.swapped ? 'red-side' : 'green-side'}`;
+          if (boxB) boxB.className = `fencer-box ${this.swapped ? 'green-side' : 'red-side'}`;
+          const scoreA = document.getElementById('score-a');
+          const scoreB = document.getElementById('score-b');
+          if (scoreA) scoreA.className = `score-display ${this.swapped ? 'red-score' : 'green-score'}`;
+          if (scoreB) scoreB.className = `score-display ${this.swapped ? 'green-score' : 'red-score'}`;
+
+          if (this.currentMatch) {
+            const left = this.swapped ? this.currentMatch.fencerB : this.currentMatch.fencerA;
+            const right = this.swapped ? this.currentMatch.fencerA : this.currentMatch.fencerB;
+            document.getElementById('fencer-a-name').textContent =
+              `${left?.lastName || ''} ${left?.firstName || ''}`.trim();
+            document.getElementById('fencer-a-club').textContent = left?.club || '';
+            document.getElementById('fencer-b-name').textContent =
+              `${right?.lastName || ''} ${right?.firstName || ''}`.trim();
+            document.getElementById('fencer-b-club').textContent = right?.club || '';
+          }
+
+          document.getElementById('btn-swap')?.classList.toggle('active', this.swapped);
+          this.updateScores();
+          this.updateCardsDisplay();
+        }
+
         updateScores() {
           const scoreAEl = document.getElementById('score-a');
           const scoreBEl = document.getElementById('score-b');
@@ -1955,8 +2009,8 @@
             scoreAEl.classList.add('not-started');
             scoreBEl.classList.add('not-started');
           } else {
-            scoreAEl.textContent = this.scoreA;
-            scoreBEl.textContent = this.scoreB;
+            scoreAEl.textContent = this.swapped ? this.scoreB : this.scoreA;
+            scoreBEl.textContent = this.swapped ? this.scoreA : this.scoreB;
             scoreAEl.classList.remove('not-started');
             scoreBEl.classList.remove('not-started');
           }
@@ -1971,8 +2025,8 @@
               )
               .join('');
 
-          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.cardsA);
-          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.cardsB);
+          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.swapped ? this.cardsB : this.cardsA);
+          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.swapped ? this.cardsA : this.cardsB);
         }
 
         toggleTimer() {
@@ -2266,6 +2320,11 @@
         handleArenaUpdate(data) {
           if (data.cardAnnounce !== undefined) {
             this.cardAnnounceEnabled = data.cardAnnounce;
+          }
+
+          if (data.swapped !== undefined && data.swapped !== this.swapped) {
+            this.swapped = data.swapped;
+            if (this.currentMatch) this.applySwapState();
           }
 
           // Nouveau match prêt côté serveur (chargement automatique après fin de match)

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -101,6 +101,7 @@ export interface Arena {
   startTime: Date | null;
   settings: ArenaSettings;
   password?: string;
+  swapped?: boolean;
 }
 
 export type DisplayTheme = 'dark' | 'light' | 'neon' | 'custom';
@@ -155,6 +156,7 @@ export interface ArenaUpdate {
   theme?: DisplayTheme; // thème visuel de l'affichage distant
   customTheme?: CustomTheme; // thème personnalisé (si theme === 'custom')
   nextMatch?: ArenaMatch | null; // prochain combat (affiché quand status=finished)
+  swapped?: boolean;
 }
 
 export interface RefereeControl {


### PR DESCRIPTION
- referee.html : bouton ⇄ dans le header, envoie toggle_swap au serveur ;
  _effectiveFencer() remapping A/B selon swap dans addScore, removeScore,
  addCard, removeLastCard, handleCardButtonPress, arenaExit ;
  applySwapState() met à jour CSS classes + noms + scores + cartons
- remoteScoreServer.ts : case toggle_swap dans handleArenaControl,
  swapped propagé automatiquement dans broadcastArenaUpdate et join_arena
- arena.html + public.html : checkbox ⇄ envoie toggle_swap au serveur,
  updateMatchDisplay/updateCardsDisplay/scores inversent le contenu JS
  au lieu du hack CSS direction:rtl

https://claude.ai/code/session_01YARrHrsy8i8sN3uinM2iKm