### PR TITLE
Verrouillage scores après signatures complètes de poule

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -67,6 +67,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
 
   const isLaserSabre = weapon === Weapon.LASER;
+  const isLocked = pool.fencers.length > 0 && signedFencerIds.filter(id => pool.fencers.some(f => f.id === id)).length >= pool.fencers.length;
   const fencers = pool.fencers;
 
   const isVisible = useCallback(
@@ -227,16 +228,18 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           target.tagName !== 'TEXTAREA'
         ) {
           e.preventDefault();
-          const firstPending = orderedMatches.pending[0];
-          if (firstPending) {
-            openScoreModal(firstPending.index);
-            setKeyboardFocusField('A');
+          if (!isLocked) {
+            const firstPending = orderedMatches.pending[0];
+            if (firstPending) {
+              openScoreModal(firstPending.index);
+              setKeyboardFocusField('A');
+            }
           }
           return;
         }
         if (e.key === 'z' && e.ctrlKey && !e.shiftKey) {
           e.preventDefault();
-          undo();
+          if (!isLocked) undo();
           return;
         }
         if (
@@ -245,7 +248,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           (e.key === 'Z' && e.ctrlKey && e.shiftKey)
         ) {
           e.preventDefault();
-          redo();
+          if (!isLocked) redo();
           return;
         }
       }
@@ -288,6 +291,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   };
 
   const handleCellClick = (rowFencer: Fencer, colFencer: Fencer) => {
+    if (isLocked) return;
     if (rowFencer.id === colFencer.id) return;
     const matchIndex = getMatchIndex(rowFencer, colFencer);
     if (matchIndex === -1) return;
@@ -886,7 +890,8 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
       toggleColumn={toggleColumn}
       onCellClick={handleCellClick}
       onFencerChangePool={onFencerChangePool}
-      onMatchReset={onMatchReset ? (rowFencer, colFencer) => {
+      isLocked={isLocked}
+      onMatchReset={!isLocked && onMatchReset ? (rowFencer, colFencer) => {
         const matchIndex = getMatchIndex(rowFencer, colFencer);
         if (matchIndex !== -1) onMatchReset(matchIndex);
       } : undefined}
@@ -1332,7 +1337,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
                     {fencerBAbandoned && ' ✕'}
                     {match.scoreB?.isVictory && !isAbandonMatch ? ' ✓' : ''}
                   </span>
-                  {!isAbandonMatch && onMatchReset && (
+                  {!isAbandonMatch && !isLocked && onMatchReset && (
                     <button
                       onClick={e => {
                         e.stopPropagation();
@@ -1424,6 +1429,23 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
 
   return (
     <div className="card">
+      {isLocked && (
+        <div style={{
+          background: '#fef2f2',
+          border: '1px solid #fca5a5',
+          borderRadius: '6px',
+          padding: '0.5rem 1rem',
+          marginBottom: '0.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          color: '#991b1b',
+          fontWeight: 600,
+          fontSize: '0.875rem',
+        }}>
+          🔒 Feuille signée par tous les combattants — scores verrouillés
+        </div>
+      )}
       <div
         className="card-header"
         style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -11,6 +11,7 @@ interface PoolScoreMatrixProps {
   onCellClick: (rowFencer: Fencer, colFencer: Fencer) => void;
   onFencerChangePool?: (fencer: Fencer) => void;
   onMatchReset?: (rowFencer: Fencer, colFencer: Fencer) => void;
+  isLocked?: boolean;
 }
 
 const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
@@ -21,6 +22,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
   onCellClick,
   onFencerChangePool,
   onMatchReset,
+  isLocked = false,
 }) => {
   const fencers = pool.fencers;
 
@@ -213,8 +215,8 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                 <div
                   key={colIndex}
                   className={`pool-cell ${cellClass}`}
-                  onClick={() => onCellClick(rowFencer, colFencer)}
-                  style={{ cursor: 'pointer', position: 'relative' }}
+                  onClick={() => !isLocked && onCellClick(rowFencer, colFencer)}
+                  style={{ cursor: isLocked ? 'default' : 'pointer', position: 'relative' }}
                 >
                   {score ? (
                     <>


### PR DESCRIPTION
## Résumé

- Calcul d'un flag `isLocked` dans `PoolView` : vrai quand tous les tireurs de la poule ont signé
- Bannière rouge affichée en haut de la poule quand verrouillée
- Clic sur cellule de score bloqué (`handleCellClick`)
- Raccourcis clavier bloqués : `N` (prochain match), `Ctrl+Z` (undo), `Ctrl+Y`/`Ctrl+Shift+Z` (redo)
- Boutons reset (↺) masqués dans la grille et la liste des matchs
- Prop `isLocked` ajoutée à `PoolScoreMatrix`

## Test

1. Signer tous les combattants d'une poule via la tablette arbitre
2. Vérifier la bannière rouge + badge vert ✍️
3. Cliquer sur une cellule → rien
4. Touche N → rien
5. Ctrl+Z → rien
6. Poule partiellement signée → tout fonctionne normalement

https://claude.ai/code/session_01LbmQtYd3G1p7BYobcsN1CP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbmQtYd3G1p7BYobcsN1CP)_