### PR TITLE
Bouton Appel DT sur interface arbitre distante

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1706,6 +1706,18 @@ ipcMain.handle('remote:clearOrgNote', async (_event, competitionId: string) => {
   }
 });
 
+ipcMain.handle('remote:acknowledgeDTCall', async (_, competitionId: string, arenaId: string) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: false, error: 'Serveur non démarré' };
+    entry.server.acknowledgeDTCall(arenaId);
+    return { success: true };
+  } catch (error) {
+    console.error('Error acknowledging DT call:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle('remote:updateLogo', async (_, logo: string | null) => {
   try {
     const logoPath = path.join(app.getPath('userData'), 'logo.dat');

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -475,6 +475,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:setWallpaper', competitionId, wallpaper),
     changePort: (competitionId: string, newPort: number) =>
       ipcRenderer.invoke('remote:changePort', competitionId, newPort),
+    acknowledgeDTCall: (competitionId: string, arenaId: string) =>
+      ipcRenderer.invoke('remote:acknowledgeDTCall', competitionId, arenaId),
   },
 
   // Remote event listeners (for real-time updates)
@@ -488,6 +490,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const handler = (_: any, note: any) => callback(note);
     ipcRenderer.on('kiosk:note', handler);
     return () => ipcRenderer.removeListener('kiosk:note', handler);
+  },
+  onDTCall: (callback: (data: { arenaId: string; arenaNumber: number; matchNumber: number | null; competitionId: string | null; timestamp: number }) => void) => {
+    const handler = (_: any, data: any) => callback(data);
+    ipcRenderer.on('remote:dt_call', handler);
+    return () => ipcRenderer.removeListener('remote:dt_call', handler);
   },
 
   getLogo: () => ipcRenderer.invoke('app:getLogo'),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1708,6 +1708,19 @@ export class RemoteScoreServer {
             });
         }
         break;
+      case 'dt_call': {
+        const mainWin = (global as any).mainWindow;
+        if (mainWin) {
+          mainWin.webContents.send('remote:dt_call', {
+            arenaId: data.arenaId,
+            arenaNumber: arena.number,
+            matchNumber: arena.currentMatch?.number ?? null,
+            competitionId: this.session?.competitionId ?? null,
+            timestamp: Date.now(),
+          });
+        }
+        break;
+      }
       case 'next':
         this.loadNextMatch(data.arenaId);
         this.arenaCards.set(data.arenaId, { cardsA: [], cardsB: [] });
