### PR TITLE
feat: signature numérique des combattants sur interface poule distante

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -2385,6 +2385,33 @@ export class DatabaseManager {
     this.run(`DELETE FROM arena_state WHERE competition_id=?`, [competitionId]);
     this.save();
   }
+
+  public savePoolSignature(poolId: string, fencerId: string, signatureData: string): void {
+    if (!this.db) throw new Error('Database not open');
+    const now = new Date().toISOString();
+    this.run(
+      `INSERT INTO pool_signatures (id, pool_id, fencer_id, signature_data, signed_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(pool_id, fencer_id) DO UPDATE SET
+         signature_data = excluded.signature_data,
+         signed_at = excluded.signed_at`,
+      [uuidv4(), poolId, fencerId, signatureData, now]
+    );
+    this.save();
+  }
+
+  public getPoolSignatures(poolId: string): { fencerId: string; signatureData: string }[] {
+    if (!this.db) throw new Error('Database not open');
+    const result = this.db.exec(
+      `SELECT fencer_id, signature_data FROM pool_signatures WHERE pool_id = ?`,
+      [poolId]
+    );
+    if (!result.length || !result[0].values.length) return [];
+    return result[0].values.map(([fencerId, signatureData]) => ({
+      fencerId: fencerId as string,
+      signatureData: signatureData as string,
+    }));
+  }
 }
 
 export const db = new DatabaseManager();

--- a/src/database/migrations/migrations.ts
+++ b/src/database/migrations/migrations.ts
@@ -260,4 +260,22 @@ export const ALL_MIGRATIONS: Migration[] = [
       db.run(`CREATE INDEX IF NOT EXISTS idx_audit_pool ON score_audit_log(pool_id)`);
     },
   },
