### PR TITLE
fix(remote): pool.html et arbitre non actualisés sur reset match / attribution arbitre

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2245,6 +2245,28 @@ export class RemoteScoreServer {
   public resetPoolMatch(matchId: string): void {
     this.sessionMatchScores.delete(matchId);
     this.io.emit('match:reset', { matchId });
+
+    const match = this.sessionMatches.find((m: any) => m.id === matchId);
+    const poolId = match?.poolId ?? match?.pool?.id;
+    if (!poolId) return;
+
+    const fencers = this.poolFencersCache.get(poolId) ?? this.db.getPoolFencers(poolId);
+    const poolMatches = this.sessionMatches
+      .filter((m: any) => !m.isTableau && (m.poolId ?? m.pool?.id) === poolId)
+      .sort((a: any, b: any) => (a.number || 0) - (b.number || 0))
+      .map((m: any) => {
+        const u = this.sessionMatchScores.get(m.id);
+        return u ? { ...m, ...u } : m;
+      });
+    const isComplete =
+      poolMatches.length > 0 && poolMatches.every((m: any) => m.status === MatchStatus.FINISHED);
+    for (const [aId, arena] of this.arenas) {
+      if ((arena.currentMatch?.poolId ?? arena.activePoolId) === poolId) {
+        this.io
+          .to(`pool:${aId}`)
+          .emit(`pool:${aId}:update`, { poolId, fencers, matches: poolMatches, isComplete });
+      }
+    }
   }
 
   public setLanguage(lang: string): void {
@@ -3615,6 +3637,24 @@ export class RemoteScoreServer {
         poolMatches.length > 0 && poolMatches.every((m: any) => m.status === MatchStatus.FINISHED);
       for (const [aId, arena] of this.arenas) {
         if ((arena.currentMatch?.poolId ?? arena.activePoolId) !== poolId) continue;
+        if (arena.currentMatch) {
+          const updatedMatch = this.sessionMatches.find((m: any) => m.id === arena.currentMatch!.id);
+          if (updatedMatch?.refereeId && updatedMatch.refereeId !== arena.currentMatch.refereeId) {
+            const resolvedRef = this.resolveReferee(updatedMatch.refereeId);
+            arena.currentMatch = {
+              ...arena.currentMatch,
+              ...(resolvedRef ? { referee: resolvedRef } : {}),
+              refereeId: updatedMatch.refereeId,
+            };
+            this.broadcastArenaUpdate(aId, {
+              arenaId: aId,
+              match: arena.currentMatch,
+              scoreA: arena.currentMatch.scoreA,
+              scoreB: arena.currentMatch.scoreB,
+              status: arena.status,
+            });
+          }
+        }
         this.io
           .to(`pool:${aId}`)
           .emit(`pool:${aId}:update`, { poolId, fencers, matches: poolMatches, isComplete });

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -150,7 +150,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     const fingerprint = pools
       .map(
         p =>
-          `${p.id}:${(p.matches ?? []).map((m: any) => `${m.id}=${m.status}|${m.scoreA ?? ''}-${m.scoreB ?? ''}`).join(',')}`
+          `${p.id}:${(p.matches ?? []).map((m: any) => `${m.id}=${m.status}|${m.scoreA ?? ''}-${m.scoreB ?? ''}|${m.refereeId ?? ''}`).join(',')}`
       )
       .join('|');
     if (!isRemoteActive || !session) {


### PR DESCRIPTION
## Résumé

- `resetPoolMatch()` émet désormais `pool:{arenaId}:update` après avoir vidé le cache de score, donc `/areneX/poule` reflète le statut réinitialisé sans rechargement
- `syncPoolMatches()` propage les changements d'arbitre vers `arena.currentMatch` et émet un update d'arène, donc `/areneX/arbitre` voit le nouvel arbitre
- Le fingerprint de `RemoteScoreManager` inclut `refereeId` pour que `syncPoolMatches` soit déclenché lors d'une affectation depuis l'UI principale

## Fichiers modifiés

- `src/main/remoteScoreServer.ts` — `resetPoolMatch()` + `syncPoolMatches()`
- `src/renderer/components/RemoteScoreManager.tsx` — fingerprint

https://claude.ai/code/session_016aMA2e4dRz1a6MseHNe5LB

---
_Generated by [Claude Code](https://claude.ai/code/session_016aMA2e4dRz1a6MseHNe5LB)_