### PR TITLE
fix(linux): corriger le crash GPU sur VMware sans accélération 3D

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1867,8 +1867,10 @@ ipcMain.handle('updater:installPendingUpdate', async () => {
 
 // VMware/ARM sans accélération 3D : forcer rendu logiciel
 if (process.platform === 'linux') {
+  app.disableHardwareAcceleration();
   app.commandLine.appendSwitch('disable-gpu');
   app.commandLine.appendSwitch('disable-gpu-sandbox');
+  app.commandLine.appendSwitch('use-gl', 'swiftshader');
 }
 
 app.whenReady().then(async () => {


### PR DESCRIPTION
## Problème

L'AppImage ne s'ouvrait pas sur VM VMware sans 3D. Logs :
```
VMware: No 3D enabled (0, Succès). [×6]
ContextResult::kTransientFailure: Failed to send GpuControl.CreateCommandBuffer.
```

## Cause

Sous Electron 40, `--disable-gpu` et `--disable-gpu-sandbox` seuls ne suffisent plus à empêcher la tentative d'initialisation du command buffer GPU.

## Fix (`src/main/main.ts`)

```diff
 if (process.platform === 'linux') {
+  app.disableHardwareAcceleration();
   app.commandLine.appendSwitch('disable-gpu');
   app.commandLine.appendSwitch('disable-gpu-sandbox');
+  app.commandLine.appendSwitch('use-gl', 'swiftshader');
 }
```

- `app.disableHardwareAcceleration()` — API Electron qui désactive l'accélération HW avant l'init du GPU process
- `use-gl=swiftshader` — force SwiftShader (OpenGL logiciel) au lieu d'un contexte matériel qui échoue

https://claude.ai/code/session_01KcRF4b9webHYf9E6AUYu66

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcRF4b9webHYf9E6AUYu66)_