### PR TITLE
feat: dissociation du système de cartons par arme

### DIFF
--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -74,6 +74,19 @@ export interface Card {
   resultingExclusion: boolean;
 }
 
+export interface WeaponCardScoreImpact {
+  white: number;
+  yellow: number;
+  red: number;
+  black: number;
+}
+
+export interface WeaponCardConfig {
+  availableReasons: CardReason[];
+  reasonToGroup: Partial<Record<CardReason, CardGroup>>;
+  scoreImpact: WeaponCardScoreImpact;
+}
+
 // ============================================================================
 // Match Mode (Sudden Death)
 // ============================================================================

--- a/src/shared/utils/cardSystem.test.ts
+++ b/src/shared/utils/cardSystem.test.ts
@@ -10,10 +10,14 @@ import {
   getReasonsByGroup,
   getCardsForFencer,
   isFencerExcluded,
+  getWeaponCardConfig,
+  getAvailableReasons,
+  getReasonsByGroupForWeapon,
+  WEAPON_CARD_CONFIGS,
   CARD_REASON_LABELS,
   CARD_GROUP_LABELS,
 } from './cardSystem';
-import { Card, CardGroup, CardReason } from '../types';
+import { Card, CardGroup, CardReason, Weapon } from '../types';
 import { CardType } from '../../features/penalties/types/penalty.types';
 
 // ============================================================================
