### PR TITLE
Fix pool scores not displayed on /poule after auto-fill

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -762,7 +762,7 @@ export class RemoteScoreServer {
       const arenaId = rawId.startsWith('arena') ? rawId : `arena${rawId}`;
       try {
         const arena = this.arenas.get(arenaId);
-        const poolId = arena?.currentMatch?.poolId;
+        const poolId = arena?.currentMatch?.poolId ?? arena?.activePoolId;
         if (!poolId) {
           return res.status(404).json({ error: 'Aucune poule assignée à cette arène' });
         }
@@ -936,11 +936,10 @@ export class RemoteScoreServer {
         const sigMap = this.poolSignaturesCache.get(poolId);
         const signatures: Record<string, string> = sigMap ? Object.fromEntries(sigMap) : {};
         for (const [aId, arena] of this.arenas) {
-          if (arena.currentMatch?.poolId === poolId) {
+          if ((arena.currentMatch?.poolId ?? arena.activePoolId) === poolId) {
             this.io
               .to(`pool:${aId}`)
               .emit(`pool:${aId}:update`, { poolId, fencers, matches, isComplete, signatures });
-            break;
           }
         }
 
@@ -1018,11 +1017,10 @@ export class RemoteScoreServer {
         const signatures = Object.fromEntries(this.poolSignaturesCache.get(poolId)!);
         const isComplete = allMatches.every((m: any) => m.status === MatchStatus.FINISHED);
         for (const [aId, arena] of this.arenas) {
-          if (arena.currentMatch?.poolId === poolId) {
+          if ((arena.currentMatch?.poolId ?? arena.activePoolId) === poolId) {
             this.io
               .to(`pool:${aId}`)
               .emit(`pool:${aId}:update`, { poolId, fencers, matches: allMatches, isComplete, signatures });
-            break;
           }
         }
 
@@ -2301,6 +2299,7 @@ export class RemoteScoreServer {
 
     arena.currentMatch = match;
     arena.status = 'ready';
+    if (match.poolId) arena.activePoolId = match.poolId;
 
     this.updateArena(arenaId, {
       status: 'ready',
@@ -3552,29 +3551,28 @@ export class RemoteScoreServer {
     }
 
     for (const poolId of updatedPoolIds) {
+      const fencers = this.poolFencersCache.get(poolId) ?? this.db.getPoolFencers(poolId);
+      const inMemory = this.sessionMatches
+        .filter(
+          (m: any) =>
+            !m.isTableau &&
+            (m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`) === poolId
+        )
+        .sort((a: any, b: any) => (a.number || 0) - (b.number || 0));
+      const poolMatches =
+        inMemory.length > 0
+          ? inMemory.map((m: any) => {
+              const u = this.sessionMatchScores.get(m.id);
+              return u ? { ...m, ...u } : m;
+            })
+          : this.db.getMatchesByPool(poolId);
+      const isComplete =
+        poolMatches.length > 0 && poolMatches.every((m: any) => m.status === MatchStatus.FINISHED);
       for (const [aId, arena] of this.arenas) {
-        if (arena.currentMatch?.poolId !== poolId) continue;
-        const fencers = this.poolFencersCache.get(poolId) ?? this.db.getPoolFencers(poolId);
-        const inMemory = this.sessionMatches
-          .filter(
-            (m: any) =>
-              !m.isTableau &&
-              (m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`) === poolId
-          )
-          .sort((a: any, b: any) => (a.number || 0) - (b.number || 0));
-        const poolMatches =
-          inMemory.length > 0
-            ? inMemory.map((m: any) => {
-                const u = this.sessionMatchScores.get(m.id);
-                return u ? { ...m, ...u } : m;
-              })
-            : this.db.getMatchesByPool(poolId);
-        const isComplete =
-          poolMatches.length > 0 && poolMatches.every((m: any) => m.status === MatchStatus.FINISHED);
+        if ((arena.currentMatch?.poolId ?? arena.activePoolId) !== poolId) continue;
         this.io
           .to(`pool:${aId}`)
           .emit(`pool:${aId}:update`, { poolId, fencers, matches: poolMatches, isComplete });
-        break;
       }
     }
   }

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -97,6 +97,7 @@ export interface Arena {
   name: string;
   number: number;
   currentMatch: ArenaMatch | null;
+  activePoolId?: string; // dernière poule assignée (persiste après currentMatch=null)
   status: 'idle' | 'ready' | 'in_progress' | 'finished';
   startTime: Date | null;
   settings: ArenaSettings;


### PR DESCRIPTION
## Problème

Après remplissage automatique de la poule :
- `/arene2/poule` n'affichait plus les scores (grille vide / 404)
- `/arene3/arbitre` listait encore tous les matchs comme disponibles

## Cause racine

`Arena.currentMatch` devient `null` quand tous les matchs sont terminés. Deux chemins critiques échouaient silencieusement :

1. `GET /api/arenas/:arenaId/pool-data` → 404 car `arena.currentMatch?.poolId` est null
2. `syncPoolMatches` → aucun emit Socket.IO car la condition `arena.currentMatch?.poolId !== poolId` est toujours vraie

## Fix

- Ajout de `activePoolId?: string` dans l'interface `Arena` (persiste après `currentMatch = null`)
- Alimenté dans `assignMatchToArena()` quand un match de poule est assigné
- Utilisé en fallback dans `pool-data`, `syncPoolMatches`, et tous les broadcasts Socket.IO `pool:${aId}:update`
- Suppression du `break` qui empêchait d'émettre vers plusieurs arènes simultanément

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCzzDTipypqMUZm9au3nsS)_