### PR TITLE
🔧 fix: use bash shell for version sync on all platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
           ref: main
 
       - name: Update version files
+        shell: bash
         run: |
           # Attendre que le commit de version soit propagé
           for i in 1 2 3 4 5; do
@@ -84,7 +85,7 @@ jobs:
                 exit 0
               fi
             fi
-            [ $i -lt 5 ] && sleep 5
+            [ $i -lt 5 ] && sleep 10
           done
           echo "⚠️ Could not sync version, using latest available"
 
@@ -136,6 +137,7 @@ jobs:
           ref: main
 
       - name: Update version files
+        shell: bash
         run: |
           # Attendre que le commit de version soit propagé
           for i in 1 2 3 4 5; do
@@ -152,7 +154,7 @@ jobs:
                 exit 0
               fi
             fi
-            [ $i -lt 5 ] && sleep 5
+            [ $i -lt 5 ] && sleep 10
           done
           echo "⚠️ Could not sync version, using latest available"
 
@@ -203,6 +205,7 @@ jobs:
           ref: main
 
       - name: Update version files
+        shell: bash
         run: |
           # Attendre que le commit de version soit propagé
           for i in 1 2 3 4 5; do
@@ -219,7 +222,7 @@ jobs:
                 exit 0
               fi
             fi
-            [ $i -lt 5 ] && sleep 5
+            [ $i -lt 5 ] && sleep 10
           done
           echo "⚠️ Could not sync version, using latest available"
 
@@ -270,6 +273,7 @@ jobs:
           ref: main
 
       - name: Update version files
+        shell: bash
         run: |
           # Attendre que le commit de version soit propagé
           for i in 1 2 3 4 5; do
@@ -286,7 +290,7 @@ jobs:
                 exit 0
               fi
             fi
-            [ $i -lt 5 ] && sleep 5
+            [ $i -lt 5 ] && sleep 10
           done
           echo "⚠️ Could not sync version, using latest available"
 
@@ -338,6 +342,7 @@ jobs:
           ref: main
 
       - name: Update version files
+        shell: bash
         run: |
           # Attendre que le commit de version soit propagé
           for i in 1 2 3 4 5; do
@@ -354,7 +359,7 @@ jobs:
                 exit 0
               fi
             fi
-            [ $i -lt 5 ] && sleep 5
+            [ $i -lt 5 ] && sleep 10
           done
           echo "⚠️ Could not sync version, using latest available"
 


### PR DESCRIPTION
Corrige lerreur PowerShell sur Windows en spécifiant shell: bash