### PR TITLE
Fix: matchs tableau non affichés dans kiosk/arènes après assignation de piste

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3190,7 +3190,7 @@ export class RemoteScoreServer {
       allMatches = realMatches.filter(
         m =>
           m.isTableau
-            ? m.status === 'not_started' || m.status === 'in_progress'
+            ? !m.status || m.status === 'not_started' || m.status === 'in_progress'
             : true // Tous les matchs de poule, y compris finished (nécessaires pour la grille)
       );
       console.log(`[RemoteScoreServer] ${allMatches.length} matchs après filtrage`);

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -268,6 +268,12 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         setCommittedCount(count);
         onArenaCountChange?.(count);
         showToast('Saisie distante démarrée', 'success');
+        // Envoyer les matchs DE avec leurs pistes au serveur (la clé ref est déjà stockée
+        // avant que session/isRemoteActive soient prêts, donc l'effet ne se déclenche pas).
+        if (deMatches.length > 0) {
+          await window.electronAPI.remote.refreshDeMatches(competition.id, deMatches);
+          prevDeMatchesKeyRef.current = deMatches.map((m: any) => m.id).join(',');
+        }
       } else {
         showToast(`Erreur session: ${result.error}`, 'error');
       }


### PR DESCRIPTION
## Problème

Après validation des poules, les matchs de tableau assignés à une piste ne s'affichaient ni dans le kiosk ni dans les arènes arbitres.

## Cause

Deux bugs distincts :

**1. Filtre `status` trop strict dans `startSession` (serveur)**

`TableauMatch` n'a pas de champ `status`. Lors du spread `{ ...m, isTableau: true }`, `m.status` est `undefined`. Le filtre `m.status === 'not_started' || m.status === 'in_progress'` renvoyait `false` → tous les matchs DE étaient exclus avant distribution.

**2. Clé `refreshDeMatches` déjà stockée avant que la session soit prête (renderer)**

L'effet `refreshDeMatches` stocke la clé (IDs des matchs) lors de sa première exécution, mais retourne tôt car `isRemoteActive=false` ou `session=null`. Quand ces états deviennent prêts, la clé est déjà identique → l'effet court-circuite → `refreshDeMatches` n'est jamais appelé.

## Fix

- `remoteScoreServer.ts` : accepter `!m.status` (undefined) comme équivalent à `not_started`
- `RemoteScoreManager.tsx` : appeler `refreshDeMatches` explicitement après `startSession` réussi, et synchroniser `prevDeMatchesKeyRef` pour éviter un double appel

https://claude.ai/code/session_01AAd2SYbVQpvQij2CmL51sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAd2SYbVQpvQij2CmL51sX)_