### PR TITLE
fix: recover from renderer crash causing blank screen

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -509,6 +509,30 @@ function createWindow(): void {
     mainWindow = null;
   });
 
+  // Reload renderer when it crashes (blank screen symptom)
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    console.error('[Main] Renderer process gone:', details.reason, details.exitCode);
+    if (details.reason !== 'clean-exit') {
+      setTimeout(() => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          if (process.env.NODE_ENV === 'development') {
+            mainWindow.loadURL('http://localhost:8066');
+          } else {
+            mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
+          }
+        }
+      }, 500);
+    }
+  });
+
+  mainWindow.webContents.on('unresponsive', () => {
+    console.warn('[Main] Renderer became unresponsive');
+  });
+
+  mainWindow.webContents.on('responsive', () => {
+    console.log('[Main] Renderer became responsive again');
+  });
+
   // Create application menu using saved language preference
   mainWindow.webContents.once('did-finish-load', async () => {
     try {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -10,6 +10,16 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import './styles/main.css';
 /// <reference path="./types.d.ts" />
 
+// Log unhandled rejections so they appear in DevTools console and don't silently crash
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('[Renderer] Unhandled promise rejection:', event.reason);
+  event.preventDefault(); // Prevent crash in some Electron versions
+});
+
+window.addEventListener('error', (event) => {
+  console.error('[Renderer] Uncaught error:', event.error ?? event.message);
+});
+
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);


### PR DESCRIPTION
## Problème

Écran blanc après un moment sans action. Les outils de développement ne s'ouvrent pas non plus. Symptôme classique d'un crash du processus renderer Electron.

## Cause

Quand le renderer process crashe (OOM, exception non gérée, etc.), Electron affiche une fenêtre blanche sans récupération automatique. Les erreurs async dans des callbacks `setInterval` ou des promesses non gérées passaient silencieusement.

## Fixes

### `src/main/main.ts`
- Ajout d'un handler `render-process-gone` : recharge automatiquement le renderer en cas de crash (corrige le symptôme écran blanc)
- Ajout handlers `unresponsive` / `responsive` pour le logging

### `src/renderer/index.tsx`
- Handler global `unhandledrejection` : log les promesses rejetées non gérées et empêche le crash silencieux
- Handler global `error` : log les erreurs JS non attrapées

https://claude.ai/code/session_01Gsfwzo9e4sMdrKMYhifxqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gsfwzo9e4sMdrKMYhifxqv)_