### PR TITLE
fix: inversion de côté arbitre indépendante de l'écran de score + couleurs conservées

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1028,8 +1028,8 @@
       <div class="match-display" id="match-display">
         <div class="fencers-row">
           <!-- Tireur A (Vert) -->
-          <div class="fencer-display green-side">
-            <div class="color-badge green"></div>
+          <div id="fencer-a-display" class="fencer-display green-side">
+            <div id="color-badge-a" class="color-badge green"></div>
             <div class="fencer-name" id="fencer-a-name">-</div>
             <div class="fencer-club" id="fencer-a-club">-</div>
             <div class="cards-container" id="fencer-a-cards"></div>
@@ -1040,8 +1040,8 @@
           <div class="vs-divider">VS</div>
 
           <!-- Tireur B (Rouge) -->
-          <div class="fencer-display red-side">
-            <div class="color-badge red"></div>
+          <div id="fencer-b-display" class="fencer-display red-side">
+            <div id="color-badge-b" class="color-badge red"></div>
             <div class="fencer-name" id="fencer-b-name">-</div>
             <div class="fencer-club" id="fencer-b-club">-</div>
             <div class="cards-container" id="fencer-b-cards"></div>
@@ -1301,6 +1301,7 @@
             const cb = document.getElementById('inversion-checkbox');
             if (cb) cb.checked = data.swapped;
             localStorage.setItem('inversionEnabled', data.swapped);
+            this.applyInversionColors();
           }
 
           // Mise à jour du statut
@@ -1408,6 +1409,24 @@
           const valB = (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
           document.getElementById('score-a').textContent = this.inversionEnabled ? valB : valA;
           document.getElementById('score-b').textContent = this.inversionEnabled ? valA : valB;
+
+          this.applyInversionColors();
+        }
+
+        applyInversionColors() {
+          const inv = this.inversionEnabled;
+          const dispA = document.getElementById('fencer-a-display');
+          const dispB = document.getElementById('fencer-b-display');
+          if (dispA) dispA.className = `fencer-display ${inv ? 'red-side' : 'green-side'}`;
+          if (dispB) dispB.className = `fencer-display ${inv ? 'green-side' : 'red-side'}`;
+          const badgeA = document.getElementById('color-badge-a');
+          const badgeB = document.getElementById('color-badge-b');
+          if (badgeA) badgeA.className = `color-badge ${inv ? 'red' : 'green'}`;
+          if (badgeB) badgeB.className = `color-badge ${inv ? 'green' : 'red'}`;
+          const scoreA = document.getElementById('score-a');
+          const scoreB = document.getElementById('score-b');
+          if (scoreA) { scoreA.className = scoreA.className.replace(/\b(green|red)\b/, inv ? 'red' : 'green'); }
+          if (scoreB) { scoreB.className = scoreB.className.replace(/\b(green|red)\b/, inv ? 'green' : 'red'); }
         }
 
         updateCardsDisplay() {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1967,7 +1967,8 @@
         }
 
         toggleSwap() {
-          this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'toggle_swap' });
+          this.swapped = !this.swapped;
+          this.applySwapState();
         }
 
         _effectiveFencer(configFencer) {
@@ -2320,11 +2321,6 @@
         handleArenaUpdate(data) {
           if (data.cardAnnounce !== undefined) {
             this.cardAnnounceEnabled = data.cardAnnounce;
-          }
-
-          if (data.swapped !== undefined && data.swapped !== this.swapped) {
-            this.swapped = data.swapped;
-            if (this.currentMatch) this.applySwapState();
           }
 
           // Nouveau match prêt côté serveur (chargement automatique après fin de match)


### PR DESCRIPTION
- referee.html: toggleSwap() devient local uniquement (ne plus émettre toggle_swap au serveur)
- referee.html: handleArenaUpdate() ne réinitialise plus this.swapped depuis le serveur
- arena.html: ajout de applyInversionColors() pour mettre à jour les classes CSS couleur (green-side/red-side, badge, score) lors de l'inversion
- arena.html: ajout d'IDs sur fencer-a-display, fencer-b-display, color-badge-a, color-badge-b

https://claude.ai/code/session_0121Lj3pUpYEmDSA87ATXdRT