+
+  {
+    version: 7,
+    description: 'Table pool_signatures pour signatures numériques des combattants',
+    up(db) {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS pool_signatures (
+          id TEXT PRIMARY KEY,
+          pool_id TEXT NOT NULL,
+          fencer_id TEXT NOT NULL,
+          signature_data TEXT NOT NULL,
+          signed_at TEXT NOT NULL,
+          UNIQUE(pool_id, fencer_id)
+        )
+      `);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_pool_sigs_pool ON pool_signatures(pool_id)`);
+    },
+  },
 ];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1039,6 +1039,9 @@ ipcMain.handle('db:getPoolFencers', async (_, poolId) => {
 ipcMain.handle('db:getPoolsByPhase', async (_, phaseId) => {
   return db.getPoolsByPhase(phaseId);
 });
+ipcMain.handle('db:getPoolSignatures', async (_, poolId: string) => {
+  return db.getPoolSignatures(poolId);
+});
 
 // Phase handlers
 ipcMain.handle('db:createPhase', async (_, competitionId, type, order, name) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -183,6 +183,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return ipcRenderer.invoke('db:updatePool', pool);
     },
     getPoolsByPhase: (phaseId: string) => ipcRenderer.invoke('db:getPoolsByPhase', phaseId),
+    getPoolSignatures: (poolId: string) => ipcRenderer.invoke('db:getPoolSignatures', poolId),
 
     // Phases
     createPhase: (competitionId: string, type: string, order: number, name: string) =>

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -76,6 +76,9 @@ export class RemoteScoreServer {
   // Rate limiting pour les soumissions de score : { ip → { count, resetAt } }
   private scoreRateLimiter: Map<string, { count: number; resetAt: number }> = new Map();
   private readonly SCORE_RATE_LIMIT = 30; // soumissions par minute par IP
+  // Signatures numériques par poule : poolId → (fencerId → base64PNG)
+  private poolSignaturesCache: Map<string, Map<string, string>> = new Map();
+
   // Buffer d'événements par arène pour la reconnexion WebSocket (replay)
   private arenaEventBuffer: Map<string, Array<{ event: ArenaUpdate; timestamp: number }>> =
     new Map();
@@ -787,7 +790,17 @@ export class RemoteScoreServer {
           return allPools.find(p => p.id === poolId)?.name ?? 'Poule';
         })();
 
-        res.json({ poolId, poolName, arenaId, fencers, matches, isComplete });
+        const cachedSigs = this.poolSignaturesCache.get(poolId);
+        const signatures: Record<string, string> = cachedSigs
+          ? Object.fromEntries(cachedSigs)
+          : Object.fromEntries(
+              this.db.getPoolSignatures(poolId).map(s => [s.fencerId, s.signatureData])
+            );
+        if (!cachedSigs && Object.keys(signatures).length > 0) {
+          this.poolSignaturesCache.set(poolId, new Map(Object.entries(signatures)));
+        }
+
+        res.json({ poolId, poolName, arenaId, fencers, matches, isComplete, signatures });
       } catch (err) {
         console.error('[RemoteScoreServer] Erreur pool-data:', err);
         res.status(500).json({ error: 'Erreur interne' });
@@ -920,11 +933,13 @@ export class RemoteScoreServer {
           return this.db.getMatchesByPool(poolId);
         })();
         const isComplete = matches.every((m: any) => m.status === MatchStatus.FINISHED);
+        const sigMap = this.poolSignaturesCache.get(poolId);
+        const signatures: Record<string, string> = sigMap ? Object.fromEntries(sigMap) : {};
         for (const [aId, arena] of this.arenas) {
           if (arena.currentMatch?.poolId === poolId) {
             this.io
               .to(`pool:${aId}`)
-              .emit(`pool:${aId}:update`, { poolId, fencers, matches, isComplete });
+              .emit(`pool:${aId}:update`, { poolId, fencers, matches, isComplete, signatures });
             break;
           }
         }
@@ -946,6 +961,75 @@ export class RemoteScoreServer {
       } catch (err) {
         console.error('[RemoteScoreServer] Erreur score poule:', err);
         res.status(500).json({ error: 'Erreur enregistrement score' });
+      }
+    });
+
+    // API: signature numérique d'un combattant pour une poule
+    this.app.post('/api/pools/:poolId/fencers/:fencerId/signature', (req, res) => {
+      if (!this.hasAnyValidToken(req.headers.cookie)) {
+        return res.status(401).json({ error: 'Non authentifié' });
+      }
+      const { poolId, fencerId } = req.params;
+      const { signatureData } = req.body as { signatureData: string };
+
+      if (!signatureData || !signatureData.startsWith('data:image/png;base64,')) {
+        return res.status(400).json({ error: 'Données de signature invalides' });
+      }
+      if (signatureData.length > 200_000) {
+        return res.status(400).json({ error: 'Signature trop volumineuse (max 150 Ko)' });
+      }
+
+      // Vérifier que le combattant a terminé tous ses matchs
+      const allMatches = (() => {
+        const inMemory = this.sessionMatches
+          .filter(m => (m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`) === poolId);
+        if (inMemory.length > 0) {
+          return inMemory.map(m => {
+            const upd = this.sessionMatchScores.get(m.id);
+            return upd ? { ...m, ...upd } : m;
+          });
+        }
+        return this.db.getMatchesByPool(poolId);
+      })();
+
+      const fencerMatches = allMatches.filter((m: any) =>
+        m.fencerA?.id === fencerId || m.fencerAId === fencerId ||
+        m.fencerB?.id === fencerId || m.fencerBId === fencerId
+      );
+
+      if (fencerMatches.length === 0) {
+        return res.status(404).json({ error: 'Combattant introuvable dans cette poule' });
+      }
+      const allDone = fencerMatches.every((m: any) => m.status === MatchStatus.FINISHED);
+      if (!allDone) {
+        return res.status(403).json({ error: 'Matchs non terminés pour ce combattant' });
+      }
+
+      try {
+        this.db.savePoolSignature(poolId, fencerId, signatureData);
+
+        if (!this.poolSignaturesCache.has(poolId)) {
+          this.poolSignaturesCache.set(poolId, new Map());
+        }
+        this.poolSignaturesCache.get(poolId)!.set(fencerId, signatureData);
+
+        // Broadcaster la mise à jour avec signatures
+        const fencers = this.poolFencersCache.get(poolId) ?? this.db.getPoolFencers(poolId);
+        const signatures = Object.fromEntries(this.poolSignaturesCache.get(poolId)!);
+        const isComplete = allMatches.every((m: any) => m.status === MatchStatus.FINISHED);
+        for (const [aId, arena] of this.arenas) {
+          if (arena.currentMatch?.poolId === poolId) {
+            this.io
+              .to(`pool:${aId}`)
+              .emit(`pool:${aId}:update`, { poolId, fencers, matches: allMatches, isComplete, signatures });
+            break;
+          }
+        }
+
+        res.json({ success: true });
+      } catch (err) {
+        console.error('[RemoteScoreServer] Erreur signature:', err);
+        res.status(500).json({ error: 'Erreur enregistrement signature' });
       }
     });
 

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -530,6 +530,99 @@
 
       .fin-overlay .fin-icon { font-size: 4rem; }
 
+      /* ── Bouton signature ── */
+      .sig-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 26px;
+        height: 26px;
+        border-radius: 50%;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        background: rgba(99, 102, 241, 0.2);
+        color: #a5b4fc;
+        font-size: 0.85rem;
+        cursor: pointer;
+        margin-left: 0.4rem;
+        flex-shrink: 0;
+        transition: background 0.2s, color 0.2s;
+        vertical-align: middle;
+      }
+      .sig-btn:hover:not(:disabled) {
+        background: rgba(99, 102, 241, 0.45);
+        color: #fff;
+      }
+      .sig-btn:disabled {
+        opacity: 0.3;
+        cursor: default;
+      }
+      .sig-btn.signed {
+        background: rgba(34, 197, 94, 0.2);
+        border-color: rgba(34, 197, 94, 0.4);
+        color: #86efac;
+      }
+      .sig-btn.signed:hover {
+        background: rgba(34, 197, 94, 0.4);
+        color: #fff;
+      }
+
+      /* ── Modal signature ── */
+      .sig-modal-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.8);
+        z-index: 150;
+        align-items: center;
+        justify-content: center;
+      }
+      .sig-modal-overlay.visible { display: flex; }
+      .sig-modal {
+        background: #1e293b;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        width: 400px;
+        max-width: 96vw;
+        box-shadow: 0 25px 50px rgba(0, 0, 0, 0.6);
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+      }
+      .sig-modal h2 {
+        font-size: 0.95rem;
+        color: #94a3b8;
+        text-align: center;
+        font-weight: 500;
+        margin: 0;
+      }
+      .sig-modal h2 strong {
+        color: #e2e8f0;
+        display: block;
+        font-size: 1.05rem;
+        margin-top: 0.15rem;
+      }
+      .sig-instructions {
+        font-size: 0.8rem;
+        color: #64748b;
+        text-align: center;
+        margin: 0;
+      }
+      #sig-canvas {
+        background: #fff;
+        border-radius: 0.5rem;
+        cursor: crosshair;
+        touch-action: none;
+        display: block;
+        width: 100%;
+        height: 180px;
+      }
+      .sig-modal-actions {
+        display: flex;
+        gap: 0.6rem;
+        justify-content: center;
+      }
+
       /* ── Responsive ── */
       @media (max-width: 480px) {
         .pool-container { padding: 0.75rem; }
@@ -589,6 +682,20 @@
       <h1 data-i18n="pool.finished">POULE TERMINÉE</h1>
     </div>
 
+    <!-- Modal signature -->
+    <div class="sig-modal-overlay" id="sig-modal-overlay">
+      <div class="sig-modal">
+        <h2>Signature<strong id="sig-modal-name"></strong></h2>
+        <p class="sig-instructions">Signez dans le cadre ci-dessous</p>
+        <canvas id="sig-canvas"></canvas>
+        <div class="sig-modal-actions">
+          <button class="btn btn-secondary" id="sig-btn-clear">Effacer</button>
+          <button class="btn btn-secondary" id="sig-btn-cancel">Annuler</button>
+          <button class="btn btn-primary" id="sig-btn-submit">Valider</button>
+        </div>
+      </div>
+    </div>
+
     <script>
       window.initRemoteI18n().catch(() => {});
 
@@ -601,6 +708,8 @@
       let poolData = null;
       let pendingMatch = null;
       let currentTab = 'tableau';
+      let signaturesData = {};   // { fencerId: dataURL }
+      let signingFencer = null;
 
       // ── Onglets ──
       function switchTab(tab) {
@@ -627,6 +736,7 @@
 
       socket.on(`pool:${arenaId}:update`, data => {
         poolData = data;
+        if (data.signatures) signaturesData = data.signatures;
         renderAll(data);
       });
 
@@ -640,6 +750,7 @@
             return;
           }
           poolData = await res.json();
+          if (poolData.signatures) signaturesData = poolData.signatures;
           renderAll(poolData);
         } catch (e) {
           showStatusMessage(window.T('pool.error_connection'));
@@ -720,6 +831,27 @@
           th.appendChild(rank);
           th.appendChild(lastName);
           th.appendChild(firstName);
+
+          // Bouton signature
+          const sigBtn = document.createElement('button');
+          sigBtn.className = 'sig-btn';
+          const isDone = fencerFinishedAll(rowFencer, matches);
+          const isSigned = !!signaturesData[rowFencer.id];
+          if (!isDone) {
+            sigBtn.disabled = true;
+            sigBtn.title = 'Matchs non terminés';
+            sigBtn.textContent = '✍';
+          } else {
+            sigBtn.textContent = isSigned ? '✓' : '✍';
+            sigBtn.title = isSigned ? 'Re-signer' : 'Signer';
+            if (isSigned) sigBtn.classList.add('signed');
+            sigBtn.addEventListener('click', e => {
+              e.stopPropagation();
+              openSignatureModal(rowFencer);
+            });
+          }
+          th.appendChild(sigBtn);
+
           tr.appendChild(th);
 
           fencers.forEach((colFencer, colIdx) => {
@@ -913,6 +1045,110 @@
         const last = (f.lastName || f.last_name || '').toUpperCase();
         const first = f.firstName || f.first_name || '';
         return `${last} ${first}`.trim();
+      }
+
+      // ── Helpers signature ──
+      function fencerFinishedAll(fencer, matches) {
+        const mine = matches.filter(m =>
+          (m.fencerA?.id === fencer.id || m.fencerAId === fencer.id) ||
+          (m.fencerB?.id === fencer.id || m.fencerBId === fencer.id)
+        );
+        return mine.length > 0 && mine.every(m => m.status === 'finished');
+      }
+
+      // ── Signature canvas ──
+      const sigOverlay = document.getElementById('sig-modal-overlay');
+      const sigCanvas = document.getElementById('sig-canvas');
+      const sigCtx = sigCanvas.getContext('2d');
+      let isDrawing = false;
+
+      function resizeCanvas() {
+        const rect = sigCanvas.getBoundingClientRect();
+        sigCanvas.width = rect.width * window.devicePixelRatio;
+        sigCanvas.height = rect.height * window.devicePixelRatio;
+        sigCtx.scale(window.devicePixelRatio, window.devicePixelRatio);
+        sigCtx.strokeStyle = '#1e293b';
+        sigCtx.lineWidth = 2.5;
+        sigCtx.lineCap = 'round';
+        sigCtx.lineJoin = 'round';
+      }
+
+      function clearCanvas() {
+        const rect = sigCanvas.getBoundingClientRect();
+        sigCtx.clearRect(0, 0, rect.width, rect.height);
+      }
+
+      function getPos(e) {
+        const rect = sigCanvas.getBoundingClientRect();
+        return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      }
+
+      sigCanvas.addEventListener('pointerdown', e => {
+        isDrawing = true;
+        const pos = getPos(e);
+        sigCtx.beginPath();
+        sigCtx.moveTo(pos.x, pos.y);
+        sigCanvas.setPointerCapture(e.pointerId);
+      });
+
+      sigCanvas.addEventListener('pointermove', e => {
+        if (!isDrawing) return;
+        const pos = getPos(e);
+        sigCtx.lineTo(pos.x, pos.y);
+        sigCtx.stroke();
+      });
+
+      sigCanvas.addEventListener('pointerup', () => { isDrawing = false; });
+      sigCanvas.addEventListener('pointercancel', () => { isDrawing = false; });
+
+      function openSignatureModal(fencer) {
+        signingFencer = fencer;
+        document.getElementById('sig-modal-name').textContent = fullName(fencer);
+        sigOverlay.classList.add('visible');
+        resizeCanvas();
+        clearCanvas();
+        sigCtx.strokeStyle = '#1e293b';
+        sigCtx.lineWidth = 2.5;
+        sigCtx.lineCap = 'round';
+        sigCtx.lineJoin = 'round';
+      }
+
+      function closeSignatureModal() {
+        signingFencer = null;
+        sigOverlay.classList.remove('visible');
+      }
+
+      document.getElementById('sig-btn-clear').addEventListener('click', clearCanvas);
+      document.getElementById('sig-btn-cancel').addEventListener('click', closeSignatureModal);
+      document.getElementById('sig-btn-submit').addEventListener('click', submitSignature);
+
+      async function submitSignature() {
+        if (!signingFencer || !poolData) return;
+        const dataURL = sigCanvas.toDataURL('image/png');
+        const submitBtn = document.getElementById('sig-btn-submit');
+        submitBtn.disabled = true;
+        try {
+          const res = await fetch(
+            `/api/pools/${poolData.poolId}/fencers/${signingFencer.id}/signature`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ signatureData: dataURL }),
+            }
+          );
+          if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            alert(err.error || 'Erreur lors de la sauvegarde de la signature.');
+            return;
+          }
+          signaturesData[signingFencer.id] = dataURL;
+          closeSignatureModal();
+          if (poolData) renderAll(poolData);
+        } catch {
+          alert('Erreur réseau.');
+        } finally {
+          submitBtn.disabled = false;
+        }
       }
 
       // ── Modal ──

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -464,6 +464,8 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const handleExportPDF = async () => {
     try {
       const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+      const sigsArray = await window.electronAPI.db.getPoolSignatures(pool.id);
+      const signatures = Object.fromEntries(sigsArray.map(s => [s.fencerId, s.signatureData]));
       await exportPoolToPDF(
         pool,
         {
@@ -474,6 +476,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           logoBase64: logo,
           competitionName,
           visibleColumns: getVisibleColumns('pool'),
+          signatures,
         },
         poolTemplate
       );

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -483,6 +483,7 @@ export interface DatabaseAPI {
   getPoolFencers: (poolId: string) => Promise<Fencer[]>;
   getPoolsByPhase: (phaseId: string) => Promise<Pool[]>;
   updatePool: (pool: Pool) => Promise<void>;
+  getPoolSignatures: (poolId: string) => Promise<{ fencerId: string; signatureData: string }[]>;
 
   // Phases
   createPhase: (competitionId: string, type: string, order: number, name: string) => Promise<Phase>;

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -17,6 +17,7 @@ export interface PoolExportOptions {
   includePoolStats?: boolean;
   logoBase64?: string;
   visibleColumns?: string[];
+  signatures?: Record<string, string>; // fencerId → data URL PNG
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -292,13 +293,17 @@ export function generatePoolHTML(pool: Pool, options: PoolExportOptions, templat
       return `<td class="${s.isVictory ? 'cell-victory' : 'cell-defeat'}">${s.display}</td>`;
     }).join('');
     const statCells = activeCols.map(c => `<td class="${c.cls}">${c.render(data)}</td>`).join('');
+    const sig = options.signatures?.[fencer.id];
+    const sigCell = sig
+      ? `<td class="sig-cell"><img src="${sig}" style="max-height:12mm;max-width:30mm;display:block;margin:auto;" /></td>`
+      : `<td class="sig-cell"></td>`;
     return `
       <tr>
         <td class="num-cell">${row + 1}</td>
         <td class="name-cell">${fencer.lastName.toUpperCase()} ${fencer.firstName?.charAt(0) ?? ''}.</td>
         ${cells}
         ${statCells}
-        <td class="sig-cell"></td>
+        ${sigCell}
       </tr>`;
   }).join('');
 
@@ -444,6 +449,9 @@ export function generatePoolHTML(pool: Pool, options: PoolExportOptions, templat
     .score-grid .sig-cell {
       min-width: 32mm;
       border-left: 2px solid var(--border) !important;
+      text-align: center;
+      vertical-align: middle;
+      padding: 1mm !important;
     }
     .score-grid thead .sig-header {
       min-width: 32mm;


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Bouton ✍ par combattant dans la grille poule (`pool.html`) — déverrouillé uniquement quand tous ses matchs sont terminés
- Canvas de signature tactile/souris avec modal Effacer / Annuler / Valider
- Signatures persistées en DB (`pool_signatures`) et en cache mémoire serveur
- Signatures incluses dans l'export PDF de la poule (colonne "Signature" déjà présente dans le template)

## Plan de test

- [ ] Ouvrir `/areneX/poule` sur une tablette avec une poule active
- [ ] Vérifier que le bouton ✍ est grisé tant que le combattant a des matchs en cours
- [ ] Terminer tous les matchs d'un combattant → bouton ✍ s'active
- [ ] Cliquer ✍ → modal canvas s'ouvre, dessiner une signature → Valider → bouton passe en ✓ vert
- [ ] Re-signer : cliquer ✓ → le modal se rouvre, nouvelle signature remplace l'ancienne
- [ ] Depuis l'appli Electron, exporter la poule en PDF → colonne Signature contient les images
- [ ] Vérifier en base : `SELECT * FROM pool_signatures;`

https://claude.ai/code/session_01BJ5DmVuyf3hqwrte7fjFVb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJ5DmVuyf3hqwrte7fjFVb)_