### PR TITLE
fix: marquer correctement le vainqueur du tirage au sort dans la poule

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2423,6 +2423,12 @@ export class RemoteScoreServer {
           else if (dbM?.scoreB?.isVictory) winnerForRenderer = 'B';
         } catch { /* non bloquant */ }
       }
+      // Fallback pour les matchs en mémoire (non persistés en DB) : tirage au sort
+      if (!winnerForRenderer) {
+        const memScore = this.sessionMatchScores.get(finishedMatch.id);
+        if ((memScore?.scoreA as any)?.isVictory) winnerForRenderer = 'A';
+        else if ((memScore?.scoreB as any)?.isVictory) winnerForRenderer = 'B';
+      }
       mainWindow.webContents.send('match:finished', {
         matchId: finishedMatch.id,
         scoreA: finishedMatch.scoreA,

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -260,8 +260,9 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     setEditScoreB(
       inverted ? match.scoreA?.value?.toString() || '' : match.scoreB?.value?.toString() || ''
     );
-    setVictoryA(false);
-    setVictoryB(false);
+    // Restaurer la victoire existante (ex: match déjà saisi par tirage au sort)
+    setVictoryA(!inverted ? !!match.scoreA?.isVictory : !!match.scoreB?.isVictory);
+    setVictoryB(!inverted ? !!match.scoreB?.isVictory : !!match.scoreA?.isVictory);
   };
 
   const handleCellClick = (rowFencer: Fencer, colFencer: Fencer) => {
@@ -332,6 +333,24 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
       } else if (isLaserSabre) {
         showToast('Match nul : cliquez sur V pour attribuer la victoire', 'warning');
         return;
+      } else if (victoryA || victoryB) {
+        // Tirage au sort déjà décidé (ex: résultat importé depuis une tablette arbitre)
+        const winnerLeft = victoryA;
+        const winner: 'A' | 'B' = isMatchInverted
+          ? winnerLeft ? 'B' : 'A'
+          : winnerLeft ? 'A' : 'B';
+        addAction({
+          type: 'UPDATE_SCORE',
+          description: `Score poule ${pool.number} match ${matchIdx + 1}`,
+          undo: () => {
+            if (prevScoreA !== null && prevScoreB !== null)
+              onScoreUpdate(matchIdx, prevScoreA, prevScoreB);
+          },
+          redo: () => {
+            onScoreUpdate(matchIdx, actualScoreA, actualScoreB, winner);
+          },
+        });
+        onScoreUpdate(editingMatch, actualScoreA, actualScoreB, winner);
       } else {
         showToast(
           "Match nul impossible ! En match en direct, la mort subite de 30s s'applique automatiquement",


### PR DESCRIPTION
- remoteScoreServer: dans finishArenaMatch(), ajouter un fallback sur
  sessionMatchScores pour les matchs en mémoire (non persistés en DB).
  Quand les scores sont égaux (tirage au sort), la détermination du
  vainqueur échouait silencieusement → IPC match:finished envoyé avec
  winner:null → isVictory=false pour les deux tireurs.

- PoolView: restaurer victoryA/victoryB depuis le match existant à
  l'ouverture du modal (au lieu de toujours remettre à false). Permet
  de ré-valider un résultat de tirage au sort sans perdre le vainqueur.
  Ajoute aussi le cas non-Laser Sabre avec victoire déjà décidée dans
  handleScoreSubmit.

https://claude.ai/code/session_012viXz2r4MLnyXL85LwzL11