### PR TITLE
Bouton ↺ dans la liste des matchs terminés (vue liste poule)

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -1291,6 +1291,28 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
                     {fencerBAbandoned && ' ✕'}
                     {match.scoreB?.isVictory && !isAbandonMatch ? ' ✓' : ''}
                   </span>
+                  {!isAbandonMatch && onMatchReset && (
+                    <button
+                      onClick={e => {
+                        e.stopPropagation();
+                        onMatchReset(index);
+                      }}
+                      title="Annuler ce résultat"
+                      style={{
+                        marginLeft: '0.5rem',
+                        padding: '0.25rem 0.5rem',
+                        fontSize: '0.75rem',
+                        background: 'rgba(239,68,68,0.1)',
+                        border: '1px solid rgba(239,68,68,0.3)',
+                        borderRadius: '4px',
+                        cursor: 'pointer',
+                        color: '#dc2626',
+                        flexShrink: 0,
+                      }}
+                    >
+                      ↺
+                    </button>
+                  )}
                 </div>
               );
             })}


### PR DESCRIPTION
## Résumé

Le bouton ↺ pour annuler un match terminé était présent uniquement dans la vue grille (matrice). Il est maintenant aussi visible directement dans la **vue liste** (section "Matches terminés"), bouton rouge permanent (pas besoin de survol).

## Test

- Aller en vue liste dans une poule
- Un match terminé → bouton ↺ visible à droite
- Cliquer → score effacé, match revient en file d'arbitrage distant

https://claude.ai/code/session_01TgMJHVsQPnSMDFWCMZvNxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgMJHVsQPnSMDFWCMZvNxg)_