### PR TITLE
fix: retour au tableau depuis le classement final

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.688",
+  "version": "1.0.3-build.758",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.688",
+      "version": "1.0.3-build.758",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -176,6 +176,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const [autoAssignArenas, setAutoAssignArenas] = useState(true);
   const isUnlimitedScore = maxScore === 999;
   const prevMatchesLengthRef = useRef(0);
+  const isInitialMatchesRef = useRef(true);
 
   const { modalRef } = useModalResize({
     defaultWidth: 600,
@@ -261,6 +262,12 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   // Filet de sécurité : détecte la complétion du tableau à chaque mise à jour de matches
   // Couvre les chemins qui ne passent pas par handleScoreSubmit (saisie distante, statuts spéciaux)
   useEffect(() => {
+    // Ignorer le premier rendu : si le tableau est déjà complet au montage (ex : retour depuis
+    // le classement final), ne pas déclencher onComplete qui redirigerait immédiatement vers results.
+    if (isInitialMatchesRef.current) {
+      isInitialMatchesRef.current = false;
+      return;
+    }
     if (matches.length === 0 || !onComplete) return;
     const champion = matches.find(m => m.round === 2)?.winner;
     if (!champion) return;


### PR DESCRIPTION
## Problème

Depuis la phase "classement final" (`results`), cliquer sur l'onglet "Tableau" redirige immédiatement vers le classement au lieu d'afficher le tableau d'élimination.

## Cause racine

`TableauView` est un composant conditionnel (`{currentPhase === 'tableau' && <TableauView/>}`). À chaque navigation vers la phase `tableau`, une nouvelle instance est montée. Un `useEffect([matches])` de détection de fin de tableau s'exécutait dès le montage : si `matches` contenait déjà un tableau complet (champion + 3e place), il appelait `onComplete` immédiatement, déclenchant `setCurrentPhase('results')` dans le parent.

## Correctif

`src/renderer/components/TableauView.tsx` — ajout d'un ref `isInitialMatchesRef` qui saute la **première** exécution du `useEffect`. Les complétions réelles (match joué pendant la session) restent détectées normalement via les exécutions suivantes.

## Test

1. Créer un tournoi, passer par : check-in → poules → classement → tableau
2. Compléter le tableau → classement final s'affiche
3. Cliquer sur "Tableau" → le tableau s'affiche ✓
4. Cliquer sur "Classement final" → retour au classement ✓

https://claude.ai/code/session_01XVdv2kAgRXMJ7HsbnDHsWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVdv2kAgRXMJ7HsbnDHsWS)_