### PR TITLE
feat: tirage au sort animé (pièce 3D) + fix bannière temps supplémentaire

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -999,7 +999,7 @@ export class RemoteScoreServer {
       }
       try {
         const { matchId } = req.params;
-        const { scoreA: rawA, scoreB: rawB, cardsA, cardsB } = req.body;
+        const { scoreA: rawA, scoreB: rawB, cardsA, cardsB, winner: winnerOverride } = req.body;
 
         const scoreA = Number(rawA);
         const scoreB = Number(rawB);
@@ -1024,8 +1024,9 @@ export class RemoteScoreServer {
           return res.status(404).json({ error: 'Match non trouvé' });
         }
 
-        // Déterminer le vainqueur
-        const winner = scoreA > scoreB ? 'A' : scoreB > scoreA ? 'B' : null;
+        // Déterminer le vainqueur : scores égaux + tirage au sort → utiliser winnerOverride
+        const winner =
+          scoreA > scoreB ? 'A' : scoreB > scoreA ? 'B' : (winnerOverride === 'A' || winnerOverride === 'B' ? winnerOverride : null);
 
         // Créer les objets Score
         const scoreAObj = {
@@ -1591,6 +1592,7 @@ export class RemoteScoreServer {
   // Stockage des sorties d'arène par arène
   private arenaExits: Map<string, Array<{ fencer: 'A' | 'B'; isVoluntary: boolean }>> = new Map();
   private arenaSuddenDeath: Map<string, boolean> = new Map();
+  private arenaOvertimeType: Map<string, string | null> = new Map();
   // Debounce par socket pour update_score : clé = socketId:arenaId, valeur = timestamp dernier envoi
   private scoreUpdateDebounce: Map<string, number> = new Map();
   private readonly SCORE_UPDATE_DEBOUNCE_MS = 200;
@@ -1657,10 +1659,23 @@ export class RemoteScoreServer {
         this.pauseArenaMatch(data.arenaId);
         break;
       case 'finish':
+        this.arenaSuddenDeath.set(data.arenaId, false);
+        this.arenaOvertimeType.set(data.arenaId, null);
         this.finishArenaMatch(data.arenaId);
         this.arenaCards.set(data.arenaId, { cardsA: [], cardsB: [] });
         this.arenaTouches.set(data.arenaId, { touchesA: [], touchesB: [] });
         this.arenaExits.set(data.arenaId, []);
+        break;
+      case 'coin_flip':
+        if (data.winner === 'A' || data.winner === 'B') {
+          this.io
+            .to(`arena:${data.arenaId}`)
+            .emit(`arena:${data.arenaId}:coin_flip`, {
+              winner: data.winner,
+              fencerA: arena.currentMatch?.fencerA,
+              fencerB: arena.currentMatch?.fencerB,
+            });
+        }
         break;
       case 'next':
         this.loadNextMatch(data.arenaId);
@@ -1673,10 +1688,13 @@ export class RemoteScoreServer {
         const lastUpdate = this.scoreUpdateDebounce.get(debounceKey) ?? 0;
         if (Date.now() - lastUpdate < this.SCORE_UPDATE_DEBOUNCE_MS) break;
         this.scoreUpdateDebounce.set(debounceKey, Date.now());
+        if (data.suddenDeath !== undefined) {
+          this.arenaSuddenDeath.set(data.arenaId, data.suddenDeath);
+        }
+        if (data.overtimeType !== undefined) {
+          this.arenaOvertimeType.set(data.arenaId, data.overtimeType);
+        }
         if (data.scoreA !== undefined && data.scoreB !== undefined) {
-          if (data.suddenDeath !== undefined) {
-            this.arenaSuddenDeath.set(data.arenaId, data.suddenDeath);
-          }
           this.updateArenaScore(data.arenaId, data.scoreA, data.scoreB);
         }
         // Mettre à jour aussi les cartons si fournis
@@ -1693,6 +1711,7 @@ export class RemoteScoreServer {
             cardsA: currentCards.cardsA,
             cardsB: currentCards.cardsB,
             suddenDeath: this.arenaSuddenDeath.get(data.arenaId) ?? false,
+            overtimeType: this.arenaOvertimeType.get(data.arenaId) ?? null,
             status: arena.status,
           });
         }
@@ -1733,6 +1752,7 @@ export class RemoteScoreServer {
       case 'reset_scores':
         if (arena.currentMatch) {
           this.arenaSuddenDeath.set(data.arenaId, false);
+          this.arenaOvertimeType.set(data.arenaId, null);
           this.updateArenaScore(data.arenaId, 0, 0);
           this.arenaCards.set(data.arenaId, { cardsA: [], cardsB: [] });
           this.arenaTouches.set(data.arenaId, { touchesA: [], touchesB: [] });
@@ -1745,6 +1765,7 @@ export class RemoteScoreServer {
             cardsA: [],
             cardsB: [],
             suddenDeath: false,
+            overtimeType: null,
             status: arena.status,
           });
         }
@@ -1781,13 +1802,19 @@ export class RemoteScoreServer {
       case 'update_timer':
       case 'pause_timer':
       case 'reset_timer':
-        // Relay timer updates to arena display
+        if (data.suddenDeath !== undefined) {
+          this.arenaSuddenDeath.set(data.arenaId, data.suddenDeath);
+        }
+        if (data.overtimeType !== undefined) {
+          this.arenaOvertimeType.set(data.arenaId, data.overtimeType);
+        }
         this.broadcastArenaUpdate(data.arenaId, {
           arenaId: data.arenaId,
           match: arena.currentMatch,
           time: data.time,
           timerStatus: data.timerStatus,
-          suddenDeath: data.suddenDeath ?? false,
+          suddenDeath: this.arenaSuddenDeath.get(data.arenaId) ?? false,
+          overtimeType: this.arenaOvertimeType.get(data.arenaId) ?? null,
           status: arena.status,
         });
         break;
@@ -2239,6 +2266,7 @@ export class RemoteScoreServer {
       scoreA,
       scoreB,
       suddenDeath: this.arenaSuddenDeath.get(arenaId) ?? false,
+      overtimeType: this.arenaOvertimeType.get(arenaId) ?? null,
       status: arena.status,
     });
 
@@ -2382,10 +2410,22 @@ export class RemoteScoreServer {
     // Émettre l'event pour le renderer (pour sauvegarder le score dans les pools)
     const mainWindow = (global as any).mainWindow;
     if (mainWindow) {
+      // Dériver le vainqueur depuis la DB pour gérer le cas tirage au sort (scores égaux)
+      let winnerForRenderer: 'A' | 'B' | null =
+        finishedMatch.scoreA > finishedMatch.scoreB ? 'A' :
+        finishedMatch.scoreB > finishedMatch.scoreA ? 'B' : null;
+      if (!winnerForRenderer) {
+        try {
+          const dbM = this.db.getMatch(finishedMatch.id) as any;
+          if (dbM?.scoreA?.isVictory) winnerForRenderer = 'A';
+          else if (dbM?.scoreB?.isVictory) winnerForRenderer = 'B';
+        } catch { /* non bloquant */ }
+      }
       mainWindow.webContents.send('match:finished', {
         matchId: finishedMatch.id,
         scoreA: finishedMatch.scoreA,
         scoreB: finishedMatch.scoreB,
+        winner: winnerForRenderer,
         poolId: finishedMatch.poolId,
         isTableau: finishedMatch.isTableau ?? false,
       });

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -905,9 +905,153 @@
           padding: 0;
         }
       }
+
+      /* ── Animation tirage au sort (pièce 3D) ── */
+      #coin-flip-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.92);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 99999;
+        animation: coinOverlayIn 0.4s ease-out;
+      }
+      #coin-flip-overlay.hidden { display: none; }
+
+      .coin-flip-content {
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2rem;
+      }
+
+      .coin-flip-title {
+        font-size: clamp(1.8rem, 5vw, 3.5rem);
+        font-weight: 900;
+        color: #fff;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .coin-flip-subtitle {
+        font-size: clamp(1rem, 2.5vw, 1.6rem);
+        color: #d1d5db;
+        margin-top: -1.5rem;
+      }
+
+      .coin-scene {
+        perspective: 1200px;
+        width: clamp(200px, 30vw, 340px);
+        height: clamp(200px, 30vw, 340px);
+      }
+
+      .coin {
+        width: 100%;
+        height: 100%;
+        transform-style: preserve-3d;
+        position: relative;
+      }
+
+      .coin-face {
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        backface-visibility: hidden;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        box-shadow: 0 0 40px rgba(0,0,0,0.6), inset 0 0 20px rgba(255,255,255,0.1);
+      }
+
+      .coin-face-label {
+        font-size: clamp(1rem, 2.5vw, 1.5rem);
+        font-weight: 900;
+        color: rgba(255,255,255,0.85);
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+      }
+
+      .coin-face-name {
+        font-size: clamp(1.2rem, 3vw, 2rem);
+        font-weight: 700;
+        color: #fff;
+        text-align: center;
+        padding: 0 1rem;
+        word-break: break-word;
+        max-width: 90%;
+        text-shadow: 0 2px 8px rgba(0,0,0,0.4);
+      }
+
+      .coin-front {
+        background: radial-gradient(circle at 35% 35%, #4ade80, #16a34a 60%, #14532d);
+        border: 6px solid rgba(255,255,255,0.25);
+      }
+
+      .coin-back {
+        background: radial-gradient(circle at 35% 35%, #f87171, #dc2626 60%, #7f1d1d);
+        border: 6px solid rgba(255,255,255,0.25);
+        transform: rotateY(180deg);
+      }
+
+      #coin-result {
+        font-size: clamp(2rem, 6vw, 4rem);
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        animation: resultPop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+        padding: 0.75rem 2.5rem;
+        border-radius: 16px;
+      }
+      #coin-result.winner-green {
+        color: #22c55e;
+        background: rgba(34, 197, 94, 0.15);
+        border: 3px solid #22c55e;
+        text-shadow: 0 0 30px rgba(34, 197, 94, 0.6);
+      }
+      #coin-result.winner-red {
+        color: #ef4444;
+        background: rgba(239, 68, 68, 0.15);
+        border: 3px solid #ef4444;
+        text-shadow: 0 0 30px rgba(239, 68, 68, 0.6);
+      }
+      #coin-result.hidden { display: none; }
+
+      @keyframes coinOverlayIn {
+        from { opacity: 0; }
+        to   { opacity: 1; }
+      }
+      @keyframes resultPop {
+        from { transform: scale(0.5); opacity: 0; }
+        to   { transform: scale(1);   opacity: 1; }
+      }
     </style>
   </head>
   <body>
+    <!-- Overlay tirage au sort (pièce 3D) -->
+    <div id="coin-flip-overlay" class="hidden">
+      <div class="coin-flip-content">
+        <div class="coin-flip-title">Tirage au sort</div>
+        <div class="coin-flip-subtitle">Égalité persistante — fin du temps supplémentaire</div>
+        <div class="coin-scene">
+          <div class="coin" id="coin-3d">
+            <div class="coin-face coin-front">
+              <span class="coin-face-label">VERT</span>
+              <span class="coin-face-name" id="coin-name-green">—</span>
+            </div>
+            <div class="coin-face coin-back">
+              <span class="coin-face-label">ROUGE</span>
+              <span class="coin-face-name" id="coin-name-red">—</span>
+            </div>
+          </div>
+        </div>
+        <div id="coin-result" class="hidden"></div>
+      </div>
+    </div>
+
     <div id="card-announcement-banner" class="card-announcement-banner"></div>
 
     <div class="arena-number-strip">
@@ -1226,6 +1370,67 @@
           this.socket.on(`arena:${this.arenaId}:exit_announcement`, ann => {
             this.showExitAnnouncement(ann);
           });
+
+          this.socket.on(`arena:${this.arenaId}:coin_flip`, data => {
+            this.showCoinFlipAnimation(data.winner, data.fencerA, data.fencerB);
+          });
+        }
+
+        showCoinFlipAnimation(winner, fencerA, fencerB) {
+          const overlay  = document.getElementById('coin-flip-overlay');
+          const coin     = document.getElementById('coin-3d');
+          const nameGreen = document.getElementById('coin-name-green');
+          const nameRed   = document.getElementById('coin-name-red');
+          const result   = document.getElementById('coin-result');
+          if (!overlay || !coin || !nameGreen || !nameRed || !result) return;
+
+          // Noms des tireurs (respecte l'inversion de l'affichage)
+          const fA = this.inversionEnabled ? fencerB : fencerA;
+          const fB = this.inversionEnabled ? fencerA : fencerB;
+          const nameA = fA ? `${fA.lastName || ''} ${fA.firstName || ''}`.trim() || 'VERT'   : 'VERT';
+          const nameB = fB ? `${fB.lastName || ''} ${fB.firstName || ''}`.trim() || 'ROUGE'  : 'ROUGE';
+          nameGreen.textContent = nameA;
+          nameRed.textContent   = nameB;
+
+          // Réinitialiser l'état visuel
+          result.className = 'hidden';
+          result.textContent = '';
+          coin.style.transition = 'none';
+          coin.style.transform  = 'rotateY(0deg)';
+
+          // Afficher l'overlay
+          overlay.classList.remove('hidden');
+
+          // Calculer les rotations : 10 tours + face gagnante
+          // Face verte = 0° / 360°, face rouge = 180°
+          // winner 'A' → face verte → 3600° (10 tours)
+          // winner 'B' → face rouge → 3600° + 180° = 3780°
+          // Si l'affichage est inversé : winner 'A' = tireur B visuel = face rouge
+          const visualWinner = this.inversionEnabled
+            ? (winner === 'A' ? 'B' : 'A')
+            : winner;
+          const finalDeg = visualWinner === 'A' ? 3600 : 3780;
+
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              coin.style.transition = 'transform 3.5s cubic-bezier(0.33, 1, 0.68, 1)';
+              coin.style.transform  = `rotateY(${finalDeg}deg)`;
+            });
+          });
+
+          // Afficher le résultat après l'animation
+          setTimeout(() => {
+            const winnerName = visualWinner === 'A' ? nameA : nameB;
+            const colorClass  = visualWinner === 'A' ? 'winner-green' : 'winner-red';
+            const colorLabel  = visualWinner === 'A' ? 'VERT' : 'ROUGE';
+            result.textContent = `🏆 ${winnerName} gagne ! (${colorLabel})`;
+            result.className   = colorClass;
+          }, 3600);
+
+          // Masquer l'overlay automatiquement après 8s
+          setTimeout(() => {
+            overlay.classList.add('hidden');
+          }, 8000);
         }
 
         showExitAnnouncement(ann) {

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -584,9 +584,153 @@
           font-size: clamp(1.2rem, 4vw, 5vh);
         }
       }
