### PR TITLE
fix(results): inclure les tireurs éliminés en poules dans le classement final

### DIFF
--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -41,15 +41,24 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
     return {};
   };
 
-  // Si pas de résultats finaux, afficher le classement des poules
-  const resultsToDisplay =
-    finalResults.length > 0
-      ? finalResults
-      : poolRanking.map((pr, idx) => ({
-          rank: idx + 1,
-          fencer: pr.fencer,
-          eliminatedAt: 'Poules',
-        }));
+  const resultsToDisplay = (() => {
+    if (finalResults.length === 0) {
+      return poolRanking.map((pr, idx) => ({
+        rank: idx + 1,
+        fencer: pr.fencer,
+        eliminatedAt: 'Poules' as const,
+      }));
+    }
+    const tableauIds = new Set(finalResults.map(r => r.fencer.id));
+    const poolEliminated = poolRanking
+      .filter(pr => !tableauIds.has(pr.fencer.id))
+      .map((pr, idx) => ({
+        rank: finalResults.length + idx + 1,
+        fencer: pr.fencer,
+        eliminatedAt: 'Poules' as const,
+      }));
+    return [...finalResults, ...poolEliminated];
+  })();
 
   // Export CSV
   const exportCSV = () => {


### PR DESCRIPTION
$(cat <<'EOF'
## Problème

Quand un tournoi comportait plus de tireurs en poules que la taille du tableau (ex. 16 en poules → tableau de 4), le classement final (`ResultsView`) n'affichait que les participants au tableau. Les tireurs éliminés en poules étaient absents de l'impression, du PDF, du CSV, du XML et du copier-coller.

## Cause

Dans `ResultsView.tsx`, `resultsToDisplay` était égal à `finalResults` en entier quand celui-ci était non vide — le prop `poolRanking` (qui contient TOUS les participants) était ignoré.

## Fix

`resultsToDisplay` fusionne maintenant `finalResults` avec les tireurs de `poolRanking` absents du tableau, classés à la suite (`éliminé en : Poules`).

## Test

- Créer une compétition avec ≥ 8 tireurs, jouer les poules, qualifier seulement les 4 premiers pour le tableau
- Jouer le tableau jusqu'à la fin
- Vérifier que "Classement final - N tireurs" affiche N = total des participants
- Imprimer / exporter : tous les tireurs présents

https://claude.ai/code/session_01XuELTQw397sMp23ByYTQky
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuELTQw397sMp23ByYTQky)_