### PR TITLE
Fix build: ArenaMatch.number inexistant dans dt_call payload

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1714,7 +1714,7 @@ export class RemoteScoreServer {
           mainWin.webContents.send('remote:dt_call', {
             arenaId: data.arenaId,
             arenaNumber: arena.number,
-            matchNumber: arena.currentMatch?.number ?? null,
+            matchNumber: null,
             competitionId: this.session?.competitionId ?? null,
             timestamp: Date.now(),
           });


### PR DESCRIPTION
Fix build CI cassé après merge de #392.

`ArenaMatch` n'a pas de champ `number` — seul `Arena` l'a. Le `matchNumber` est retiré du payload `remote:dt_call` (le numéro de piste `arenaNumber` suffit pour identifier la demande).

https://claude.ai/code/session_01VSaF5hKb6Ugeqmqxh9KWgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSaF5hKb6Ugeqmqxh9KWgh)_