### PR TITLE
fix: classement final tronqué à 4 et export PDF vide

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -747,7 +747,10 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     // Issue #61: Les éliminés en quarts se retrouvaient en bas du classement
     // Issue #60: Les tireurs éliminés à chaque tour ont des rangs distincts
     // Issue #59: Départage par somme des points Quest (poules + tableau)
-    const rounds = [4, 8, 16, 32, 64, 128].filter(r => r <= tableauSize);
+    const effectiveSize = matchList.length > 0
+      ? Math.max(...matchList.filter(m => m.round !== 3).map(m => m.round))
+      : tableauSize;
+    const rounds = [4, 8, 16, 32, 64, 128].filter(r => r <= effectiveSize);
     let currentRank = thirdPlaceMatch?.winner ? 5 : 3;
 
     // DEBUG: console.log('Rounds à traiter:', rounds, 'currentRank de départ:', currentRank);

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -933,7 +933,7 @@ function generateResultsHTML(
     <div class="doc-header-badge" style="font-size:11pt">RF</div>
   </div>`,
     'gold-bar': `  <div class="gold-bar"></div>`,
-    'results-table': `
+    'ranking-table': `
   <table>
     <thead>
       <tr>


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- **Classement tronqué à 4** : `calculateFinalResults` utilisait `tableauSize` depuis la closure React. Le useEffect "filet de sécurité" se déclenchait au premier montage avant que `setTableauSize` ait pris effet (`tableauSize=0` → `rounds=[]` → seuls les rangs 1-4 issus de la finale et de la petite finale étaient retournés). Fix : `effectiveSize` calculé directement depuis `matchList` (max des rounds hors round 3 spécial).

- **PDF vide** : `generateResultsHTML` définissait la section sous la clé `'results-table'`, mais `assembleBody` itère les IDs du template `ranking` qui valent `['header', 'gold-bar', 'ranking-table', 'footer']`. La clé `'results-table'` n'était jamais trouvée → tableau absent du PDF. Fix : renommer la clé en `'ranking-table'`.

## Fichiers modifiés

| Fichier | Changement |
|---------|-----------|
| `src/renderer/components/TableauView.tsx` | `effectiveSize` calculé depuis `matchList` |
| `src/shared/utils/pdfExport.ts` | Clé `'results-table'` → `'ranking-table'` |

## Test

1. Compétition ≥ 8 tireurs, poules terminées, tableau de 8 complet
2. Vue Résultats → 8 tireurs classés (pas seulement 4)
3. Export PDF → tableau complet présent
4. Rechargement appli → classement toujours complet

https://claude.ai/code/session_01MgvKiQoqnxE7DVTg2UFPFw
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgvKiQoqnxE7DVTg2UFPFw)_