### PR TITLE
Indicateur de signatures par poule

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -515,6 +515,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('score:ip-conflict', handler);
   },
 
+  onPoolSignatureUpdated: (callback: (data: { poolId: string; signedFencerIds: string[]; totalFencers: number }) => void) => {
+    const handler = (_: any, data: any) => callback(data);
+    ipcRenderer.on('pool:signature:updated', handler);
+    return () => ipcRenderer.removeListener('pool:signature:updated', handler);
+  },
+
   getLogo: () => ipcRenderer.invoke('app:getLogo'),
   onLogoLoaded: (callback: (logo: string | null) => void) => {
     const handler = (_: any, logo: string | null) => callback(logo);

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1026,6 +1026,17 @@ export class RemoteScoreServer {
           }
         }
 
+        const mainWin = (global as any).mainWindow;
+        if (mainWin) {
+          const sigs = this.poolSignaturesCache.get(poolId)!;
+          const poolFencers = this.poolFencersCache.get(poolId) ?? this.db.getPoolFencers(poolId);
+          mainWin.webContents.send('pool:signature:updated', {
+            poolId,
+            signedFencerIds: Array.from(sigs.keys()),
+            totalFencers: poolFencers.length,
+          });
+        }
+
         res.json({ success: true });
       } catch (err) {
         console.error('[RemoteScoreServer] Erreur signature:', err);

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -62,6 +62,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const [victoryB, setVictoryB] = useState(false);
   const [matchesUpdateTrigger, setMatchesUpdateTrigger] = useState(0);
   const [keyboardFocusField, setKeyboardFocusField] = useState<'A' | 'B'>('A');
+  const [signedFencerIds, setSignedFencerIds] = useState<string[]>([]);
 
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
 
@@ -92,6 +93,19 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [showColumnMenu]);
+
+  // Charger les signatures au montage et écouter les mises à jour en temps réel
+  useEffect(() => {
+    window.electronAPI.db.getPoolSignatures(pool.id).then(sigs => {
+      setSignedFencerIds(sigs.map(s => s.fencerId));
+    });
+    const unsub = window.electronAPI.onPoolSignatureUpdated(data => {
+      if (data.poolId === pool.id) {
+        setSignedFencerIds(data.signedFencerIds);
+      }
+    });
+    return unsub;
+  }, [pool.id]);
 
   // Raccourcis clavier
 
@@ -1419,6 +1433,31 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           <span className={`badge ${pool.isComplete ? 'badge-success' : 'badge-warning'}`}>
             {pool.isComplete ? 'Terminée' : `${finishedCount}/${totalMatches}`}
           </span>
+          {(() => {
+            const total = pool.fencers.length;
+            const signed = signedFencerIds.filter(id => pool.fencers.some(f => f.id === id)).length;
+            const allSigned = signed === total && total > 0;
+            const noneSigned = signed === 0;
+            return (
+              <span
+                title={allSigned ? 'Tous les combattants ont signé — PDF disponible' : `${signed}/${total} signature(s)`}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '0.25rem',
+                  padding: '0.2rem 0.5rem',
+                  borderRadius: '12px',
+                  fontSize: '0.75rem',
+                  fontWeight: 600,
+                  background: allSigned ? '#d1fae5' : noneSigned ? '#f3f4f6' : '#fef3c7',
+                  color: allSigned ? '#065f46' : noneSigned ? '#6b7280' : '#92400e',
+                  border: `1px solid ${allSigned ? '#6ee7b7' : noneSigned ? '#e5e7eb' : '#fcd34d'}`,
+                }}
+              >
+                ✍️ {signed}/{total}
+              </span>
+            );
+          })()}
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
           <button

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -709,6 +709,7 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   ) => () => void;
   onDTCallCancel: (callback: (data: { arenaId: string }) => void) => () => void;
   onScoreIpConflict: (callback: (data: ScoreIpConflict) => void) => () => void;
+  onPoolSignatureUpdated: (callback: (data: { poolId: string; signedFencerIds: string[]; totalFencers: number }) => void) => () => void;
   notifyLanguageChanged: (lang: string) => void;
   getLogo: () => Promise<string | null>;
   onLogoLoaded: (callback: (logo: string | null) => void) => () => void;


### PR DESCRIPTION
## Résumé

- Badge `✍️ X/N` dans l'en-tête de chaque poule indiquant le nombre de combattants ayant signé
- Gris (0 signé) → Jaune (partiel) → Vert (tous signés = PDF prêt)
- Mise à jour en temps réel via IPC `pool:signature:updated` déclenché par le serveur distant à chaque signature tablette

## Fichiers modifiés

- `src/main/remoteScoreServer.ts` — envoie l'événement IPC après chaque signature enregistrée
- `src/main/preload.ts` — expose `onPoolSignatureUpdated` au renderer
- `src/shared/types/preload.ts` — typage du listener
- `src/renderer/components/PoolView.tsx` — state + fetch initial + écoute IPC + badge header

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvbDAohqobW8Kr63xpSwS1)_