### PR TITLE
fix(tableau): phase tableau re-cliquable après fin de tableau (StrictMode)

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -176,7 +176,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const [autoAssignArenas, setAutoAssignArenas] = useState(true);
   const isUnlimitedScore = maxScore === 999;
   const prevMatchesLengthRef = useRef(0);
-  const isInitialMatchesRef = useRef(true);
+  const mountMatchesRef = useRef(matches);
 
   const { modalRef } = useModalResize({
     defaultWidth: 600,
@@ -268,12 +268,10 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   // Filet de sécurité : détecte la complétion du tableau à chaque mise à jour de matches
   // Couvre les chemins qui ne passent pas par handleScoreSubmit (saisie distante, statuts spéciaux)
   useEffect(() => {
-    // Ignorer le premier rendu : si le tableau est déjà complet au montage (ex : retour depuis
-    // le classement final), ne pas déclencher onComplete qui redirigerait immédiatement vers results.
-    if (isInitialMatchesRef.current) {
-      isInitialMatchesRef.current = false;
-      return;
-    }
+    // Ignorer si matches n'a pas changé depuis le montage du composant.
+    // Robuste au double-invoke de React StrictMode : le ref de montage reste stable
+    // entre les deux passes, contrairement à un booléen consommé au premier run.
+    if (matches === mountMatchesRef.current) return;
     if (matches.length === 0 || !onComplete) return;
     const champion = matches.find(m => m.round === 2)?.winner;
     if (!champion) return;


### PR DESCRIPTION
## Cause

`isInitialMatchesRef` (booléen) était consommé au **premier** run de l'effet `[matches]`. React StrictMode double-invoke les effets au montage **sans réinitialiser les refs** → le deuxième run voyait `isInitialMatchesRef.current = false` et appelait `onComplete` → redirection immédiate vers Résultats → onglet Tableau figé.

## Fix

`mountMatchesRef` stocke la **référence** de `matches` au montage du composant. L'effet compare `matches === mountMatchesRef.current` :

- **Même référence** (montage ou double-invoke StrictMode) → skip ✓  
- **Nouvelle référence** (match joué → `onMatchesChange` → nouveau tableau parent) → `onComplete` si tableau complet ✓

## Test

1. Créer compétition avec tableau direct
2. Jouer tous les matchs jusqu'à la fin
3. App redirige vers Résultats automatiquement
4. Cliquer sur l'onglet Tableau → doit s'afficher (plus de bounce immédiat vers Résultats)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbtPPjrn7kXqrAUn2vyvpi)_