### PR TITLE
fix: type errors referees phase + CompetitionSettings timer fields

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -329,6 +329,8 @@ export class DatabaseManager {
       let settings: CompetitionSettings = {
         defaultPoolMaxScore: 5,
         defaultTableMaxScore: 21,
+        defaultPoolTimerSeconds: 180,
+        defaultTableTimerSeconds: 180,
         poolRounds: 1,
         hasDirectElimination: true,
         thirdPlaceMatch: true,

--- a/src/renderer/hooks/useMenuEvents.ts
+++ b/src/renderer/hooks/useMenuEvents.ts
@@ -9,7 +9,7 @@ import { PoolRanking } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { FinalResult } from '../components/TableauView';
 
-type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs';
+type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs' | 'referees';
 
 interface UseMenuEventsProps {
   currentPhase: Phase;

--- a/src/shared/services/tournamentFlow.test.ts
+++ b/src/shared/services/tournamentFlow.test.ts
@@ -73,6 +73,8 @@ const makeCompetition = (): Competition => ({
   settings: {
     defaultPoolMaxScore: 5,
     defaultTableMaxScore: 10,
+    defaultPoolTimerSeconds: 180,
+    defaultTableTimerSeconds: 180,
     poolRounds: 1,
     hasDirectElimination: true,
     thirdPlaceMatch: false,


### PR DESCRIPTION
## Summary\n- Ajout de `'referees'` dans le type `Phase` de `useMenuEvents.ts` et `useCompetitionSession.ts`\n- Ajout de `defaultPoolTimerSeconds` et `defaultTableTimerSeconds` dans les objets defaults de `database/index.ts` et `tournamentFlow.test.ts`\n- Correction du `phaseMap` manquant `referees: 9`

---
_Generated by [Claude Code](https://claude.ai/code/session_018LS22J6pFvtjVJ6yzH6Kys)_