### PR TITLE
fix: vue poule distante non synchronisée avec les matchs du logiciel

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1497,6 +1497,19 @@ ipcMain.handle(
   }
 );
 
+ipcMain.handle(
+  'remote:syncPoolMatches',
+  async (_, poolsData: Array<{ poolId: string; matches: any[] }>) => {
+    try {
+      if (!remoteScoreServer) return { success: false, error: 'Serveur non démarré' };
+      remoteScoreServer.syncPoolMatches(poolsData);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+    }
+  }
+);
+
 ipcMain.handle('remote:refreshDeMatches', async (_, matches: any[]) => {
   try {
     if (!remoteScoreServer) return { success: false, error: 'Serveur non démarré' };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -441,6 +441,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:updateMatchArena', matchId, fromArena, toArena),
     updatePoolFencers: (updates: Array<{ poolId: string; fencers: any[] }>) =>
       ipcRenderer.invoke('remote:updatePoolFencers', updates),
+    syncPoolMatches: (poolsData: Array<{ poolId: string; matches: any[] }>) =>
+      ipcRenderer.invoke('remote:syncPoolMatches', poolsData),
     refreshDeMatches: (matches: any[]) => ipcRenderer.invoke('remote:refreshDeMatches', matches),
     setArenaPassword: (arenaId: string, password: string) =>
       ipcRenderer.invoke('remote:setArenaPassword', arenaId, password),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2908,9 +2908,12 @@ export class RemoteScoreServer {
       }
 
       allMatches = realMatches.filter(
-        m => m.isTableau || m.status === 'not_started' || m.status === 'in_progress'
+        m =>
+          m.isTableau
+            ? m.status === 'not_started' || m.status === 'in_progress'
+            : true // Tous les matchs de poule, y compris finished (nécessaires pour la grille)
       );
-      console.log(`[RemoteScoreServer] ${allMatches.length} matchs en attente après filtrage`);
+      console.log(`[RemoteScoreServer] ${allMatches.length} matchs après filtrage`);
     } else {
       // Récupérer les matchs en attente depuis la DB
       console.log('[RemoteScoreServer] Pas de matches reçus, recherche dans la DB...');
@@ -3283,6 +3286,49 @@ export class RemoteScoreServer {
         this.io
           .to(`pool:${aId}`)
           .emit(`pool:${aId}:update`, { poolId, fencers: updatedFencers, matches, isComplete });
+        break;
+      }
+    }
+  }
+
+  public syncPoolMatches(poolsData: Array<{ poolId: string; matches: any[] }>): void {
+    const updatedPoolIds = new Set<string>();
+
+    for (const { poolId, matches } of poolsData) {
+      this.sessionMatches = [
+        ...this.sessionMatches.filter(
+          (m: any) =>
+            m.isTableau ||
+            (m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`) !== poolId
+        ),
+        ...matches,
+      ];
+      updatedPoolIds.add(poolId);
+    }
+
+    for (const poolId of updatedPoolIds) {
+      for (const [aId, arena] of this.arenas) {
+        if (arena.currentMatch?.poolId !== poolId) continue;
+        const fencers = this.poolFencersCache.get(poolId) ?? this.db.getPoolFencers(poolId);
+        const inMemory = this.sessionMatches
+          .filter(
+            (m: any) =>
+              !m.isTableau &&
+              (m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`) === poolId
+          )
+          .sort((a: any, b: any) => (a.number || 0) - (b.number || 0));
+        const poolMatches =
+          inMemory.length > 0
+            ? inMemory.map((m: any) => {
+                const u = this.sessionMatchScores.get(m.id);
+                return u ? { ...m, ...u } : m;
+              })
+            : this.db.getMatchesByPool(poolId);
+        const isComplete =
+          poolMatches.length > 0 && poolMatches.every((m: any) => m.status === MatchStatus.FINISHED);
+        this.io
+          .to(`pool:${aId}`)
+          .emit(`pool:${aId}:update`, { poolId, fencers, matches: poolMatches, isComplete });
         break;
       }
     }

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -129,6 +129,31 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     });
   }, [pools, isRemoteActive, session]);
 
