### PR TITLE
fix: éviter le Maximum update depth lors de l'import de gros fichiers .fff

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -106,6 +106,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     fencers,
     loadFencers,
     addFencer,
+    bulkAddFencers,
     updateFencer,
     deleteFencer,
     deleteAllFencers,
@@ -341,9 +342,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   };
 
   const handleImportFencers = async (importedFencers: Partial<Fencer>[]) => {
-    for (const fencerData of importedFencers) {
-      await addFencer(fencerData as any);
-    }
+    await bulkAddFencers(importedFencers as any);
     setImportData(null);
   };
 

--- a/src/renderer/hooks/useFencerManagement.ts
+++ b/src/renderer/hooks/useFencerManagement.ts
@@ -189,6 +189,29 @@ export const useFencerManagement = ({ competition, onUpdate }: UseFencerManageme
     return fencers.filter(f => f.status === FencerStatus.CHECKED_IN);
   }, [fencers]);
 
+  // Importer plusieurs tireurs en une seule opération (évite N re-renders)
+  const bulkAddFencers = useCallback(
+    async (fencersData: Omit<Fencer, 'id' | 'createdAt' | 'updatedAt'>[]) => {
+      if (!window.electronAPI?.db?.addFencer) {
+        showToast('Erreur: API non disponible', 'error');
+        throw new Error('API non disponible');
+      }
+
+      const added: Fencer[] = [];
+      for (const fencerData of fencersData) {
+        const newFencer = await window.electronAPI.db.addFencer(competition.id, fencerData as any);
+        added.push(newFencer);
+      }
+
+      const updatedFencers = [...fencers, ...added];
+      setFencers(updatedFencers);
+      onUpdate({ ...competition, fencers: updatedFencers });
+      showToast(`${added.length} tireur${added.length !== 1 ? 's' : ''} importé${added.length !== 1 ? 's' : ''}`, 'success');
+      return added;
+    },
+    [fencers, competition, onUpdate, showToast]
+  );
+
   // Importer un classement depuis un fichier FFF
   const importRanking = useCallback(
     async (fileContent: string): Promise<RankingImportResult> => {
@@ -270,6 +293,7 @@ export const useFencerManagement = ({ competition, onUpdate }: UseFencerManageme
     setFencers,
     loadFencers,
     addFencer,
+    bulkAddFencers,
     updateFencer,
     deleteFencer,
     deleteAllFencers,


### PR DESCRIPTION
## Summary

- `handleImportFencers` appelait `addFencer` en boucle séquentielle : chaque appel déclenchait `setFencers` + `onUpdate`, provoquant N re-renders en cascade
- Le `useEffect` de sync `competition.fencers` se retriggait à chaque cycle → "Maximum update depth exceeded"
- Ajout de `bulkAddFencers` dans `useFencerManagement` : insère tous les tireurs en DB, puis fait **un seul** `setFencers`/`onUpdate` à la fin

## Test plan

- [ ] Importer un fichier `.fff` avec 50+ tireurs → aucun "Maximum update depth exceeded" en console
- [ ] Vérifier que tous les tireurs sont bien importés (pas juste le dernier)
- [ ] Import avec un petit fichier (< 5 tireurs) → comportement inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)