### PR TITLE
fix: erreurs CI build — Weapon.CUSTOM + imports manquants

### DIFF
--- a/src/shared/utils/cardSystem.ts
+++ b/src/shared/utils/cardSystem.ts
@@ -53,6 +53,11 @@ export const WEAPON_CARD_CONFIGS: Record<Weapon, WeaponCardConfig> = {
     reasonToGroup: REASON_TO_GROUP,
     scoreImpact: { white: 0, yellow: 1, red: 1, black: 0 },
   },
+  [Weapon.CUSTOM]: {
+    availableReasons: ALL_REASONS,
+    reasonToGroup: REASON_TO_GROUP,
+    scoreImpact: CLASSICAL_SCORE_IMPACT,
+  },
 };
 
 export function getWeaponCardConfig(weapon: Weapon): WeaponCardConfig {

--- a/src/shared/utils/customRankingCalculator.ts
+++ b/src/shared/utils/customRankingCalculator.ts
@@ -6,6 +6,7 @@
 
 import {
   AdvancementRule,
+  CustomDEConfig,
   CustomFormulaConfig,
   CustomPoolRoundConfig,
   FormulaPhaseSimulation,
@@ -161,7 +162,7 @@ export function calculateOverallRankingCustom(
   allRankings.sort(comparator);
 
   allRankings.forEach((r, i) => {
-    r.overallRank = i + 1;
+    (r as PoolRanking & { overallRank: number }).overallRank = i + 1;
   });
 
   return allRankings;


### PR DESCRIPTION
## Résumé

Corrections des 3 erreurs bloquantes détectées par le CI sur le build précédent.

- `cardSystem.ts` — ajout de `[Weapon.CUSTOM]` dans `WEAPON_CARD_CONFIGS` (même config que les armes classiques)
- `customRankingCalculator.ts` — import manquant de `CustomDEConfig`
- `customRankingCalculator.ts:164` — cast explicite pour l'assignation de `overallRank` (champ optionnel)

## Plan de test

- [ ] `npm run build:ci` → 0 erreur
- [ ] `npm run type-check` → 0 erreur

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhVHcph5LZKqqhbiKEVoZh)_