### PR TITLE
Tirage au sort : maintenir l'overlay jusqu'à la fin du combat

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1427,10 +1427,6 @@
             result.className   = colorClass;
           }, 3600);
 
-          // Masquer l'overlay automatiquement après 8s
-          setTimeout(() => {
-            overlay.classList.add('hidden');
-          }, 8000);
         }
 
         showExitAnnouncement(ann) {
@@ -1516,6 +1512,10 @@
           if (data.status) {
             this.matchStatus = data.status;
             this.updateStatusBadge();
+            if (data.status === 'finished') {
+              const overlay = document.getElementById('coin-flip-overlay');
+              if (overlay) overlay.classList.add('hidden');
+            }
           }
 
           // Mise à jour du match


### PR DESCRIPTION
L'overlay du tirage au sort restait affiché 8s fixe, indépendamment
du moment où l'arbitre terminait le combat. Il est désormais masqué
uniquement quand le statut du match passe à 'finished'.

https://claude.ai/code/session_01DrALjJ5W9PjNWikUKAHTy6