### PR TITLE
fix: suppression cascade signatures + vidage cache session

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -392,6 +392,12 @@ export class DatabaseManager {
 
   public deleteCompetition(id: string): void {
     if (!this.db) throw new Error('Database not open');
+    this.run(
+      `DELETE FROM pool_signatures WHERE pool_id IN (
+         SELECT p.id FROM pools p JOIN phases ph ON p.phase_id = ph.id WHERE ph.competition_id = ?
+       )`,
+      [id]
+    );
     this.run('DELETE FROM fencers WHERE competition_id = ?', [id]);
     this.run('DELETE FROM competitions WHERE id = ?', [id]);
     this.save();
@@ -1337,6 +1343,7 @@ export class DatabaseManager {
 
   public clearPoolsForPhase(phaseId: string): void {
     if (!this.db) throw new Error('Database not open');
+    this.run('DELETE FROM pool_signatures WHERE pool_id IN (SELECT id FROM pools WHERE phase_id = ?)', [phaseId]);
     this.run('DELETE FROM matches WHERE pool_id IN (SELECT id FROM pools WHERE phase_id = ?)', [phaseId]);
     this.run('DELETE FROM pool_fencers WHERE pool_id IN (SELECT id FROM pools WHERE phase_id = ?)', [phaseId]);
     this.run('DELETE FROM pools WHERE phase_id = ?', [phaseId]);
@@ -1490,6 +1497,10 @@ export class DatabaseManager {
 
   public deletePhase(id: string): void {
     if (!this.db) throw new Error('Database not open');
+    this.run('DELETE FROM pool_signatures WHERE pool_id IN (SELECT id FROM pools WHERE phase_id = ?)', [id]);
+    this.run('DELETE FROM matches WHERE pool_id IN (SELECT id FROM pools WHERE phase_id = ?)', [id]);
+    this.run('DELETE FROM pool_fencers WHERE pool_id IN (SELECT id FROM pools WHERE phase_id = ?)', [id]);
+    this.run('DELETE FROM pools WHERE phase_id = ?', [id]);
     this.run('DELETE FROM phases WHERE id = ?', [id]);
     this.save();
   }

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3150,8 +3150,9 @@ export class RemoteScoreServer {
     // Configurer le nombre d'arènes
     this.setArenaCount(strips);
 
-    // Réinitialiser le cache tireurs pour éviter toute pollution d'une session précédente
+    // Réinitialiser les caches pour éviter toute pollution d'une session précédente
     this.poolFencersCache.clear();
+    this.poolSignaturesCache.clear();
 
     // Utiliser les matches passés depuis le renderer si disponibles, sinon chercher dans la DB
     let allMatches: any[] = [];
@@ -3425,6 +3426,7 @@ export class RemoteScoreServer {
     this.arenaMatchQueue.clear();
     this.arenaNextMatchIndex.clear();
     this.poolFencersCache.clear();
+    this.poolSignaturesCache.clear();
     this.sessionMatchScores.clear();
     this.arenaTokens.clear();
   }


### PR DESCRIPTION
## Problème
Les signatures de feuille de poule survivaient à la suppression de leur compétition/phase, et restaient en cache mémoire entre sessions.

## Corrections
- `deleteCompetition()` : supprime les `pool_signatures` via jointure phases → pools
- `deletePhase()` : cascade complète (signatures → matches → pool_fencers → pools → phase)
- `clearPoolsForPhase()` : supprime les signatures avant les pools
- `startSession()` + `stopSession()` : `poolSignaturesCache.clear()` ajouté

## Fichiers modifiés
- `src/database/index.ts`
- `src/main/remoteScoreServer.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpGN4Nqwta2Msx2Gj2Vvjs)_