### PR TITLE
fix: exclure les combattants abandonnés/forfait du tableau d'élimination directe

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Fencer, PoolRanking } from '../../shared/types';
+import { Fencer, FencerStatus, PoolRanking } from '../../shared/types';
 import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
 import Bracket from './Bracket';
@@ -183,8 +183,14 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   });
 
   useEffect(() => {
-    if (ranking.length > 0) {
-      const expectedSize = getTableauSize(ranking.length);
+    const eligibleCount = ranking.filter(
+      r =>
+        r.fencer.status !== FencerStatus.ABANDONED &&
+        r.fencer.status !== FencerStatus.FORFAIT &&
+        r.fencer.status !== FencerStatus.EXCLUDED
+    ).length;
+    if (eligibleCount > 0) {
+      const expectedSize = getTableauSize(eligibleCount);
       const currentSize = matches.length > 0 ? Math.max(...matches.map(m => m.round)) : 0;
 
       const hasThirdPlace = matches.some(m => m.round === 3);
@@ -206,8 +212,16 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     return 256;
   };
 
+  const getEligibleFencers = (): PoolRanking[] =>
+    ranking.filter(
+      r =>
+        r.fencer.status !== FencerStatus.ABANDONED &&
+        r.fencer.status !== FencerStatus.FORFAIT &&
+        r.fencer.status !== FencerStatus.EXCLUDED
+    );
+
   const generateTableau = () => {
-    const qualifiedFencers = ranking;
+    const qualifiedFencers = getEligibleFencers();
     const size = getTableauSize(qualifiedFencers.length);
     setTableauSize(size);
 


### PR DESCRIPTION
## Résumé

- Les tireurs avec statut `ABANDONED`, `FORFAIT` ou `EXCLUDED` sont maintenant filtrés avant la génération du tableau d'élimination directe
- La taille du tableau est calculée sur la base des tireurs éligibles uniquement

## Changements

`TableauView.tsx` :
- Ajout de l'import `FencerStatus`
- Ajout d'un helper `getEligibleFencers()` qui filtre les statuts non-qualifiants
- `generateTableau()` utilise désormais `getEligibleFencers()` au lieu de `ranking`
- Le `useEffect` de recalcul de taille utilise également le compte des éligibles

## Plan de test

- [ ] Créer un tournoi avec poules
- [ ] Marquer un tireur comme `ABANDONED` ou `FORFAIT` avant de générer le tableau
- [ ] Vérifier que ce tireur n'apparaît pas dans les matchs du tableau d'élimination directe
- [ ] Vérifier que la taille du tableau est correcte (basée sur les tireurs éligibles)

Fixes #314

🤖 Generated with [Claude Code](https://claude.ai/claude-code)