### PR TITLE
Restaure les boutons export tireurs+photos dans le menu FencerList

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -392,6 +392,20 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                 >
                   Exporter FFF
                 </button>
+                <button
+                  className="btn btn-ghost"
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 16px', borderRadius: 0 }}
+                  onClick={() => { handleExportFencersArchive(); setExportMenuOpen(false); }}
+                >
+                  Exporter tireurs + photos (.bpf)
+                </button>
+                <button
+                  className="btn btn-ghost"
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 16px', borderRadius: 0 }}
+                  onClick={() => { handleExportPhotos(); setExportMenuOpen(false); }}
+                >
+                  Exporter photos (.zip)
+                </button>
               </div>
             )}
           </div>


### PR DESCRIPTION
Les entrées "Exporter tireurs + photos (.bpf)" et "Exporter photos (.zip)"
avaient disparu du dropdown Exporter. Les handlers et IPC existaient déjà ;
seuls les boutons UI manquaient.

https://claude.ai/code/session_011zRqeMrNGd3Guz4RWhig3z