### PR TITLE
fix(remote): pool.html et arbitre non actualisés sur reset match / attribution arbitre

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3638,13 +3638,13 @@ export class RemoteScoreServer {
       for (const [aId, arena] of this.arenas) {
         if ((arena.currentMatch?.poolId ?? arena.activePoolId) !== poolId) continue;
         if (arena.currentMatch) {
-          const updatedMatch = this.sessionMatches.find((m: any) => m.id === arena.currentMatch!.id);
-          if (updatedMatch?.refereeId && updatedMatch.refereeId !== arena.currentMatch.refereeId) {
+          const currentMatch = arena.currentMatch;
+          const updatedMatch = this.sessionMatches.find((m: any) => m.id === currentMatch.id);
+          if (updatedMatch?.refereeId && updatedMatch.refereeId !== currentMatch.referee?.id) {
             const resolvedRef = this.resolveReferee(updatedMatch.refereeId);
             arena.currentMatch = {
-              ...arena.currentMatch,
+              ...currentMatch,
               ...(resolvedRef ? { referee: resolvedRef } : {}),
-              refereeId: updatedMatch.refereeId,
             };
             this.broadcastArenaUpdate(aId, {
               arenaId: aId,


### PR DESCRIPTION
## Résumé

- `resetPoolMatch()` émet désormais `pool:{arenaId}:update` après avoir vidé le cache de score → `/areneX/poule` reflète le statut réinitialisé sans rechargement
- `syncPoolMatches()` propage les changements d'arbitre vers `arena.currentMatch` et émet un update d'arène → `/areneX/arbitre` voit le nouvel arbitre
- Le fingerprint de `RemoteScoreManager` inclut `refereeId` → `syncPoolMatches` se déclenche lors d'une affectation depuis l'UI principale
- Correction TS : `ArenaMatch` n'a pas de `refereeId`, comparaison via `referee?.id`

## Fichiers modifiés

- `src/main/remoteScoreServer.ts`
- `src/renderer/components/RemoteScoreManager.tsx`

https://claude.ai/code/session_016aMA2e4dRz1a6MseHNe5LB

---
_Generated by [Claude Code](https://claude.ai/code/session_016aMA2e4dRz1a6MseHNe5LB)_