### PR TITLE
fix: classement final tronqué à 4 et export PDF vide (→ dev)

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -747,7 +747,10 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     // Issue #61: Les éliminés en quarts se retrouvaient en bas du classement
     // Issue #60: Les tireurs éliminés à chaque tour ont des rangs distincts
     // Issue #59: Départage par somme des points Quest (poules + tableau)
-    const rounds = [4, 8, 16, 32, 64, 128].filter(r => r <= tableauSize);
+    const effectiveSize = matchList.length > 0
+      ? Math.max(...matchList.filter(m => m.round !== 3).map(m => m.round))
+      : tableauSize;
+    const rounds = [4, 8, 16, 32, 64, 128].filter(r => r <= effectiveSize);
     let currentRank = thirdPlaceMatch?.winner ? 5 : 3;
 
     // DEBUG: console.log('Rounds à traiter:', rounds, 'currentRank de départ:', currentRank);

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1004,7 +1004,7 @@ function generateResultsHTML(
     <div class="doc-header-badge" style="font-size:11pt">RF</div>
   </div>`,
     'gold-bar': `  <div class="gold-bar"></div>`,
-    'results-table': `
+    'ranking-table': `
   <table>
     <thead>
       <tr>


### PR DESCRIPTION
Cherry-pick de #368 sur `dev`.

- `TableauView`: `effectiveSize` calculé depuis `matchList` (plus de dépendance au state `tableauSize` stale)
- `pdfExport`: clé `'results-table'` → `'ranking-table'` pour correspondre aux IDs du template ranking

https://claude.ai/code/session_01MgvKiQoqnxE7DVTg2UFPFw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgvKiQoqnxE7DVTg2UFPFw)_