+
+      /* ── Animation tirage au sort (pièce 3D) ── */
+      #coin-flip-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.92);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 99999;
+        animation: coinOverlayIn 0.4s ease-out;
+      }
+      #coin-flip-overlay.hidden { display: none; }
+
+      .coin-flip-content {
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2rem;
+      }
+
+      .coin-flip-title {
+        font-size: clamp(1.8rem, 5vw, 3.5rem);
+        font-weight: 900;
+        color: #fff;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .coin-flip-subtitle {
+        font-size: clamp(1rem, 2.5vw, 1.6rem);
+        color: #d1d5db;
+        margin-top: -1.5rem;
+      }
+
+      .coin-scene {
+        perspective: 1200px;
+        width: clamp(200px, 30vw, 340px);
+        height: clamp(200px, 30vw, 340px);
+      }
+
+      .coin {
+        width: 100%;
+        height: 100%;
+        transform-style: preserve-3d;
+        position: relative;
+      }
+
+      .coin-face {
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        backface-visibility: hidden;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        box-shadow: 0 0 40px rgba(0,0,0,0.6), inset 0 0 20px rgba(255,255,255,0.1);
+      }
+
+      .coin-face-label {
+        font-size: clamp(1rem, 2.5vw, 1.5rem);
+        font-weight: 900;
+        color: rgba(255,255,255,0.85);
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+      }
+
+      .coin-face-name {
+        font-size: clamp(1.2rem, 3vw, 2rem);
+        font-weight: 700;
+        color: #fff;
+        text-align: center;
+        padding: 0 1rem;
+        word-break: break-word;
+        max-width: 90%;
+        text-shadow: 0 2px 8px rgba(0,0,0,0.4);
+      }
+
+      .coin-front {
+        background: radial-gradient(circle at 35% 35%, #4ade80, #16a34a 60%, #14532d);
+        border: 6px solid rgba(255,255,255,0.25);
+      }
+
+      .coin-back {
+        background: radial-gradient(circle at 35% 35%, #f87171, #dc2626 60%, #7f1d1d);
+        border: 6px solid rgba(255,255,255,0.25);
+        transform: rotateY(180deg);
+      }
+
+      #coin-result {
+        font-size: clamp(2rem, 6vw, 4rem);
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        animation: resultPop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+        padding: 0.75rem 2.5rem;
+        border-radius: 16px;
+      }
+      #coin-result.winner-green {
+        color: #22c55e;
+        background: rgba(34, 197, 94, 0.15);
+        border: 3px solid #22c55e;
+        text-shadow: 0 0 30px rgba(34, 197, 94, 0.6);
+      }
+      #coin-result.winner-red {
+        color: #ef4444;
+        background: rgba(239, 68, 68, 0.15);
+        border: 3px solid #ef4444;
+        text-shadow: 0 0 30px rgba(239, 68, 68, 0.6);
+      }
+      #coin-result.hidden { display: none; }
+
+      @keyframes coinOverlayIn {
+        from { opacity: 0; }
+        to   { opacity: 1; }
+      }
+      @keyframes resultPop {
+        from { transform: scale(0.5); opacity: 0; }
+        to   { transform: scale(1);   opacity: 1; }
+      }
     </style>
   </head>
   <body>