+  // Quand les résultats de matchs de poule changent dans le logiciel, synchroniser le serveur distant
+  const sessionMatchesFingerprintRef = useRef<string>('');
+  useEffect(() => {
+    const fingerprint = pools
+      .map(
+        p =>
+          `${p.id}:${(p.matches ?? []).map((m: any) => `${m.id}=${m.status}|${m.scoreA ?? ''}-${m.scoreB ?? ''}`).join(',')}`
+      )
+      .join('|');
+    if (!isRemoteActive || !session) {
+      sessionMatchesFingerprintRef.current = fingerprint;
+      return;
+    }
+    if (fingerprint === sessionMatchesFingerprintRef.current) return;
+    sessionMatchesFingerprintRef.current = fingerprint;
+    const poolsData = pools.map(pool => ({ poolId: pool.id, matches: pool.matches ?? [] }));
+    window.electronAPI.remote.syncPoolMatches(poolsData).catch((err: unknown) => {
+      logger.warn(
+        LogCategory.NETWORK,
+        'Échec syncPoolMatches',
+        err instanceof Error ? err : undefined
+      );
+    });
+  }, [pools, isRemoteActive, session]);
+
   // Quand les matchs tableau changent pendant une session active, mettre à jour le serveur
   // sans avoir à arrêter/relancer la saisie distante (transition poules → tableau).
   const prevDeMatchesKeyRef = useRef<string>('');

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -365,6 +365,9 @@ export interface RemoteServerAPI {
   updatePoolFencers: (
     updates: Array<{ poolId: string; fencers: any[] }>
   ) => Promise<{ success: boolean; error?: string }>;
+  syncPoolMatches: (
+    poolsData: Array<{ poolId: string; matches: any[] }>
+  ) => Promise<{ success: boolean; error?: string }>;
   refreshDeMatches: (matches: any[]) => Promise<{ success: boolean; error?: string }>;
   setArenaPassword: (
     arenaId: string,


### PR DESCRIPTION
## Résumé

La vue `http://<ip>:8066/arene1/poule` n'affichait pas les matchs déjà joués dans le logiciel principal, et ne se mettait pas à jour en temps réel lors de la saisie des scores.

## Root cause

**Bug 1 — filtre `startSession()`** (`remoteScoreServer.ts` l. 2910) :
Le filtre excluait les matchs `finished` de `sessionMatches`. L'endpoint `/api/arenas/:arenaId/pool-data` utilisant `sessionMatches` en priorité (avec guard `inMemory.length > 0`), le fallback DB n'était jamais atteint → matchs terminés invisibles.

**Bug 2 — pas de sync temps-réel** :
`RemoteScoreManager.tsx` surveillait uniquement les changements de composition de poule (fencers), pas les résultats de matchs. Aucun IPC n'était émis quand un score était enregistré côté logiciel.

## Changements

| Fichier | Modification |
|---------|-------------|
| `src/main/remoteScoreServer.ts` | Filtre corrigé (pool matches tous inclus) + nouvelle méthode `syncPoolMatches()` |
| `src/main/main.ts` | Handler IPC `remote:syncPoolMatches` |
| `src/main/preload.ts` | Exposition `syncPoolMatches` via contextBridge |
| `src/shared/types/preload.ts` | Signature TypeScript |
| `src/renderer/components/RemoteScoreManager.tsx` | `useEffect` fingerprint sur statuts/scores → appelle `syncPoolMatches` |

## Test

1. Démarrer le logiciel + activer le serveur distant
2. Ouvrir `http://localhost:8066/arene1/poule`
3. Jouer 2-3 matchs dans le logiciel → **Fix 1** : fermer/rouvrir la page → matchs terminés visibles
4. Garder la page ouverte, jouer un autre match → **Fix 2** : grille mise à jour automatiquement sans refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)