### PR TITLE
fix: supprimer l'appel orphelin applyInversionState() dans init()

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1124,7 +1124,6 @@
           document.getElementById('arena-idle-number').textContent = this.arenaNumber;
           document.getElementById('arena-strip-number').textContent = this.arenaNumber;
           this.setupInversionToggle();
-          this.applyInversionState();
           this.applyTheme(this.theme);
           this.setupHeaderAutoHide();
           this.setupSocketListeners();


### PR DESCRIPTION
applyInversionState() a été retirée dans 37504f0 mais son appel dans
init() était resté, causant un TypeError qui interrompait init() avant
setupSocketListeners() — le socket ne se connectait jamais, indicateur
rouge permanent.

https://claude.ai/code/session_01GRra8dVqtZrgw3JVKmRcfF