### PR TITLE
fix: matchs abandonnés + assignation auto arènes (#330, #331)

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2465,7 +2465,7 @@ export class RemoteScoreServer {
           return scoreUpdate ? { ...m, ...scoreUpdate } : m;
         });
       const poolMatches = this.applySmartMatchOrder(rawPoolMatches as Match[]).filter(
-        m => m.status !== MatchStatus.FINISHED
+        m => m.status !== MatchStatus.FINISHED && this.isMatchPlayable(m)
       );
       const nextMatch = poolMatches.find(m => m.id !== currentMatchId);
       if (nextMatch) {
@@ -2532,7 +2532,7 @@ export class RemoteScoreServer {
           return scoreUpdate ? { ...m, ...scoreUpdate } : m;
         });
       const poolMatches = this.applySmartMatchOrder(rawPoolMatches as Match[]).filter(
-        m => m.status !== MatchStatus.FINISHED
+        m => m.status !== MatchStatus.FINISHED && this.isMatchPlayable(m)
       );
 
       console.log(

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Fencer, FencerStatus, PoolRanking } from '../../shared/types';
 import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
@@ -173,7 +173,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const [showPdfModal, setShowPdfModal] = useState(false);
   const [pdfMode, setPdfMode] = useState<'print' | 'pdf'>('pdf');
   const [pdfMatchesPerPage, setPdfMatchesPerPage] = useState<number>(MAX_MATCHES_PER_PAGE_TABLEAU);
+  const [autoAssignArenas, setAutoAssignArenas] = useState(true);
   const isUnlimitedScore = maxScore === 999;
+  const prevMatchesLengthRef = useRef(0);
 
   const { modalRef } = useModalResize({
     defaultWidth: 600,
@@ -181,6 +183,58 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     minWidth: 400,
     minHeight: 300,
   });
