### PR TITLE
fix(ts): add 'logs' to Phase type in useMenuEvents

### DIFF
--- a/src/renderer/hooks/useMenuEvents.ts
+++ b/src/renderer/hooks/useMenuEvents.ts
@@ -9,7 +9,7 @@ import { PoolRanking } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { FinalResult } from '../components/TableauView';
 
-type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote';
+type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs';
 
 interface UseMenuEventsProps {
   currentPhase: Phase;


### PR DESCRIPTION
## Problème

Erreur CI `TS2322` : le type `Phase` local dans `useMenuEvents.ts` ne contenait pas `'logs'`, alors que `useCompetitionSession.ts` (source canonique) l'inclut. L'assignation de `currentPhase` dans `CompetitionView.tsx:324` échouait.

## Fix

Ajout de `'logs'` au type local `Phase` dans `src/renderer/hooks/useMenuEvents.ts`.

## Cause racine

Le type `Phase` est dupliqué localement dans plusieurs hooks au lieu d'être importé depuis une source unique. À terme, il faudrait l'exporter depuis `useCompetitionSession` et l'importer partout.

https://claude.ai/code/session_0167MxoPX2L7184N7x1gstfw

---
_Generated by [Claude Code](https://claude.ai/code/session_0167MxoPX2L7184N7x1gstfw)_