### PR TITLE
feat: Tour Quest — nouvelle phase Sabre Laser avec planning aléatoire équilibré

### DIFF
--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -263,22 +263,28 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
             </h3>
 
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
-              <div className="form-group">
-                <label htmlFor="poolRounds">Tours de poules</label>
-                <select
-                  id="poolRounds"
-                  className="form-input form-select"
-                  value={poolRounds}
-                  onChange={e => setPoolRounds(parseInt(e.target.value))}
-                >
-                  <option value="1">1 tour</option>
-                  <option value="2">2 tours</option>
-                  <option value="3">3 tours</option>
-                </select>
-                <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
-                  Nombre de phases de poules avant le tableau
-                </small>
-              </div>
+              {/* Tours de poules — masqué en mode Quest sans poules préliminaires */}
+              {(!questEnabled || questHasPools) && (
+                <div className="form-group">
+                  <label htmlFor="poolRounds">Tours de poules</label>
+                  <select
+                    id="poolRounds"
+                    className="form-input form-select"
+                    value={questEnabled && questHasPools ? 1 : poolRounds}
+                    onChange={e => setPoolRounds(parseInt(e.target.value))}
+                    disabled={questEnabled && questHasPools}
+                  >
+                    <option value="1">1 tour</option>
+                    <option value="2">2 tours</option>
+                    <option value="3">3 tours</option>
+                  </select>
+                  <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+                    {questEnabled && questHasPools
+                      ? '1 tour imposé avant le Tour Quest'
+                      : 'Nombre de phases de poules avant le tableau'}
+                  </small>
+                </div>
+              )}
 
               <div className="form-group">
                 <label htmlFor="hasDirectElimination">Élimination directe</label>

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -544,31 +544,36 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       disabled: false,
       title: undefined as string | undefined,
     },
-    {
-      id: 'poolprep',
-      label: t('phases.poolprep'),
-      icon: '⚙️',
-      disabled: false,
-      title: undefined as string | undefined,
-    },
-    {
-      id: 'pools',
-      label: skipPoolPhase
-        ? t('phases.pools_skip')
-        : poolRounds > 1
-          ? t('phases.pools_round', { current: currentPoolRound, total: poolRounds })
-          : t('phases.pools'),
-      icon: skipPoolPhase ? '⏭' : '🎯',
-      disabled: skipPoolPhase,
-      title: skipPoolPhase ? t('phases.pools_skip_tooltip') : (undefined as string | undefined),
-    },
-    {
-      id: 'ranking',
-      label: t('phases.ranking'),
-      icon: '📊',
-      disabled: false,
-      title: undefined as string | undefined,
-    },
+    // Phases de poules : masquées en mode Quest sans poules préliminaires
+    ...(!questEnabled || questConfig?.hasPreliminaryPools
+      ? [
+          {
+            id: 'poolprep',
+            label: t('phases.poolprep'),
+            icon: '⚙️',
+            disabled: false,
+            title: undefined as string | undefined,
+          },
+          {
+            id: 'pools',
+            label: skipPoolPhase
+              ? t('phases.pools_skip')
+              : poolRounds > 1
+                ? t('phases.pools_round', { current: currentPoolRound, total: poolRounds })
+                : t('phases.pools'),
+            icon: skipPoolPhase ? '⏭' : '🎯',
+            disabled: skipPoolPhase,
+            title: skipPoolPhase ? t('phases.pools_skip_tooltip') : (undefined as string | undefined),
+          },
+          {
+            id: 'ranking',
+            label: t('phases.ranking'),
+            icon: '📊',
+            disabled: false,
+            title: undefined as string | undefined,
+          },
+        ]
+      : []),
     ...(questEnabled
       ? [
           {
@@ -1035,10 +1040,11 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
           competition={competition}
           onSave={async updates => {
             const updatedCompetition = { ...competition, ...updates };
+            // Mettre à jour l'UI immédiatement avant l'écriture DB pour éviter le flash
+            onUpdate(updatedCompetition);
             if (window.electronAPI) {
               await window.electronAPI.db.updateCompetition(competition.id, updatedCompetition);
             }
-            onUpdate(updatedCompetition);
           }}
           onClose={() => setShowPropertiesModal(false)}
         />


### PR DESCRIPTION
## Summary

- Nouvelle phase **Tour Quest** pour les compétitions Sabre Laser
- Méga-poule unique avec planning de combats généré aléatoirement (K combats/tireur, aucune paire dupliquée)
- Deux nouveaux formats activés : `Quest → Tableau` et `Poules → Quest → Tableau`
- Choix du format dans les Propriétés de la compétition (visible uniquement pour Sabre Laser)
- Algorithme round-based garantissant une distribution K±1 et les contraintes club/région/nation
- Fix flash d'interface et perte de paramètres Quest lors de la sauvegarde

## Fichiers clés

- `src/shared/types/index.ts` — `PhaseType.QUEST` + `QuestPhaseConfig` + `questConfig?` dans `CompetitionSettings`
- `src/shared/utils/questScheduler.ts` (nouveau) — génération et validation du planning
- `src/shared/utils/questScheduler.test.ts` (nouveau) — 13 tests unitaires
- `src/renderer/components/QuestPhaseView.tsx` (nouveau) — UI config + planning + combats
- `src/renderer/components/CompetitionPropertiesModal.tsx` — section Tour Quest
- `src/renderer/components/CompetitionView.tsx` — routing de phases dynamique

## Test plan

- [ ] Créer une compétition Sabre Laser
- [ ] Propriétés → activer Tour Quest "Sans poules préliminaires"
- [ ] Ajouter ≥2 tireurs → Phase Quest → générer le planning → vérifier K combats/tireur, aucun doublon
- [ ] Réordonner des combats avec ↑↓ → lancer → saisir les scores
- [ ] Activer Tour Quest "Avec poules préliminaires" → vérifier que la phase poules précède Quest
- [ ] Vérifier qu'aucun flash n'apparaît lors de la sauvegarde des paramètres Quest
- [ ] `npm run test:run` → tous les tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)