### PR TITLE
fix: type annotation destructuring getPoolSignatures (strict mode)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -2407,9 +2407,9 @@ export class DatabaseManager {
       [poolId]
     );
     if (!result.length || !result[0].values.length) return [];
-    return result[0].values.map(([fencerId, signatureData]) => ({
-      fencerId: fencerId as string,
-      signatureData: signatureData as string,
+    return result[0].values.map((row: any[]) => ({
+      fencerId: row[0] as string,
+      signatureData: row[1] as string,
     }));
   }
 }


### PR DESCRIPTION
Corrige l'erreur TypeScript CI :

```
src/database/index.ts(2410,35): error TS7031: Binding element 'fencerId' implicitly has an 'any' type.
src/database/index.ts(2410,45): error TS7031: Binding element 'signatureData' implicitly has an 'any' type.
```

La destructuration `([fencerId, signatureData])` dans `getPoolSignatures` n'était pas typée — remplacée par `(row: any[])` avec accès indexé.

https://claude.ai/code/session_01BJ5DmVuyf3hqwrte7fjFVb

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJ5DmVuyf3hqwrte7fjFVb)_