### PR TITLE
Annuler match terminé en poules pour arbitrage distant

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1537,6 +1537,17 @@ ipcMain.handle('remote:refreshDeMatches', async (_, competitionId: string, match
   }
 });
 
+ipcMain.handle('remote:resetPoolMatch', async (_, competitionId: string, matchId: string) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: true };
+    entry.server.resetPoolMatch(matchId);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+  }
+});
+
 ipcMain.handle('remote:stopSession', async (_event, competitionId: string) => {
   try {
     const entry = remoteServers.get(competitionId);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -481,6 +481,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:changePort', competitionId, newPort),
     acknowledgeDTCall: (competitionId: string, arenaId: string) =>
       ipcRenderer.invoke('remote:acknowledgeDTCall', competitionId, arenaId),
+    resetPoolMatch: (competitionId: string, matchId: string) =>
+      ipcRenderer.invoke('remote:resetPoolMatch', competitionId, matchId),
   },
 
   // Remote event listeners (for real-time updates)

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2149,6 +2149,11 @@ export class RemoteScoreServer {
   }
 
   // Méthode publique pour mettre à jour le nombre d'arènes
+  public resetPoolMatch(matchId: string): void {
+    this.sessionMatchScores.delete(matchId);
+    this.io.emit('match:reset', { matchId });
+  }
+
   public setLanguage(lang: string): void {
     this.currentLang = lang;
   }

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -129,6 +129,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     setOverallRanking,
     generatePools: generatePoolsHook,
     updateScore,
+    resetMatch,
     updateMatchFromRemote,
     computePoolRanking,
     computeOverallRanking,
@@ -1081,6 +1082,14 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                         onScoreUpdate={(matchIndex, scoreA, scoreB, winner, specialStatus) =>
                           updateScore(poolIndex, matchIndex, scoreA, scoreB, winner, specialStatus)
                         }
+                        onMatchReset={(matchIndex) => {
+                          const match = pool.matches[matchIndex];
+                          if (!match) return;
+                          resetMatch(poolIndex, matchIndex);
+                          if (competition?.id) {
+                            window.electronAPI.remote.resetPoolMatch(competition.id, match.id).catch(() => {});
+                          }
+                        }}
                         onFencerStatusChange={(fencerId, status) => {
                           if (
                             status === 'abandon' ||

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -28,6 +28,7 @@ interface PoolViewProps {
     winnerOverride?: 'A' | 'B',
     specialStatus?: 'abandon' | 'forfait' | 'exclusion'
   ) => void;
+  onMatchReset?: (matchIndex: number) => void;
   onFencerChangePool?: (fencer: Fencer) => void;
   onFencerStatusChange?: (fencerId: string, status: 'abandon' | 'forfait' | 'exclusion') => void;
 }
@@ -40,6 +41,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   weapon,
   competitionName,
   onScoreUpdate,
+  onMatchReset,
   onFencerChangePool,
   onFencerStatusChange,
 }) => {
@@ -843,6 +845,10 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
       toggleColumn={toggleColumn}
       onCellClick={handleCellClick}
       onFencerChangePool={onFencerChangePool}
+      onMatchReset={onMatchReset ? (rowFencer, colFencer) => {
+        const matchIndex = getMatchIndex(rowFencer, colFencer);
+        if (matchIndex !== -1) onMatchReset(matchIndex);
+      } : undefined}
     />
   );
 

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -10,6 +10,7 @@ interface PoolScoreMatrixProps {
   toggleColumn: (context: 'pool' | 'ranking', columnId: ColumnId) => void;
   onCellClick: (rowFencer: Fencer, colFencer: Fencer) => void;
   onFencerChangePool?: (fencer: Fencer) => void;
+  onMatchReset?: (rowFencer: Fencer, colFencer: Fencer) => void;
 }
 
 const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
@@ -19,6 +20,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
   toggleColumn,
   onCellClick,
   onFencerChangePool,
+  onMatchReset,
 }) => {
   const fencers = pool.fencers;
 
@@ -212,13 +214,44 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                   key={colIndex}
                   className={`pool-cell ${cellClass}`}
                   onClick={() => onCellClick(rowFencer, colFencer)}
-                  style={{ cursor: 'pointer' }}
+                  style={{ cursor: 'pointer', position: 'relative' }}
                 >
                   {score ? (
-                    <span>
-                      {score.isVictory ? 'V' : ''}
-                      {score.value}
-                    </span>
+                    <>
+                      <span>
+                        {score.isVictory ? 'V' : ''}
+                        {score.value}
+                      </span>
+                      {onMatchReset && (
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            onMatchReset(rowFencer, colFencer);
+                          }}
+                          title="Annuler ce résultat"
+                          className="pool-cell-reset-btn"
+                          style={{
+                            position: 'absolute',
+                            top: '1px',
+                            right: '1px',
+                            padding: '0 2px',
+                            fontSize: '0.55rem',
+                            lineHeight: 1,
+                            background: 'rgba(239,68,68,0.15)',
+                            border: 'none',
+                            borderRadius: '2px',
+                            cursor: 'pointer',
+                            opacity: 0,
+                            transition: 'opacity 0.15s',
+                            color: '#dc2626',
+                          }}
+                          onMouseEnter={e => (e.currentTarget.style.opacity = '1')}
+                          onMouseLeave={e => (e.currentTarget.style.opacity = '0')}
+                        >
+                          ↺
+                        </button>
+                      )}
+                    </>
                   ) : (
                     <span style={{ color: '#9CA3AF' }}>-</span>
                   )}

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -191,6 +191,35 @@ export const usePoolManagement = ({
     [computePoolRanking, computeOverallRankingAllRounds]
   );
 
+  // Annuler un match terminé pour le remettre à NOT_STARTED
+  const resetMatch = useCallback(
+    (poolIndex: number, matchIndex: number) => {
+      setPools(prevPools => {
+        const updatedPools = [...prevPools];
+        const pool = { ...updatedPools[poolIndex] };
+        const match = { ...pool.matches[matchIndex] };
+
+        match.scoreA = null;
+        match.scoreB = null;
+        match.status = MatchStatus.NOT_STARTED;
+        match.updatedAt = new Date();
+
+        pool.matches = [...pool.matches];
+        pool.matches[matchIndex] = match;
+        pool.updatedAt = new Date();
+        pool.ranking = computePoolRanking(pool);
+
+        updatedPools[poolIndex] = pool;
+
+        const newOverallRanking = computeOverallRankingAllRounds(updatedPools);
+        setOverallRanking(newOverallRanking);
+
+        return updatedPools;
+      });
+    },
+    [computePoolRanking, computeOverallRankingAllRounds]
+  );
+
   // Passer au tour de poules suivant
   const nextPoolRound = useCallback(
     (checkedInFencers: Fencer[]) => {
@@ -621,6 +650,7 @@ export const usePoolManagement = ({
     setOverallRanking,
     generatePools,
     updateScore,
+    resetMatch,
     updateMatchFromRemote,
     nextPoolRound,
     areAllPoolsComplete,

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -416,6 +416,10 @@ export interface RemoteServerAPI {
     competitionId: string,
     arenaId: string
   ) => Promise<{ success: boolean; error?: string }>;
+  resetPoolMatch: (
+    competitionId: string,
+    matchId: string
+  ) => Promise<{ success: boolean; error?: string }>;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Résumé

- Bouton ↺ (visible au survol) sur chaque cellule de score terminé dans la grille de poule
- Cliquer remet le match à `NOT_STARTED` : scores effacés, flags spéciaux réinitialisés, classement recalculé
- Persistance DB automatique via l'useEffect existant dans CompetitionView
- Notification au serveur distant : le match réapparaît dans la file d'arbitrage des tablettes

## Fichiers modifiés

- `src/renderer/components/pool/PoolScoreMatrix.tsx` — prop `onMatchReset` + bouton ↺ hover
- `src/renderer/components/PoolView.tsx` — prop `onMatchReset` filaire vers la matrice
- `src/renderer/hooks/usePoolManagement.ts` — fonction `resetMatch(poolIndex, matchIndex)`
- `src/renderer/components/CompetitionView.tsx` — câblage + appel IPC distant
- `src/main/remoteScoreServer.ts` — méthode `resetPoolMatch(matchId)` (supprime du cache + émet `match:reset`)
- `src/main/main.ts` — handler IPC `remote:resetPoolMatch`
- `src/main/preload.ts` + `src/shared/types/preload.ts` — exposition de l'API

## Plan de test

- [ ] Saisir un match en saisie rapide → cellule affiche le score
- [ ] Survoler la cellule → bouton ↺ apparaît
- [ ] Cliquer ↺ → score effacé, cellule redevient `-`
- [ ] Classement de la poule recalculé immédiatement
- [ ] Ouvrir tablette arbitre → match réapparaît dans la liste
- [ ] Saisir le score sur tablette → match repasse FINISHED, visible dans l'app

https://claude.ai/code/session_01TgMJHVsQPnSMDFWCMZvNxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgMJHVsQPnSMDFWCMZvNxg)_