### PR TITLE
fix(quest): validation combat et remplissage auto

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -525,8 +525,9 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           }
         }
       } else {
-        // Scores différents, pas besoin de traitement spécial
-        onScoreUpdate(index, scoreA, scoreB);
+        // Scores différents : désigner le vainqueur explicitement
+        const winnerOverride: 'A' | 'B' = scoreA > scoreB ? 'A' : 'B';
+        onScoreUpdate(index, scoreA, scoreB, winnerOverride);
       }
     }
 

--- a/src/renderer/components/QuestPhaseView.tsx
+++ b/src/renderer/components/QuestPhaseView.tsx
@@ -117,6 +117,15 @@ const QuestPhaseView: React.FC<QuestPhaseViewProps> = ({
     winner?: 'A' | 'B',
     specialStatus?: 'abandon' | 'forfait' | 'exclusion'
   ) => {
+    const effectiveWinner: 'A' | 'B' | undefined =
+      winner !== undefined
+        ? winner
+        : scoreA > scoreB
+          ? 'A'
+          : scoreB > scoreA
+            ? 'B'
+            : undefined;
+
     setPools(prev =>
       prev.map(pool => ({
         ...pool,
@@ -133,16 +142,16 @@ const QuestPhaseView: React.FC<QuestPhaseViewProps> = ({
 
           return {
             ...m,
-            scoreA: makeScore(scoreA, winner === 'A'),
-            scoreB: makeScore(scoreB, winner === 'B'),
-            status: winner !== undefined ? MatchStatus.FINISHED : m.status,
+            scoreA: makeScore(scoreA, effectiveWinner === 'A'),
+            scoreB: makeScore(scoreB, effectiveWinner === 'B'),
+            status: effectiveWinner !== undefined ? MatchStatus.FINISHED : m.status,
             updatedAt: new Date(),
           };
         }),
         isComplete: pool.matches.every(
           (m, i) => i !== matchIndex
             ? m.status === MatchStatus.FINISHED
-            : winner !== undefined
+            : effectiveWinner !== undefined
         ),
       }))
     );


### PR DESCRIPTION
## Problème

Deux bugs en mode Quest (Laser Sabre) avec la même cause racine.

**Bug 1 — Valider un combat ne fonctionne pas**
Entrer 5-3 et cliquer Valider → match reste `NOT_STARTED` → `allComplete` jamais true → bouton "Valider le Tour Quest" n'apparaît pas.

**Bug 2 — Remplissage auto : un seul match à la fois, toujours égalité**
L'auto-fill ne marquait FINISHED que les matchs à égalité (où `winnerOverride` était passé). Les matchs avec scores différents gardaient leur status `NOT_STARTED`.

## Cause racine

`QuestPhaseView.updateScore` conditionne le status FINISHED à `winner !== undefined` :
```typescript
status: winner !== undefined ? MatchStatus.FINISHED : m.status,
```
Mais `PoolView.handleScoreSubmit` et l'auto-fill appellent `onScoreUpdate(index, scoreA, scoreB)` **sans `winner`** quand les scores sont différents.

## Correctifs

- **`QuestPhaseView.tsx`** : calcule `effectiveWinner` depuis les scores quand `winner` n'est pas fourni (alignement avec `usePoolManagement.ts`)
- **`PoolView.tsx`** : auto-fill passe `winnerOverride` explicite pour les scores différents

https://claude.ai/code/session_01SNuin8QVKgsaThVfy6rUNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNuin8QVKgsaThVfy6rUNz)_