### PR TITLE
fix: appliquer l'inversion aux combattants du prochain match

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1527,14 +1527,16 @@
           if (!this.nextMatch) return;
           const fA = this.nextMatch.fencerA || {};
           const fB = this.nextMatch.fencerB || {};
+          const left  = this.inversionEnabled ? fB : fA;
+          const right = this.inversionEnabled ? fA : fB;
 
           document.getElementById('next-name-a').textContent =
-            `${fA.lastName || ''} ${fA.firstName || ''}`.trim() || '-';
+            `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
           document.getElementById('next-name-b').textContent =
-            `${fB.lastName || ''} ${fB.firstName || ''}`.trim() || '-';
+            `${right.lastName || ''} ${right.firstName || ''}`.trim() || '-';
 
-          this.setNextFencerPhoto('a', fA.photo);
-          this.setNextFencerPhoto('b', fB.photo);
+          this.setNextFencerPhoto('a', left.photo);
+          this.setNextFencerPhoto('b', right.photo);
         }
 
         setNextFencerPhoto(side, photoBase64) {
@@ -1587,14 +1589,16 @@
           if (this.nextMatch) {
             const fA = this.nextMatch.fencerA || {};
             const fB = this.nextMatch.fencerB || {};
+            const left  = this.inversionEnabled ? fB : fA;
+            const right = this.inversionEnabled ? fA : fB;
             document.getElementById('idle-name-a').textContent =
-              `${fA.lastName || ''} ${fA.firstName || ''}`.trim() || '-';
-            document.getElementById('idle-club-a').textContent = fA.club || '';
+              `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
+            document.getElementById('idle-club-a').textContent = left.club || '';
             document.getElementById('idle-name-b').textContent =
-              `${fB.lastName || ''} ${fB.firstName || ''}`.trim() || '-';
-            document.getElementById('idle-club-b').textContent = fB.club || '';
-            this.setIdleFencerPhoto('a', fA.photo);
-            this.setIdleFencerPhoto('b', fB.photo);
+              `${right.lastName || ''} ${right.firstName || ''}`.trim() || '-';
+            document.getElementById('idle-club-b').textContent = right.club || '';
+            this.setIdleFencerPhoto('a', left.photo);
+            this.setIdleFencerPhoto('b', right.photo);
             preview.classList.remove('hidden');
             idleNumber.style.display = 'none';
             if (idleLabel) idleLabel.style.display = 'none';


### PR DESCRIPTION
## Summary
- Quand l'inversion est activée sur l'écran arène, les combattants du **prochain match** s'affichent désormais dans l'ordre inversé
- Corrige `updateNextMatchPanel()` (panneau bas après match terminé) et `updateIdleNextMatchDisplay()` (écran d'attente idle)

## Test plan
- [ ] Activer l'inversion sur l'écran arène
- [ ] Vérifier que le panneau "⚔ Prochain" affiche les combattants en ordre inversé (gauche/droite swappés)
- [ ] Vérifier que l'écran idle "⚔ Prochain combat" affiche également l'ordre inversé
- [ ] Désactiver l'inversion → ordre normal rétabli pour les deux panneaux

🤖 Generated with [Claude Code](https://claude.com/claude-code)