### PR TITLE
Fix TS2551: referee access on raw sessionMatches objects

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2560,7 +2560,7 @@ export class RemoteScoreServer {
       );
       const nextMatch = poolMatches.find(m => m.id !== currentMatchId);
       if (nextMatch) {
-        const nextReferee = this.resolveReferee(nextMatch.refereeId);
+        const nextReferee = this.resolveReferee((nextMatch as any).refereeId ?? nextMatch.referee?.id);
         return {
           id: nextMatch.id,
           poolId: currentPoolId,


### PR DESCRIPTION
## Summary

- Fixes `TS2551: Property 'refereeId' does not exist on type 'Match'` in `remoteScoreServer.ts`
- `sessionMatches` contains raw objects (from renderer) that carry `refereeId` directly; `Match` typed objects use `referee?.id` instead — cast to `any` to handle both cases

## Test plan

- [ ] `npm run build:ci` passes without TS errors

https://claude.ai/code/session_01SaVjiu6ps34XGesEEVrHx4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaVjiu6ps34XGesEEVrHx4)_