### PR TITLE
Fonctionnalité gestion des arbitres sur arènes et saisie distante

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1584,6 +1584,52 @@ export class DatabaseManager {
     } as Referee;
   }
 
+  public getMatchesWithReferees(competitionId: string): Array<{
+    matchId: string; matchNumber: number; poolName: string | null;
+    fencerAName: string; fencerBName: string;
+    scoreA: number | null; scoreB: number | null; status: string;
+    refereeId: string | null; refereeName: string | null;
+  }> {
+    if (!this.db) return [];
+    const results: any[] = [];
+    const stmt = this.db.prepare(`
+      SELECT m.id AS match_id, m.number AS match_number,
+             p.name AS pool_name,
+             fa.last_name || ' ' || fa.first_name AS fencer_a_name,
+             fb.last_name || ' ' || fb.first_name AS fencer_b_name,
+             m.score_a, m.score_b, m.status,
+             r.id AS referee_id, r.name AS referee_name
+      FROM matches m
+      LEFT JOIN pools p ON m.pool_id = p.id
+      LEFT JOIN phases ph ON p.phase_id = ph.id
+      LEFT JOIN fencers fa ON m.fencer_a_id = fa.id
+      LEFT JOIN fencers fb ON m.fencer_b_id = fb.id
+      LEFT JOIN referees r ON m.referee_id = r.id
+      WHERE ph.competition_id = ? AND m.referee_id IS NOT NULL
+      ORDER BY p.name, m.number
+    `);
+    stmt.bind([competitionId]);
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      const scoreARaw = row.score_a ? JSON.parse(row.score_a as string) : null;
+      const scoreBRaw = row.score_b ? JSON.parse(row.score_b as string) : null;
+      results.push({
+        matchId: row.match_id as string,
+        matchNumber: row.match_number as number,
+        poolName: (row.pool_name as string) ?? null,
+        fencerAName: (row.fencer_a_name as string) ?? '?',
+        fencerBName: (row.fencer_b_name as string) ?? '?',
+        scoreA: scoreARaw?.value ?? null,
+        scoreB: scoreBRaw?.value ?? null,
+        status: row.status as string,
+        refereeId: (row.referee_id as string) ?? null,
+        refereeName: (row.referee_name as string) ?? null,
+      });
+    }
+    stmt.free();
+    return results;
+  }
+
   // ─── Touch / Card read methods ───────────────────────────────────────────────
 
   public getTouches(matchId: string): Array<{

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1024,6 +1024,9 @@ ipcMain.handle('db:updateReferee', async (_, id, updates) => {
 ipcMain.handle('db:deleteReferee', async (_, id) => {
   return db.deleteReferee(id);
 });
+ipcMain.handle('db:getMatchesWithReferees', async (_, competitionId) => {
+  return db.getMatchesWithReferees(competitionId);
+});
 
 // Touch / Card read handlers
 ipcMain.handle('db:getTouches', async (_, matchId) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -212,6 +212,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     updateReferee: (id: string, updates: Record<string, string | undefined>) =>
       ipcRenderer.invoke('db:updateReferee', id, updates),
     deleteReferee: (id: string) => ipcRenderer.invoke('db:deleteReferee', id),
+    getMatchesWithReferees: (competitionId: string) =>
+      ipcRenderer.invoke('db:getMatchesWithReferees', competitionId),
 
     // Touch / Card read
     getTouches: (matchId: string) => ipcRenderer.invoke('db:getTouches', matchId),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -43,6 +43,7 @@ export class RemoteScoreServer {
   private sessionMatchScores: Map<string, { scoreA: any; scoreB: any; status: string }> = new Map(); // Scores en mémoire
   private sessionShowPhotos: boolean = false; // Afficher les photos des combattants avant le combat
   private sessionCardAnnounce: boolean = false; // Annoncer les cartons avec raison sur les affichages
+  private sessionRefereeFeatureEnabled: boolean = false; // Fonctionnalité gestion arbitres activée
   private sessionTheme: DisplayTheme = 'dark'; // Thème visuel de l'affichage distant (global)
   private arenaThemeOverrides: Map<string, { theme: DisplayTheme; customTheme?: CustomTheme }> =
     new Map();
@@ -1559,6 +1560,8 @@ export class RemoteScoreServer {
             customTheme: override?.customTheme,
             fencerA: arena.currentMatch?.fencerA,
             fencerB: arena.currentMatch?.fencerB,
+            refereeFeatureEnabled: this.sessionRefereeFeatureEnabled,
+            referees: this.session?.referees ?? [],
             ...(arena.status === 'finished' && {
               nextMatch: this.peekNextMatch(data.arenaId),
             }),
@@ -1632,6 +1635,8 @@ export class RemoteScoreServer {
       winner?: 'A' | 'B';
       overtimeType?: string | null;
       isVoluntary?: boolean;
+      matchId?: string;
+      refereeId?: string;
       announcement?: {
         fencer: 'A' | 'B';
         fencerName: string;
@@ -1873,6 +1878,25 @@ export class RemoteScoreServer {
           status: arena.status,
         });
         break;
+      case 'change_referee': {
+        if (!data.matchId || !data.refereeId || !arena.currentMatch) break;
+        if (arena.currentMatch.id !== data.matchId) break;
+        this.db.updateMatch(data.matchId, { refereeId: data.refereeId });
+        // Mettre à jour sessionMatches en mémoire
+        const idx = this.sessionMatches.findIndex((m: any) => m.id === data.matchId);
+        if (idx >= 0) this.sessionMatches[idx] = { ...this.sessionMatches[idx], refereeId: data.refereeId };
+        // Mettre à jour l'ArenaMatch courant
+        const resolvedRef = this.resolveReferee(data.refereeId);
+        arena.currentMatch = { ...arena.currentMatch, ...(resolvedRef ? { referee: resolvedRef } : {}) };
+        this.broadcastArenaUpdate(data.arenaId, {
+          arenaId: data.arenaId,
+          match: arena.currentMatch,
+          scoreA: arena.currentMatch.scoreA,
+          scoreB: arena.currentMatch.scoreB,
+          status: arena.status,
+        });
+        break;
+      }
       default:
         socket.emit('error', { message: 'Action non reconnue' });
     }
@@ -2508,6 +2532,12 @@ export class RemoteScoreServer {
     }, 3000);
   }
 
+  private resolveReferee(refereeId?: string | null): { id: string; name: string } | null {
+    if (!refereeId || !this.session) return null;
+    const ref = this.session.referees.find(r => r.id === refereeId);
+    return ref ? { id: ref.id, name: ref.name } : null;
+  }
+
   private peekNextMatch(arenaId: string): ArenaMatch | null {
     const arena = this.arenas.get(arenaId);
     if (!arena || !this.session) return null;
@@ -2530,6 +2560,7 @@ export class RemoteScoreServer {
       );
       const nextMatch = poolMatches.find(m => m.id !== currentMatchId);
       if (nextMatch) {
+        const nextReferee = this.resolveReferee(nextMatch.refereeId);
         return {
           id: nextMatch.id,
           poolId: currentPoolId,
@@ -2540,6 +2571,7 @@ export class RemoteScoreServer {
           status: 'not_started',
           startTime: null,
           endTime: null,
+          ...(nextReferee ? { referee: nextReferee } : {}),
         };
       }
     }
@@ -2740,6 +2772,8 @@ export class RemoteScoreServer {
       cardAnnounce: this.sessionCardAnnounce,
       theme: override?.theme ?? this.sessionTheme,
       customTheme: override?.customTheme,
+      refereeFeatureEnabled: this.sessionRefereeFeatureEnabled,
+      referees: this.session?.referees ?? [],
     };
 
     // Stocker dans le buffer de replay (TTL + max size)
@@ -2891,6 +2925,9 @@ export class RemoteScoreServer {
 
     // Stocker le réglage d'annonce de carton
     this.sessionCardAnnounce = cardAnnounce ?? false;
+
+    // Stocker l'activation de la gestion des arbitres
+    this.sessionRefereeFeatureEnabled = competition.settings?.refereeFeatureEnabled ?? false;
 
     // Stocker les vues kiosk activées
     this.sessionKioskViews = kioskViews ?? {
@@ -3147,13 +3184,21 @@ export class RemoteScoreServer {
 
     // Créer la session - utiliser allMatches au lieu de pendingMatches
     const assignedMatchCount = Math.min(allMatches.length, strips);
+    const dbReferees = this.db.getRefereesByCompetition(competitionId);
+    const sessionReferees = dbReferees.map(r => ({
+      id: r.id,
+      name: `${r.firstName} ${r.lastName}`.trim(),
+      code: r.license ?? r.ref.toString(),
+      isActive: r.status !== 'unavailable',
+      lastActivity: r.updatedAt,
+    }));
     this.session = {
       competitionId,
       strips: Array.from({ length: strips }, (_, i) => ({
         number: i + 1,
         status: i < assignedMatchCount ? 'occupied' : 'available',
       })),
-      referees: [],
+      referees: sessionReferees,
       activeMatches: [],
       isRunning: true,
       startTime: new Date(),

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -918,6 +918,16 @@
         flex-shrink: 0;
       }
 
+      .next-referee-name {
+        font-size: 0.72rem;
+        color: rgba(255, 255, 255, 0.55);
+        white-space: nowrap;
+        flex-shrink: 0;
+        margin-left: 0.25rem;
+      }
+
+      .next-referee-name.hidden { display: none; }
+
       /* Responsive portrait/mobile */
       @media (max-width: 768px) {
         .fencers-row {
@@ -1269,6 +1279,7 @@
               <span class="next-fighter-name" id="next-name-b">-</span>
             </div>
           </div>
+          <div class="next-referee-name hidden" id="next-referee-name">⚖️ <span id="next-referee-label"></span></div>
         </div>
       </div>
     </div>
@@ -1290,6 +1301,7 @@
           this.waitingOvertime = false;
           this.inversionEnabled = localStorage.getItem('inversionEnabled') === 'true';
           this.showPhotos = false;
+          this.refereeFeatureEnabled = false;
           this.theme = localStorage.getItem('displayTheme') || 'dark';
           this.currentCustomTheme = null;
 
@@ -1552,6 +1564,11 @@
           // Mise à jour du réglage photos
           if (data.showPhotos !== undefined) {
             this.showPhotos = data.showPhotos;
+          }
+
+          // Mise à jour flag gestion arbitres
+          if (data.refereeFeatureEnabled !== undefined) {
+            this.refereeFeatureEnabled = data.refereeFeatureEnabled;
           }
 
           // Mise à jour état d'inversion (synchronisé avec le serveur)
@@ -1840,6 +1857,15 @@
 
           this.setNextFencerPhoto('a', left.photo);
           this.setNextFencerPhoto('b', right.photo);
+
+          const refEl = document.getElementById('next-referee-name');
+          const refLabel = document.getElementById('next-referee-label');
+          if (this.refereeFeatureEnabled && this.nextMatch.referee && refEl && refLabel) {
+            refLabel.textContent = this.nextMatch.referee.name;
+            refEl.classList.remove('hidden');
+          } else if (refEl) {
+            refEl.classList.add('hidden');
+          }
         }
 
         setNextFencerPhoto(side, photoBase64) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -546,6 +546,64 @@
       .control-buttons-dt {
         margin-top: 0.5rem;
       }
+
+      .referee-bar {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.6rem;
+        padding: 0.5rem 0.75rem;
+        background: rgba(255,255,255,0.06);
+        border-radius: 0.5rem;
+        font-size: 0.85rem;
+      }
+
+      .referee-bar.hidden { display: none; }
+
+      .referee-bar-label {
+        font-weight: 600;
+        opacity: 0.75;
+        white-space: nowrap;
+      }
+
+      .referee-bar-name {
+        flex: 1;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .referee-change-btn {
+        padding: 0.3rem 0.7rem;
+        border: 1px solid rgba(255,255,255,0.3);
+        border-radius: 0.4rem;
+        background: transparent;
+        color: inherit;
+        font-size: 0.8rem;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+
+      .referee-change-btn:active { opacity: 0.7; }
+
+      .referee-selector {
+        width: 100%;
+        margin-top: 0.25rem;
+      }
+
+      .referee-selector.hidden { display: none; }
+
+      .referee-selector select {
+        width: 100%;
+        padding: 0.5rem;
+        border-radius: 0.4rem;
+        border: 1px solid rgba(255,255,255,0.3);
+        background: #1f2937;
+        color: white;
+        font-size: 0.9rem;
+      }
         opacity: 0.6;
       }
 
@@ -1138,6 +1196,18 @@
             <span id="btn-dt-label" data-i18n="referee.dt_call">📣 Appel DT</span>
           </button>
         </div>
+
+        <!-- Barre arbitre (visible si refereeFeatureEnabled) -->
+        <div class="referee-bar hidden" id="referee-bar">
+          <div class="referee-bar-label">⚖️ Arbitre :</div>
+          <div class="referee-bar-name" id="referee-bar-name">—</div>
+          <button class="referee-change-btn" id="referee-change-btn" onclick="refereeApp.toggleRefereeSelector()">Changer</button>
+          <div class="referee-selector hidden" id="referee-selector">
+            <select id="referee-select" onchange="refereeApp.changeReferee(this.value)">
+              <option value="">— Sélectionner un arbitre —</option>
+            </select>
+          </div>
+        </div>
       </div>
 
       <!-- Écran de sélection de match -->
@@ -1398,6 +1468,8 @@
           this.coinFlipWinner = null; // 'A' | 'B' | null — vainqueur par tirage au sort
           this.actionHistory = []; // Historique pour undo (max 10)
           this.cardAnnounceEnabled = false; // Réglé depuis les paramètres de saisie distante
+          this.refereeFeatureEnabled = false; // Fonctionnalité gestion arbitres
+          this.refereesList = []; // Liste des arbitres de la compétition
           this.swapped = false;
           this.pausedForModal = false;
           this.offlineQueue = new OfflineQueueInline();
@@ -1776,6 +1848,9 @@
 
           // Afficher le panneau de match
           document.getElementById('active-match').classList.add('visible');
+
+          // Mettre à jour la barre arbitre
+          this.updateRefereeBar();
 
           // Informer le serveur
           this.socket.emit('arena_control', {
@@ -2721,6 +2796,14 @@
             this.cardAnnounceEnabled = data.cardAnnounce;
           }
 
+          if (data.refereeFeatureEnabled !== undefined) {
+            this.refereeFeatureEnabled = data.refereeFeatureEnabled;
+          }
+          if (data.referees !== undefined) {
+            this.refereesList = data.referees;
+          }
+          this.updateRefereeBar();
+
           // Nouveau match prêt côté serveur (chargement automatique après fin de match)
           if (data.status === 'ready' && data.match && data.match.id) {
             // Ignorer si c'est déjà notre match actuel
@@ -2756,6 +2839,56 @@
             this.loadNextMatches();
             this.showNotification('⏭️ Match suivant disponible !');
           }
+        }
+
+        updateRefereeBar() {
+          const bar = document.getElementById('referee-bar');
+          if (!bar) return;
+          if (!this.refereeFeatureEnabled) {
+            bar.classList.add('hidden');
+            return;
+          }
+          bar.classList.remove('hidden');
+
+          const nameEl = document.getElementById('referee-bar-name');
+          const ref = this.currentMatch?.referee;
+          if (nameEl) nameEl.textContent = ref ? ref.name : '—';
+
+          const sel = document.getElementById('referee-select');
+          if (sel) {
+            sel.innerHTML = '<option value="">— Sélectionner un arbitre —</option>';
+            for (const r of (this.refereesList || [])) {
+              const opt = document.createElement('option');
+              opt.value = r.id;
+              opt.textContent = r.name;
+              if (ref && r.id === ref.id) opt.selected = true;
+              sel.appendChild(opt);
+            }
+          }
+        }
+
+        toggleRefereeSelector() {
+          const sel = document.getElementById('referee-selector');
+          if (sel) sel.classList.toggle('hidden');
+        }
+
+        changeReferee(refereeId) {
+          if (!refereeId || !this.currentMatch) return;
+          this.socket.emit('arena_control', {
+            arenaId: this.arenaId,
+            action: 'change_referee',
+            matchId: this.currentMatch.id,
+            refereeId,
+          });
+          const ref = (this.refereesList || []).find(r => r.id === refereeId);
+          if (ref) {
+            this.currentMatch.referee = { id: ref.id, name: ref.name };
+            const nameEl = document.getElementById('referee-bar-name');
+            if (nameEl) nameEl.textContent = ref.name;
+          }
+          const sel = document.getElementById('referee-selector');
+          if (sel) sel.classList.add('hidden');
+          this.showNotification('✅ Arbitre mis à jour');
         }
 
         showNextMatchesScreen() {

--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -40,6 +40,10 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
     competition.settings?.thirdPlaceMatch ?? false
   );
 
+  const [refereeFeatureEnabled, setRefereeFeatureEnabled] = useState(
+    competition.settings?.refereeFeatureEnabled ?? false
+  );
+
   // Tour Quest (Sabre Laser)
   const existingQuest = competition.settings?.questConfig;
   const [questEnabled, setQuestEnabled] = useState(existingQuest?.enabled ?? false);
@@ -92,6 +96,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
       randomScore: competition.settings?.randomScore ?? false,
       minTeamSize: competition.settings?.minTeamSize ?? 3,
       questConfig,
+      refereeFeatureEnabled,
     };
 
     onSave({
@@ -482,6 +487,34 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
               )}
             </div>
           )}
+
+          {/* Gestion des arbitres */}
+          <div style={{ marginBottom: '1rem' }}>
+            <h3
+              style={{
+                fontSize: '0.875rem',
+                fontWeight: '600',
+                color: '#6b7280',
+                marginBottom: '0.75rem',
+                textTransform: 'uppercase',
+              }}
+            >
+              Arbitrage
+            </h3>
+            <div className="form-group">
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={refereeFeatureEnabled}
+                  onChange={e => setRefereeFeatureEnabled(e.target.checked)}
+                />
+                Activer la gestion des arbitres
+              </label>
+              <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+                Affiche le nom de l'arbitre sur l'arène et permet de le changer depuis la saisie distante
+              </small>
+            </div>
+          </div>
 
           <div className="modal-footer">
             <button type="button" className="btn btn-secondary" onClick={onClose}>

--- a/src/renderer/components/RefereeManager.tsx
+++ b/src/renderer/components/RefereeManager.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { Referee, Match, Pool, Competition } from '../../shared/types';
 import { RefereeManager, RefereeRotationConfig } from '../../shared/services/refereeManager';
 
@@ -33,6 +33,24 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
   });
   const [assignments, setAssignments] = useState<Map<string, Referee>>(new Map());
   const [showReport, setShowReport] = useState(false);
+  const [activeTab, setActiveTab] = useState<'assignments' | 'history'>('assignments');
+  const [historyRows, setHistoryRows] = useState<Array<{
+    matchId: string; matchNumber: number; poolName: string | null;
+    fencerAName: string; fencerBName: string;
+    scoreA: number | null; scoreB: number | null; status: string;
+    refereeId: string | null; refereeName: string | null;
+  }>>([]);
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const rows = await window.electronAPI.db.getMatchesWithReferees(competition.id);
+      setHistoryRows(rows);
+    } catch { /* silencieux */ }
+  }, [competition.id]);
+
+  useEffect(() => {
+    if (activeTab === 'history') loadHistory();
+  }, [activeTab, loadHistory]);
 
   const manager = useMemo(() => new RefereeManager(referees, config), [referees, config]);
 
@@ -87,7 +105,7 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
     >
       <h2
         style={{
-          marginBottom: '1.5rem',
+          marginBottom: '1rem',
           color: '#1f2937',
           borderBottom: '2px solid #e5e7eb',
           paddingBottom: '0.5rem',
@@ -95,6 +113,72 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
       >
         👨‍⚖️ Gestion des Arbitres
       </h2>
+
+      {/* Onglets */}
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem' }}>
+        {(['assignments', 'history'] as const).map(tab => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            style={{
+              padding: '0.5rem 1.25rem',
+              borderRadius: '6px',
+              border: 'none',
+              cursor: 'pointer',
+              fontWeight: activeTab === tab ? '700' : '400',
+              background: activeTab === tab ? '#3b82f6' : '#e5e7eb',
+              color: activeTab === tab ? 'white' : '#374151',
+            }}
+          >
+            {tab === 'assignments' ? '📋 Assignations' : '📜 Historique'}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'history' && (
+        <div>
+          <div style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'flex-end' }}>
+            <button
+              onClick={loadHistory}
+              style={{ padding: '0.4rem 1rem', borderRadius: '5px', border: '1px solid #d1d5db', cursor: 'pointer', background: 'white' }}
+            >
+              ↻ Actualiser
+            </button>
+          </div>
+          {historyRows.length === 0 ? (
+            <p style={{ color: '#6b7280', fontStyle: 'italic' }}>Aucun match avec arbitre assigné.</p>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+              <thead>
+                <tr style={{ background: '#f3f4f6' }}>
+                  {['Poule', 'Match', 'Tireur A', 'Tireur B', 'Score', 'Statut', 'Arbitre'].map(h => (
+                    <th key={h} style={{ padding: '0.5rem 0.75rem', textAlign: 'left', borderBottom: '2px solid #e5e7eb' }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {historyRows.map(row => (
+                  <tr key={row.matchId} style={{ borderBottom: '1px solid #e5e7eb' }}>
+                    <td style={{ padding: '0.45rem 0.75rem' }}>{row.poolName ?? '—'}</td>
+                    <td style={{ padding: '0.45rem 0.75rem' }}>#{row.matchNumber}</td>
+                    <td style={{ padding: '0.45rem 0.75rem' }}>{row.fencerAName}</td>
+                    <td style={{ padding: '0.45rem 0.75rem' }}>{row.fencerBName}</td>
+                    <td style={{ padding: '0.45rem 0.75rem', textAlign: 'center' }}>
+                      {row.scoreA !== null && row.scoreB !== null ? `${row.scoreA} – ${row.scoreB}` : '—'}
+                    </td>
+                    <td style={{ padding: '0.45rem 0.75rem', color: row.status === 'finished' ? '#166534' : '#6b7280' }}>
+                      {row.status === 'finished' ? '✓ Terminé' : row.status}
+                    </td>
+                    <td style={{ padding: '0.45rem 0.75rem', fontWeight: '500' }}>{row.refereeName ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'assignments' && (<>
 
       {/* Configuration */}
       <div
@@ -383,6 +467,7 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
           })}
         </div>
       </div>
+      </>)}
     </div>
   );
 };

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -463,6 +463,7 @@ export interface CompetitionSettings {
   randomScore: boolean; // Scores aléatoires (pour tests)
   minTeamSize: number; // Taille min équipe (compétitions par équipes)
   questConfig?: QuestPhaseConfig; // Configuration du Tour Quest (Sabre Laser uniquement)
+  refereeFeatureEnabled?: boolean; // Activer la gestion des arbitres sur arènes et saisie distante
 }
 
 export interface Phase extends BaseEntity {

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -503,6 +503,12 @@ export interface DatabaseAPI {
   getRefereesByCompetition: (competitionId: string) => Promise<Referee[]>;
   updateReferee: (id: string, updates: Record<string, string | undefined>) => Promise<void>;
   deleteReferee: (id: string) => Promise<void>;
+  getMatchesWithReferees: (competitionId: string) => Promise<Array<{
+    matchId: string; matchNumber: number; poolName: string | null;
+    fencerAName: string; fencerBName: string;
+    scoreA: number | null; scoreB: number | null; status: string;
+    refereeId: string | null; refereeName: string | null;
+  }>>;
 
   // Touch / Card read
   getTouches: (matchId: string) => Promise<

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -136,6 +136,7 @@ export interface ArenaMatch {
   startTime: Date | null;
   endTime: Date | null;
   duration?: number; // in seconds
+  referee?: { id: string; name: string }; // Arbitre assigné au match
 }
 
 export interface ArenaUpdate {
@@ -159,6 +160,8 @@ export interface ArenaUpdate {
   customTheme?: CustomTheme; // thème personnalisé (si theme === 'custom')
   nextMatch?: ArenaMatch | null; // prochain combat (affiché quand status=finished)
   swapped?: boolean;
+  refereeFeatureEnabled?: boolean; // fonctionnalité arbitres activée
+  referees?: RemoteReferee[]; // liste de tous les arbitres de la compétition
 }
 
 export interface RefereeControl {


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- **Toggle par compétition** : nouvelle option "Activer la gestion des arbitres" dans les propriétés de compétition (`refereeFeatureEnabled` dans `CompetitionSettings`)
- **Arène** : nom de l'arbitre affiché discrètement dans le panneau "prochain combat" (si feature activée et arbitre assigné)
- **Saisie distante** (`referee.html`) : barre arbitre avec nom actuel + bouton "Changer" + liste déroulante de tous les arbitres de la compétition
- **Persistance** : changement d'arbitre via la tablette → mis à jour en DB + broadcasté en temps réel sur l'arène
- **Session remote** : liste des arbitres chargée depuis la DB au démarrage de la session
- **Historique** : onglet "Historique" dans `RefereeManager.tsx` — tableau récapitulatif Match → Arbitre (`getMatchesWithReferees` IPC)

## Plan de test

- [ ] Créer une compétition, activer "Activer la gestion des arbitres" dans les propriétés
- [ ] Ajouter des arbitres via RefereeManager, assigner à des matchs
- [ ] Démarrer une session remote → ouvrir arena.html → vérifier que le prochain combat affiche le nom de l'arbitre
- [ ] Ouvrir referee.html → vérifier la barre arbitre (nom + bouton Changer)
- [ ] Changer l'arbitre → vérifier la mise à jour en temps réel sur l'arène et en DB
- [ ] Désactiver le toggle → vérifier que la barre et le nom disparaissent
- [ ] Onglet Historique dans RefereeManager → vérifier le tableau match → arbitre

https://claude.ai/code/session_01SaVjiu6ps34XGesEEVrHx4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaVjiu6ps34XGesEEVrHx4)_