### PR TITLE
fix: correction stale closure et re-démarrage timer en mort subite

### DIFF
--- a/src/renderer/components/TouchOptimizedReferee.tsx
+++ b/src/renderer/components/TouchOptimizedReferee.tsx
@@ -54,6 +54,17 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
 
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  // Refs pour éviter les stale closures dans le timer
+  const matchModeRef = useRef(matchMode);
+  const scoreARef = useRef(scoreA);
+  const scoreBRef = useRef(scoreB);
+  const handleTimeUpRef = useRef<() => void>(() => {});
+  const [timerPhase, setTimerPhase] = useState(0);
+
+  // Mise à jour des refs pendant le rendu (pattern "latest value cache")
+  matchModeRef.current = matchMode;
+  scoreARef.current = scoreA;
+  scoreBRef.current = scoreB;
 
   // Timer management (countdown)
   useEffect(() => {
@@ -64,7 +75,7 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
           if (next <= 0) {
             clearInterval(intervalRef.current!);
             intervalRef.current = null;
-            handleTimeUp();
+            handleTimeUpRef.current();
             return 0;
           }
           return next;
@@ -82,7 +93,7 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
         clearInterval(intervalRef.current);
       }
     };
-  }, [isRunning]);
+  }, [isRunning, timerPhase]);
 
   // Touch gesture handlers
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
@@ -260,37 +271,36 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
   };
 
   const handleTimeUp = useCallback(() => {
-    if (matchMode === MatchMode.SUPPLEMENTARY_TIME) {
-      if (scoreA === scoreB) {
+    const mode = matchModeRef.current;
+    const sA = scoreARef.current;
+    const sB = scoreBRef.current;
+
+    if (mode === MatchMode.SUPPLEMENTARY_TIME || mode === MatchMode.SUDDEN_DEATH_TIMEOUT) {
+      if (sA === sB) {
         setShowTiebreaker(true);
       } else {
         setIsRunning(false);
-        onMatchEnd(scoreA > scoreB ? 'A' : 'B');
+        onMatchEnd(sA > sB ? 'A' : 'B');
       }
       return;
     }
 
-    if (matchMode === MatchMode.SUDDEN_DEATH_TIMEOUT) {
-      if (scoreA === scoreB) {
-        setShowTiebreaker(true);
-      } else {
-        setIsRunning(false);
-        onMatchEnd(scoreA > scoreB ? 'A' : 'B');
-      }
-      return;
-    }
-
-    const suddenDeath = checkTimeoutSuddenDeath(0, scoreA, scoreB);
+    const suddenDeath = checkTimeoutSuddenDeath(0, sA, sB);
     if (suddenDeath.shouldTrigger) {
       setMatchMode(suddenDeath.mode!);
       setOvertimeActive(true);
       setMatchTime(getSuddenDeathOvertimeDuration());
-      setIsRunning(true);
+      // timerPhase force le re-démarrage de l'intervalle même si isRunning ne change pas
+      setTimerPhase(p => p + 1);
     } else {
       setIsRunning(false);
-      onMatchEnd(scoreA > scoreB ? 'A' : 'B');
+      onMatchEnd(sA > sB ? 'A' : 'B');
     }
-  }, [matchMode, scoreA, scoreB, onMatchEnd]);
+  }, [onMatchEnd]);
+
+  useEffect(() => {
+    handleTimeUpRef.current = handleTimeUp;
+  }, [handleTimeUp]);
 
   const formatTime = (seconds: number): string => {
     const mins = Math.floor(seconds / 60);


### PR DESCRIPTION
Deux bugs empêchaient le passage en mort subite et le blocage zones A/B :

1. Stale closure : l'intervalle capturait handleTimeUp au démarrage
   (scoreA=0, scoreB=0, matchMode=NORMAL), donc checkTimeoutSuddenDeath
   recevait toujours 0-0 → mode SUPPLEMENTARY_TIME systématique même
   si les scores réels étaient 10-10.

2. Timer bloqué : setIsRunning(true) n'avait aucun effet quand
   isRunning était déjà true, donc l'effet ne se relançait pas et
   le chrono de la prolongation ne décomptait jamais.

Fix : refs "latest value cache" (matchModeRef, scoreARef, scoreBRef)
mises à jour à chaque rendu, handleTimeUpRef pour toujours appeler
la version courante, et timerPhase pour forcer le re-démarrage de
l'intervalle indépendamment d'isRunning.

https://claude.ai/code/session_01FXs1fZBy24SHsWpF2Hh4fW