### PR TITLE
fix: inverser rafraîchit les noms et positions des combattants

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1302,6 +1302,8 @@
             if (cb) cb.checked = data.swapped;
             localStorage.setItem('inversionEnabled', data.swapped);
             this.applyInversionColors();
+            this.updateMatchDisplay();
+            this.updateVisibility();
           }
 
           // Mise à jour du statut


### PR DESCRIPTION
## Summary
- Correction du bug où cliquer sur "Inverser" ne changeait que les couleurs (CSS) mais pas les noms/positions des combattants
- Après le toggle, `updateMatchDisplay()` et `updateVisibility()` sont maintenant rappelés pour rafraîchir tous les panneaux (match en cours, prochain match, écran idle)

## Test plan
- [ ] Lancer un match sur l'arène
- [ ] Cliquer sur "Inverser" → les combattants (noms + positions) s'inversent immédiatement
- [ ] Vérifier le panneau "⚔ Prochain" en fin de match → ordre inversé respecté
- [ ] Vérifier l'écran idle "⚔ Prochain combat" → ordre inversé respecté
- [ ] Désactiver l'inversion → retour à l'ordre normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)