+    <!-- Overlay tirage au sort (pièce 3D) -->
+    <div id="coin-flip-overlay" class="hidden">
+      <div class="coin-flip-content">
+        <div class="coin-flip-title">Tirage au sort</div>
+        <div class="coin-flip-subtitle">Égalité persistante — fin du temps supplémentaire</div>
+        <div class="coin-scene">
+          <div class="coin" id="coin-3d">
+            <div class="coin-face coin-front">
+              <span class="coin-face-label">VERT</span>
+              <span class="coin-face-name" id="coin-name-green">—</span>
+            </div>
+            <div class="coin-face coin-back">
+              <span class="coin-face-label">ROUGE</span>
+              <span class="coin-face-name" id="coin-name-red">—</span>
+            </div>
+          </div>
+        </div>
+        <div id="coin-result" class="hidden"></div>
+      </div>
+    </div>
+
     <div id="card-announcement-banner" class="card-announcement-banner"></div>
 
     <div class="header">
@@ -752,6 +896,57 @@
           this.socket.on(`arena:${this.arenaId}:card_announcement`, ann => {
             this.showCardAnnouncement(ann);
           });
+
+          this.socket.on(`arena:${this.arenaId}:coin_flip`, data => {
+            this.showCoinFlipAnimation(data.winner, data.fencerA, data.fencerB);
+          });
+        }
+
+        showCoinFlipAnimation(winner, fencerA, fencerB) {
+          const overlay   = document.getElementById('coin-flip-overlay');
+          const coin      = document.getElementById('coin-3d');
+          const nameGreen = document.getElementById('coin-name-green');
+          const nameRed   = document.getElementById('coin-name-red');
+          const result    = document.getElementById('coin-result');
+          if (!overlay || !coin || !nameGreen || !nameRed || !result) return;
+
+          const fA = this.inversionEnabled ? fencerB : fencerA;
+          const fB = this.inversionEnabled ? fencerA : fencerB;
+          const nameA = fA ? `${fA.lastName || ''} ${fA.firstName || ''}`.trim() || 'VERT'  : 'VERT';
+          const nameB = fB ? `${fB.lastName || ''} ${fB.firstName || ''}`.trim() || 'ROUGE' : 'ROUGE';
+          nameGreen.textContent = nameA;
+          nameRed.textContent   = nameB;
+
+          result.className = 'hidden';
+          result.textContent = '';
+          coin.style.transition = 'none';
+          coin.style.transform  = 'rotateY(0deg)';
+
+          overlay.classList.remove('hidden');
+
+          const visualWinner = this.inversionEnabled
+            ? (winner === 'A' ? 'B' : 'A')
+            : winner;
+          const finalDeg = visualWinner === 'A' ? 3600 : 3780;
+
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              coin.style.transition = 'transform 3.5s cubic-bezier(0.33, 1, 0.68, 1)';
+              coin.style.transform  = `rotateY(${finalDeg}deg)`;
+            });
+          });
+
+          setTimeout(() => {
+            const winnerName = visualWinner === 'A' ? nameA : nameB;
+            const colorClass  = visualWinner === 'A' ? 'winner-green' : 'winner-red';
+            const colorLabel  = visualWinner === 'A' ? 'VERT' : 'ROUGE';
+            result.textContent = `🏆 ${winnerName} gagne ! (${colorLabel})`;
+            result.className   = colorClass;
+          }, 3600);
+
+          setTimeout(() => {
+            overlay.classList.add('hidden');
+          }, 8000);
         }
 
         showCardAnnouncement(ann) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1256,6 +1256,7 @@
           this.isLaserSabre = false;
           this.isSuddenDeath = false;
           this.overtimeType = null; // 'supplementary' | 'challenger' | null
