### PR TITLE
Fix: match annulé → relance auto + visibilité remote arbitre

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1096,7 +1096,12 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                           }
                         }}
                         onMatchCancel={(matchIndex) => {
+                          const match = pool.matches[matchIndex];
+                          if (!match) return;
                           cancelMatch(poolIndex, matchIndex);
+                          if (competition?.id) {
+                            window.electronAPI.remote.resetPoolMatch(competition.id, match.id).catch(() => {});
+                          }
                         }}
                         onFencerStatusChange={(fencerId, status) => {
                           if (

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -199,7 +199,9 @@ export const usePoolManagement = ({
         const pool = { ...updatedPools[poolIndex] };
         const match = { ...pool.matches[matchIndex] };
 
-        match.status = MatchStatus.CANCELLED;
+        match.scoreA = null;
+        match.scoreB = null;
+        match.status = MatchStatus.NOT_STARTED;
         match.updatedAt = new Date();
 
         pool.matches = [...pool.matches];


### PR DESCRIPTION
## Bugs corrigés

- `cancelMatch` mettait `CANCELLED` sans reset des scores → match bloqué, jamais rejoué
- `onMatchCancel` n'appelait pas `resetPoolMatch` → serveur remote jamais notifié → match invisible chez l'arbitre

## Changements

**`usePoolManagement.ts`** — `cancelMatch` reset scores + passe `NOT_STARTED` (comportement identique à `resetMatch`)

**`CompetitionView.tsx`** — `onMatchCancel` appelle `window.electronAPI.remote.resetPoolMatch()` comme le fait déjà `onMatchReset`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tr9yQq93EUz1S7exHoLGPm)_