### PR TITLE
Fix toasts dupliqués lors de l'import de classement .fff

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -384,19 +384,33 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   };
 
   const handleImportRanking = async (result: RankingImportResult) => {
+    if (!window.electronAPI?.db?.updateFencer) {
+      showToast('Erreur: API non disponible', 'error');
+      return;
+    }
+
     try {
-      // Mettre à jour chaque tireur individuellement
-      for (const detail of result.details) {
-        if (detail.matched && detail.fencerId) {
-          await updateFencer(detail.fencerId, { ranking: detail.ranking });
-        }
-      }
+      const updatePromises = result.details
+        .filter(d => d.matched && d.fencerId)
+        .map(d =>
+          window.electronAPI!.db!.updateFencer!(d.fencerId!, { ranking: d.ranking }).catch(err =>
+            logger.error(LogCategory.UI, `Failed to update ranking for fencer ${d.fencerId}`, err as Error)
+          )
+        );
+      await Promise.allSettled(updatePromises);
+
+      onUpdate({
+        ...competition,
+        fencers: (competition.fencers || []).map(f => {
+          const detail = result.details.find(d => d.fencerId === f.id);
+          return detail?.matched ? { ...f, ranking: detail.ranking, updatedAt: new Date() } : f;
+        }),
+      });
 
       showToast(
         `Classement importé: ${result.updated} tireur(s) mis à jour`,
         result.errors.length > 0 ? 'warning' : 'success'
       );
-
       setImportData(null);
     } catch (error) {
       logger.error(LogCategory.UI, 'Failed to import ranking', error as Error);


### PR DESCRIPTION
handleImportRanking appelait updateFencer en boucle, ce qui déclenchait
un toast "Tireur mis à jour" par tireur. Remplacé par des appels directs
à l'API DB sans toast, mise à jour de l'état local en une passe, et un
seul toast récapitulatif final.

https://claude.ai/code/session_01HKRXf8Ko89XpTj8pEguYV1