### PR TITLE
Update GitHub release action and improve build artifact matching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,7 +330,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: latest
           name: '🚀 BellePoule Modern v${{ needs.increment-version.outputs.version }} Build #${{ needs.increment-version.outputs.build }}'
@@ -353,10 +353,11 @@ jobs:
             Menu **Aide > À propos** ou **F1**
           files: |
             builds/windows-exe/*.exe
-            builds/macos-x64-dmg/*.dmg
-            builds/macos-arm64-dmg/*.dmg
+            builds/macos-x64-dmg/*-x64.dmg
+            builds/macos-arm64-dmg/*-arm64.dmg
             builds/linux-x64-appimage/*.AppImage
             builds/linux-arm64-appimage/*.AppImage
+          fail_on_unmatched_files: false
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
## Summary
Updated the GitHub release workflow to use a newer version of the release action and improved the build artifact file matching patterns for macOS builds.

## Key Changes
- Upgraded `softprops/action-gh-release` from v1 to v2
- Updated macOS DMG file patterns to be more specific:
  - `builds/macos-x64-dmg/*.dmg` → `builds/macos-x64-dmg/*-x64.dmg`
  - `builds/macos-arm64-dmg/*.dmg` → `builds/macos-arm64-dmg/*-arm64.dmg`
- Added `fail_on_unmatched_files: false` to prevent workflow failures if expected artifacts are missing

## Implementation Details
The more specific file patterns for macOS builds ensure that only architecture-specific DMG files are matched and uploaded to the correct release. The `fail_on_unmatched_files: false` flag provides graceful handling in cases where certain build artifacts may not be available, improving workflow reliability.

https://claude.ai/code/session_01Q3yXkARtZ2Wg5C8shWGsnf