### PR TITLE
Fix export photos ignorant les combattants sans numéro de licence

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -571,16 +571,30 @@ export class DatabaseManager {
     return results;
   }
 
-  public getFencerPhotos(competitionId: string): { license: string; photo: string }[] {
+  public getFencerPhotos(
+    competitionId: string
+  ): { id: string; license: string | null; lastName: string; firstName: string; photo: string }[] {
     if (!this.db) throw new Error('Database not open');
-    const results: { license: string; photo: string }[] = [];
+    const results: {
+      id: string;
+      license: string | null;
+      lastName: string;
+      firstName: string;
+      photo: string;
+    }[] = [];
     const stmt = this.db.prepare(
-      "SELECT license, photo FROM fencers WHERE competition_id = ? AND photo IS NOT NULL AND license IS NOT NULL AND license != ''"
+      'SELECT id, license, last_name, first_name, photo FROM fencers WHERE competition_id = ? AND photo IS NOT NULL'
     );
     stmt.bind([competitionId]);
     while (stmt.step()) {
       const row = stmt.getAsObject();
-      results.push({ license: row.license as string, photo: row.photo as string });
+      results.push({
+        id: row.id as string,
+        license: (row.license as string | null) || null,
+        lastName: row.last_name as string,
+        firstName: row.first_name as string,
+        photo: row.photo as string,
+      });
     }
     stmt.free();
     return results;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1108,10 +1108,13 @@ ipcMain.handle('file:exportPhotos', async (_, competitionId: string, filepath: s
   const photos = db.getFencerPhotos(competitionId);
   const zip = new JSZip();
 
-  for (const { license, photo } of photos) {
+  for (const { id, license, lastName, firstName, photo } of photos) {
     const base64 = photo.replace(/^data:image\/\w+;base64,/, '');
     const buffer = Buffer.from(base64, 'base64');
-    zip.file(`${license}.jpg`, buffer);
+    const filename = license
+      ? license
+      : `${lastName}_${firstName}_${id.slice(0, 8)}`.replace(/[^a-zA-Z0-9_\-]/g, '_');
+    zip.file(`${filename}.jpg`, buffer);
   }
 
   const content = await zip.generateAsync({ type: 'nodebuffer' });


### PR DESCRIPTION
## Problème

L'export de photos (ZIP) excluait silencieusement tous les combattants sans numéro de licence. La requête SQL contenait `AND license IS NOT NULL AND license != ''`, et le nom de fichier dans le ZIP utilisait `license` directement — résultat : 0 photo exportée pour les combattants sans licence.

## Changements

### `src/database/index.ts` — `getFencerPhotos`
- Suppression du filtre `AND license IS NOT NULL AND license != ''`
- Ajout de `id`, `last_name`, `first_name` dans le SELECT
- Nouvelle signature de retour : `{ id, license: string | null, lastName, firstName, photo }[]`

### `src/main/main.ts` — handler `file:exportPhotos`
- Nom de fichier ZIP : `license` si présent, sinon `NOM_Prenom_id8chars` (caractères spéciaux nettoyés)

## Test plan
- [ ] Combattant SANS licence avec photo → présent dans le ZIP sous `NOM_Prenom_XXXXXXXX.jpg`
- [ ] Combattant AVEC licence avec photo → toujours exporté sous `123456.jpg`
- [ ] `npm run type-check` passe sans nouvelles erreurs

https://claude.ai/code/session_013ryQBAshJahYjzC1WxjDbw

---
_Generated by [Claude Code](https://claude.ai/code/session_013ryQBAshJahYjzC1WxjDbw)_