+          this.coinFlipWinner = null; // 'A' | 'B' | null — vainqueur par tirage au sort
           this.actionHistory = []; // Historique pour undo (max 10)
           this.cardAnnounceEnabled = false; // Réglé depuis les paramètres de saisie distante
           this.swapped = false;
@@ -1825,7 +1826,7 @@
             faultHistoryA: { ...this.faultHistoryA },
             faultHistoryB: { ...this.faultHistoryB },
             isSuddenDeath: this.isSuddenDeath,
-            overtypeType: this.overtimeType,
+            overtimeType: this.overtimeType,
           };
           this.actionHistory.push(snapshot);
           if (this.actionHistory.length > 10) this.actionHistory.shift();
@@ -2143,27 +2144,72 @@
         }
 
         triggerTiebreaker() {
-          this.showNotification('⚡ Tirage au sort en cours...');
-          setTimeout(() => {
-            const winner = Math.random() < 0.5 ? 'A' : 'B';
-            const nameEl = document.getElementById(`fencer-${winner.toLowerCase()}-name`);
-            const winnerName = nameEl ? nameEl.textContent.trim() : `Tireur ${winner}`;
+          const winner = Math.random() < 0.5 ? 'A' : 'B';
+          this.coinFlipWinner = winner;
 
-            if (winner === 'A') {
-              this.scoreA++;
-            } else {
-              this.scoreB++;
-            }
-            this.updateScores();
-            this.broadcastUpdate();
+          // Déclencher l'animation plein écran sur l'affichage de score
+          this.socket.emit('arena_control', {
+            arenaId: this.arenaId,
+            action: 'coin_flip',
+            winner,
+          });
 
-            this.showNotification(`🏆 ${winnerName} remporte le match (tirage au sort)`);
-            this.isSuddenDeath = false;
-            this.overtimeType = null;
-            this.updateSuddenDeathUI();
+          this.showNotification('🪙 Tirage au sort — animation en cours...');
 
-            setTimeout(() => this.finishMatch(), 2500);
-          }, 1500);
+          // Attendre la fin de l'animation (~4.5s) avant de terminer le match
+          setTimeout(() => this.confirmFinishWithCoinFlip(winner), 4500);
+        }
+
+        async confirmFinishWithCoinFlip(winner) {
+          if (!this.currentMatch) return;
+
+          const nameEl = document.getElementById(`fencer-${winner.toLowerCase()}-name`);
+          const winnerName = nameEl ? nameEl.textContent.trim() : `Tireur ${winner}`;
+          this.showNotification(`🏆 ${winnerName} remporte le match (tirage au sort)`);
+
+          this.isSuddenDeath = false;
+          this.overtimeType = null;
+          this.updateSuddenDeathUI();
+          this.matchStatus = 'finished';
+          this.stopTimer();
+
+          try {
+            await fetch(`/api/matches/${this.currentMatch.id}/finish`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                scoreA: this.scoreA,
+                scoreB: this.scoreB,
+                winner,
+                cardsA: this.cardsA,
+                cardsB: this.cardsB,
+              }),
+            });
+
+            this.updateControlButtons();
+            this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'finish' });
+
+            setTimeout(() => {
+              this.currentMatch = null;
+              this.scoreA = 0;
+              this.scoreB = 0;
+              this.cardsA = [];
+              this.cardsB = [];
+              this.touchesA = [];
+              this.touchesB = [];
+              this.faultHistoryA = { 1: 0, 2: 0, 3: 0 };
+              this.faultHistoryB = { 1: 0, 2: 0, 3: 0 };
+              this.coinFlipWinner = null;
+              this.matchStatus = 'not_started';
+              this.timerSeconds = 180;
+              this.updateTimerDisplay();
+              document.getElementById('active-match').classList.remove('visible');
+              this.showNextMatchesScreen();
+            }, 2000);
+          } catch (error) {
+            console.error('Erreur fin de match (tirage au sort):', error);
+            this.showNotification(window.T('referee.error_save'), true);
+          }
         }
 
         updateTimerDisplay() {
@@ -2199,7 +2245,7 @@
             time: this.timerSeconds,
             timerStatus: this.timerRunning ? 'running' : 'paused',
             suddenDeath: this.isSuddenDeath,
-            overtypeType: this.overtimeType,
+            overtimeType: this.overtimeType,
           });
         }
 
