### PR TITLE
Appel DT : icône dans le header + annulation par appui long

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -500,6 +500,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('remote:dt_call', handler);
     return () => ipcRenderer.removeListener('remote:dt_call', handler);
   },
+  onDTCallCancel: (callback: (data: { arenaId: string }) => void) => {
+    const handler = (_: any, data: any) => callback(data);
+    ipcRenderer.on('remote:dt_cancel', handler);
+    return () => ipcRenderer.removeListener('remote:dt_cancel', handler);
+  },
 
   onScoreIpConflict: (callback: (data: any) => void) => {
     const handler = (_: any, data: any) => callback(data);

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1759,6 +1759,13 @@ export class RemoteScoreServer {
         }
         break;
       }
+      case 'dt_cancel': {
+        const mainWin = (global as any).mainWindow;
+        if (mainWin) {
+          mainWin.webContents.send('remote:dt_cancel', { arenaId: data.arenaId });
+        }
+        break;
+      }
       case 'next':
         this.loadNextMatch(data.arenaId);
         this.arenaCards.set(data.arenaId, { cardsA: [], cardsB: [] });

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -543,8 +543,33 @@
         cursor: default;
       }
 
-      .control-buttons-dt {
-        margin-top: 0.5rem;
+      .dt-icon-btn {
+        background: none;
+        border: 1.5px solid rgba(249, 115, 22, 0.6);
+        color: #f97316;
+        border-radius: 50%;
+        width: 34px;
+        height: 34px;
+        font-size: 1rem;
+        cursor: pointer;
+        line-height: 1;
+        padding: 0;
+        margin-left: 0.4rem;
+        flex-shrink: 0;
+        transition: background 0.2s, border-color 0.2s, color 0.2s;
+        touch-action: none;
+        user-select: none;
+      }
+      .dt-icon-btn.dt-active {
+        background: rgba(107, 114, 128, 0.35);
+        border-color: #6b7280;
+        color: #9ca3af;
+        cursor: not-allowed;
+      }
+      .dt-icon-btn.dt-ack {
+        background: rgba(34, 197, 94, 0.2);
+        border-color: #22c55e;
+        color: #22c55e;
       }
 
       .referee-bar {
@@ -1015,6 +1040,12 @@
         >
           ⟳ Sync...
         </span>
+        <button
+          id="btn-dt-icon"
+          class="dt-icon-btn"
+          title="Appel DT (appui long = annuler)"
+          aria-label="Appel DT"
+        >📣</button>
       </div>
     </div>
 
@@ -1184,16 +1215,6 @@
             onclick="refereeApp.arenaExit('B')"
           >
             <span data-i18n="referee.exit_green">🚪 Sortie verte</span>
-          </button>
-        </div>
-        <!-- Bouton appel Directeur Technique -->
-        <div class="control-buttons-dt">
-          <button
-            class="control-btn btn-dt-call"
-            id="btn-dt-call"
-            onclick="refereeApp.callDT()"
-          >
-            <span id="btn-dt-label" data-i18n="referee.dt_call">📣 Appel DT</span>
           </button>
         </div>
 
@@ -1714,6 +1735,42 @@
               btn.classList.remove('long-press-active');
             });
           });
+
+          // Icône DT : tap court = appel, appui long = annulation
+          const dtIcon = document.getElementById('btn-dt-icon');
+          if (dtIcon) {
+            let dtLongPressTimer = null;
+            let dtLongPressTriggered = false;
+
+            const dtDown = () => {
+              dtLongPressTriggered = false;
+              dtLongPressTimer = setTimeout(() => {
+                dtLongPressTriggered = true;
+                dtLongPressTimer = null;
+                this.cancelDTCall();
+              }, 600);
+            };
+            const dtUp = (e) => {
+              if (dtLongPressTimer) {
+                clearTimeout(dtLongPressTimer);
+                dtLongPressTimer = null;
+              }
+              if (!dtLongPressTriggered) this.callDT();
+            };
+            const dtCancel = () => {
+              if (dtLongPressTimer) {
+                clearTimeout(dtLongPressTimer);
+                dtLongPressTimer = null;
+              }
+            };
+
+            dtIcon.addEventListener('mousedown', dtDown);
+            dtIcon.addEventListener('mouseup', dtUp);
+            dtIcon.addEventListener('mouseleave', dtCancel);
+            dtIcon.addEventListener('touchstart', e => { e.preventDefault(); dtDown(); });
+            dtIcon.addEventListener('touchend', e => { e.preventDefault(); dtUp(e); });
+            dtIcon.addEventListener('touchcancel', dtCancel);
+          }
         }
 
         setupSocketListeners() {
@@ -1739,16 +1796,18 @@
           });
 
           this.socket.on(`arena:${this.arenaId}:dt_call_ack`, () => {
-            const btn = document.getElementById('btn-dt-call');
-            const label = document.getElementById('btn-dt-label');
+            const btn = document.getElementById('btn-dt-icon');
             if (btn) {
               btn.classList.remove('dt-active');
               btn.classList.add('dt-ack');
-              btn.disabled = true;
-              if (label) label.textContent = window.T('referee.dt_en_route');
+              btn.title = 'DT en route (appui long = annuler)';
             }
             this.showNotification('✅ DT en route !');
-            setTimeout(() => this._resetDTButton(), 10000);
+            setTimeout(() => {
+              this._resetDTButton();
+              const b = document.getElementById('btn-dt-icon');
+              if (b) b.title = 'Appel DT (appui long = annuler)';
+            }, 10000);
           });
         }
 
