### PR TITLE
Intègre l'onglet Arbitres dans CompetitionView

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Competition, Fencer, FencerStatus, Match, MatchStatus, Weapon, QuestPhaseConfig } from '../../shared/types';
+import { Competition, Fencer, FencerStatus, Match, MatchStatus, Weapon, QuestPhaseConfig, Referee } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { RankingImportResult } from '../../shared/utils/fileParser';
 import FencerList from './FencerList';
@@ -39,6 +39,7 @@ import KioskDisplay from './KioskDisplay';
 import { FencerPhoto } from './FencerPhoto';
 import QuestPhaseView from './QuestPhaseView';
 import { ScoreAuditLog } from './ScoreAuditLog';
+import { RefereeManagerComponent } from './RefereeManager';
 
 interface CompetitionViewProps {
   competition: Competition;
@@ -88,6 +89,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const [showPresentation, setShowPresentation] = useState(false);
   const [showKioskDisplay, setShowKioskDisplay] = useState(false);
   const [selectedMatch, setSelectedMatch] = useState<Match | null>(null);
+  const [referees, setReferees] = useState<Referee[]>([]);
 
   // Paramètres de préparation des poules (persistés entre les phases)
   const [minFencersPerPool, setMinFencersPerPool] = useState<number>(5);
@@ -219,6 +221,14 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   useEffect(() => {
     loadFencers();
   }, [loadFencers]);
+
+  // Charger les arbitres si la fonction est activée
+  useEffect(() => {
+    if (!competition.settings?.refereeFeatureEnabled) return;
+    window.electronAPI.db.getRefereesByCompetition(competition.id)
+      .then((rows: Referee[]) => setReferees(rows))
+      .catch(() => {});
+  }, [competition.id, competition.settings?.refereeFeatureEnabled]);
 
   // Synchroniser les photos/données tireurs dans les matches de poule à chaque mise à jour
   useEffect(() => {
@@ -750,6 +760,17 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       disabled: false,
       title: undefined as string | undefined,
     },
+    ...(competition.settings?.refereeFeatureEnabled
+      ? [
+          {
+            id: 'referees',
+            label: t('phases.referees') || 'Arbitres',
+            icon: '🧑‍⚖️',
+            disabled: false,
+            title: undefined as string | undefined,
+          },
+        ]
+      : []),
   ];
 
   const getPoolsNextAction = () => {
@@ -1183,6 +1204,17 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
         {currentPhase === 'logs' && (
           <ScoreAuditLog competitionId={competition.id} />
+        )}
+
+        {currentPhase === 'referees' && competition.settings?.refereeFeatureEnabled && (
+          <RefereeManagerComponent
+            competition={competition}
+            referees={referees}
+            pools={pools}
+            matches={pools.flatMap(p => p.matches ?? [])}
+            onRefereesChange={setReferees}
+            onAssignmentsChange={() => {}}
+          />
         )}
       </div>
 

--- a/src/renderer/hooks/useCompetitionSession.ts
+++ b/src/renderer/hooks/useCompetitionSession.ts
@@ -9,7 +9,7 @@ import { Pool, PoolRanking } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { TableauMatch, FinalResult } from '../components/TableauView';
 
-export type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs';
+export type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs' | 'referees';
 
 interface SessionState {
   currentPhase: number;
@@ -69,6 +69,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
     results: 6,
     remote: 7,
     logs: 8,
+    referees: 9,
   };
 
   const numberToPhase: Record<number, Phase> = {
@@ -81,6 +82,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
     6: 'results',
     7: 'remote',
     8: 'logs',
+    9: 'referees',
   };
 
   // Sauvegarder l'état - lit depuis propsRef pour rester stable (pas de re-création à chaque render)

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -103,7 +103,8 @@
     "ranking": "Renk",
     "tableau": "Taolenn",
     "results": "Disoc'hoùezioù",
-    "remote": "Enrollañ a-bell"
+    "remote": "Enrollañ a-bell",
+    "referees": "Varnourien"
   },
   "pools": {
     "generate": "Genelañ ar poullou",

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -103,7 +103,8 @@
     "ranking": "Classificació",
     "tableau": "Quadre",
     "results": "Resultats",
-    "remote": "Entrada Remota"
+    "remote": "Entrada Remota",
+    "referees": "Àrbitres"
   },
   "pools": {
     "generate": "Generar Poules",

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -104,7 +104,8 @@
     "tableau": "Tabelle",
     "results": "Ergebnisse",
     "remote": "Ferne Eingabe",
-    "logs": "Verlauf"
+    "logs": "Verlauf",
+    "referees": "Schiedsrichter"
   },
   "pools": {
     "generate": "Pools Generieren",

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -104,7 +104,8 @@
     "tableau": "Table",
     "results": "Results",
     "remote": "Remote Entry",
-    "logs": "History"
+    "logs": "History",
+    "referees": "Referees"
   },
   "pools": {
     "generate": "Generate Pools",

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -103,7 +103,8 @@
     "ranking": "Clasificación",
     "tableau": "Cuadro",
     "results": "Resultados",
-    "remote": "Entrada Remota"
+    "remote": "Entrada Remota",
+    "referees": "Árbitros"
   },
   "pools": {
     "generate": "Generar Poules",

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -104,7 +104,8 @@
     "tableau": "Tableau",
     "results": "Résultats",
     "remote": "Saisie distante",
-    "logs": "Historique"
+    "logs": "Historique",
+    "referees": "Arbitres"
   },
   "pools": {
     "generate": "Générer les poules",

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -103,7 +103,8 @@
     "ranking": "排名",
     "tableau": "淘汰賽",
     "results": "成績",
-    "remote": "遠程輸入"
+    "remote": "遠程輸入",
+    "referees": "裁判"
   },
   "pools": {
     "generate": "生成分組",


### PR DESCRIPTION
## Problème

`RefereeManager.tsx` existait (476 lignes) avec toute la logique UI arbitres, mais n'était jamais importé ni affiché. Activer « Gestion des arbitres » dans les propriétés de la compétition ne produisait aucun effet visible.

## Changements

- `CompetitionView.tsx` : import de `RefereeManagerComponent`, état `referees`, chargement IPC au montage, onglet conditionnel + panel conditionnel
- `useCompetitionSession.ts` : ajout de `'referees'` au type `Phase` et aux mappings numérique
- Toutes les locales (fr/en/de/es/br/ca/zh-HK) : clé `phases.referees`

## Comportement

1. Ouvrir **Propriétés** de la compétition → cocher **Gestion des arbitres**
2. Un onglet **Arbitres** apparaît dans la barre de navigation des phases
3. L'onglet affiche `RefereeManagerComponent` avec les tabs Assignations / Historique

https://claude.ai/code/session_018y89Q9z2c4uPFNmUw2y9o6

---
_Generated by [Claude Code](https://claude.ai/code/session_018y89Q9z2c4uPFNmUw2y9o6)_