@@ -339,5 +343,120 @@ describe('Labels français', () => {
     expect(CARD_REASON_LABELS[CardReason.EARLY_START]).toBe('Départ anticipé');
     expect(CARD_REASON_LABELS[CardReason.CHEATING]).toBe('Tricherie');
     expect(CARD_GROUP_LABELS[CardGroup.GROUP_1]).toContain('Jaune');
+  });
+});
+
+// ============================================================================
+// Tests dissociation par arme
+// ============================================================================
+
+describe('Dissociation par arme', () => {
+  describe('getWeaponCardConfig', () => {
+    it('retourne une config pour chaque arme', () => {
+      for (const weapon of Object.values(Weapon)) {
+        const config = getWeaponCardConfig(weapon);
+        expect(config).toBeDefined();
+        expect(config.availableReasons.length).toBeGreaterThan(0);
+        expect(config.scoreImpact).toBeDefined();
+      }
+    });
+
+    it('chaque arme a une config indépendante (pas de référence partagée)', () => {
+      const laserConfig = getWeaponCardConfig(Weapon.LASER);
+      const epeeConfig = getWeaponCardConfig(Weapon.EPEE);
+      expect(laserConfig).not.toBe(epeeConfig);
+    });
+  });
+
+  describe('getAvailableReasons', () => {
+    it('retourne toutes les raisons pour le Sabre Laser', () => {
+      const reasons = getAvailableReasons(Weapon.LASER);
+      expect(reasons).toContain(CardReason.EARLY_START);
+      expect(reasons).toContain(CardReason.CHEATING);
+      expect(reasons.length).toBe(Object.values(CardReason).length);
+    });
+
+    it('retourne des raisons pour l\'épée', () => {
+      const reasons = getAvailableReasons(Weapon.EPEE);
+      expect(reasons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getReasonsByGroupForWeapon', () => {
+    it('retourne les 4 groupes pour le Laser', () => {
+      const groups = getReasonsByGroupForWeapon(Weapon.LASER);
+      expect(groups[CardGroup.GROUP_1].length).toBeGreaterThan(0);
+      expect(groups[CardGroup.GROUP_4]).toContain(CardReason.CHEATING);
+    });
+
+    it('retourne les 4 groupes pour l\'épée', () => {
+      const groups = getReasonsByGroupForWeapon(Weapon.EPEE);
+      expect(Object.keys(groups)).toHaveLength(4);
+    });
+  });
+
+  describe('determineCardType avec weapon param', () => {
+    it('comportement identique avec ou sans weapon (config actuelle identique)', () => {
+      const withoutWeapon = determineCardType(CardReason.EARLY_START, []);
+      const withLaser = determineCardType(CardReason.EARLY_START, [], Weapon.LASER);
+      expect(withoutWeapon.type).toBe(withLaser.type);
+      expect(withoutWeapon.points).toBe(withLaser.points);
+    });
+
+    it('scoreImpact yellow reflète la config arme', () => {
+      const result = determineCardType(CardReason.ESTOC, [], Weapon.LASER);
+      expect(result.type).toBe(CardType.YELLOW);
+      expect(result.points).toBe(WEAPON_CARD_CONFIGS[Weapon.LASER].scoreImpact.yellow);
+    });
+
+    it('scoreImpact personnalisable par arme', () => {
+      // Simule une config épée avec impact yellow différent
+      const originalConfig = { ...WEAPON_CARD_CONFIGS[Weapon.EPEE] };
+      WEAPON_CARD_CONFIGS[Weapon.EPEE] = {
+        ...originalConfig,
+        scoreImpact: { white: 0, yellow: 2, red: 2, black: 0 },
+      };
+
+      const result = determineCardType(CardReason.ESTOC, [], Weapon.EPEE);
+      expect(result.points).toBe(2);
+
+      // Restore
+      WEAPON_CARD_CONFIGS[Weapon.EPEE] = originalConfig;
+    });
+
+    it('raison non applicable retourne BLANC (0 point)', () => {
+      // Simule une arme dont COUNTER_ATTACK n'est pas dans le reasonToGroup
+      const originalConfig = { ...WEAPON_CARD_CONFIGS[Weapon.EPEE] };
+      const reasonToGroupWithout: Partial<Record<CardReason, CardGroup>> = {
+        ...originalConfig.reasonToGroup,
+      };
+      delete reasonToGroupWithout[CardReason.COUNTER_ATTACK];
+
+      WEAPON_CARD_CONFIGS[Weapon.EPEE] = {
+        ...originalConfig,
+        availableReasons: originalConfig.availableReasons.filter(r => r !== CardReason.COUNTER_ATTACK),
+        reasonToGroup: reasonToGroupWithout,
+      };
+
+      const result = determineCardType(CardReason.COUNTER_ATTACK, [], Weapon.EPEE);
+      expect(result.type).toBe(CardType.WHITE);
+      expect(result.points).toBe(0);
+      expect(result.shouldExclude).toBe(false);
+
+      // Restore
+      WEAPON_CARD_CONFIGS[Weapon.EPEE] = originalConfig;
+    });
+  });
+
+  describe('createCard avec weapon param', () => {
+    it('crée un carton avec l\'arme courante', () => {
+      const card = createCard('m1', 'f1', CardReason.ESTOC, [], Weapon.LASER);
+      expect(card.group).toBe(CardGroup.GROUP_2);
+    });
+
+    it('reste compatible sans weapon param', () => {
+      const card = createCard('m1', 'f1', CardReason.ESTOC, []);
+      expect(card.group).toBe(CardGroup.GROUP_2);
+    });
   });
 });

--- a/src/shared/utils/cardSystem.ts
+++ b/src/shared/utils/cardSystem.ts
@@ -5,7 +5,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { Card, CardGroup, CardReason, Match, Fencer } from '../types';
+import { Card, CardGroup, CardReason, Weapon, WeaponCardConfig } from '../types';
 import { CardType } from '../../features/penalties/types/penalty.types';
 
 const REASON_TO_GROUP: Record<CardReason, CardGroup> = {
@@ -27,6 +27,56 @@ const REASON_TO_GROUP: Record<CardReason, CardGroup> = {
   [CardReason.UNSPORTSMANLIKE]: CardGroup.GROUP_4,
   [CardReason.CHEATING]: CardGroup.GROUP_4,
 };
+
+const ALL_REASONS = Object.values(CardReason);
+
+const CLASSICAL_SCORE_IMPACT = { white: 0, yellow: 1, red: 1, black: 0 };
+
+export const WEAPON_CARD_CONFIGS: Record<Weapon, WeaponCardConfig> = {
+  [Weapon.EPEE]: {
+    availableReasons: ALL_REASONS,
+    reasonToGroup: REASON_TO_GROUP,
+    scoreImpact: CLASSICAL_SCORE_IMPACT,
+  },
+  [Weapon.FOIL]: {
+    availableReasons: ALL_REASONS,
+    reasonToGroup: REASON_TO_GROUP,
+    scoreImpact: CLASSICAL_SCORE_IMPACT,
+  },
+  [Weapon.SABRE]: {
+    availableReasons: ALL_REASONS,
+    reasonToGroup: REASON_TO_GROUP,
+    scoreImpact: CLASSICAL_SCORE_IMPACT,
+  },
+  [Weapon.LASER]: {
+    availableReasons: ALL_REASONS,
+    reasonToGroup: REASON_TO_GROUP,
+    scoreImpact: { white: 0, yellow: 1, red: 1, black: 0 },
+  },
+};
+
+export function getWeaponCardConfig(weapon: Weapon): WeaponCardConfig {
+  return WEAPON_CARD_CONFIGS[weapon];
+}
+
+export function getAvailableReasons(weapon: Weapon): CardReason[] {
+  return WEAPON_CARD_CONFIGS[weapon].availableReasons;
+}
+
+export function getReasonsByGroupForWeapon(weapon: Weapon): Record<CardGroup, CardReason[]> {
+  const config = WEAPON_CARD_CONFIGS[weapon];
+  const grouped: Record<CardGroup, CardReason[]> = {
+    [CardGroup.GROUP_1]: [],
+    [CardGroup.GROUP_2]: [],
+    [CardGroup.GROUP_3]: [],
+    [CardGroup.GROUP_4]: [],
+  };
+  for (const reason of config.availableReasons) {
+    const group = config.reasonToGroup[reason];
+    if (group !== undefined) grouped[group].push(reason);
+  }
+  return grouped;
+}
 
 export const CARD_REASON_LABELS: Record<CardReason, string> = {
   [CardReason.EARLY_START]: 'Départ anticipé',
@@ -61,29 +111,41 @@ export interface CardResult {
   points: number;
 }
 
-export function determineCardType(reason: CardReason, previousCards: Card[]): CardResult {
-  const group = REASON_TO_GROUP[reason];
+export function determineCardType(
+  reason: CardReason,
+  previousCards: Card[],
+  weapon?: Weapon
+): CardResult {
+  const config = weapon !== undefined ? WEAPON_CARD_CONFIGS[weapon] : null;
+  const reasonToGroup = config?.reasonToGroup ?? REASON_TO_GROUP;
+  const si = config?.scoreImpact ?? { white: 0, yellow: 1, red: 1, black: 0 };
+
+  const group = reasonToGroup[reason];
+  if (group === undefined) {
+    return { type: CardType.WHITE, shouldExclude: false, points: 0 };
+  }
+
   const sameGroupCards = previousCards.filter(c => c.group === group);
   const count = sameGroupCards.length;
 
   switch (group) {
     case CardGroup.GROUP_1:
-      if (count === 0) return { type: CardType.WHITE,  shouldExclude: false, points: 0 };
-      return { type: CardType.YELLOW, shouldExclude: false, points: 1 };
+      if (count === 0) return { type: CardType.WHITE,  shouldExclude: false, points: si.white };
+      return { type: CardType.YELLOW, shouldExclude: false, points: si.yellow };
 
     case CardGroup.GROUP_2:
-      if (count === 0) return { type: CardType.YELLOW, shouldExclude: false, points: 1 };
-      return { type: CardType.RED, shouldExclude: false, points: 1 };
+      if (count === 0) return { type: CardType.YELLOW, shouldExclude: false, points: si.yellow };
+      return { type: CardType.RED, shouldExclude: false, points: si.red };
 
     case CardGroup.GROUP_3:
-      if (count === 0) return { type: CardType.RED, shouldExclude: false, points: 1 };
-      return { type: CardType.BLACK, shouldExclude: true, points: 0 };
+      if (count === 0) return { type: CardType.RED, shouldExclude: false, points: si.red };
+      return { type: CardType.BLACK, shouldExclude: true, points: si.black };
 
     case CardGroup.GROUP_4:
-      return { type: CardType.BLACK, shouldExclude: true, points: 0 };
+      return { type: CardType.BLACK, shouldExclude: true, points: si.black };
 
     default:
-      return { type: CardType.WHITE, shouldExclude: false, points: 0 };
+      return { type: CardType.WHITE, shouldExclude: false, points: si.white };
   }
 }
 
@@ -91,9 +153,12 @@ export function createCard(
   matchId: string,
   fencerId: string,
   reason: CardReason,
-  previousCards: Card[]
+  previousCards: Card[],
+  weapon?: Weapon
 ): Card {
-  const { type, shouldExclude, points } = determineCardType(reason, previousCards);
+  const config = weapon !== undefined ? WEAPON_CARD_CONFIGS[weapon] : null;
+  const reasonToGroup = config?.reasonToGroup ?? REASON_TO_GROUP;
+  const { type, shouldExclude, points } = determineCardType(reason, previousCards, weapon);
 
   return {
     id: uuidv4(),
@@ -101,7 +166,7 @@ export function createCard(
     fencerId,
     type,
     reason,
-    group: REASON_TO_GROUP[reason],
+    group: reasonToGroup[reason] ?? REASON_TO_GROUP[reason],
     timestamp: new Date(),
     pointsAwarded: points,
     resultingExclusion: shouldExclude,
@@ -122,6 +187,7 @@ export function getReasonsByGroup(): Record<CardGroup, CardReason[]> {
 
   return grouped;
 }
+
 
 export function getCardsForFencer(fencerId: string, matchCards: Card[]): Card[] {
   return matchCards.filter(card => card.fencerId === fencerId);


### PR DESCRIPTION
## Résumé

- Ajoute `WeaponCardConfig` (interface) dans `src/shared/types/index.ts` avec `availableReasons`, `reasonToGroup`, et `scoreImpact` par arme
- Ajoute `WEAPON_CARD_CONFIGS` dans `cardSystem.ts` — une entrée par arme (Épée, Fleuret, Sabre, Laser)
- `determineCardType` et `createCard` acceptent un paramètre `weapon?` optionnel (rétrocompatibilité totale)
- Nouvelles exports : `getWeaponCardConfig`, `getAvailableReasons`, `getReasonsByGroupForWeapon`
- Tests de dissociation par arme ajoutés dans `cardSystem.test.ts`

## Prochaine étape

Quand tu fournis les fautes spécifiques épée/fleuret (ou les impacts score Laser en points fixes), il suffit de modifier `WEAPON_CARD_CONFIGS` dans `cardSystem.ts` — l'infrastructure est en place.

https://claude.ai/code/session_01U5PHLCBpWa7MGZHfFBiP3E

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5PHLCBpWa7MGZHfFBiP3E)_