@@ -2214,7 +2260,7 @@
             touchesA: this.touchesA,
             touchesB: this.touchesB,
             suddenDeath: this.isSuddenDeath,
-            overtypeType: this.overtimeType,
+            overtimeType: this.overtimeType,
           });
         }
 

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -216,14 +216,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       matchId: string;
       scoreA: number;
       scoreB: number;
+      winner?: 'A' | 'B';
       isTableau?: boolean;
     }) => {
-      const { matchId, scoreA, scoreB } = data;
+      const { matchId, scoreA, scoreB, winner: winnerOverride } = data;
       logger.debug(
         LogCategory.UI,
         `[CompetitionView] Match terminé reçu: ${matchId} - Score: ${scoreA}-${scoreB}`
       );
-      updateMatchFromRemote(matchId, scoreA, scoreB, MatchStatus.FINISHED);
+      updateMatchFromRemote(matchId, scoreA, scoreB, MatchStatus.FINISHED, winnerOverride);
 
       // Mise à jour du tableau d'élimination directe si c'est un match DE
       setTableauMatches(prev => {

--- a/src/renderer/components/TiebreakerAnimation.tsx
+++ b/src/renderer/components/TiebreakerAnimation.tsx
@@ -1,10 +1,10 @@
 /**
  * BellePoule Modern - Tiebreaker Animation Component
- * Animated random draw to determine winner after sudden death overtime
+ * Animated 3D coin flip to determine winner after sudden death overtime
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Fencer } from '../../shared/types';
 import { drawWinner } from '../../shared/utils/suddenDeath';
 
@@ -19,83 +19,65 @@ const TiebreakerAnimation: React.FC<TiebreakerAnimationProps> = ({
   fencerB,
   onComplete,
 }) => {
-  const [phase, setPhase] = useState<'shuffling' | 'revealing' | 'done'>('shuffling');
-  const [highlighted, setHighlighted] = useState<'A' | 'B' | null>(null);
+  const [phase, setPhase] = useState<'spinning' | 'done'>('spinning');
   const [winner, setWinner] = useState<'A' | 'B' | null>(null);
+  const coinRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const decided = drawWinner();
     setWinner(decided);
 
-    // Shuffling phase: alternate between A and B rapidly
-    let shuffleIndex = 0;
-    const shuffleInterval = setInterval(() => {
-      shuffleIndex++;
-      setHighlighted(shuffleIndex % 2 === 0 ? 'A' : 'B');
+    // Face verte (front) = tireur A  → 0° / 3600°
+    // Face rouge (back)  = tireur B  → 180° / 3780°
+    const finalDeg = decided === 'A' ? 3600 : 3780;
 
-      if (shuffleIndex > 20) {
-        clearInterval(shuffleInterval);
-        // Revealing phase: slow down then show winner
-        setPhase('revealing');
-        setTimeout(() => {
-          setHighlighted(decided);
-          setPhase('done');
-        }, 500);
-      }
-    }, 100);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (coinRef.current) {
+          coinRef.current.style.transition = 'transform 3.5s cubic-bezier(0.33, 1, 0.68, 1)';
+          coinRef.current.style.transform  = `rotateY(${finalDeg}deg)`;
+        }
+      });
+    });
 
-    return () => clearInterval(shuffleInterval);
+    const t = setTimeout(() => setPhase('done'), 3600);
+    return () => clearTimeout(t);
   }, []);
 
   const handleContinue = useCallback(() => {
-    if (winner) {
-      onComplete(winner);
-    }
+    if (winner) onComplete(winner);
   }, [winner, onComplete]);
+
+  const nameA = `${fencerA.lastName} ${fencerA.firstName}`.trim();
+  const nameB = `${fencerB.lastName} ${fencerB.firstName}`.trim();
 
   return (
     <div className="tiebreaker-overlay" onClick={e => e.stopPropagation()}>
       <div className="tiebreaker-container">
         <h2 className="tiebreaker-title">Tirage au sort</h2>
-        <p className="tiebreaker-subtitle">Temps écoulé - Égalité persistante</p>
+        <p className="tiebreaker-subtitle">Temps écoulé — Égalité persistante</p>
 
-        <div className="tiebreaker-fencers">
-          <div
-            className={`tiebreaker-fencer ${
-              phase === 'done' && winner === 'A' ? 'winner' : ''
-            } ${highlighted === 'A' ? 'highlighted' : ''}`}
-          >
-            <div className="fencer-avatar green">
-              <span className="fencer-initials">
-                {fencerA.firstName[0]}
-                {fencerA.lastName[0]}
-              </span>
+        <div className="coin-scene">
+          <div className="coin-3d" ref={coinRef}>
+            {/* Face verte — Tireur A */}
+            <div className="coin-face coin-green">
+              <span className="coin-color-label">VERT</span>
+              <span className="coin-fencer-name">{nameA}</span>
             </div>
-            <div className="fencer-name">
-              {fencerA.lastName} {fencerA.firstName}
+            {/* Face rouge — Tireur B */}
+            <div className="coin-face coin-red">
+              <span className="coin-color-label">ROUGE</span>
+              <span className="coin-fencer-name">{nameB}</span>
             </div>
-            {phase === 'done' && winner === 'A' && <div className="winner-badge">VAINQUEUR</div>}
-          </div>
-
-          <div className="tiebreaker-vs">VS</div>
-
-          <div
-            className={`tiebreaker-fencer ${
-              phase === 'done' && winner === 'B' ? 'winner' : ''
-            } ${highlighted === 'B' ? 'highlighted' : ''}`}
-          >
-            <div className="fencer-avatar red">
-              <span className="fencer-initials">
-                {fencerB.firstName[0]}
-                {fencerB.lastName[0]}
-              </span>
-            </div>
-            <div className="fencer-name">
-              {fencerB.lastName} {fencerB.firstName}
-            </div>
-            {phase === 'done' && winner === 'B' && <div className="winner-badge">VAINQUEUR</div>}
           </div>
         </div>
+
+        {phase === 'done' && winner && (
+          <div className={`tiebreaker-result ${winner === 'A' ? 'result-green' : 'result-red'}`}>
+            🏆 {winner === 'A' ? nameA : nameB} gagne !
+            <span className="result-color">({winner === 'A' ? 'VERT' : 'ROUGE'})</span>
+          </div>
+        )}
 
         {phase === 'done' && (
           <button className="btn btn-primary btn-continue" onClick={handleContinue}>
@@ -104,142 +86,159 @@ const TiebreakerAnimation: React.FC<TiebreakerAnimationProps> = ({
         )}
       </div>
 
-      <style
-        dangerouslySetInnerHTML={{
-          __html: `
+      <style dangerouslySetInnerHTML={{ __html: `
         .tiebreaker-overlay {
           position: fixed;
           inset: 0;
-          background: rgba(0, 0, 0, 0.85);
+          background: rgba(0, 0, 0, 0.88);
           display: flex;
           align-items: center;
           justify-content: center;
           z-index: 10000;
-          animation: fadeIn 0.3s ease-out;
+          animation: tieFadeIn 0.3s ease-out;
         }
 
         .tiebreaker-container {
-          background: white;
-          border-radius: 16px;
-          padding: 2rem;
-          max-width: 600px;
+          background: #111827;
+          border: 1px solid rgba(255,255,255,0.1);
+          border-radius: 20px;
+          padding: 2.5rem 2rem;
+          max-width: 520px;
           width: 90%;
           text-align: center;
-          animation: scaleIn 0.4s ease-out;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 1.5rem;
+          animation: tieScaleIn 0.4s ease-out;
         }
 
         .tiebreaker-title {
-          font-size: 1.8rem;
-          font-weight: 700;
-          color: #1f2937;
-          margin-bottom: 0.25rem;
+          font-size: 2rem;
+          font-weight: 800;
+          color: #fff;
+          margin: 0;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
         }
 
         .tiebreaker-subtitle {
-          color: #6b7280;
-          margin-bottom: 2rem;
-          font-size: 0.95rem;
-        }
-
-        .tiebreaker-fencers {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 1.5rem;
-          margin-bottom: 2rem;
-        }
-
-        .tiebreaker-fencer {
-          flex: 1;
-          padding: 1.5rem 1rem;
-          border-radius: 12px;
-          border: 3px solid #e5e7eb;
-          transition: all 0.2s ease;
-          min-width: 0;
-        }
-
-        .tiebreaker-fencer.highlighted {
-          border-color: #fbbf24;
-          background: #fef3c7;
-          transform: scale(1.05);
-        }
-
-        .tiebreaker-fencer.winner {
-          border-color: #22c55e;
-          background: #f0fdf4;
-          transform: scale(1.08);
-          box-shadow: 0 0 20px rgba(34, 197, 94, 0.3);
-        }
-
-        .fencer-avatar {
-          width: 80px;
-          height: 80px;
-          border-radius: 50%;
-          margin: 0 auto 0.75rem;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          font-size: 1.5rem;
-          font-weight: 700;
-          color: white;
-        }
-
-        .fencer-avatar.green {
-          background: linear-gradient(135deg, #22c55e, #16a34a);
-        }
-
-        .fencer-avatar.red {
-          background: linear-gradient(135deg, #ef4444, #dc2626);
-        }
-
-        .fencer-name {
-          font-weight: 600;
-          font-size: 0.95rem;
-          color: #374151;
-          word-break: break-word;
-        }
-
-        .tiebreaker-vs {
-          font-size: 1.5rem;
-          font-weight: 700;
           color: #9ca3af;
-          flex-shrink: 0;
+          margin: -1rem 0 0;
+          font-size: 0.9rem;
         }
 
-        .winner-badge {
-          margin-top: 0.75rem;
-          background: #22c55e;
-          color: white;
-          padding: 0.35rem 1rem;
-          border-radius: 20px;
-          font-weight: 700;
+        .coin-scene {
+          perspective: 1000px;
+          width: 220px;
+          height: 220px;
+        }
+
+        .coin-3d {
+          width: 100%;
+          height: 100%;
+          transform-style: preserve-3d;
+          position: relative;
+        }
+
+        .coin-face {
+          position: absolute;
+          inset: 0;
+          border-radius: 50%;
+          backface-visibility: hidden;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 0.5rem;
+          box-shadow: 0 0 30px rgba(0,0,0,0.5), inset 0 0 15px rgba(255,255,255,0.12);
+        }
+
+        .coin-green {
+          background: radial-gradient(circle at 35% 35%, #4ade80, #16a34a 60%, #14532d);
+          border: 5px solid rgba(255,255,255,0.2);
+        }
+
+        .coin-red {
+          background: radial-gradient(circle at 35% 35%, #f87171, #dc2626 60%, #7f1d1d);
+          border: 5px solid rgba(255,255,255,0.2);
+          transform: rotateY(180deg);
+        }
+
+        .coin-color-label {
           font-size: 0.85rem;
-          display: inline-block;
-          animation: pulse 1s ease-in-out infinite;
+          font-weight: 800;
+          color: rgba(255,255,255,0.8);
+          text-transform: uppercase;
+          letter-spacing: 0.2em;
+        }
+
+        .coin-fencer-name {
+          font-size: 1.1rem;
+          font-weight: 700;
+          color: #fff;
+          text-align: center;
+          padding: 0 0.5rem;
+          word-break: break-word;
+          max-width: 85%;
+          text-shadow: 0 2px 6px rgba(0,0,0,0.4);
+        }
+
+        .tiebreaker-result {
+          font-size: 1.4rem;
+          font-weight: 800;
+          padding: 0.75rem 2rem;
+          border-radius: 12px;
+          animation: resultPop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+          display: flex;
+          flex-direction: column;
+          gap: 0.25rem;
+        }
+
+        .tiebreaker-result.result-green {
+          color: #22c55e;
+          background: rgba(34, 197, 94, 0.12);
+          border: 2px solid #22c55e;
+        }
+
+        .tiebreaker-result.result-red {
+          color: #ef4444;
+          background: rgba(239, 68, 68, 0.12);
+          border: 2px solid #ef4444;
+        }
+
+        .result-color {
+          font-size: 0.85rem;
+          opacity: 0.75;
+          font-weight: 600;
         }
 
         .btn-continue {
-          padding: 0.75rem 2rem;
+          padding: 0.85rem 2.5rem;
           font-size: 1.1rem;
+          background: #3b82f6;
+          color: #fff;
+          border: none;
+          border-radius: 10px;
+          cursor: pointer;
+          font-weight: 700;
+          transition: background 0.2s;
         }
+        .btn-continue:hover { background: #2563eb; }
 
-        @keyframes fadeIn {
+        @keyframes tieFadeIn {
           from { opacity: 0; }
-          to { opacity: 1; }
+          to   { opacity: 1; }
         }
-
-        @keyframes scaleIn {
-          from { transform: scale(0.9); opacity: 0; }
-          to { transform: scale(1); opacity: 1; }
+        @keyframes tieScaleIn {
+          from { transform: scale(0.85); opacity: 0; }
+          to   { transform: scale(1);    opacity: 1; }
         }
-
-        @keyframes pulse {
-          0%, 100% { transform: scale(1); }
-          50% { transform: scale(1.05); }
+        @keyframes resultPop {
+          from { transform: scale(0.5); opacity: 0; }
+          to   { transform: scale(1);   opacity: 1; }
         }
-      `,
-        }}
-      />
+      ` }} />
     </div>
   );
 };

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -484,7 +484,7 @@ export const usePoolManagement = ({
 
   // Mettre à jour un match depuis une source externe (serveur distant)
   const updateMatchFromRemote = useCallback(
-    (matchId: string, scoreA: number, scoreB: number, status: MatchStatus) => {
+    (matchId: string, scoreA: number, scoreB: number, status: MatchStatus, winnerOverride?: 'A' | 'B') => {
       setPools(prevPools => {
         const updatedPools = [...prevPools];
         let matchFound = false;
@@ -495,7 +495,11 @@ export const usePoolManagement = ({
             if (pool.matches[matchIdx].id === matchId) {
               matchFound = true;
               const match = pool.matches[matchIdx];
-              const winner = scoreA > scoreB ? 'A' : scoreB > scoreA ? 'B' : null;
+              // Pour le tirage au sort : scores égaux mais vainqueur explicite
+              const winner =
+                scoreA > scoreB ? 'A' :
+                scoreB > scoreA ? 'B' :
+                (winnerOverride ?? null);
 
               pool.matches[matchIdx] = {
                 ...match,

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -151,6 +151,7 @@ export interface ArenaUpdate {
   cardsA?: string[];
   cardsB?: string[];
   suddenDeath?: boolean;
+  overtimeType?: string | null;
   showPhotos?: boolean; // afficher les photos avant le combat
   cardAnnounce?: boolean; // annoncer les cartons avec raison sur les affichages
   theme?: DisplayTheme; // thème visuel de l'affichage distant


### PR DESCRIPTION
- Fix: typo `overtypeType` → `overtimeType` dans referee.html (3 occurrences)
  causait l'affichage "MORT SUBITE" au lieu de "30s SUPPLEMENTAIRE"
- Fix: remoteScoreServer stocke et broadcase overtimeType par arène via
  la nouvelle Map arenaOvertimeType
- Fix: triggerTiebreaker() ne modifie plus les scores (scores restent
  identiques), appelle confirmFinishWithCoinFlip() (finishMatch() n'existait
  pas)
- Fix: endpoint /api/matches/:matchId/finish accepte un champ `winner`
  optionnel pour les égalités résolues par tirage
- Fix: updateMatchFromRemote accepte winnerOverride pour scores égaux
- Feat: animation pièce 3D plein écran dans arena.html (socket
  arena:N:coin_flip), face verte = tireur A, face rouge = tireur B
- Feat: TiebreakerAnimation.tsx remplacé par animation CSS 3D rotateY
- Feat: case 'coin_flip' dans arena_control de remoteScoreServer

https://claude.ai/code/session_01EhrCxWPUQZx9mGqNFXqdft