### PR TITLE
fix(pool): bouton signature dans colonne dédiée à gauche du nom

### DIFF
--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -544,7 +544,6 @@
         color: #a5b4fc;
         font-size: 0.85rem;
         cursor: pointer;
-        margin-left: 0.4rem;
         flex-shrink: 0;
         transition: background 0.2s, color 0.2s;
         vertical-align: middle;
@@ -565,6 +564,21 @@
       .sig-btn.signed:hover {
         background: rgba(34, 197, 94, 0.4);
         color: #fff;
+      }
+
+      table.pool-grid .sig-header {
+        background: rgba(0, 0, 0, 0.25);
+        width: 36px;
+        min-width: 36px;
+        padding: 0;
+      }
+      table.pool-grid .sig-cell {
+        background: rgba(30, 60, 120, 0.3);
+        width: 36px;
+        min-width: 36px;
+        padding: 0;
+        text-align: center;
+        vertical-align: middle;
       }
 
       /* ── Modal signature ── */
@@ -801,6 +815,10 @@
         const thead = document.createElement('thead');
         const headerRow = document.createElement('tr');
 
+        const sigHeader = document.createElement('th');
+        sigHeader.className = 'sig-header';
+        headerRow.appendChild(sigHeader);
+
         const corner = document.createElement('th');
         corner.className = 'corner-cell';
         headerRow.appendChild(corner);
@@ -836,7 +854,9 @@
           th.appendChild(lastName);
           th.appendChild(firstName);
 
-          // Bouton signature
+          // Colonne signature dédiée (avant le nom)
+          const sigCell = document.createElement('td');
+          sigCell.className = 'sig-cell';
           const sigBtn = document.createElement('button');
           sigBtn.className = 'sig-btn';
           const isDone = fencerFinishedAll(rowFencer, matches);
@@ -854,8 +874,9 @@
               openSignatureModal(rowFencer);
             });
           }
-          th.appendChild(sigBtn);
+          sigCell.appendChild(sigBtn);
 
+          tr.appendChild(sigCell);
           tr.appendChild(th);
 
           fencers.forEach((colFencer, colIdx) => {


### PR DESCRIPTION
## Problème
Le bouton signature (✍/✓) était appendé à l'intérieur du `<th class="fencer-header">`. Pour les noms longs (ex : CAPTAIN FALCON Douglas), le bouton débordait hors du `th` et chevauchait la première cellule de score.

## Solution
- Nouvelle colonne `<td class="sig-cell">` (36px) dédiée au bouton, insérée **avant** la colonne nom
- `<th class="sig-header">` correspondant dans l'en-tête
- `margin-left` supprimé du `.sig-btn` (inutile dans sa propre cellule)

## Test
1. Ouvrir interface arbitre (port 8066)
2. Vérifier colonne sig visible à gauche du nom sur toutes les lignes
3. Vérifier aucun débordement sur noms longs (dernière ligne)
4. Cliquer ✍ → modal signature s'ouvre
5. Après signature → bouton passe ✓ vert

https://claude.ai/code/session_01BhNiwrSJvA8jkcLw5appXm

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhNiwrSJvA8jkcLw5appXm)_