### PR TITLE
feat: classement Tour Quest par V/M, Points Quest et cartons

### DIFF
--- a/src/renderer/components/QuestPhaseView.tsx
+++ b/src/renderer/components/QuestPhaseView.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { Fencer, QuestPhaseConfig, Pool, Match, MatchStatus, Score } from '../../shared/types';
 import {
   calculateFightsPerFencer,
@@ -13,6 +13,8 @@ import {
   QuestFight,
   OpponentConstraint,
 } from '../../shared/utils/questScheduler';
+import { calculatePoolRankingQuest } from '../../shared/utils/poolCalculations';
+import { formatRatio } from '../../shared/utils/poolCalculations';
 import PoolView from './PoolView';
 
 interface QuestPhaseViewProps {
@@ -43,6 +45,7 @@ const QuestPhaseView: React.FC<QuestPhaseViewProps> = ({
   );
   const [schedule, setSchedule] = useState<QuestFight[]>([]);
   const [pools, setPools] = useState<Pool[]>([]);
+  const [cardCounts, setCardCounts] = useState<Record<string, number>>({});
 
   const autoFights = calculateFightsPerFencer(timeMinutes, arenas, fencers.length);
   const effectiveFights = manualFights !== '' ? Number(manualFights) : autoFights;
@@ -178,6 +181,16 @@ const QuestPhaseView: React.FC<QuestPhaseViewProps> = ({
 
   if (state === 'running') {
     const allComplete = pools.every(p => p.isComplete);
+    const questPool = pools[0] ?? null;
+    const ranking = allComplete && questPool
+      ? calculatePoolRankingQuest(questPool, cardCounts)
+      : null;
+
+    const addCard = (fencerId: string) =>
+      setCardCounts(prev => ({ ...prev, [fencerId]: (prev[fencerId] ?? 0) + 1 }));
+    const removeCard = (fencerId: string) =>
+      setCardCounts(prev => ({ ...prev, [fencerId]: Math.max(0, (prev[fencerId] ?? 0) - 1) }));
+
     return (
       <div className="content">
         <div style={{ marginBottom: '1rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -188,7 +201,8 @@ const QuestPhaseView: React.FC<QuestPhaseViewProps> = ({
             </button>
           )}
         </div>
-        {pools.map((pool, poolIndex) => (
+
+        {pools.map(pool => (
           <PoolView
             key={pool.id}
             pool={pool}
@@ -201,6 +215,93 @@ const QuestPhaseView: React.FC<QuestPhaseViewProps> = ({
             onFencerStatusChange={() => {}}
           />
         ))}
+
+        {/* Compteur de cartons */}
+        <div style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '1.25rem', marginTop: '1.5rem' }}>
+          <p style={{ fontSize: '0.8rem', fontWeight: 600, color: '#6b7280', textTransform: 'uppercase', marginBottom: '0.75rem' }}>
+            Cartons reçus
+          </p>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {fencers.map(f => {
+              const count = cardCounts[f.id] ?? 0;
+              return (
+                <div
+                  key={f.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.4rem',
+                    padding: '0.35rem 0.6rem',
+                    background: count > 0 ? '#fef3c7' : 'white',
+                    border: `1px solid ${count > 0 ? '#fbbf24' : '#e5e7eb'}`,
+                    borderRadius: '6px',
+                    fontSize: '0.85rem',
+                  }}
+                >
+                  <span style={{ fontWeight: 500 }}>{f.lastName} {f.firstName?.charAt(0)}.</span>
+                  <button
+                    onClick={() => removeCard(f.id)}
+                    disabled={count === 0}
+                    style={{ padding: '0 0.35rem', border: '1px solid #d1d5db', borderRadius: '4px', background: 'white', cursor: count === 0 ? 'not-allowed' : 'pointer', opacity: count === 0 ? 0.4 : 1, lineHeight: 1.4 }}
+                  >−</button>
+                  <span style={{ minWidth: '1.2rem', textAlign: 'center', fontWeight: 700, color: count > 0 ? '#b45309' : '#6b7280' }}>{count}</span>
+                  <button
+                    onClick={() => addCard(f.id)}
+                    style={{ padding: '0 0.35rem', border: '1px solid #d1d5db', borderRadius: '4px', background: 'white', cursor: 'pointer', lineHeight: 1.4 }}
+                  >+</button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Classement final (affiché quand tous les matchs sont terminés) */}
+        {allComplete && ranking && (
+          <div style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '1.25rem', marginTop: '1.5rem' }}>
+            <p style={{ fontSize: '0.8rem', fontWeight: 600, color: '#6b7280', textTransform: 'uppercase', marginBottom: '0.75rem' }}>
+              Classement Tour Quest
+            </p>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+              <thead>
+                <tr style={{ background: '#f3f4f6' }}>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center', borderBottom: '2px solid #e5e7eb', width: '3rem' }}>Rg</th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', borderBottom: '2px solid #e5e7eb' }}>Tireur</th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center', borderBottom: '2px solid #e5e7eb' }} title="Victoires / Matchs joués">V/M</th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center', borderBottom: '2px solid #e5e7eb' }} title="Points Quest">Pts Q</th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center', borderBottom: '2px solid #e5e7eb' }} title="Cartons reçus (moins = mieux)">Cart.</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ranking.map((r, i) => (
+                  <tr
+                    key={r.fencer.id}
+                    style={{ background: i % 2 === 0 ? 'white' : '#f9fafb', borderBottom: '1px solid #e5e7eb' }}
+                  >
+                    <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center', fontWeight: 700, color: r.rank <= 3 ? '#1d4ed8' : '#374151' }}>
+                      {r.rank}
+                    </td>
+                    <td style={{ padding: '0.5rem 0.75rem', fontWeight: 500 }}>
+                      {r.fencer.lastName} {r.fencer.firstName}
+                      {r.fencer.club && <span style={{ color: '#6b7280', fontWeight: 400 }}> ({r.fencer.club})</span>}
+                    </td>
+                    <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center' }}>
+                      {formatRatio(r.ratio)}
+                    </td>
+                    <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center', fontWeight: 600, color: '#1d4ed8' }}>
+                      {r.questPoints ?? 0}
+                    </td>
+                    <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center', color: (r.totalCards ?? 0) > 0 ? '#b45309' : '#6b7280' }}>
+                      {r.totalCards ?? 0}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p style={{ fontSize: '0.75rem', color: '#6b7280', marginTop: '0.75rem' }}>
+              Critères : V/M décroissant → Points Quest décroissants → Cartons croissants
+            </p>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -304,6 +304,7 @@ export interface PoolRanking {
   questVictories3?: number; // Nombre de victoires à 3 points (écart 8-11)
   questVictories2?: number; // Nombre de victoires à 2 points (écart 4-7)
   questVictories1?: number; // Nombre de victoires à 1 point (écart ≤3)
+  totalCards?: number;      // Nombre total de cartons reçus (critère de départage Quest)
 }
 
 // ============================================================================

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -888,12 +888,14 @@ export function calculateFencerQuestStats(
  * 3. Nombre de victoires
  * 4. Nombre de victoires à 4 points, puis 3, puis 2, puis 1
  */
-export function calculatePoolRankingQuest(pool: Pool): PoolRanking[] {
+export function calculatePoolRankingQuest(
+  pool: Pool,
+  cardsByFencer: Record<string, number> = {}
+): PoolRanking[] {
   const rankings: PoolRanking[] = [];
   const forfeitFencers: PoolRanking[] = [];
 
   for (const fencer of pool.fencers) {
-    // Si tireur forfait/abandon/exclu, l'ajouter à la liste séparée
     if (
       fencer.status === FencerStatus.EXCLUDED ||
       fencer.status === FencerStatus.FORFAIT ||
@@ -914,6 +916,7 @@ export function calculatePoolRankingQuest(pool: Pool): PoolRanking[] {
         questVictories3: 0,
         questVictories2: 0,
         questVictories1: 0,
+        totalCards: cardsByFencer[fencer.id] ?? 0,
       });
       continue;
     }
@@ -936,29 +939,29 @@ export function calculatePoolRankingQuest(pool: Pool): PoolRanking[] {
       questVictories3: questStats.v3,
       questVictories2: questStats.v2,
       questVictories1: questStats.v1,
+      totalCards: cardsByFencer[fencer.id] ?? 0,
     });
   }
 
-  // Trier selon les critères demandés (même ordre que calculatePoolRanking)
+  // Critères de classement Quest :
+  // 1. Ratio V/M décroissant
+  // 2. Points Quest décroissants
+  // 3. Moins de cartons (croissant)
+  // 4. Indice (TD-TR) décroissant
+  // 5. Classement initial
   rankings.sort((a, b) => {
-    // 1. Ratio de victoires V/M (décroissant)
-    if (a.ratio !== b.ratio) {
-      return b.ratio - a.ratio;
-    }
+    if (a.ratio !== b.ratio) return b.ratio - a.ratio;
 
-    // 2. Points Quest (décroissant)
     const aQuest = a.questPoints ?? 0;
     const bQuest = b.questPoints ?? 0;
-    if (aQuest !== bQuest) {
-      return bQuest - aQuest;
-    }
+    if (aQuest !== bQuest) return bQuest - aQuest;
 
-    // 3. Indice (TD-TR) (décroissant)
-    if (a.index !== b.index) {
-      return b.index - a.index;
-    }
+    const aCards = a.totalCards ?? 0;
+    const bCards = b.totalCards ?? 0;
+    if (aCards !== bCards) return aCards - bCards;
 
-    // 4. Égalité parfaite - classement initial
+    if (a.index !== b.index) return b.index - a.index;
+
     return (a.fencer.ranking ?? 9999) - (b.fencer.ranking ?? 9999);
   });
 


### PR DESCRIPTION
## Summary

- Nouveau classement dédié à la phase Quest (n'affecte pas les poules classiques)
- Critères de tri : V/M décroissant → Points Quest décroissants → Cartons croissants → Indice (TD-TR)
- Panneau "Cartons reçus" avec boutons +/− par tireur, visible pendant toute la phase
- Tableau de classement affiché automatiquement dès que tous les matchs sont terminés

## Fichiers modifiés

- `src/shared/types/index.ts` — ajout `totalCards?` dans `PoolRanking`
- `src/shared/utils/poolCalculations.ts` — `calculatePoolRankingQuest()` accepte `cardsByFencer` et applique les 3 critères
- `src/renderer/components/QuestPhaseView.tsx` — compteur de cartons + affichage du classement final

## Test plan

- [ ] Lancer une phase Quest avec ≥4 tireurs → saisir tous les scores
- [ ] Vérifier que le classement s'affiche automatiquement en fin de phase (V/M, Pts Q, Cartons)
- [ ] Ajouter des cartons à plusieurs tireurs → vérifier que l'ordre change correctement
- [ ] Deux tireurs avec V/M et Pts Q identiques : celui avec moins de cartons doit être devant
- [ ] Vérifier que les poules classiques ne sont pas affectées

🤖 Generated with [Claude Code](https://claude.com/claude-code)