+
+  const distributeArenasRoundRobin = useCallback(
+    (matchList: TableauMatch[]): TableauMatch[] => {
+      if (arenaCount <= 0) return matchList;
+      let arenaIdx = 0;
+      return matchList.map(m => {
+        if (m.fencerA && m.fencerB && !m.isBye && !m.winner) {
+          const arena = (arenaIdx % arenaCount) + 1;
+          arenaIdx++;
+          return { ...m, arena };
+        }
+        return m;
+      });
+    },
+    [arenaCount]
+  );
+
+  // Auto-assign arenas when matches are (re)generated and autoAssignArenas is on
+  useEffect(() => {
+    const playable = matches.filter(m => m.fencerA && m.fencerB && !m.isBye);
+    const prev = prevMatchesLengthRef.current;
+    prevMatchesLengthRef.current = playable.length;
+    if (!autoAssignArenas || arenaCount <= 0 || playable.length === 0) return;
+    // Only auto-assign on initial generation (prev was 0) to avoid overriding manual changes
+    if (prev === 0 && playable.length > 0) {
+      const updated = distributeArenasRoundRobin(matches);
+      onMatchesChange(updated);
+      updated.forEach(m => {
+        const orig = matches.find(o => o.id === m.id);
+        if (orig && orig.arena !== m.arena) {
+          onMatchArenaChange?.(m.id, orig.arena ?? null, m.arena ?? null);
+        }
+      });
+    }
+  }, [matches.length]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleAutoAssignToggle = useCallback(
+    (enabled: boolean) => {
+      setAutoAssignArenas(enabled);
+      if (enabled && arenaCount > 0) {
+        const updated = distributeArenasRoundRobin(matches);
+        onMatchesChange(updated);
+        updated.forEach(m => {
+          const orig = matches.find(o => o.id === m.id);
+          if (orig && orig.arena !== m.arena) {
+            onMatchArenaChange?.(m.id, orig.arena ?? null, m.arena ?? null);
+          }
+        });
+      }
+    },
+    [arenaCount, distributeArenasRoundRobin, matches, onMatchesChange, onMatchArenaChange]
+  );
 
   useEffect(() => {
     const eligibleCount = ranking.filter(
@@ -966,6 +1020,32 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
           Tableau de {tableauSize} - {ranking.length} qualifiés
         </h2>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          {arenaCount > 0 && (
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.4rem',
+                fontSize: '0.875rem',
+                color: '#374151',
+                cursor: 'pointer',
+                padding: '0.5rem 0.75rem',
+                background: autoAssignArenas ? '#eff6ff' : '#f3f4f6',
+                border: `1px solid ${autoAssignArenas ? '#3b82f6' : '#d1d5db'}`,
+                borderRadius: '6px',
+                userSelect: 'none',
+              }}
+              title="Assigne automatiquement les matchs aux arènes disponibles en round-robin"
+            >
+              <input
+                type="checkbox"
+                checked={autoAssignArenas}
+                onChange={e => handleAutoAssignToggle(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span>🏟️ Assignation auto</span>
+            </label>
+          )}
           <button
             onClick={handleAutoFillScores}
             style={{

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -255,7 +255,19 @@ export const usePoolManagement = ({
 
   // Vérifier si toutes les poules sont complètes
   const areAllPoolsComplete = useCallback(() => {
-    return pools.every(pool => pool.matches.every(match => match.status === MatchStatus.FINISHED));
+    const inactiveStatuses = new Set<FencerStatus>([
+      FencerStatus.ABANDONED,
+      FencerStatus.FORFAIT,
+      FencerStatus.EXCLUDED,
+    ]);
+    return pools.every(pool =>
+      pool.matches.every(match => {
+        const hasInactive =
+          inactiveStatuses.has(match.fencerA?.status as FencerStatus) ||
+          inactiveStatuses.has(match.fencerB?.status as FencerStatus);
+        return hasInactive || match.status === MatchStatus.FINISHED;
+      })
+    );
   }, [pools]);
 
   // Obtenir les statistiques des poules


### PR DESCRIPTION
## Résumé

Traitement de 2 issues ouvertes sur la branche `dev`.

### Fix #330 — Matchs d'un tireur abandonné bloquant la transition vers le tableau

**Problème** : Quand un tireur abandonne en cours de poules, ses matchs restants (non disputés) continuaient d'apparaître sur la tablette d'arbitrage et empêchaient le passage en mode tableau.

**Changements** :
- `src/renderer/hooks/usePoolManagement.ts` — `areAllPoolsComplete()` ignore désormais les matchs dont un des tireurs est ABANDONED/FORFAIT/EXCLUDED
- `src/main/remoteScoreServer.ts` — `peekNextMatch()` et `loadNextMatch()` filtrent avec `isMatchPlayable()` (déjà existante) pour ne plus proposer ces matchs à l'arbitre

### Feature #331 — Assignation automatique des arènes (tableau d'élimination)

**Ajout** : Checkbox "🏟️ Assignation auto" (cochée par défaut) dans la barre d'outils du tableau d'élimination.

- Lorsque cochée : les matchs sont distribués automatiquement en round-robin sur les arènes disponibles à la génération du tableau
- L'utilisateur peut toujours forcer manuellement une piste via la modale d'arène existante
- L'arbitre peut voir tous les matchs de SA file d'attente et en lancer un depuis l'écran "Matchs suivants" (fonctionnalité déjà en place via `/api/arenas/:arenaId/matches`)

## Fichiers modifiés

- `src/main/remoteScoreServer.ts` — 2 lignes de filtre
- `src/renderer/hooks/usePoolManagement.ts` — refactoring de `areAllPoolsComplete()`
- `src/renderer/components/TableauView.tsx` — checkbox + logique d'auto-distribution

## Plan de test

- [ ] Créer une compétition avec poules, faire abandonner un tireur à mi-parcours
- [ ] Vérifier que le bouton "passer au tableau" s'active sans attendre ses matchs restants
- [ ] Vérifier que la tablette d'arbitrage ne propose plus les matchs du tireur abandonné
- [ ] Lancer une session distante avec plusieurs arènes en phase DE
- [ ] Vérifier que les matchs sont auto-distribués (badges numéros d'arène visibles)
- [ ] Décocher la checkbox → matches sans arène, assignation manuelle via modal
- [ ] Sur la tablette arbitre, ouvrir "Matchs suivants" → vérifier la file de l'arène

https://claude.ai/code/session_01Fz7Zs6T7nJYgajNYXKJjFB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fz7Zs6T7nJYgajNYXKJjFB)_