@@ -3452,6 +3465,10 @@ export class RemoteScoreServer {
   public clearOrgNote(): void {
     this.orgNote = null;
     this.io.emit('kiosk:note', null);
+  }
+
+  public acknowledgeDTCall(arenaId: string): void {
+    this.io.to(`arena:${arenaId}`).emit(`arena:${arenaId}:dt_call_ack`);
   }
 
   public setLogo(logo: string | null): void {

--- a/src/remote/i18n.js
+++ b/src/remote/i18n.js
@@ -48,6 +48,9 @@
       'referee.match_resumed': '▶️ Combat repris',
       'referee.error_save': "❌ Erreur lors de l'enregistrement",
       'referee.arena_exit_notif': '🚪 Sortie d\'arène {{label}} — +{{points}} pts adversaire',
+      'referee.dt_call': '📣 Appel DT',
+      'referee.dt_called': '⏳ DT appelé...',
+      'referee.dt_en_route': '✅ DT en route',
       /* arena / public */
       'arena.title': 'Arène BellePoule',
       'arena.invert': '⇄ Inverser',
@@ -143,6 +146,9 @@
       'referee.match_resumed': '▶️ Match resumed',
       'referee.error_save': '❌ Error saving result',
       'referee.arena_exit_notif': '🚪 Arena exit {{label}} — +{{points}} pts opponent',
+      'referee.dt_call': '📣 Call DT',
+      'referee.dt_called': '⏳ DT called...',
+      'referee.dt_en_route': '✅ DT on the way',
       /* arena / public */
       'arena.title': 'BellePoule Arena',
       'arena.invert': '⇄ Invert',
@@ -237,6 +243,9 @@
       'referee.match_paused': '⏸ 比賽暫停',
       'referee.match_resumed': '▶️ 比賽繼續',
       'referee.error_save': '❌ 儲存結果時發生錯誤',
+      'referee.dt_call': '📣 呼叫DT',
+      'referee.dt_called': '⏳ 已呼叫DT...',
+      'referee.dt_en_route': '✅ DT正在前來',
       'referee.arena_exit_notif': '🚪 場地離場 {{label}} — +{{points}} 分對手',
       /* arena / public */
       'arena.title': 'BellePoule 場地',

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -521,6 +521,31 @@
       .btn-undo:disabled {
         background: #6b7280;
         cursor: not-allowed;
+      }
+
+      .btn-dt-call {
+        background: linear-gradient(135deg, #f97316, #ea580c);
+        color: white;
+        font-size: 0.85rem;
+        padding: 0.65rem 0.4rem;
+        min-height: 48px;
+        width: 100%;
+      }
+
+      .btn-dt-call.dt-active {
+        background: linear-gradient(135deg, #6b7280, #4b5563);
+        cursor: not-allowed;
+        opacity: 0.85;
+      }
+
+      .btn-dt-call.dt-ack {
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+        cursor: default;
+      }
+
+      .control-buttons-dt {
+        margin-top: 0.5rem;
+      }
         opacity: 0.6;
       }
 
@@ -1103,6 +1128,16 @@
             <span data-i18n="referee.exit_green">🚪 Sortie verte</span>
           </button>
         </div>
+        <!-- Bouton appel Directeur Technique -->
+        <div class="control-buttons-dt">
+          <button
+            class="control-btn btn-dt-call"
+            id="btn-dt-call"
+            onclick="refereeApp.callDT()"
+          >
+            <span id="btn-dt-label" data-i18n="referee.dt_call">📣 Appel DT</span>
+          </button>
+        </div>
       </div>
 
       <!-- Écran de sélection de match -->
@@ -1630,6 +1665,19 @@
           this.socket.on(`arena:${this.arenaId}:score_limit_reached`, () => {
             this.showFinishModal();
           });
+
+          this.socket.on(`arena:${this.arenaId}:dt_call_ack`, () => {
+            const btn = document.getElementById('btn-dt-call');
+            const label = document.getElementById('btn-dt-label');
+            if (btn) {
+              btn.classList.remove('dt-active');
+              btn.classList.add('dt-ack');
+              btn.disabled = true;
+              if (label) label.textContent = window.T('referee.dt_en_route');
+            }
+            this.showNotification('✅ DT en route !');
+            setTimeout(() => this._resetDTButton(), 10000);
+          });
         }
 
         setupTimerInteractions() {
@@ -1946,6 +1994,26 @@
           this.actionHistory.push(snapshot);
           if (this.actionHistory.length > 10) this.actionHistory.shift();
           document.getElementById('btn-undo').disabled = false;
+        }
+
+        callDT() {
+          const btn = document.getElementById('btn-dt-call');
+          const label = document.getElementById('btn-dt-label');
+          if (!btn || btn.classList.contains('dt-active') || btn.classList.contains('dt-ack')) return;
+          btn.classList.add('dt-active');
+          btn.disabled = true;
+          if (label) label.textContent = window.T('referee.dt_called');
+          this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'dt_call' });
+          this.showNotification(window.T('referee.dt_called'));
+        }
+
+        _resetDTButton() {
+          const btn = document.getElementById('btn-dt-call');
+          const label = document.getElementById('btn-dt-label');
+          if (!btn) return;
+          btn.classList.remove('dt-active', 'dt-ack');
+          btn.disabled = false;
+          if (label) label.textContent = window.T('referee.dt_call');
         }
 
         undoLastAction() {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import NewCompetitionModal from './components/NewCompetitionModal';
 import ReportIssueModal from './components/ReportIssueModal';
 import UpdateNotification from './components/UpdateNotification';
 import SettingsModal from './components/SettingsModal';
+import DTCallNotification from './components/DTCallNotification';
 import { ToastProvider, useToast } from './components/Toast';
 import { ConfirmProvider, useConfirm } from './components/ConfirmDialog';
 import { TranslationProvider, useTranslation } from './contexts/TranslationContext';
@@ -254,6 +255,7 @@ const AppContent: React.FC = () => {
   return (
     <>
       <UpdateNotification />
+      <DTCallNotification />
       <div className="app">
         <header className="header">
           <div className="header-title">

--- a/src/renderer/components/DTCallNotification.tsx
+++ b/src/renderer/components/DTCallNotification.tsx
@@ -1,0 +1,124 @@
+/**
+ * BellePoule Modern - DT Call Notification
+ * Persistent alert panel shown when a referee requests DT intervention
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+
+interface DTCallEntry {
+  id: string;
+  arenaId: string;
+  arenaNumber: number;
+  matchNumber: number | null;
+  competitionId: string | null;
+  timestamp: number;
+  acknowledging: boolean;
+}
+
+const DTCallNotification: React.FC = () => {
+  const [calls, setCalls] = useState<DTCallEntry[]>([]);
+
+  useEffect(() => {
+    if (!window.electronAPI?.onDTCall) return;
+    const unsub = window.electronAPI.onDTCall((data) => {
+      setCalls(prev => {
+        // remplacer un appel existant pour la même arène
+        const filtered = prev.filter(c => c.arenaId !== data.arenaId);
+        return [...filtered, {
+          id: `${data.arenaId}-${data.timestamp}`,
+          arenaId: data.arenaId,
+          arenaNumber: data.arenaNumber,
+          matchNumber: data.matchNumber,
+          competitionId: data.competitionId,
+          timestamp: data.timestamp,
+          acknowledging: false,
+        }];
+      });
+      // Alerte sonore
+      try {
+        const ctx = new AudioContext();
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.frequency.setValueAtTime(880, ctx.currentTime);
+        osc.frequency.setValueAtTime(660, ctx.currentTime + 0.15);
+        osc.frequency.setValueAtTime(880, ctx.currentTime + 0.3);
+        gain.gain.setValueAtTime(0.3, ctx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
+        osc.start(ctx.currentTime);
+        osc.stop(ctx.currentTime + 0.5);
+      } catch {
+        // AudioContext non disponible
+      }
+    });
+    return unsub;
+  }, []);
+
+  const acknowledge = useCallback(async (call: DTCallEntry) => {
+    setCalls(prev => prev.map(c => c.id === call.id ? { ...c, acknowledging: true } : c));
+    if (call.competitionId) {
+      await window.electronAPI.remote.acknowledgeDTCall(call.competitionId, call.arenaId);
+    }
+    setCalls(prev => prev.filter(c => c.id !== call.id));
+  }, []);
+
+  if (calls.length === 0) return null;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: '20px',
+      right: '20px',
+      zIndex: 10001,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '10px',
+      maxWidth: '340px',
+    }}>
+      {calls.map(call => (
+        <div key={call.id} style={{
+          backgroundColor: '#1f2937',
+          borderLeft: '4px solid #f97316',
+          borderRadius: '8px',
+          padding: '14px 16px',
+          boxShadow: '0 4px 16px rgba(0,0,0,0.4)',
+          color: '#f9fafb',
+          animation: 'slideInRight 0.3s ease-out',
+        }}>
+          <div style={{ fontSize: '16px', fontWeight: 'bold', marginBottom: '4px' }}>
+            📣 Appel DT — Piste {call.arenaNumber}
+          </div>
+          {call.matchNumber != null && (
+            <div style={{ fontSize: '13px', color: '#9ca3af', marginBottom: '4px' }}>
+              Match n° {call.matchNumber}
+            </div>
+          )}
+          <div style={{ fontSize: '12px', color: '#6b7280', marginBottom: '10px' }}>
+            {new Date(call.timestamp).toLocaleTimeString()}
+          </div>
+          <button
+            onClick={() => acknowledge(call)}
+            disabled={call.acknowledging}
+            style={{
+              backgroundColor: call.acknowledging ? '#374151' : '#f97316',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              padding: '8px 14px',
+              fontSize: '13px',
+              cursor: call.acknowledging ? 'not-allowed' : 'pointer',
+              fontWeight: 'bold',
+              width: '100%',
+            }}
+          >
+            {call.acknowledging ? '⏳ En cours...' : '✅ DT en route — Résolu'}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DTCallNotification;

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -412,6 +412,10 @@ export interface RemoteServerAPI {
     competitionId: string,
     newPort: number
   ) => Promise<{ success: boolean; serverInfo?: RemoteServerInfo; error?: string }>;
+  acknowledgeDTCall: (
+    competitionId: string,
+    arenaId: string
+  ) => Promise<{ success: boolean; error?: string }>;
 }
 
 // ============================================================================
@@ -654,6 +658,9 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   onRemoteMatchFinished: (callback: (data: any) => void) => void;
   onKioskNoteUpdate: (
     callback: (note: import('../types/remote').OrgNote | null) => void
+  ) => () => void;
+  onDTCall: (
+    callback: (data: { arenaId: string; arenaNumber: number; matchNumber: number | null; competitionId: string | null; timestamp: number }) => void
   ) => () => void;
   notifyLanguageChanged: (lang: string) => void;
   getLogo: () => Promise<string | null>;


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Bouton "📣 Appel DT" orange ajouté sur l'interface tablet arbitre (`referee.html`), en dessous des boutons sortie d'arène/annuler
- Notification persistante dans l'app Electron avec numéro de piste, heure et alerte sonore
- Bouton "✅ DT en route — Résolu" sur chaque notification : acquitte l'appel et envoie un retour visuel à la tablette
- Support multi-piste : plusieurs appels DT simultanés affichés en pile

## Flux complet

1. Arbitre appuie sur "📣 Appel DT" → bouton passe en gris "⏳ DT appelé..."
2. `arena_control { action: 'dt_call' }` envoyé via Socket.IO
3. `remoteScoreServer` forward via IPC `remote:dt_call` vers le renderer
4. `DTCallNotification` affiche une carte persistante avec alerte sonore
5. Organisateur clique "✅ DT en route — Résolu" → IPC `remote:acknowledgeDTCall`
6. Serveur émet `arena:X:dt_call_ack` → tablette passe en vert "✅ DT en route" (reset après 10s)

## Fichiers modifiés

- `src/remote/referee.html` — bouton HTML, CSS, méthodes JS `callDT()` / `_resetDTButton()`, listener `dt_call_ack`
- `src/remote/i18n.js` — clés fr / en / zh-HK pour les 3 états du bouton
- `src/main/remoteScoreServer.ts` — case `dt_call` dans `handleArenaControl` + méthode publique `acknowledgeDTCall`
- `src/main/main.ts` — handler IPC `remote:acknowledgeDTCall`
- `src/main/preload.ts` — `remote.acknowledgeDTCall` + `onDTCall` listener
- `src/shared/types/preload.ts` — types `RemoteServerAPI.acknowledgeDTCall` + `ElectronAPI.onDTCall`
- `src/renderer/components/DTCallNotification.tsx` — nouveau composant React
- `src/renderer/App.tsx` — import + rendu de `<DTCallNotification />`

https://claude.ai/code/session_01VSaF5hKb6Ugeqmqxh9KWgh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSaF5hKb6Ugeqmqxh9KWgh)_