### PR TITLE
fix: mort subite correcte lors d'égalité >= 10 en fin de timer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.652",
+  "version": "1.0.3-build.688",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.652",
+      "version": "1.0.3-build.688",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/renderer/components/TouchOptimizedReferee.tsx
+++ b/src/renderer/components/TouchOptimizedReferee.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Fencer, Match, MatchStatus, TargetZone, MatchMode } from '../../shared/types';
 import {
   checkTimeoutSuddenDeath,
+  checkChallengerSuddenDeath,
   isValidSuddenDeathTouch,
   getSuddenDeathOvertimeDuration,
   drawWinner,
@@ -205,7 +206,30 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
         return;
       }
     }
+
+    // Calcul des nouveaux scores avant setState (React ne met pas à jour synchroniquement)
+    const newScoreA = fencer === 'A' ? Math.min(scoreA + points, maxScore) : scoreA;
+    const newScoreB = fencer === 'B' ? Math.min(scoreB + points, maxScore) : scoreB;
+
     handleScoreIncrement(fencer, points);
+
+    // Vérifications post-touche pour les modes spéciaux
+    if (
+      matchMode === MatchMode.SUPPLEMENTARY_TIME ||
+      matchMode === MatchMode.SUDDEN_DEATH_TIMEOUT ||
+      matchMode === MatchMode.SUDDEN_DEATH_CHALLENGER
+    ) {
+      if (newScoreA !== newScoreB) {
+        setIsRunning(false);
+        onMatchEnd(newScoreA > newScoreB ? 'A' : 'B');
+        return;
+      }
+      if (matchMode === MatchMode.SUPPLEMENTARY_TIME) {
+        if (checkChallengerSuddenDeath(newScoreA, newScoreB).shouldTrigger) {
+          setMatchMode(MatchMode.SUDDEN_DEATH_TIMEOUT);
+        }
+      }
+    }
   };
 
   const handleMatchEnd = () => {

--- a/src/shared/utils/suddenDeath.test.ts
+++ b/src/shared/utils/suddenDeath.test.ts
@@ -67,17 +67,34 @@ describe('checkChallengerSuddenDeath', () => {
 
 describe('checkTimeoutSuddenDeath', () => {
   describe('Déclenchement', () => {
-    it('se déclenche si temps = 0 ET égalité (temps supplémentaire)', () => {
+    it('retourne SUPPLEMENTARY_TIME si scores < 10 à égalité', () => {
       const result = checkTimeoutSuddenDeath(0, 7, 7);
 
       expect(result.shouldTrigger).toBe(true);
       expect(result.mode).toBe(MatchMode.SUPPLEMENTARY_TIME);
     });
 
+    it('retourne SUPPLEMENTARY_TIME si scores = 9 à égalité (sous le seuil)', () => {
+      expect(checkTimeoutSuddenDeath(0, 9, 9).mode).toBe(MatchMode.SUPPLEMENTARY_TIME);
+    });
+
     it('se déclenche même avec égalité à 0-0', () => {
       const result = checkTimeoutSuddenDeath(0, 0, 0);
 
       expect(result.shouldTrigger).toBe(true);
+      expect(result.mode).toBe(MatchMode.SUPPLEMENTARY_TIME);
+    });
+
+    it('retourne SUDDEN_DEATH_TIMEOUT si scores = 10 à égalité', () => {
+      const result = checkTimeoutSuddenDeath(0, 10, 10);
+
+      expect(result.shouldTrigger).toBe(true);
+      expect(result.mode).toBe(MatchMode.SUDDEN_DEATH_TIMEOUT);
+    });
+
+    it('retourne SUDDEN_DEATH_TIMEOUT si scores > 10 à égalité', () => {
+      expect(checkTimeoutSuddenDeath(0, 11, 11).mode).toBe(MatchMode.SUDDEN_DEATH_TIMEOUT);
+      expect(checkTimeoutSuddenDeath(0, 13, 13).mode).toBe(MatchMode.SUDDEN_DEATH_TIMEOUT);
     });
   });
 

--- a/src/shared/utils/suddenDeath.ts
+++ b/src/shared/utils/suddenDeath.ts
@@ -48,10 +48,13 @@ export function checkTimeoutSuddenDeath(
   const isTie = scoreA === scoreB;
 
   if (timeUp && isTie) {
+    const bothAtThreshold = scoreA >= CHALLENGER_THRESHOLD && scoreB >= CHALLENGER_THRESHOLD;
     return {
       shouldTrigger: true,
-      mode: MatchMode.SUPPLEMENTARY_TIME,
-      reason: 'Fin du temps avec score égal - 30s supplémentaire',
+      mode: bothAtThreshold ? MatchMode.SUDDEN_DEATH_TIMEOUT : MatchMode.SUPPLEMENTARY_TIME,
+      reason: bothAtThreshold
+        ? 'Fin du temps avec score ≥10 égal - 30s mort subite (Zone C uniquement)'
+        : 'Fin du temps avec score égal - 30s supplémentaire',
     };
   }
 


### PR DESCRIPTION
- checkTimeoutSuddenDeath retourne SUDDEN_DEATH_TIMEOUT (Zone C uniquement)
  quand les deux scores sont >= 10 à égalité en fin de temps, au lieu
  d'utiliser SUPPLEMENTARY_TIME (toutes zones) dans tous les cas
- handleZoneScore calcule les nouveaux scores avant setState et termine
  automatiquement le match dès qu'il y a un écart en mode spécial
- Escalade automatique vers SUDDEN_DEATH_TIMEOUT si les scores atteignent
  10-10 pendant un SUPPLEMENTARY_TIME (ex : démarré à 7-7)
- Nouveaux tests unitaires couvrant les deux comportements

https://claude.ai/code/session_01RjBMHbAUXpdVWRSLuuV7Rt