### PR TITLE
fix: journal des scores vide + option d'activation dans les paramètres

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2477,8 +2477,8 @@ export class RemoteScoreServer {
           reason: 'remote_entry',
         });
       }
-    } catch {
-      /* non bloquant */
+    } catch (e) {
+      console.warn('[RemoteScoreServer] logScoreChange (updateArenaScore) failed:', e);
     }
 
     // Envoyer la mise à jour via WebSocket
@@ -2628,6 +2628,49 @@ export class RemoteScoreServer {
       fencerB: arena.currentMatch?.fencerB,
       nextMatch,
     });
+
+    // Persister le score final dans la DB et dans l'audit log
+    try {
+      const finalMatchId = finishedMatch.id;
+      const dbMatch = this.db.getMatch(finalMatchId);
+      if (dbMatch && !finishedMatch.isTableau) {
+        const winner =
+          finishedMatch.scoreA > finishedMatch.scoreB ? 'A' :
+          finishedMatch.scoreB > finishedMatch.scoreA ? 'B' : null;
+        const scoreAObj = {
+          value: finishedMatch.scoreA,
+          isVictory: winner === 'A',
+          isAbstention: false,
+          isExclusion: false,
+          isForfait: false,
+        };
+        const scoreBObj = {
+          value: finishedMatch.scoreB,
+          isVictory: winner === 'B',
+          isAbstention: false,
+          isExclusion: false,
+          isForfait: false,
+        };
+        this.db.updateMatch(finalMatchId, {
+          scoreA: scoreAObj,
+          scoreB: scoreBObj,
+          status: MatchStatus.FINISHED,
+        });
+        this.db.logScoreChange({
+          matchId: finalMatchId,
+          arenaId,
+          previousScoreA: dbMatch.scoreA ?? null,
+          previousScoreB: dbMatch.scoreB ?? null,
+          newScoreA: scoreAObj,
+          newScoreB: scoreBObj,
+          changedBy: 'referee',
+          reason: 'arena_finish',
+          poolId: finishedMatch.poolId,
+        });
+      }
+    } catch (e) {
+      console.warn('[RemoteScoreServer] logScoreChange (finishArenaMatch) failed:', e);
+    }
 
     // Émettre l'event pour le renderer (pour sauvegarder le score dans les pools)
     const mainWindow = (global as any).mainWindow;

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -60,6 +60,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const tableMaxScore = competition.settings?.defaultTableMaxScore ?? 0;
   const isLaserSabre = competition.weapon === Weapon.LASER;
 
+  const auditLogEnabled = localStorage.getItem('bellepoule-audit-log-enabled') === 'true';
+
   // États locaux
   const [currentPhase, setCurrentPhase] = useState<Phase>('checkin');
 
@@ -759,13 +761,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       disabled: false,
       title: undefined as string | undefined,
     },
-    {
+    ...(auditLogEnabled ? [{
       id: 'logs',
       label: t('phases.logs'),
       icon: '📜',
       disabled: false,
       title: undefined as string | undefined,
-    },
+    }] : []),
     ...(competition.settings?.refereeFeatureEnabled
       ? [
           {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -12,6 +12,7 @@ import { logger, LogCategory } from '@shared/services/logger';
 
 const LOGO_STORAGE_KEY = 'bellepoule-logo';
 const WEBHOOK_STORAGE_KEY = 'bellepoule-webhook-url';
+const AUDIT_LOG_KEY = 'bellepoule-audit-log-enabled';
 
 function isWebhookUrlSafe(rawUrl: string): boolean {
   try {
@@ -76,6 +77,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [logoError, setLogoError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [auditLogEnabled, setAuditLogEnabled] = useState<boolean>(
+    () => localStorage.getItem(AUDIT_LOG_KEY) === 'true'
+  );
 
   const [webhookUrl, setWebhookUrl] = useState<string>(
     () => localStorage.getItem(WEBHOOK_STORAGE_KEY) ?? ''
@@ -194,6 +199,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
     }
   };
 
+  const handleAuditLogChange = (enabled: boolean) => {
+    setAuditLogEnabled(enabled);
+    localStorage.setItem(AUDIT_LOG_KEY, String(enabled));
+  };
+
   const handleSave = () => {
     if (settings.language !== language) {
       changeLanguage(settings.language);
@@ -304,6 +314,22 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
             >
               {t('pdfTemplate.openButton')}
             </button>
+          </div>
+
+          {/* Journal des scores */}
+          <div className="form-group" style={{ marginTop: '1rem', borderTop: '1px solid var(--border, #e5e7eb)', paddingTop: '1rem' }}>
+            <label style={{ fontWeight: 600 }}>Journal des scores</label>
+            <p style={{ fontSize: '0.8rem', color: 'var(--text-muted, #6b7280)', marginBottom: '0.5rem' }}>
+              Active l'onglet "Historique des scores" dans la vue compétition.
+            </p>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={auditLogEnabled}
+                onChange={e => handleAuditLogChange(e.target.checked)}
+              />
+              <span style={{ fontSize: '0.875rem' }}>Activer le journal d'audit des scores</span>
+            </label>
           </div>
 
           {/* Notifications webhook */}


### PR DESCRIPTION
## Résumé

### Bug fix — journal vide après saisie distante sur arène
`finishArenaMatch` ne loggait jamais directement dans `score_audit_log`. Il envoyait un event `match:finished` au renderer, qui devait en retour appeler `db:updateMatch`. Si ce chemin ratait (match non trouvé dans le pool state React, timing...) → 0 entrées.

**Fix :** `finishArenaMatch` persiste maintenant le score final et écrit dans `score_audit_log` directement, sans dépendre du renderer. Les erreurs de log ne sont plus avalées silencieusement (`console.warn` dans les devtools Electron).

### Feature — journal optionnel dans les paramètres
- Nouveau toggle dans `SettingsModal` : "Activer le journal d'audit des scores"
- L'onglet "Historique des scores" est masqué par défaut
- Persisté en `localStorage` (`bellepoule-audit-log-enabled`)
- Le logging en base continue même si l'UI est désactivée

## Fichiers modifiés
- `src/main/remoteScoreServer.ts` — fix audit log + warn sur erreurs
- `src/renderer/components/SettingsModal.tsx` — toggle journal
- `src/renderer/components/CompetitionView.tsx` — masquer onglet si désactivé