### PR TITLE
Historique des scores + détection conflit IP arbitre

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -2211,13 +2211,17 @@ export class DatabaseManager {
     newScoreB: any;
     changedBy: string;
     reason?: string;
+    refereeId?: string;
+    refereeName?: string;
+    ipAddress?: string;
+    poolId?: string;
   }): void {
     if (!this.db) throw new Error('Database not open');
     const { v4: uuidv4gen } = require('uuid');
     this.run(
       `INSERT INTO score_audit_log
-        (id, match_id, arena_id, previous_score_a, previous_score_b, new_score_a, new_score_b, changed_by, changed_at, reason)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, match_id, arena_id, previous_score_a, previous_score_b, new_score_a, new_score_b, changed_by, changed_at, reason, referee_id, referee_name, ip_address, pool_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         uuidv4gen(),
         entry.matchId,
@@ -2229,32 +2233,69 @@ export class DatabaseManager {
         entry.changedBy,
         new Date().toISOString(),
         entry.reason ?? null,
+        entry.refereeId ?? null,
+        entry.refereeName ?? null,
+        entry.ipAddress ?? null,
+        entry.poolId ?? null,
       ]
     );
     this.save();
   }
 
+  private parseAuditRow(r: any) {
+    return {
+      id: r.id as string,
+      matchId: r.match_id as string,
+      arenaId: r.arena_id as string | null,
+      poolId: r.pool_id as string | null,
+      matchNumber: r.match_number != null ? Number(r.match_number) : null,
+      poolNumber: r.pool_number != null ? Number(r.pool_number) : null,
+      previousScoreA: r.previous_score_a ? JSON.parse(r.previous_score_a as string) : null,
+      previousScoreB: r.previous_score_b ? JSON.parse(r.previous_score_b as string) : null,
+      newScoreA: JSON.parse(r.new_score_a as string),
+      newScoreB: JSON.parse(r.new_score_b as string),
+      changedBy: r.changed_by as string,
+      changedAt: r.changed_at as string,
+      reason: r.reason as string | null,
+      refereeId: r.referee_id as string | null,
+      refereeName: r.referee_name as string | null,
+      ipAddress: r.ip_address as string | null,
+    };
+  }
+
   public getScoreAuditLog(matchId: string): any[] {
     if (!this.db) throw new Error('Database not open');
     const stmt = this.db.prepare(
-      `SELECT * FROM score_audit_log WHERE match_id=? ORDER BY changed_at ASC`
+      `SELECT sal.*, m.number as match_number, p.number as pool_number
+       FROM score_audit_log sal
+       LEFT JOIN matches m ON sal.match_id = m.id
+       LEFT JOIN pools p ON m.pool_id = p.id
+       WHERE sal.match_id=? ORDER BY sal.changed_at ASC`
     );
     stmt.bind([matchId]);
     const rows: any[] = [];
     while (stmt.step()) {
-      const r = stmt.getAsObject();
-      rows.push({
-        id: r.id,
-        matchId: r.match_id,
-        arenaId: r.arena_id,
-        previousScoreA: r.previous_score_a ? JSON.parse(r.previous_score_a as string) : null,
-        previousScoreB: r.previous_score_b ? JSON.parse(r.previous_score_b as string) : null,
-        newScoreA: JSON.parse(r.new_score_a as string),
-        newScoreB: JSON.parse(r.new_score_b as string),
-        changedBy: r.changed_by,
-        changedAt: r.changed_at,
-        reason: r.reason,
-      });
+      rows.push(this.parseAuditRow(stmt.getAsObject()));
+    }
+    stmt.free();
+    return rows;
+  }
+
+  public getScoreAuditLogByCompetition(competitionId: string): any[] {
+    if (!this.db) throw new Error('Database not open');
+    const stmt = this.db.prepare(
+      `SELECT sal.*, m.number as match_number, p.number as pool_number
+       FROM score_audit_log sal
+       JOIN matches m ON sal.match_id = m.id
+       JOIN pools p ON m.pool_id = p.id
+       JOIN phases ph ON p.phase_id = ph.id
+       WHERE ph.competition_id = ?
+       ORDER BY sal.changed_at DESC`
+    );
+    stmt.bind([competitionId]);
+    const rows: any[] = [];
+    while (stmt.step()) {
+      rows.push(this.parseAuditRow(stmt.getAsObject()));
     }
     stmt.free();
     return rows;

--- a/src/database/migrations/migrations.ts
+++ b/src/database/migrations/migrations.ts
@@ -248,4 +248,16 @@ export const ALL_MIGRATIONS: Migration[] = [
       db.run(`CREATE INDEX IF NOT EXISTS idx_arena_exits_fencer ON match_arena_exits(fencer_id)`);
     },
   },
+
+  {
+    version: 6,
+    description: 'Enrichissement score_audit_log : arbitre, IP, poule',
+    up(db) {
+      try { db.run(`ALTER TABLE score_audit_log ADD COLUMN referee_id TEXT`); } catch { /* */ }
+      try { db.run(`ALTER TABLE score_audit_log ADD COLUMN referee_name TEXT`); } catch { /* */ }
+      try { db.run(`ALTER TABLE score_audit_log ADD COLUMN ip_address TEXT`); } catch { /* */ }
+      try { db.run(`ALTER TABLE score_audit_log ADD COLUMN pool_id TEXT`); } catch { /* */ }
+      db.run(`CREATE INDEX IF NOT EXISTS idx_audit_pool ON score_audit_log(pool_id)`);
+    },
+  },
 ];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1081,6 +1081,10 @@ ipcMain.handle('db:deleteAbandonSnapshot', async (_, fencerId) => {
   db.deleteAbandonSnapshot(fencerId);
 });
 
+ipcMain.handle('db:getScoreAuditLogByCompetition', async (_, competitionId) => {
+  return db.getScoreAuditLogByCompetition(competitionId);
+});
+
 // File handlers
 ipcMain.handle('file:export', async (_, filepath) => {
   db.exportToFile(filepath);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -277,6 +277,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         snapshots
       ),
     getAbandonSnapshot: (fencerId: string) => ipcRenderer.invoke('db:getAbandonSnapshot', fencerId),
+    getScoreAuditLogByCompetition: (competitionId: string) =>
+      ipcRenderer.invoke('db:getScoreAuditLogByCompetition', competitionId),
     deleteAbandonSnapshot: (fencerId: string) =>
       ipcRenderer.invoke('db:deleteAbandonSnapshot', fencerId),
   },
@@ -497,6 +499,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const handler = (_: any, data: any) => callback(data);
     ipcRenderer.on('remote:dt_call', handler);
     return () => ipcRenderer.removeListener('remote:dt_call', handler);
+  },
+
+  onScoreIpConflict: (callback: (data: any) => void) => {
+    const handler = (_: any, data: any) => callback(data);
+    ipcRenderer.on('score:ip-conflict', handler);
+    return () => ipcRenderer.removeListener('score:ip-conflict', handler);
   },
 
   getLogo: () => ipcRenderer.invoke('app:getLogo'),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -808,10 +808,11 @@ export class RemoteScoreServer {
       if (!/^[0-9a-f-]{36}$/i.test(matchId) && !/^[0-9a-f-]{36}$/i.test(poolId)) {
         // Accepter aussi des IDs non-UUID (matchs en mémoire) - on valide le format souple
       }
-      const { scoreA, scoreB, specialStatus } = req.body as {
+      const { scoreA, scoreB, specialStatus, refereeId: bodyRefereeId } = req.body as {
         scoreA: number;
         scoreB: number;
         specialStatus?: string;
+        refereeId?: string;
       };
       // Validation des scores
       const sA = Number(scoreA);
@@ -843,6 +844,34 @@ export class RemoteScoreServer {
           isForfait: specialStatus === 'forfait_B',
         };
         const previousMatch = this.db.getMatch(matchId);
+        const resolvedRef = this.resolveReferee(bodyRefereeId ?? previousMatch?.referee?.id ?? null);
+
+        // Détection conflit IP : alerte si une IP différente tente de modifier un score déjà saisi
+        try {
+          const existingLog = this.db.getScoreAuditLog(matchId);
+          if (existingLog.length > 0) {
+            const lastEntry = existingLog[existingLog.length - 1];
+            if (lastEntry.ipAddress && lastEntry.ipAddress !== clientIp) {
+              const mainWin = (global as any).mainWindow;
+              if (mainWin) {
+                mainWin.webContents.send('score:ip-conflict', {
+                  matchId,
+                  poolId,
+                  matchNumber: lastEntry.matchNumber,
+                  poolNumber: lastEntry.poolNumber,
+                  originalIp: lastEntry.ipAddress,
+                  originalReferee: lastEntry.refereeName ?? lastEntry.changedBy,
+                  attemptIp: clientIp,
+                  attemptReferee: resolvedRef?.name ?? 'inconnu',
+                  timestamp: new Date().toISOString(),
+                });
+              }
+            }
+          }
+        } catch {
+          /* non bloquant */
+        }
+
         this.db.updateMatch(matchId, {
           scoreA: scoreAObj,
           scoreB: scoreBObj,
@@ -852,12 +881,16 @@ export class RemoteScoreServer {
         try {
           this.db.logScoreChange({
             matchId,
+            poolId,
             previousScoreA: previousMatch?.scoreA ?? null,
             previousScoreB: previousMatch?.scoreB ?? null,
             newScoreA: scoreAObj,
             newScoreB: scoreBObj,
-            changedBy: 'referee',
+            changedBy: resolvedRef?.name ?? bodyRefereeId ?? 'referee',
             reason: 'pool_remote_entry',
+            refereeId: resolvedRef?.id ?? bodyRefereeId,
+            refereeName: resolvedRef?.name,
+            ipAddress: clientIp,
           });
         } catch {
           /* non bloquant */

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -38,6 +38,7 @@ import { PresentationMode } from './PresentationMode';
 import KioskDisplay from './KioskDisplay';
 import { FencerPhoto } from './FencerPhoto';
 import QuestPhaseView from './QuestPhaseView';
+import { ScoreAuditLog } from './ScoreAuditLog';
 
 interface CompetitionViewProps {
   competition: Competition;
@@ -742,6 +743,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       disabled: false,
       title: undefined as string | undefined,
     },
+    {
+      id: 'logs',
+      label: t('phases.logs'),
+      icon: '📜',
+      disabled: false,
+      title: undefined as string | undefined,
+    },
   ];
 
   const getPoolsNextAction = () => {
@@ -1171,6 +1179,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onStopRemote={() => setIsRemoteActive(false)}
             isRemoteActive={isRemoteActive}
           />
+        )}
+
+        {currentPhase === 'logs' && (
+          <ScoreAuditLog competitionId={competition.id} />
         )}
       </div>
 

--- a/src/renderer/components/ScoreAuditLog.tsx
+++ b/src/renderer/components/ScoreAuditLog.tsx
@@ -1,0 +1,157 @@
+/**
+ * BellePoule Modern - Historique des scores par poules
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { ScoreAuditEntry, ScoreIpConflict } from '../../shared/types/preload';
+import { useToast } from './Toast';
+
+interface Props {
+  competitionId: string;
+}
+
+function formatScore(score: any): string {
+  if (!score) return '—';
+  const v = score.value ?? '?';
+  if (score.isAbstention) return `${v} (Ab.)`;
+  if (score.isExclusion) return `${v} (Excl.)`;
+  if (score.isForfait) return `${v} (FF)`;
+  return String(v);
+}
+
+export const ScoreAuditLog: React.FC<Props> = ({ competitionId }) => {
+  const { showToast } = useToast();
+  const [entries, setEntries] = useState<ScoreAuditEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [filterPool, setFilterPool] = useState('');
+  const [filterReferee, setFilterReferee] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await window.electronAPI.db.getScoreAuditLogByCompetition(competitionId);
+      setEntries(data);
+    } catch {
+      showToast('Erreur chargement historique', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [competitionId, showToast]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Écoute des alertes de conflit IP
+  useEffect(() => {
+    const unsub = window.electronAPI.onScoreIpConflict((conflict: ScoreIpConflict) => {
+      const msg = `⚠️ Conflit IP — Poule ${conflict.poolNumber ?? '?'} Match ${conflict.matchNumber ?? '?'} : ${conflict.attemptReferee} (${conflict.attemptIp}) tente de modifier un score saisi par ${conflict.originalReferee ?? 'inconnu'} (${conflict.originalIp})`;
+      showToast(msg, 'error');
+      load();
+    });
+    return unsub;
+  }, [load, showToast]);
+
+  const poolNumbers = Array.from(new Set(entries.map(e => e.poolNumber).filter(n => n != null))).sort((a, b) => (a as number) - (b as number));
+
+  const filtered = entries.filter(e => {
+    if (filterPool && String(e.poolNumber) !== filterPool) return false;
+    if (filterReferee) {
+      const ref = (e.refereeName ?? e.changedBy ?? '').toLowerCase();
+      if (!ref.includes(filterReferee.toLowerCase())) return false;
+    }
+    return true;
+  });
+
+  return (
+    <div style={{ padding: '1.5rem', maxWidth: '100%', overflowX: 'auto' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1rem', flexWrap: 'wrap' }}>
+        <h2 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>📜 Historique des scores</h2>
+
+        <select
+          value={filterPool}
+          onChange={e => setFilterPool(e.target.value)}
+          style={{ padding: '0.3rem 0.6rem', borderRadius: 4, border: '1px solid #D1D5DB' }}
+        >
+          <option value="">Toutes les poules</option>
+          {poolNumbers.map(n => (
+            <option key={n} value={String(n)}>Poule {n}</option>
+          ))}
+        </select>
+
+        <input
+          type="text"
+          placeholder="Filtrer arbitre…"
+          value={filterReferee}
+          onChange={e => setFilterReferee(e.target.value)}
+          style={{ padding: '0.3rem 0.6rem', borderRadius: 4, border: '1px solid #D1D5DB', minWidth: 140 }}
+        />
+
+        <button
+          className="btn btn-secondary"
+          onClick={load}
+          disabled={loading}
+          style={{ marginLeft: 'auto' }}
+        >
+          {loading ? '…' : '↻ Actualiser'}
+        </button>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div style={{ textAlign: 'center', color: '#6B7280', padding: '3rem' }}>
+          {loading ? 'Chargement…' : 'Aucune entrée dans le journal.'}
+        </div>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+          <thead>
+            <tr style={{ background: '#F3F4F6', textAlign: 'left' }}>
+              <th style={th}>Horodatage</th>
+              <th style={th}>Poule</th>
+              <th style={th}>Match</th>
+              <th style={th}>Avant</th>
+              <th style={th}>Après</th>
+              <th style={th}>Arbitre</th>
+              <th style={th}>IP</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(e => (
+              <tr key={e.id} style={{ borderBottom: '1px solid #E5E7EB' }}>
+                <td style={td}>{new Date(e.changedAt).toLocaleString()}</td>
+                <td style={td}>{e.poolNumber != null ? `Poule ${e.poolNumber}` : '—'}</td>
+                <td style={td}>{e.matchNumber != null ? `Match ${e.matchNumber}` : '—'}</td>
+                <td style={td}>
+                  {e.previousScoreA != null
+                    ? `${formatScore(e.previousScoreA)} / ${formatScore(e.previousScoreB)}`
+                    : '—'}
+                </td>
+                <td style={{ ...td, fontWeight: 600 }}>
+                  {formatScore(e.newScoreA)} / {formatScore(e.newScoreB)}
+                </td>
+                <td style={td}>{e.refereeName ?? e.changedBy ?? '—'}</td>
+                <td style={{ ...td, fontFamily: 'monospace', color: '#6B7280' }}>{e.ipAddress ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <div style={{ marginTop: '0.75rem', color: '#9CA3AF', fontSize: '0.75rem' }}>
+        {filtered.length} entrée{filtered.length !== 1 ? 's' : ''}
+        {entries.length !== filtered.length ? ` (${entries.length} au total)` : ''}
+      </div>
+    </div>
+  );
+};
+
+const th: React.CSSProperties = {
+  padding: '0.5rem 0.75rem',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+};
+
+const td: React.CSSProperties = {
+  padding: '0.4rem 0.75rem',
+  whiteSpace: 'nowrap',
+};

--- a/src/renderer/hooks/useCompetitionSession.ts
+++ b/src/renderer/hooks/useCompetitionSession.ts
@@ -9,7 +9,7 @@ import { Pool, PoolRanking } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { TableauMatch, FinalResult } from '../components/TableauView';
 
-export type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote';
+export type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs';
 
 interface SessionState {
   currentPhase: number;
@@ -68,6 +68,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
     tableau: 5,
     results: 6,
     remote: 7,
+    logs: 8,
   };
 
   const numberToPhase: Record<number, Phase> = {
@@ -79,6 +80,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
     5: 'tableau',
     6: 'results',
     7: 'remote',
+    8: 'logs',
   };
 
   // Sauvegarder l'état - lit depuis propsRef pour rester stable (pas de re-création à chaque render)
@@ -167,7 +169,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
       const p = propsRef.current;
       const phaseMap: Record<Phase, number> = {
         checkin: 0, poolprep: 1, pools: 2, ranking: 3,
-        quest: 4, tableau: 5, results: 6, remote: 7,
+        quest: 4, tableau: 5, results: 6, remote: 7, logs: 8,
       };
       window.electronAPI.db.saveSessionStateSync(p.competitionId, {
         currentPhase: phaseMap[p.currentPhase],

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -103,7 +103,8 @@
     "ranking": "Rangliste",
     "tableau": "Tabelle",
     "results": "Ergebnisse",
-    "remote": "Ferne Eingabe"
+    "remote": "Ferne Eingabe",
+    "logs": "Verlauf"
   },
   "pools": {
     "generate": "Pools Generieren",

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -103,7 +103,8 @@
     "ranking": "Ranking",
     "tableau": "Table",
     "results": "Results",
-    "remote": "Remote Entry"
+    "remote": "Remote Entry",
+    "logs": "History"
   },
   "pools": {
     "generate": "Generate Pools",

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -103,7 +103,8 @@
     "ranking": "Classement",
     "tableau": "Tableau",
     "results": "Résultats",
-    "remote": "Saisie distante"
+    "remote": "Saisie distante",
+    "logs": "Historique"
   },
   "pools": {
     "generate": "Générer les poules",

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -558,6 +558,9 @@ export interface DatabaseAPI {
   ) => Promise<void>;
   getAbandonSnapshot: (fencerId: string) => Promise<AbandonSnapshot | null>;
   deleteAbandonSnapshot: (fencerId: string) => Promise<void>;
+
+  // Score audit log
+  getScoreAuditLogByCompetition: (competitionId: string) => Promise<ScoreAuditEntry[]>;
 }
 
 export interface FileAPI {
@@ -640,6 +643,37 @@ export interface ScoreAuditLogEntry {
   newValue: string | null; // JSON
 }
 
+export interface ScoreAuditEntry {
+  id: string;
+  matchId: string;
+  arenaId: string | null;
+  poolId: string | null;
+  matchNumber: number | null;
+  poolNumber: number | null;
+  previousScoreA: any | null;
+  previousScoreB: any | null;
+  newScoreA: any;
+  newScoreB: any;
+  changedBy: string;
+  changedAt: string; // ISO 8601
+  reason: string | null;
+  refereeId: string | null;
+  refereeName: string | null;
+  ipAddress: string | null;
+}
+
+export interface ScoreIpConflict {
+  matchId: string;
+  poolId: string;
+  matchNumber: number | null;
+  poolNumber: number | null;
+  originalIp: string;
+  originalReferee: string | null;
+  attemptIp: string;
+  attemptReferee: string;
+  timestamp: string; // ISO 8601
+}
+
 // ============================================================================
 // Arena State Types
 // ============================================================================
@@ -668,6 +702,7 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   onDTCall: (
     callback: (data: { arenaId: string; arenaNumber: number; matchNumber: number | null; competitionId: string | null; timestamp: number }) => void
   ) => () => void;
+  onScoreIpConflict: (callback: (data: ScoreIpConflict) => void) => () => void;
   notifyLanguageChanged: (lang: string) => void;
   getLogo: () => Promise<string | null>;
   onLogoLoaded: (callback: (logo: string | null) => void) => () => void;


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- **Migration DB v6** : 4 colonnes ajoutées à `score_audit_log` (`referee_id`, `referee_name`, `ip_address`, `pool_id`)
- **Horodatage** : le champ `changed_at` (ISO 8601) était déjà présent — maintenant affiché dans l'UI
- **Détection conflit IP** : si une tablette différente tente de modifier un score déjà saisi, une alerte toast apparaît sur le desktop (aucun blocage côté arbitre)
- **Onglet Historique** (📜) dans CompetitionView : tableau filtrable par poule et par nom d'arbitre, rechargement manuel

## Détail des changements

| Fichier | Changement |
|---|---|
| `src/database/migrations/migrations.ts` | Migration v6 : ALTER TABLE score_audit_log |
| `src/database/index.ts` | `logScoreChange()` étendu + `getScoreAuditLogByCompetition()` |
| `src/main/remoteScoreServer.ts` | Extraction IP, résolution nom arbitre, détection conflit IP → `score:ip-conflict` |
| `src/main/main.ts` | Handler IPC `db:getScoreAuditLogByCompetition` |
| `src/main/preload.ts` | Exposition `getScoreAuditLogByCompetition` + `onScoreIpConflict` |
| `src/shared/types/preload.ts` | Types `ScoreAuditEntry`, `ScoreIpConflict` |
| `src/renderer/hooks/useCompetitionSession.ts` | Phase `logs` ajoutée (index 8) |
| `src/renderer/components/CompetitionView.tsx` | Onglet 📜 Historique + rendu `<ScoreAuditLog>` |
| `src/renderer/components/ScoreAuditLog.tsx` | Nouveau composant (tableau + filtres + alerte IP) |
| `src/renderer/locales/fr|en|de.json` | Clé `phases.logs` |

## Plan de test

- [ ] Ouvrir une compétition, saisir des scores via la saisie distante (deux tablettes différentes sur le même match)
- [ ] Vérifier l'alerte toast "Conflit IP" dans le desktop
- [ ] Cliquer sur l'onglet 📜 Historique → vérifier colonnes Horodatage / Poule / Match / Avant / Après / Arbitre / IP
- [ ] Tester les filtres par poule et par nom d'arbitre
- [ ] Vérifier que les DB existantes migrent correctement (colonnes NULL pour les anciens enregistrements)

https://claude.ai/code/session_01GBqX1M3q33c92V4jTjq1SG
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBqX1M3q33c92V4jTjq1SG)_