### PR TITLE
fix(linux): interface muette sous Linux ARM / VMware sans 3D

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -458,7 +458,11 @@ function createWindow(): void {
     icon: path.join(__dirname, '../../resources/icons/icon.png'),
   });
 
+  const showFallback = setTimeout(() => {
+    if (mainWindow && !mainWindow.isVisible()) mainWindow.show();
+  }, 10000);
   mainWindow.once('ready-to-show', () => {
+    clearTimeout(showFallback);
     mainWindow?.show();
   });
 
@@ -1857,6 +1861,12 @@ ipcMain.handle('updater:installPendingUpdate', async () => {
 // ============================================================================
 // App Lifecycle
 // ============================================================================
+
+// VMware/ARM sans accélération 3D : forcer rendu logiciel
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('disable-gpu');
+  app.commandLine.appendSwitch('disable-gpu-sandbox');
+}
 
 app.whenReady().then(async () => {
   // Initialize database dans un répertoire inscriptible (userData)


### PR DESCRIPTION
## Problème

Sur Linux ARM dans VMware sans accélération 3D, l'interface ne s'ouvre pas.
Chromium tente d'initialiser le GPU, échoue (`VMware: No 3D enabled`), et l'événement `ready-to-show` ne se déclenche jamais → fenêtre créée avec `show: false` qui reste invisible.

## Fix

- `disable-gpu` + `disable-gpu-sandbox` ajoutés via `app.commandLine.appendSwitch()` **avant** `app.whenReady()` sur Linux → force le rendu logiciel (SwiftShader)
- Fallback timeout 10 s sur `ready-to-show` : si l'événement n'arrive pas, la fenêtre est forcée visible

## Impact

- Linux ARM / VMware : fenêtre s'ouvre correctement
- macOS / Windows : aucun changement (guard `process.platform === 'linux'`)

https://claude.ai/code/session_0167MxoPX2L7184N7x1gstfw

---
_Generated by [Claude Code](https://claude.ai/code/session_0167MxoPX2L7184N7x1gstfw)_