### PR TITLE
Fix crash "Invalid match ID format" sur annulation de match

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -300,11 +300,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         const prevMatch = prev[pIdx]?.matches[mIdx];
         if (!prevMatch) return;
         if (match.status !== prevMatch.status || match.scoreA !== prevMatch.scoreA || match.scoreB !== prevMatch.scoreB) {
-          window.electronAPI!.db!.updateMatch(match.id, {
-            scoreA: match.scoreA ?? undefined,
-            scoreB: match.scoreB ?? undefined,
-            status: match.status,
-          }).catch((e: unknown) => logger.warn(LogCategory.DATABASE, 'updateMatch pool failed', e instanceof Error ? e : undefined));
+          try {
+            window.electronAPI!.db!.updateMatch(match.id, {
+              scoreA: match.scoreA ?? undefined,
+              scoreB: match.scoreB ?? undefined,
+              status: match.status,
+            }).catch((e: unknown) => logger.warn(LogCategory.DATABASE, 'updateMatch pool failed', e instanceof Error ? e : undefined));
+          } catch (e: unknown) {
+            logger.warn(LogCategory.DATABASE, 'updateMatch pool failed', e instanceof Error ? e : undefined);
+          }
         }
       });
     });


### PR DESCRIPTION
## Problème

Annuler un match crashait React avec `Error: Invalid match ID format`.

## Cause

Le `useEffect` de sync DB dans `CompetitionView` appelle `window.electronAPI.db.updateMatch(match.id, ...)`. La validation dans le preload (`validateUUID`) est **synchrone** — elle lève une exception avant même le `invoke`. Cette exception sortait du `useEffect` sans être catchée, crashant le composant.

## Fix

Wrapper l'appel `updateMatch` dans un `try/catch` pour que les erreurs de validation synchrones soient loguées proprement sans crasher React.

https://claude.ai/code/session_016Qw9BkYx5ZQmxeV4RWAm4a

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qw9BkYx5ZQmxeV4RWAm4a)_