### PR TITLE
🔧 fix: add git pull after checkout to sync version files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           ref: main
 
+      - name: Update version files
+        run: git pull origin main || true
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -114,6 +117,9 @@ jobs:
         with:
           ref: main
 
+      - name: Update version files
+        run: git pull origin main || true
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -159,6 +165,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+
+      - name: Update version files
+        run: git pull origin main || true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -206,6 +215,9 @@ jobs:
         with:
           ref: main
 
+      - name: Update version files
+        run: git pull origin main || true
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -252,6 +264,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+
+      - name: Update version files
+        run: git pull origin main || true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Fix le problème de décalage de numéro de build entre les artifacts et la release.

Ajoute un `git pull` après chaque checkout dans les jobs de build pour synchroniser les fichiers de version.