### PR TITLE
feat: double bandeau mort subite + temps supplémentaire simultanés

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -622,6 +622,25 @@
         }
       }
 
+      .mort-subite-banner {
+        margin-top: 0.3rem;
+        padding: 0.4rem 1.2rem;
+        background: linear-gradient(135deg, #ea580c, #fb923c);
+        color: #fff;
+        font-size: clamp(1.8rem, 5vw, 7vh);
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.2em;
+        border-radius: 0.5rem;
+        text-align: center;
+        animation: timer-pulse 0.6s infinite;
+        display: none;
+      }
+
+      .mort-subite-banner.active {
+        display: block;
+      }
+
       .sudden-death-banner {
         margin-top: 0.3rem;
         padding: 0.3rem 1rem;
@@ -1195,8 +1214,9 @@
 
         <!-- Chronomètre -->
         <div class="timer-section">
+          <div class="mort-subite-banner" id="mort-subite-banner">⚡ MORT SUBITE</div>
           <div class="timer-display" id="timer-display">03:00</div>
-          <div class="sudden-death-banner" id="sudden-death-banner">⚡ MORT SUBITE</div>
+          <div class="sudden-death-banner" id="sudden-death-banner">⏱ 30s SUPPLEMENTAIRE</div>
           <div class="timer-label">Temps restant</div>
         </div>
 
@@ -1681,15 +1701,26 @@
 
         updateSuddenDeathBanner() {
           const banner = document.getElementById('sudden-death-banner');
-          if (!banner) return;
-          if (this.isSuddenDeath && this.overtimeType === 'supplementary') {
-            banner.textContent = '⏱ 30s SUPPLEMENTAIRE';
-            banner.classList.add('active');
-          } else if (this.isSuddenDeath) {
-            banner.textContent = '⚡ MORT SUBITE';
-            banner.classList.add('active');
-          } else {
-            banner.classList.remove('active');
+          const msBanner = document.getElementById('mort-subite-banner');
+
+          const isSupplementary = this.isSuddenDeath &&
+            (this.overtimeType === 'supplementary' || this.overtimeType === 'challenger_supplementary');
+          const isChallengerSD = this.isSuddenDeath &&
+            (this.overtimeType === 'challenger' || this.overtimeType === 'challenger_supplementary');
+
+          if (banner) {
+            if (isSupplementary) {
+              banner.classList.add('active');
+            } else {
+              banner.classList.remove('active');
+            }
+          }
+          if (msBanner) {
+            if (isChallengerSD) {
+              msBanner.classList.add('active');
+            } else {
+              msBanner.classList.remove('active');
+            }
           }
         }
 

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -418,6 +418,25 @@
         }
       }
 
+      .mort-subite-banner {
+        margin-top: 0.3rem;
+        padding: 0.4rem 1.2rem;
+        background: linear-gradient(135deg, #ea580c, #fb923c);
+        color: #fff;
+        font-size: clamp(1.8rem, 5vw, 7vh);
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.2em;
+        border-radius: 0.5rem;
+        text-align: center;
+        animation: timer-pulse 0.6s infinite;
+        display: none;
+      }
+
+      .mort-subite-banner.active {
+        display: block;
+      }
+
       .sudden-death-banner {
         margin-top: 0.3rem;
         padding: 0.3rem 1rem;
@@ -827,8 +846,9 @@
 
         <!-- Chronomètre -->
         <div class="timer-section">
+          <div class="mort-subite-banner" id="mort-subite-banner">⚡ MORT SUBITE</div>
           <div class="timer-display" id="timer-display">03:00</div>
-          <div class="sudden-death-banner" id="sudden-death-banner">⚡ MORT SUBITE</div>
+          <div class="sudden-death-banner" id="sudden-death-banner">⏱ 30s SUPPLEMENTAIRE</div>
           <div class="timer-label">Temps restant</div>
         </div>
       </div>
@@ -1149,15 +1169,26 @@
 
         updateSuddenDeathBanner() {
           const banner = document.getElementById('sudden-death-banner');
-          if (!banner) return;
-          if (this.isSuddenDeath && this.overtimeType === 'supplementary') {
-            banner.textContent = '⏱ 30s SUPPLEMENTAIRE';
-            banner.classList.add('active');
-          } else if (this.isSuddenDeath) {
-            banner.textContent = '⚡ MORT SUBITE';
-            banner.classList.add('active');
-          } else {
-            banner.classList.remove('active');
+          const msBanner = document.getElementById('mort-subite-banner');
+
+          const isSupplementary = this.isSuddenDeath &&
+            (this.overtimeType === 'supplementary' || this.overtimeType === 'challenger_supplementary');
+          const isChallengerSD = this.isSuddenDeath &&
+            (this.overtimeType === 'challenger' || this.overtimeType === 'challenger_supplementary');
+
+          if (banner) {
+            if (isSupplementary) {
+              banner.classList.add('active');
+            } else {
+              banner.classList.remove('active');
+            }
+          }
+          if (msBanner) {
+            if (isChallengerSD) {
+              msBanner.classList.add('active');
+            } else {
+              msBanner.classList.remove('active');
+            }
           }
         }
 

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1011,6 +1011,21 @@
 
         <!-- Chronomètre -->
         <div class="timer-section">
+          <div
+            id="mort-subite-label"
+            style="
+              display: none;
+              color: #ea580c;
+              font-weight: 900;
+              font-size: 1.6rem;
+              text-align: center;
+              margin-bottom: 0.3rem;
+              letter-spacing: 0.1em;
+              animation: pulse-timer 0.6s infinite;
+            "
+          >
+            ⚡ MORT SUBITE – Zone C uniquement !
+          </div>
           <div class="timer-display" id="timer-display">03:00</div>
           <div
             id="sudden-death-label"
@@ -1026,7 +1041,7 @@
               animation: pulse-timer 0.8s infinite;
             "
           >
-            ⚡ MORT SUBITE
+            ⏱ 30s SUPPLEMENTAIRE
           </div>
           <div class="timer-hint" data-i18n="referee.timer_hint">
             Tapez pour démarrer/pause - Appui long pour reset
@@ -1716,7 +1731,11 @@
           if (this.matchStatus === 'finished') return;
 
           // En mort subite challenger (10-10), seule la zone C (+5) est autorisée
-          if (this.isSuddenDeath && this.overtimeType === 'challenger' && points !== 5) {
+          if (
+            this.isSuddenDeath &&
+            (this.overtimeType === 'challenger' || this.overtimeType === 'challenger_supplementary') &&
+            points !== 5
+          ) {
             this.showNotification('⚡ Mort subite : Zone C uniquement !');
             return;
           }
@@ -1737,7 +1756,11 @@
 
           // Mode Challenger : mort subite si les DEUX combattants ≥ 10 pts (Laser Sabre uniquement)
           // Vérifier AVANT broadcastUpdate pour que le serveur reçoive l'état correct
-          if (this.isLaserSabre && !this.isSuddenDeath) {
+          // Le déclenchement est autorisé hors mort subite ET pendant le temps supplémentaire
+          if (
+            this.isLaserSabre &&
+            (!this.isSuddenDeath || this.overtimeType === 'supplementary')
+          ) {
             if (this.scoreA >= 10 && this.scoreB >= 10) {
               this.triggerSuddenDeathChallenger();
             }
@@ -1933,26 +1956,31 @@
 
         triggerSuddenDeathChallenger() {
           this.isSuddenDeath = true;
-          this.overtimeType = 'challenger';
+          // Si on est déjà en temps supplémentaire, on combine les deux états
+          this.overtimeType = this.overtimeType === 'supplementary'
+            ? 'challenger_supplementary'
+            : 'challenger';
           this.updateSuddenDeathUI();
           this.showNotification(
             '⚡ MORT SUBITE – Les deux tireurs ont 10 pts ! Zone C uniquement.'
           );
         }
 
-        // Afficher le label sans désactiver les zones (la validation se fait dans addScore)
+        // Afficher les labels selon l'état courant
         updateSuddenDeathUI() {
           const sdLabel = document.getElementById('sudden-death-label');
+          const msLabel = document.getElementById('mort-subite-label');
+
+          const isSupplementary = this.isSuddenDeath &&
+            (this.overtimeType === 'supplementary' || this.overtimeType === 'challenger_supplementary');
+          const isChallengerSD = this.isSuddenDeath &&
+            (this.overtimeType === 'challenger' || this.overtimeType === 'challenger_supplementary');
+
           if (sdLabel) {
-            if (this.isSuddenDeath && this.overtimeType === 'supplementary') {
-              sdLabel.style.display = 'block';
-              sdLabel.textContent = '⏱ 30s SUPPLEMENTAIRE';
-            } else if (this.isSuddenDeath && this.overtimeType === 'challenger') {
-              sdLabel.style.display = 'block';
-              sdLabel.textContent = '⚡ MORT SUBITE';
-            } else {
-              sdLabel.style.display = 'none';
-            }
+            sdLabel.style.display = isSupplementary ? 'block' : 'none';
+          }
+          if (msLabel) {
+            msLabel.style.display = isChallengerSD ? 'block' : 'none';
           }
         }
 
@@ -2012,11 +2040,17 @@
             if (idx !== -1) this.touchesB.splice(idx, 1);
           }
 
-          // Ré-évaluer la mort subite : si un score repasse sous 10, on quitte la mort subite
-          if (this.isSuddenDeath && this.isLaserSabre && this.overtimeType === 'challenger') {
+          // Ré-évaluer la mort subite : si un score repasse sous 10, on quitte la mort subite challenger
+          if (
+            this.isSuddenDeath && this.isLaserSabre &&
+            (this.overtimeType === 'challenger' || this.overtimeType === 'challenger_supplementary')
+          ) {
             if (!(this.scoreA >= 10 && this.scoreB >= 10)) {
-              this.isSuddenDeath = false;
-              this.overtimeType = null;
+              // Revenir au temps supplémentaire si c'était déclenché pendant le supplémentaire
+              this.overtimeType = this.overtimeType === 'challenger_supplementary'
+                ? 'supplementary'
+                : null;
+              if (this.overtimeType === null) this.isSuddenDeath = false;
               this.updateSuddenDeathUI();
             }
           }
@@ -2064,10 +2098,15 @@
           }
 
           // Ré-évaluer la mort subite
-          if (this.isSuddenDeath && this.isLaserSabre && this.overtimeType === 'challenger') {
+          if (
+            this.isSuddenDeath && this.isLaserSabre &&
+            (this.overtimeType === 'challenger' || this.overtimeType === 'challenger_supplementary')
+          ) {
             if (!(this.scoreA >= 10 && this.scoreB >= 10)) {
-              this.isSuddenDeath = false;
-              this.overtimeType = null;
+              this.overtimeType = this.overtimeType === 'challenger_supplementary'
+                ? 'supplementary'
+                : null;
+              if (this.overtimeType === null) this.isSuddenDeath = false;
               this.updateSuddenDeathUI();
             }
           }

--- a/src/renderer/components/TouchOptimizedReferee.tsx
+++ b/src/renderer/components/TouchOptimizedReferee.tsx
@@ -51,6 +51,7 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
   const [matchMode, setMatchMode] = useState<MatchMode>(MatchMode.NORMAL);
   const [showTiebreaker, setShowTiebreaker] = useState(false);
   const [overtimeActive, setOvertimeActive] = useState(false);
+  const [supplementaryActive, setSupplementaryActive] = useState(false);
 
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
@@ -245,6 +246,7 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
 
   const handleMatchEnd = () => {
     setIsRunning(false);
+    setSupplementaryActive(false);
     if (scoreA === scoreB) {
       setShowTiebreaker(true);
     } else {
@@ -255,6 +257,7 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
   const handleTiebreakerComplete = (winner: 'A' | 'B') => {
     setShowTiebreaker(false);
     setIsRunning(false);
+    setSupplementaryActive(false);
     onMatchEnd(winner);
   };
 
@@ -289,11 +292,15 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
     if (suddenDeath.shouldTrigger) {
       setMatchMode(suddenDeath.mode!);
       setOvertimeActive(true);
+      if (suddenDeath.mode === MatchMode.SUPPLEMENTARY_TIME) {
+        setSupplementaryActive(true);
+      }
       setMatchTime(getSuddenDeathOvertimeDuration());
       // timerPhase force le re-démarrage de l'intervalle même si isRunning ne change pas
       setTimerPhase(p => p + 1);
     } else {
       setIsRunning(false);
+      setSupplementaryActive(false);
       onMatchEnd(sA > sB ? 'A' : 'B');
     }
   }, [onMatchEnd]);
@@ -324,15 +331,14 @@ export const TouchOptimizedReferee: React.FC<TouchOptimizedRefereeProps> = ({
         <div className="flex justify-between items-center">
           <div className="text-2xl font-bold text-gray-800">Piste {match.number || 1}</div>
           <div className="flex items-center space-x-4">
-            {overtimeActive && (
-              <div
-                className={`px-3 py-1 rounded-full text-sm font-bold animate-pulse ${
-                  matchMode === MatchMode.SUPPLEMENTARY_TIME
-                    ? 'bg-blue-100 text-blue-700'
-                    : 'bg-yellow-100 text-yellow-700'
-                }`}
-              >
-                {matchMode === MatchMode.SUPPLEMENTARY_TIME ? '30s SUPPLEMENTAIRE' : 'MORT SUBITE'}
+            {overtimeActive && (matchMode === MatchMode.SUDDEN_DEATH_TIMEOUT || matchMode === MatchMode.SUDDEN_DEATH_CHALLENGER) && (
+              <div className="px-3 py-1 rounded-full text-sm font-bold animate-pulse bg-orange-100 text-orange-700">
+                ⚡ MORT SUBITE
+              </div>
+            )}
+            {overtimeActive && (matchMode === MatchMode.SUPPLEMENTARY_TIME || supplementaryActive) && (
+              <div className="px-3 py-1 rounded-full text-sm font-bold animate-pulse bg-blue-100 text-blue-700">
+                ⏱ 30s SUPPLEMENTAIRE
               </div>
             )}
             <div


### PR DESCRIPTION
Quand les deux tireurs atteignent 10 pts pendant le temps supplémentaire
(30s), un bandeau ⚡ MORT SUBITE (orange) s'affiche au-dessus du bandeau
⏱ 30s SUPPLEMENTAIRE (rouge), les deux visibles en même temps.

- Nouveau `overtimeType = 'challenger_supplementary'` pour l'état combiné
- Correction du bug : `!this.isSuddenDeath` empêchait le déclenchement du
  challenger SD pendant le temps supplémentaire (referee.html)
- arena.html / public.html : nouveau `.mort-subite-banner` (fond orange)
  au-dessus du `.sudden-death-banner` ; `updateSuddenDeathBanner()` adapté
- referee.html : nouveau `#mort-subite-label` au-dessus du chronomètre ;
  `updateSuddenDeathUI()` gère les 4 états ; `removeScore()` revient à
  `'supplementary'` si le score repasse sous 10 pendant le supplémentaire
- TouchOptimizedReferee.tsx : état `supplementaryActive` pour afficher
  simultanément les deux indicateurs dans l'interface tablette

https://claude.ai/code/session_01X1quJrgveVLn1Uzsb4pKZr