@@ -2072,23 +2131,25 @@
         }
 
         callDT() {
-          const btn = document.getElementById('btn-dt-call');
-          const label = document.getElementById('btn-dt-label');
+          const btn = document.getElementById('btn-dt-icon');
           if (!btn || btn.classList.contains('dt-active') || btn.classList.contains('dt-ack')) return;
           btn.classList.add('dt-active');
-          btn.disabled = true;
-          if (label) label.textContent = window.T('referee.dt_called');
           this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'dt_call' });
           this.showNotification(window.T('referee.dt_called'));
         }
 
+        cancelDTCall() {
+          const btn = document.getElementById('btn-dt-icon');
+          if (!btn || (!btn.classList.contains('dt-active') && !btn.classList.contains('dt-ack'))) return;
+          this._resetDTButton();
+          this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'dt_cancel' });
+          this.showNotification('❌ Appel DT annulé');
+        }
+
         _resetDTButton() {
-          const btn = document.getElementById('btn-dt-call');
-          const label = document.getElementById('btn-dt-label');
+          const btn = document.getElementById('btn-dt-icon');
           if (!btn) return;
           btn.classList.remove('dt-active', 'dt-ack');
-          btn.disabled = false;
-          if (label) label.textContent = window.T('referee.dt_call');
         }
 
         undoLastAction() {

--- a/src/renderer/components/DTCallNotification.tsx
+++ b/src/renderer/components/DTCallNotification.tsx
@@ -56,6 +56,14 @@ const DTCallNotification: React.FC = () => {
     return unsub;
   }, []);
 
+  useEffect(() => {
+    if (!window.electronAPI?.onDTCallCancel) return;
+    const unsub = window.electronAPI.onDTCallCancel((data) => {
+      setCalls(prev => prev.filter(c => c.arenaId !== data.arenaId));
+    });
+    return unsub;
+  }, []);
+
   const acknowledge = useCallback(async (call: DTCallEntry) => {
     setCalls(prev => prev.map(c => c.id === call.id ? { ...c, acknowledging: true } : c));
     if (call.competitionId) {

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -702,6 +702,7 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   onDTCall: (
     callback: (data: { arenaId: string; arenaNumber: number; matchNumber: number | null; competitionId: string | null; timestamp: number }) => void
   ) => () => void;
+  onDTCallCancel: (callback: (data: { arenaId: string }) => void) => () => void;
   onScoreIpConflict: (callback: (data: ScoreIpConflict) => void) => () => void;
   notifyLanguageChanged: (lang: string) => void;
   getLogo: () => Promise<string | null>;


### PR DESCRIPTION
## Résumé

- Remplace le bouton pleine largeur "📣 Appel DT" par une icône circulaire dans le bandeau de connexion de la tablette arbitre, à côté du statut EN LIGNE
- Tap court = appel DT (comportement inchangé)
- Appui long ≥600 ms = annule l'appel en cours + notifie le serveur
- La notification opérateur (DTCallNotification côté Electron) se ferme automatiquement à l'annulation

## États visuels de l'icône
- 🟠 Orange (repos) → appuyer pour appeler
- ⚫ Gris (appelé) → DT en route
- 🟢 Vert (acquitté) → DT confirmé, reset auto après 10 s

## Fichiers modifiés
- `src/remote/referee.html` — UI, CSS, JS (icône + long press)
- `src/main/remoteScoreServer.ts` — nouveau case `dt_cancel`
- `src/main/preload.ts` — expose `onDTCallCancel`
- `src/shared/types/preload.ts` — type `onDTCallCancel`
- `src/renderer/components/DTCallNotification.tsx` — écoute cancel → retire la notif

## Plan de test
- [ ] Icône 📣 visible dans le bandeau à côté de "EN LIGNE"
- [ ] Tap court → icône grise, notification opérateur apparaît
- [ ] Appui long sur icône active → icône reset, notification opérateur disparaît
- [ ] Acquittement opérateur → icône verte → reset après 10 s

https://claude.ai/code/session_01ECEb9UDKUY8JZJc2rMxu5t

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECEb9UDKUY8JZJc2rMxu5t)_