### PR TITLE
fix: add missing 'referees' key to phaseMap

### DIFF
--- a/src/renderer/hooks/useCompetitionSession.ts
+++ b/src/renderer/hooks/useCompetitionSession.ts
@@ -171,7 +171,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
       const p = propsRef.current;
       const phaseMap: Record<Phase, number> = {
         checkin: 0, poolprep: 1, pools: 2, ranking: 3,
-        quest: 4, tableau: 5, results: 6, remote: 7, logs: 8,
+        quest: 4, tableau: 5, results: 6, remote: 7, logs: 8, referees: 9,
       };
       window.electronAPI.db.saveSessionStateSync(p.competitionId, {
         currentPhase: phaseMap[p.currentPhase],


### PR DESCRIPTION
## Summary\n- `phaseMap` in `useCompetitionSession.ts:172` was typed as `Record<Phase, number>` but missing the `referees` key, causing a CI type error\n- Added `referees: 9` to complete the mapping

---
_Generated by [Claude Code](https://claude.ai/code/session_018LS22J6pFvtjVJ6yzH6Kys)_