### PR TITLE
fix: corriger l'inversion des scores dans la saisie de poule (#312)

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -50,7 +50,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [editingMatch, setEditingMatch] = useState<number | null>(null);
   const [showColumnMenu, setShowColumnMenu] = useState(false);
-  const [editingFromRowA, setEditingFromRowA] = useState<boolean>(true);
+
   const [editScoreA, setEditScoreA] = useState('');
   const [editScoreB, setEditScoreB] = useState('');
   const [victoryA, setVictoryA] = useState(false);
@@ -160,7 +160,6 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         if (e.key === 'Escape') {
           e.preventDefault();
           setEditingMatch(null);
-          setEditingFromRowA(true);
           setKeyboardFocusField('A');
           return;
         }
@@ -253,20 +252,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     if (rowFencer.id === colFencer.id) return;
     const matchIndex = getMatchIndex(rowFencer, colFencer);
     if (matchIndex === -1) return;
-
-    const match = pool.matches[matchIndex];
-    const isRowA = match.fencerA?.id === rowFencer.id;
-
-    setEditingMatch(matchIndex);
-    setEditingFromRowA(isRowA);
-    setEditScoreA(
-      isRowA ? match.scoreA?.value?.toString() || '' : match.scoreB?.value?.toString() || ''
-    );
-    setEditScoreB(
-      isRowA ? match.scoreB?.value?.toString() || '' : match.scoreA?.value?.toString() || ''
-    );
-    setVictoryA(false);
-    setVictoryB(false);
+    openScoreModal(matchIndex);
   };
 
   const handleScoreSubmit = () => {
@@ -289,9 +275,8 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
       }
     }
 
-    // Si on édite depuis la ligne B, inverser les scores pour les enregistrer correctement
-    const actualScoreA = editingFromRowA ? scoreA : scoreB;
-    const actualScoreB = editingFromRowA ? scoreB : scoreA;
+    const actualScoreA = scoreA;
+    const actualScoreB = scoreB;
 
     // Capturer l'ancien score pour l'historique
     const match = pool.matches[editingMatch];
@@ -302,7 +287,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     if (actualScoreA === actualScoreB) {
       if (isLaserSabre && (victoryA || victoryB)) {
         // Déterminer qui gagne selon la perspective
-        const winner = editingFromRowA ? (victoryA ? 'A' : 'B') : victoryB ? 'A' : 'B';
+        const winner = victoryA ? 'A' : 'B';
         addAction({
           type: 'UPDATE_SCORE',
           description: `Score poule ${pool.number} match ${matchIdx + 1}`,
@@ -332,7 +317,6 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
 
     // Fermer le modal immédiatement après la mise à jour
     setEditingMatch(null);
-    setEditingFromRowA(true);
     setEditScoreA('');
     setEditScoreB('');
     setVictoryA(false);
@@ -379,7 +363,6 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
 
     // Fermer le modal immédiatement après la mise à jour
     setEditingMatch(null);
-    setEditingFromRowA(true);
     setEditScoreA('');
     setEditScoreB('');
     setVictoryA(false);
@@ -481,7 +464,6 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         className="modal-overlay"
         onClick={() => {
           setEditingMatch(null);
-          setEditingFromRowA(true);
         }}
       >
         <div
@@ -745,7 +727,6 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
               className="btn btn-secondary"
               onClick={() => {
                 setEditingMatch(null);
-                setEditingFromRowA(true);
               }}
             >
               Annuler


### PR DESCRIPTION
## Problème

Cliquer sur la case (ligne 5, colonne 2) dans le tableau de poule ouvrait une fenêtre de saisie. Le combattant de la ligne 5 était affiché à droite (fencerB) et celui de la colonne 2 à gauche (fencerA). En saisissant 4-15, on s'attendait à ce que le combattant 2 reçoive 4 touches et le combattant 5 en reçoive 15 — mais les scores étaient inversés.

## Cause

La logique `editingFromRowA` dans `handleCellClick` permutait `editScoreA`/`editScoreB` selon que le combattant de la ligne était `fencerA` ou `fencerB`. Puis `handleScoreSubmit` inversait à nouveau en fonction de ce flag — mais le dialog affiche **toujours** `fencerA` à gauche et `fencerB` à droite, indépendamment de quelle cellule a été cliquée. Le double renversement était donc incorrect.

## Correction

- `handleCellClick` appelle désormais directement `openScoreModal` (qui initialise correctement `editScoreA = match.scoreA`, `editScoreB = match.scoreB`)
- `handleScoreSubmit` utilise `scoreA`/`scoreB` directement, sans inversion
- La logique vainqueur Sabre Laser est simplifiée : `victoryA ? 'A' : 'B'`
- Le state `editingFromRowA` est supprimé (devenu inutile)

## Test

- Cliquer sur la case (ligne i, colonne j) → le combattant j est à gauche, le combattant i est à droite
- Saisir X-Y → combattant j reçoit X touches, combattant i reçoit Y touches
- Cliquer sur la case symétrique (ligne j, colonne i) → même résultat

Fixes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)