### PR TITLE
Chrono configurable par compétition + fix démarrage match tablette

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -36,6 +36,8 @@ export class RemoteScoreServer {
   private arenas: Map<string, Arena> = new Map();
   private arenaCount: number = 4; // Nombre d'arènes par défaut
   private sessionWeapon: string | null = null; // Type d'arme de la compétition (L = Laser)
+  private sessionPoolTimerSeconds: number = 180; // Durée chrono poules
+  private sessionTableTimerSeconds: number = 180; // Durée chrono tableau
   private sessionMatches: any[] = []; // Matches passés depuis le renderer
   private arenaNextMatchIndex: Map<string, number> = new Map(); // Index du prochain match par arène
   private arenaMatchQueue: Map<string, ArenaMatch[]> = new Map(); // File d'attente DE par arène
@@ -1580,6 +1582,7 @@ export class RemoteScoreServer {
           }
 
           // Sinon : état courant complet
+          const isPoolMatch = !!(arena.currentMatch?.poolId);
           socket.emit(`arena:${data.arenaId}:update`, {
             arenaId: data.arenaId,
             match: arena.currentMatch,
@@ -1595,6 +1598,7 @@ export class RemoteScoreServer {
             fencerB: arena.currentMatch?.fencerB,
             refereeFeatureEnabled: this.sessionRefereeFeatureEnabled,
             referees: this.session?.referees ?? [],
+            timerDuration: isPoolMatch ? this.sessionPoolTimerSeconds : this.sessionTableTimerSeconds,
             ...(arena.status === 'finished' && {
               nextMatch: this.peekNextMatch(data.arenaId),
             }),
@@ -2805,6 +2809,7 @@ export class RemoteScoreServer {
   private broadcastArenaUpdate(arenaId: string, update: ArenaUpdate): void {
     const arena = this.getArena(arenaId);
     const override = this.arenaThemeOverrides.get(arenaId);
+    const isPoolMatch = !!(arena?.currentMatch?.poolId);
     const updateWithPhotos: ArenaUpdate = {
       ...update,
       swapped: arena?.swapped ?? false,
@@ -2814,6 +2819,7 @@ export class RemoteScoreServer {
       customTheme: override?.customTheme,
       refereeFeatureEnabled: this.sessionRefereeFeatureEnabled,
       referees: this.session?.referees ?? [],
+      timerDuration: isPoolMatch ? this.sessionPoolTimerSeconds : this.sessionTableTimerSeconds,
     };
 
     // Stocker dans le buffer de replay (TTL + max size)
@@ -2979,6 +2985,8 @@ export class RemoteScoreServer {
 
     // Stocker le type d'arme pour l'arrêt automatique à 15 points en Laser Sabre
     this.sessionWeapon = competition.weapon || null;
+    this.sessionPoolTimerSeconds = competition.settings?.defaultPoolTimerSeconds ?? 180;
+    this.sessionTableTimerSeconds = competition.settings?.defaultTableTimerSeconds ?? 180;
     console.log(`[RemoteScoreServer] Type d'arme de la compétition: ${this.sessionWeapon}`);
 
     // Auto-detect number of strips from pool count if not specified or too small.

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1478,6 +1478,7 @@
           this.faultHistoryA = { 1: 0, 2: 0, 3: 0 };
           this.faultHistoryB = { 1: 0, 2: 0, 3: 0 };
           this.matchStatus = 'not_started';
+          this.defaultTimerSeconds = 180; // durée par défaut, mise à jour depuis les settings
           this.timerSeconds = 180; // 3 minutes
           this.timerInterval = null;
           this.timerRunning = false;
@@ -1814,13 +1815,14 @@
         setupTimerInteractions() {
           const timerDisplay = document.getElementById('timer-display');
 
-          // Click simple : play/pause
+          // Click simple : démarre le match si pas encore commencé, sinon play/pause
           timerDisplay.addEventListener('click', e => {
             if (this.longPressTimer) {
               clearTimeout(this.longPressTimer);
               this.longPressTimer = null;
+              return;
             }
-            this.toggleTimer();
+            this.handleStartPauseClick();
           });
 
           // Appui long : reset
@@ -1889,7 +1891,7 @@
           this.touchesB = [];
           this.faultHistoryA = { 1: 0, 2: 0, 3: 0 };
           this.faultHistoryB = { 1: 0, 2: 0, 3: 0 };
-          this.timerSeconds = 180;
+          this.timerSeconds = this.defaultTimerSeconds;
           this.isSuddenDeath = false;
           this.waitingOvertimeStart = false;
           this.overtimeType = null;
@@ -2466,7 +2468,7 @@
           this.isSuddenDeath = false;
           this.waitingOvertimeStart = false;
           this.overtimeType = null;
-          this.timerSeconds = 180;
+          this.timerSeconds = this.defaultTimerSeconds;
           this.updateTimerDisplay();
           this.broadcastTimerUpdate();
           this.updateSuddenDeathUI();
@@ -2594,7 +2596,7 @@
               this.faultHistoryB = { 1: 0, 2: 0, 3: 0 };
               this.coinFlipWinner = null;
               this.matchStatus = 'not_started';
-              this.timerSeconds = 180;
+              this.timerSeconds = this.defaultTimerSeconds;
               this.updateTimerDisplay();
               document.getElementById('active-match').classList.remove('visible');
               this.showNextMatchesScreen();
@@ -2617,7 +2619,7 @@
           timerEl.className = 'timer-display';
           if (this.timerRunning) {
             timerEl.classList.add('running');
-          } else if (this.timerSeconds < 180) {
+          } else if (this.timerSeconds < this.defaultTimerSeconds) {
             timerEl.classList.add('paused');
           }
 
@@ -2771,7 +2773,7 @@
               this.faultHistoryA = { 1: 0, 2: 0, 3: 0 };
               this.faultHistoryB = { 1: 0, 2: 0, 3: 0 };
               this.matchStatus = 'not_started';
-              this.timerSeconds = 180;
+              this.timerSeconds = this.defaultTimerSeconds;
               this.isSuddenDeath = false;
               this.waitingOvertimeStart = false;
               this.overtimeType = null;
@@ -2853,6 +2855,10 @@
         }
 
         handleArenaUpdate(data) {
+          if (data.timerDuration !== undefined && data.timerDuration > 0) {
+            this.defaultTimerSeconds = data.timerDuration;
+          }
+
           if (data.cardAnnounce !== undefined) {
             this.cardAnnounceEnabled = data.cardAnnounce;
           }

--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -40,6 +40,13 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
     competition.settings?.thirdPlaceMatch ?? false
   );
 
+  const [poolTimerSeconds, setPoolTimerSeconds] = useState(
+    competition.settings?.defaultPoolTimerSeconds ?? 180
+  );
+  const [tableTimerSeconds, setTableTimerSeconds] = useState(
+    competition.settings?.defaultTableTimerSeconds ?? 180
+  );
+
   const [refereeFeatureEnabled, setRefereeFeatureEnabled] = useState(
     competition.settings?.refereeFeatureEnabled ?? false
   );
@@ -91,6 +98,8 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
       thirdPlaceMatch,
       defaultPoolMaxScore: poolMaxScore,
       defaultTableMaxScore: tableMaxScore,
+      defaultPoolTimerSeconds: poolTimerSeconds,
+      defaultTableTimerSeconds: tableTimerSeconds,
       manualRanking: competition.settings?.manualRanking ?? false,
       defaultRanking: competition.settings?.defaultRanking ?? 9999,
       randomScore: competition.settings?.randomScore ?? false,
@@ -338,6 +347,22 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 </small>
               </div>
 
+              <div className="form-group">
+                <label htmlFor="poolTimerSeconds">Chrono poules (secondes)</label>
+                <input
+                  type="number"
+                  id="poolTimerSeconds"
+                  className="form-input"
+                  value={poolTimerSeconds}
+                  onChange={e => setPoolTimerSeconds(Math.max(1, parseInt(e.target.value) || 180))}
+                  min="1"
+                  placeholder="180"
+                />
+                <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+                  {`${Math.floor(poolTimerSeconds / 60)}min ${poolTimerSeconds % 60}s par match de poule`}
+                </small>
+              </div>
+
               {hasDirectElimination && (
                 <>
                   <div className="form-group">
@@ -355,6 +380,22 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                       {tableMaxScore === 0
                         ? '0 = illimité (pas de limite)'
                         : `${tableMaxScore} touches pour gagner`}
+                    </small>
+                  </div>
+
+                  <div className="form-group">
+                    <label htmlFor="tableTimerSeconds">Chrono tableau (secondes)</label>
+                    <input
+                      type="number"
+                      id="tableTimerSeconds"
+                      className="form-input"
+                      value={tableTimerSeconds}
+                      onChange={e => setTableTimerSeconds(Math.max(1, parseInt(e.target.value) || 180))}
+                      min="1"
+                      placeholder="180"
+                    />
+                    <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+                      {`${Math.floor(tableTimerSeconds / 60)}min ${tableTimerSeconds % 60}s par match tableau`}
                     </small>
                   </div>
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -455,6 +455,8 @@ export interface QuestPhaseConfig {
 export interface CompetitionSettings {
   defaultPoolMaxScore: number; // Score max en poules (défaut: 5)
   defaultTableMaxScore: number; // Score max en tableau (défaut: 10 ou 15)
+  defaultPoolTimerSeconds: number; // Durée chrono poules en secondes (défaut: 180)
+  defaultTableTimerSeconds: number; // Durée chrono tableau en secondes (défaut: 180)
   poolRounds: number; // Nombre de tours de poules (défaut: 1)
   hasDirectElimination: boolean; // Phase d'élimination directe activée (défaut: true)
   thirdPlaceMatch: boolean; // Match pour la 3ème place activé (défaut: false)

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -162,6 +162,7 @@ export interface ArenaUpdate {
   swapped?: boolean;
   refereeFeatureEnabled?: boolean; // fonctionnalité arbitres activée
   referees?: RemoteReferee[]; // liste de tous les arbitres de la compétition
+  timerDuration?: number; // durée du chrono en secondes pour ce match
 }
 
 export interface RefereeControl {

--- a/src/shared/utils/tournamentTemplates.ts
+++ b/src/shared/utils/tournamentTemplates.ts
@@ -50,6 +50,8 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       defaultRanking: 0,
       randomScore: false,
       minTeamSize: 3,
+      defaultPoolTimerSeconds: 180,
+      defaultTableTimerSeconds: 180,
     },
     poolConfig: {
       minPoolSize: 5,
@@ -82,6 +84,8 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       defaultRanking: 0,
       randomScore: false,
       minTeamSize: 3,
+      defaultPoolTimerSeconds: 180,
+      defaultTableTimerSeconds: 180,
     },
     poolConfig: {
       minPoolSize: 5,
@@ -114,6 +118,8 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       defaultRanking: 0,
       randomScore: false,
       minTeamSize: 3,
+      defaultPoolTimerSeconds: 180,
+      defaultTableTimerSeconds: 180,
     },
     poolConfig: {
       minPoolSize: 4,
@@ -146,6 +152,8 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       defaultRanking: 0,
       randomScore: false,
       minTeamSize: 3,
+      defaultPoolTimerSeconds: 180,
+      defaultTableTimerSeconds: 180,
     },
     poolConfig: {
       minPoolSize: 5,
@@ -178,6 +186,8 @@ export const OFFICIAL_TEMPLATES: TournamentTemplate[] = [
       defaultRanking: 0,
       randomScore: false,
       minTeamSize: 3,
+      defaultPoolTimerSeconds: 180,
+      defaultTableTimerSeconds: 180,
     },
     poolConfig: {
       minPoolSize: 5,


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Ajout de deux champs `defaultPoolTimerSeconds` / `defaultTableTimerSeconds` dans `CompetitionSettings`
- Inputs de configuration chrono (en secondes) dans les propriétés de compétition, sous les scores max
- Transmission de la durée configurée à la tablette arbitre via `timerDuration` dans `ArenaUpdate`
- Correction : cliquer sur l'affichage du chrono tablette quand le match n'a pas démarré lance maintenant le match (identique au bouton "Démarrer")

## Plan de test

- [ ] Créer/modifier une compétition → vérifier que les champs chrono poules et tableau s'affichent et se sauvegardent
- [ ] Lancer une session distante → vérifier que la tablette reçoit la bonne durée au chargement d'un match
- [ ] Sur la tablette (match `not_started`) : cliquer sur le chrono → le match démarre avec notification "▶️ Match démarré !"
- [ ] Sur la tablette (match `in_progress`) : cliquer sur le chrono → pause/reprise comme avant
- [ ] Reset long-press du chrono toujours fonctionnel

https://claude.ai/code/session_017oaPLTPshhYHXTLV2qeU6a
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017oaPLTPshhYHXTLV2qeU6a)_