### PR TITLE
fix: classement cumulatif en mode multi-tours de poules (#313)

### DIFF
--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -63,6 +63,16 @@ export const usePoolManagement = ({
     [isLaserSabre]
   );
 
+  // Inclut l'historique des tours précédents pour un classement cumulatif
+  const computeOverallRankingAllRounds = useCallback(
+    (currentPools: Pool[], extraHistory?: Pool[][]) => {
+      const history = extraHistory ?? poolHistory;
+      const allPools = [...history.flat(), ...currentPools];
+      return computeOverallRanking(allPools);
+    },
+    [poolHistory, computeOverallRanking]
+  );
+
   // Générer les poules
   const generatePools = useCallback(
     (checkedInFencers: Fencer[]) => {
@@ -171,14 +181,14 @@ export const usePoolManagement = ({
 
         updatedPools[poolIndex] = pool;
 
-        // Recalculer le classement général
-        const newOverallRanking = computeOverallRanking(updatedPools);
+        // Recalculer le classement général (tous les tours cumulés)
+        const newOverallRanking = computeOverallRankingAllRounds(updatedPools);
         setOverallRanking(newOverallRanking);
 
         return updatedPools;
       });
     },
-    [computePoolRanking, computeOverallRanking]
+    [computePoolRanking, computeOverallRankingAllRounds]
   );
 
   // Passer au tour de poules suivant
@@ -232,12 +242,15 @@ export const usePoolManagement = ({
       setPools(newPools);
       setCurrentPoolRound(prev => prev + 1);
 
-      const ranking = computeOverallRanking(newPools);
+      // Classement cumulatif sur tous les tours terminés (historique + tour courant)
+      // newPools est vide, le classement reflète l'état après le tour qui vient de finir
+      const allCompletedPools = [...poolHistory, pools];
+      const ranking = computeOverallRanking(allCompletedPools.flat());
       setOverallRanking(ranking);
 
       showToast(`Tour ${currentPoolRound + 1} de poules créé`, 'success');
     },
-    [pools, currentPoolRound, poolMaxScore, computeOverallRanking, showToast]
+    [pools, poolHistory, currentPoolRound, poolMaxScore, computeOverallRanking, showToast]
   );
 
   // Vérifier si toutes les poules sont complètes
@@ -362,9 +375,9 @@ export const usePoolManagement = ({
           }
         });
 
-        // Recalculer le classement général
+        // Recalculer le classement général (tous les tours cumulés)
         if (modifiedCount > 0) {
-          const newOverallRanking = computeOverallRanking(updatedPools);
+          const newOverallRanking = computeOverallRankingAllRounds(updatedPools);
           setOverallRanking(newOverallRanking);
           showToast(
             `${modifiedCount} match(s) marqué(s) comme non disputés (${status})`,
@@ -375,7 +388,7 @@ export const usePoolManagement = ({
         return updatedPools;
       });
     },
-    [competitionId, pools, computePoolRanking, computeOverallRanking, showToast]
+    [competitionId, pools, computePoolRanking, computeOverallRankingAllRounds, showToast]
   );
 
   // Annuler un abandon/forfait/exclusion et restaurer les matchs affectés
@@ -449,7 +462,7 @@ export const usePoolManagement = ({
           pool.updatedAt = new Date();
         });
 
-        const newOverallRanking = computeOverallRanking(updatedPools);
+        const newOverallRanking = computeOverallRankingAllRounds(updatedPools);
         setOverallRanking(newOverallRanking);
 
         if (restoredCount > 0) {
@@ -466,7 +479,7 @@ export const usePoolManagement = ({
         await window.electronAPI.db.deleteAbandonSnapshot(fencerId).catch(() => {});
       }
     },
-    [competitionId, computePoolRanking, computeOverallRanking, showToast]
+    [competitionId, computePoolRanking, computeOverallRankingAllRounds, showToast]
   );
 
   // Mettre à jour un match depuis une source externe (serveur distant)
@@ -519,8 +532,8 @@ export const usePoolManagement = ({
           return prevPools;
         }
 
-        // Recalculer le classement général
-        const newOverallRanking = computeOverallRanking(updatedPools);
+        // Recalculer le classement général (tous les tours cumulés)
+        const newOverallRanking = computeOverallRankingAllRounds(updatedPools);
         setOverallRanking(newOverallRanking);
 
         logger.debug(
@@ -530,7 +543,7 @@ export const usePoolManagement = ({
         return updatedPools;
       });
     },
-    [computePoolRanking, computeOverallRanking]
+    [computePoolRanking, computeOverallRankingAllRounds]
   );
 
   // Synchroniser les données des tireurs (ex: photo) dans les matches de poule
@@ -574,6 +587,7 @@ export const usePoolManagement = ({
     getPoolStats,
     computePoolRanking,
     computeOverallRanking,
+    computeOverallRankingAllRounds,
     handleFencerForfeit,
     handleUndoAbandon,
     syncFencersToPool,

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -983,8 +983,10 @@ export function calculateOverallRankingQuest(pools: Pool[]): PoolRanking[] {
     allRankings.push(...ranking);
   });
 
-  // Trier selon les critères demandés (même ordre que calculateOverallRanking)
-  allRankings.sort((a, b) => {
+  // Fusionner les stats du même tireur (multi-tours de poules)
+  const mergedRankings = mergeFencerRankings(allRankings);
+
+  mergedRankings.sort((a, b) => {
     // 1. Ratio de victoires V/M (décroissant)
     if (a.ratio !== b.ratio) {
       return b.ratio - a.ratio;
@@ -1003,9 +1005,38 @@ export function calculateOverallRankingQuest(pools: Pool[]): PoolRanking[] {
     return 0;
   });
 
-  assignRanks(allRankings);
+  assignRanks(mergedRankings);
 
-  return allRankings;
+  return mergedRankings;
+}
+
+/**
+ * Fusionne les entrées de classement du même tireur (multi-tours de poules).
+ * Additionne victoires, défaites, touches, et recalcule ratio et indice.
+ */
+function mergeFencerRankings(rankings: PoolRanking[]): PoolRanking[] {
+  const byFencer = new Map<string, PoolRanking>();
+  for (const r of rankings) {
+    const existing = byFencer.get(r.fencer.id);
+    if (!existing) {
+      byFencer.set(r.fencer.id, { ...r });
+    } else {
+      existing.victories += r.victories;
+      existing.defeats += r.defeats;
+      existing.matchesPlayed += r.matchesPlayed;
+      existing.touchesScored += r.touchesScored;
+      existing.touchesReceived += r.touchesReceived;
+      existing.index = existing.touchesScored - existing.touchesReceived;
+      existing.ratio =
+        existing.matchesPlayed > 0 ? existing.victories / existing.matchesPlayed : 0;
+      existing.questPoints = (existing.questPoints ?? 0) + (r.questPoints ?? 0);
+      existing.questVictories4 = (existing.questVictories4 ?? 0) + (r.questVictories4 ?? 0);
+      existing.questVictories3 = (existing.questVictories3 ?? 0) + (r.questVictories3 ?? 0);
+      existing.questVictories2 = (existing.questVictories2 ?? 0) + (r.questVictories2 ?? 0);
+      existing.questVictories1 = (existing.questVictories1 ?? 0) + (r.questVictories1 ?? 0);
+    }
+  }
+  return Array.from(byFencer.values());
 }
 
 /**
@@ -1026,11 +1057,10 @@ export function calculateOverallRanking(pools: Pool[]): PoolRanking[] {
     }
   });
 
-  // Trier selon les critères demandés:
-  // 1. Ratio de victoires V/M (décroissant)
-  // 2. Points Quest (décroissant)
-  // 3. Indice (TD-TR) (décroissant)
-  allRankings.sort((a, b) => {
+  // Fusionner les stats du même tireur (multi-tours de poules)
+  const mergedRankings = mergeFencerRankings(allRankings);
+
+  mergedRankings.sort((a, b) => {
     // 1. Ratio de victoires V/M
     if (a.ratio !== b.ratio) {
       return b.ratio - a.ratio;
@@ -1049,9 +1079,9 @@ export function calculateOverallRanking(pools: Pool[]): PoolRanking[] {
     return 0;
   });
 
-  assignRanks(allRankings);
+  assignRanks(mergedRankings);
 
-  return allRankings;
+  return mergedRankings;
 }
 
 // Génère un classement initial depuis la liste des tireurs (sans données de poules)


### PR DESCRIPTION
## Problème

En mode plusieurs tours de poules, les statistiques utilisées pour constituer le tableau d'élimination directe n'étaient pas cumulatives. Seul le tour courant était pris en compte, ignorant les résultats des tours précédents.

## Cause racine

Deux bugs liés :

1. **`calculateOverallRanking` / `calculateOverallRankingQuest`** — collectait les classements de chaque poule puis les triait, mais si le même tireur apparaissait dans plusieurs rounds, il avait des entrées dupliquées au lieu de stats cumulées.

2. **`usePoolManagement`** — toutes les fonctions (`updateScore`, `nextPoolRound`, `handleFencerForfeit`, `handleUndoAbandon`, `updateMatchFromRemote`) passaient uniquement les poules du tour courant à `computeOverallRanking`, ignorant `poolHistory` (les tours précédents terminés).

## Solution

- Ajoute `mergeFencerRankings()` dans `poolCalculations.ts` : fusionne les entrées d'un même tireur (par `fencer.id`) en additionnant victoires, défaites, touches, et en recalculant ratio et indice.
- Applique cette fusion dans `calculateOverallRanking` et `calculateOverallRankingQuest` — transparent pour les tournois 1 seul tour (pas de doublons).
- Ajoute `computeOverallRankingAllRounds(currentPools)` dans `usePoolManagement` qui concatène `poolHistory.flat()` + `currentPools` avant le calcul.
- Corrige `nextPoolRound` : calcule le classement sur `[...poolHistory, pools].flat()` (tous les tours terminés), pas sur les nouvelles poules vides.
- Corrige les 4 autres fonctions pour utiliser `computeOverallRankingAllRounds`.

## Test plan

- [ ] Tournoi 1 seul tour : comportement inchangé (pas de régression)
- [ ] Tournoi 2 tours : après le 2ème tour, les victoires/touches/ratio sont bien la somme des 2 tours
- [ ] Le tableau d'élimination place les tireurs selon ce classement cumulatif
- [ ] Forfait/abandon mid-poule fonctionne toujours correctement

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)