### PR TITLE
feat: option "Jouer toutes les places" avec tableaux de consolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.688",
+  "version": "1.0.3-build.812",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.688",
+      "version": "1.0.3-build.812",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -41,6 +41,9 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
   const [thirdPlaceMatch, setThirdPlaceMatch] = useState(
     competition.settings?.thirdPlaceMatch ?? false
   );
+  const [playAllPositions, setPlayAllPositions] = useState(
+    competition.settings?.playAllPositions ?? false
+  );
 
   const [poolTimerSeconds, setPoolTimerSeconds] = useState(
     competition.settings?.defaultPoolTimerSeconds ?? 180
@@ -103,6 +106,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
       poolRounds,
       hasDirectElimination,
       thirdPlaceMatch,
+      playAllPositions,
       defaultPoolMaxScore: poolMaxScore,
       defaultTableMaxScore: tableMaxScore,
       defaultPoolTimerSeconds: poolTimerSeconds,
@@ -246,6 +250,20 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 </label>
                 <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
                   {t('competition.third_place_match_description')}
+                </small>
+              </div>
+              <div className="form-group">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={playAllPositions}
+                    onChange={e => setPlayAllPositions(e.target.checked)}
+                    style={{ marginRight: '0.5rem' }}
+                  />
+                  Jouer toutes les places
+                </label>
+                <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+                  Les perdants de chaque tour forment un tableau de classement
                 </small>
               </div>
             </>

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -56,6 +56,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const poolRounds = competition.settings?.poolRounds ?? 1;
   const hasDirectElimination = competition.settings?.hasDirectElimination ?? true;
   const thirdPlaceMatch = competition.settings?.thirdPlaceMatch ?? false;
+  const playAllPositions = competition.settings?.playAllPositions ?? false;
   const poolMaxScore = competition.settings?.defaultPoolMaxScore ?? 21;
   const tableMaxScore = competition.settings?.defaultTableMaxScore ?? 0;
   const isLaserSabre = competition.weapon === Weapon.LASER;
@@ -1184,6 +1185,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onMatchesChange={setTableauMatches}
             maxScore={tableMaxScore === 0 ? 999 : tableMaxScore}
             thirdPlaceMatch={thirdPlaceMatch}
+            playAllPositions={playAllPositions}
             arenaCount={remoteArenaCount}
             onComplete={results => {
               setFinalResults(results);

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -48,6 +48,17 @@ export interface FinalResult {
   totalTouches?: number; // Total pour départage (poules + tableau)
 }
 
+interface ConsolationBracket {
+  id: string;
+  name: string;
+  firstPlace: number;
+  matches: TableauMatch[];
+  size: number;
+  isComplete: boolean;
+  sourceRound: number; // round du bracket parent qui a généré ce bracket
+  parentBracketId: string; // 'main' ou id d'un bracket de consolation
+}
+
 interface TableauViewProps {
   ranking: PoolRanking[];
   matches: TableauMatch[];
@@ -55,6 +66,7 @@ interface TableauViewProps {
   maxScore?: number;
   onComplete?: (results: FinalResult[]) => void;
   thirdPlaceMatch?: boolean;
+  playAllPositions?: boolean;
   arenaCount?: number;
   onMatchArenaChange?: (matchId: string, oldArena: number | null, newArena: number | null) => void;
 }
@@ -152,6 +164,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   maxScore = 15,
   onComplete,
   thirdPlaceMatch = false,
+  playAllPositions = false,
   arenaCount = 4,
   onMatchArenaChange,
 }) => {
@@ -159,6 +172,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const tableauTemplate = usePdfTemplateStore(s => s.templates.tableau);
   const [tableauSize, setTableauSize] = useState<number>(0);
   const [editingMatch, setEditingMatch] = useState<string | null>(null);
+  const [editingConsolationId, setEditingConsolationId] = useState<string | null>(null);
   const [showScoreModal, setShowScoreModal] = useState(false);
   const [editScoreA, setEditScoreA] = useState<string>('');
   const [editScoreB, setEditScoreB] = useState<string>('');
@@ -177,6 +191,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const isUnlimitedScore = maxScore === 999;
   const prevMatchesLengthRef = useRef(0);
   const mountMatchesRef = useRef(matches);
+  const [consolationBrackets, setConsolationBrackets] = useState<ConsolationBracket[]>([]);
 
   const { modalRef } = useModalResize({
     defaultWidth: 600,
@@ -251,8 +266,8 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         r.fencer.status !== FencerStatus.EXCLUDED
     ).length;
     if (eligibleCount > 0) {
-      const expectedSize = getTableauSize(eligibleCount);
-      const currentSize = matches.length > 0 ? Math.max(...matches.map(m => m.round)) : 0;
+      const expectedSize = getMainTableauSize(eligibleCount);
+      const currentSize = matches.length > 0 ? Math.max(...matches.filter(m => m.round !== 3).map(m => m.round)) : 0;
 
       const hasThirdPlace = matches.some(m => m.round === 3);
       const thirdPlaceMismatch = thirdPlaceMatch !== hasThirdPlace;
@@ -277,12 +292,141 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     if (!champion) return;
     const thirdPlaceEntry = matches.find(m => m.round === 3);
     const thirdPlaceDone = !thirdPlaceEntry || !!thirdPlaceEntry.winner;
-    if (thirdPlaceDone) {
+    if (thirdPlaceDone && !playAllPositions) {
       onComplete(calculateFinalResults(matches));
     }
     // calculateFinalResults et onComplete sont stables pendant la phase tableau
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [matches]);
+
+  // Mode playAllPositions : créer les brackets de consolation quand un round du tableau principal se complète
+  useEffect(() => {
+    if (!playAllPositions || matches.length === 0) return;
+
+    setConsolationBrackets(prevBrackets => {
+      let updated = [...prevBrackets];
+      let changed = false;
+
+      // Vérifier les barrages : round = mainSize * 2
+      const barrageRound = tableauSize * 2;
+      const barrageMatches = matches.filter(m => m.round === barrageRound);
+      if (barrageMatches.length > 0 && isRoundComplete(matches, barrageRound)) {
+        const alreadyExists = updated.some(b => b.sourceRound === barrageRound && b.parentBracketId === 'main');
+        if (!alreadyExists) {
+          const losers = getRoundLosers(matches, barrageRound, ranking);
+          if (losers.length > 0) {
+            // bracket pour les dernières places
+            const firstPlace = tableauSize + 1;
+            updated.push(buildConsolationBracket(losers, firstPlace, barrageRound, 'main'));
+            changed = true;
+          }
+        }
+      }
+
+      // Vérifier chaque round du tableau principal (≥ 4, donc QF et plus profonds)
+      const mainRounds = [tableauSize, ...Array.from({ length: Math.log2(tableauSize) - 2 }, (_, i) => tableauSize / Math.pow(2, i + 1))].filter(r => r >= 4);
+      for (const round of mainRounds) {
+        if (!isRoundComplete(matches, round)) continue;
+        const alreadyExists = updated.some(b => b.sourceRound === round && b.parentBracketId === 'main');
+        if (alreadyExists) continue;
+        const losers = getRoundLosers(matches, round, ranking);
+        if (losers.length === 0) continue;
+        const fp = consolationFirstPlace(tableauSize, 1, round);
+        updated.push(buildConsolationBracket(losers, fp, round, 'main'));
+        changed = true;
+      }
+
+      // Vérifier les brackets de consolation existants pour créer des sous-brackets
+      for (const bracket of updated) {
+        if (bracket.isComplete) continue;
+        const bracketRounds = Array.from(
+          { length: Math.log2(bracket.size) - 1 },
+          (_, i) => bracket.size / Math.pow(2, i)
+        ).filter(r => r >= 4);
+
+        for (const round of bracketRounds) {
+          if (!isRoundComplete(bracket.matches, round)) continue;
+          const alreadyExists = updated.some(b => b.sourceRound === round && b.parentBracketId === bracket.id);
+          if (alreadyExists) continue;
+          const losers = getRoundLosers(bracket.matches, round, ranking);
+          if (losers.length === 0) continue;
+          const fp = consolationFirstPlace(bracket.size, bracket.firstPlace, round);
+          updated.push(buildConsolationBracket(losers, fp, round, bracket.id));
+          changed = true;
+        }
+
+        // Marquer le bracket comme complet si la finale + petite finale sont terminées
+        const finalMatch = bracket.matches.find(m => m.round === 2);
+        const thirdMatch = bracket.matches.find(m => m.round === 3);
+        const nowComplete = !!finalMatch?.winner && (!thirdMatch || !!thirdMatch.winner);
+        if (nowComplete && !bracket.isComplete) {
+          bracket.isComplete = true;
+          changed = true;
+        }
+      }
+
+      return changed ? updated : prevBrackets;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matches, tableauSize, playAllPositions]);
+
+  // Gagnants des barrages → placer dans le tableau principal
+  useEffect(() => {
+    if (!playAllPositions || tableauSize === 0) return;
+    const barrageRound = tableauSize * 2;
+    const barrageMatches = matches.filter(m => m.round === barrageRound);
+    if (barrageMatches.length === 0) return;
+
+    // Pour chaque barrage terminé, placer le gagnant dans le premier tour du tableau
+    let needsUpdate = false;
+    const updatedMatches = matches.map(m => ({ ...m }));
+    const firstRoundMatches = updatedMatches.filter(m => m.round === tableauSize);
+    const seeding = generateFIESeeding(tableauSize);
+    const directCount = firstRoundMatches.reduce((count, m) => {
+      return count + (m.fencerA ? 1 : 0) + (m.fencerB ? 1 : 0);
+    }, 0);
+
+    // Les derniers slots du seeding correspondent aux gagnants des barrages
+    // Nombre de barrages = barrageMatches.length
+    const barrageWinnerSlots: number[] = [];
+    // Les seeds au-delà de directCount (dans le seeding) sont les slots pour les gagnants de barrages
+    const allDirectSeeds = seeding.filter(s => s <= directCount);
+    const barrageSeeds = seeding.filter(s => s > directCount && s <= directCount + barrageMatches.length);
+    barrageSeeds.forEach((seed, idx) => {
+      barrageWinnerSlots.push(seed - 1); // 0-indexed rank → index dans le seeding
+    });
+
+    for (let i = 0; i < barrageMatches.length; i++) {
+      const barrage = barrageMatches[i];
+      if (!barrage.winner) continue;
+      // Le gagnant du barrage i va dans la position du barrage dans le seeding
+      // seed = directCount + i + 1, position dans le seeding
+      const targetSeed = directCount + i + 1;
+      const targetPos = seeding.indexOf(targetSeed);
+      if (targetPos < 0) continue;
+      // targetPos est un index dans les tireurs du premier tour (0..size-1)
+      // Le match dans le premier tour: match i = position [i/2], fencerA si i est pair, fencerB si impair
+      const matchIdx = Math.floor(targetPos / 2);
+      const isA = targetPos % 2 === 0;
+      const match = firstRoundMatches[matchIdx];
+      if (!match) continue;
+      const matchInUpdated = updatedMatches.find(m => m.id === match.id);
+      if (!matchInUpdated) continue;
+      if (isA && !matchInUpdated.fencerA) {
+        matchInUpdated.fencerA = barrage.winner;
+        needsUpdate = true;
+      } else if (!isA && !matchInUpdated.fencerB) {
+        matchInUpdated.fencerB = barrage.winner;
+        needsUpdate = true;
+      }
+    }
+
+    if (needsUpdate) {
+      propagateWinners(updatedMatches, tableauSize);
+      onMatchesChange(updatedMatches);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matches.filter(m => m.round === tableauSize * 2).map(m => m.winner?.id).join(','), tableauSize]);
 
   const getTableauSize = (fencerCount: number): number => {
     const sizes = [4, 8, 16, 32, 64, 128, 256];
@@ -290,6 +434,17 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
       if (fencerCount <= size) return size;
     }
     return 256;
+  };
+
+  // Pour playAllPositions : plus grande puissance de 2 ≤ fencerCount
+  const getMainTableauSize = (fencerCount: number): number => {
+    if (!playAllPositions) return getTableauSize(fencerCount);
+    const sizes = [4, 8, 16, 32, 64, 128, 256];
+    let result = 4;
+    for (const size of sizes) {
+      if (size <= fencerCount) result = size;
+    }
+    return result;
   };
 
   const getEligibleFencers = (): PoolRanking[] =>
@@ -302,21 +457,54 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
 
   const generateTableau = () => {
     const qualifiedFencers = getEligibleFencers().sort((a, b) => a.rank - b.rank);
-    const size = getTableauSize(qualifiedFencers.length);
-    setTableauSize(size);
+    const mainSize = getMainTableauSize(qualifiedFencers.length);
+    const barrageCount = qualifiedFencers.length - mainSize; // fencers en excès (0 si déjà puissance de 2)
 
-    const seeding = generateFIESeeding(size);
+    setTableauSize(mainSize);
+    setConsolationBrackets([]); // réinitialiser les brackets de consolation
+
     const newMatches: TableauMatch[] = [];
 
-    // Premier tour
+    if (playAllPositions && barrageCount > 0) {
+      // Créer les matchs de barrages pour les seeds du bas
+      // Barrage i : seed (mainSize - barrageCount + i + 1) vs seed (qualifiedFencers.length - i)
+      for (let i = 0; i < barrageCount; i++) {
+        const seedA = mainSize - barrageCount + i + 1;
+        const seedB = qualifiedFencers.length - i;
+        const fencerA = qualifiedFencers[seedA - 1]?.fencer ?? null;
+        const fencerB = qualifiedFencers[seedB - 1]?.fencer ?? null;
+        newMatches.push({
+          id: `barrage-${i}`,
+          round: mainSize * 2, // valeur spéciale > premier tour du tableau
+          position: i,
+          fencerA,
+          fencerB,
+          scoreA: null,
+          scoreB: null,
+          winner: null,
+          isBye: false,
+        });
+      }
+    }
+
+    // Premier tour du tableau principal
+    // Avec barrages : les mainSize - barrageCount premiers seeds sont placés directement,
+    // les barrageCount derniers slots seront remplis par les gagnants des barrages.
+    const directFencers = playAllPositions && barrageCount > 0
+      ? qualifiedFencers.slice(0, mainSize - barrageCount)
+      : qualifiedFencers;
+
+    const size = mainSize;
+    const seeding = generateFIESeeding(size);
+
     for (let i = 0; i < size / 2; i++) {
       const seedA = seeding[i * 2];
       const seedB = seeding[i * 2 + 1];
 
-      const fencerA = seedA <= qualifiedFencers.length ? qualifiedFencers[seedA - 1].fencer : null;
-      const fencerB = seedB <= qualifiedFencers.length ? qualifiedFencers[seedB - 1].fencer : null;
+      const fencerA = seedA <= directFencers.length ? directFencers[seedA - 1].fencer : null;
+      const fencerB = seedB <= directFencers.length ? directFencers[seedB - 1].fencer : null;
 
-      const isBye = !fencerA || !fencerB;
+      const isBye = !playAllPositions && (!fencerA || !fencerB);
       const winner = isBye ? fencerA || fencerB : null;
 
       newMatches.push({
@@ -325,8 +513,8 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         position: i,
         fencerA,
         fencerB,
-        scoreA: isBye ? null : null,
-        scoreB: isBye ? null : null,
+        scoreA: null,
+        scoreB: null,
         winner,
         isBye,
       });
@@ -351,8 +539,8 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
       currentRound = currentRound / 2;
     }
 
-    // Ajouter le match pour la 3ème place si demandé
-    if (thirdPlaceMatch && size >= 4) {
+    // Ajouter le match pour la 3ème place si demandé (ou forcé en mode playAllPositions)
+    if ((thirdPlaceMatch || playAllPositions) && size >= 4) {
       newMatches.push({
         id: '3-0',
         round: 3,
@@ -366,7 +554,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
       });
     }
 
-    // Propager les byes
+    // Propager les byes (seulement pour le tableau standard sans playAllPositions)
     propagateWinners(newMatches, size);
     onMatchesChange(newMatches);
   };
@@ -399,6 +587,127 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
       ];
     }
     return Array.from({ length: size }, (_, i) => i + 1);
+  };
+
+  // Génère les matchs d'un bracket (utilisé pour les brackets de consolation)
+  const generateBracketMatches = (
+    fencers: PoolRanking[],
+    bracketSize: number,
+    withThirdPlace: boolean,
+    idPrefix: string
+  ): TableauMatch[] => {
+    const seeding = generateFIESeeding(bracketSize);
+    const newMatches: TableauMatch[] = [];
+
+    for (let i = 0; i < bracketSize / 2; i++) {
+      const seedA = seeding[i * 2];
+      const seedB = seeding[i * 2 + 1];
+      const fencerA = seedA <= fencers.length ? fencers[seedA - 1].fencer : null;
+      const fencerB = seedB <= fencers.length ? fencers[seedB - 1].fencer : null;
+      const isBye = !fencerA || !fencerB;
+      const winner = isBye ? fencerA || fencerB : null;
+      newMatches.push({
+        id: `${idPrefix}-${bracketSize}-${i}`,
+        round: bracketSize,
+        position: i,
+        fencerA,
+        fencerB,
+        scoreA: null,
+        scoreB: null,
+        winner,
+        isBye,
+      });
+    }
+
+    let currentRound = bracketSize / 2;
+    while (currentRound >= 2) {
+      for (let i = 0; i < currentRound / 2; i++) {
+        newMatches.push({
+          id: `${idPrefix}-${currentRound}-${i}`,
+          round: currentRound,
+          position: i,
+          fencerA: null,
+          fencerB: null,
+          scoreA: null,
+          scoreB: null,
+          winner: null,
+          isBye: false,
+        });
+      }
+      currentRound = currentRound / 2;
+    }
+
+    if (withThirdPlace && bracketSize >= 4) {
+      newMatches.push({
+        id: `${idPrefix}-3-0`,
+        round: 3,
+        position: 0,
+        fencerA: null,
+        fencerB: null,
+        scoreA: null,
+        scoreB: null,
+        winner: null,
+        isBye: false,
+      });
+    }
+
+    propagateWinners(newMatches, bracketSize);
+    return newMatches;
+  };
+
+  // Crée un bracket de consolation pour les perdants donnés
+  const buildConsolationBracket = (
+    losers: PoolRanking[],
+    firstPlace: number,
+    sourceRound: number,
+    parentBracketId: string
+  ): ConsolationBracket => {
+    const sorted = [...losers].sort((a, b) => a.rank - b.rank);
+    const bracketSize = getTableauSize(sorted.length);
+    const idPrefix = `cons-${firstPlace}-${Date.now()}`;
+    const lastPlace = firstPlace + sorted.length - 1;
+    const bracketMatches = generateBracketMatches(sorted, bracketSize, true, idPrefix);
+    return {
+      id: idPrefix,
+      name: `Places ${firstPlace}–${lastPlace}`,
+      firstPlace,
+      matches: bracketMatches,
+      size: bracketSize,
+      isComplete: false,
+      sourceRound,
+      parentBracketId,
+    };
+  };
+
+  // Calcule le firstPlace d'un sous-tableau de consolation pour un round donné dans un bracket parent
+  // size = taille du bracket parent, parentFirstPlace = sa première place couverte
+  const consolationFirstPlace = (parentSize: number, parentFirstPlace: number, round: number): number => {
+    // Nombre de perdants dans ce round = parentSize / round
+    const losersCount = parentSize / round;
+    // Le bracket parent couvre les places parentFirstPlace à parentFirstPlace + parentSize - 1.
+    // Les rounds > ce round (plus profonds dans le bracket) vont vers d'autres consolations.
+    // Ce round-ci cover les dernières `losersCount` places du bracket parent.
+    return parentFirstPlace + parentSize - losersCount;
+  };
+
+  // Vérifie si un round d'un bracket est complet (tous les matchs ont un gagnant)
+  const isRoundComplete = (bracketMatches: TableauMatch[], round: number): boolean => {
+    const roundMatches = bracketMatches.filter(m => m.round === round);
+    return roundMatches.length > 0 && roundMatches.every(m => m.winner !== null);
+  };
+
+  // Collecte les perdants d'un round dans un bracket
+  const getRoundLosers = (bracketMatches: TableauMatch[], round: number, allRankings: PoolRanking[]): PoolRanking[] => {
+    const roundMatches = bracketMatches.filter(m => m.round === round && m.winner);
+    const losers: PoolRanking[] = [];
+    for (const m of roundMatches) {
+      const loser = m.fencerA?.id === m.winner?.id ? m.fencerB : m.fencerA;
+      if (loser) {
+        const rankEntry = allRankings.find(r => r.fencer.id === loser.id);
+        if (rankEntry) losers.push(rankEntry);
+      }
+    }
+    return losers;
   };
 
   const getRoundName = (round: number): string => {
@@ -517,6 +826,22 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     }
   };
 
+  // Met à jour les matchs d'un bracket de consolation
+  const updateConsolationMatch = (consolationId: string, matchId: string, scoreA: number, scoreB: number, winner: Fencer | null) => {
+    setConsolationBrackets(prev => prev.map(bracket => {
+      if (bracket.id !== consolationId) return bracket;
+      const updatedMatches = bracket.matches.map(m => {
+        if (m.id === matchId) return { ...m, scoreA, scoreB, winner };
+        return m;
+      });
+      propagateWinners(updatedMatches, bracket.size);
+      const finalMatch = updatedMatches.find(m => m.round === 2);
+      const thirdMatch = updatedMatches.find(m => m.round === 3);
+      const isComplete = !!finalMatch?.winner && (!thirdMatch || !!thirdMatch.winner);
+      return { ...bracket, matches: updatedMatches.map(m => ({ ...m })), isComplete };
+    }));
+  };
+
   const handleScoreSubmit = () => {
     if (!editingMatch) return;
 
@@ -534,6 +859,28 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         showToast(`Le score ne peut pas dépasser ${maxScore}`, 'error');
         return;
       }
+    }
+
+    // Si c'est un match de bracket de consolation
+    if (editingConsolationId) {
+      const bracket = consolationBrackets.find(b => b.id === editingConsolationId);
+      if (bracket) {
+        const match = bracket.matches.find(m => m.id === editingMatch);
+        let winner: Fencer | null = null;
+        if (victoryA) winner = match?.fencerA || null;
+        else if (victoryB) winner = match?.fencerB || null;
+        else if (scoreA > scoreB) winner = match?.fencerA || null;
+        else if (scoreB > scoreA) winner = match?.fencerB || null;
+        updateConsolationMatch(editingConsolationId, editingMatch, scoreA, scoreB, winner);
+      }
+      setShowScoreModal(false);
+      setEditingMatch(null);
+      setEditingConsolationId(null);
+      setEditScoreA('');
+      setEditScoreB('');
+      setVictoryA(false);
+      setVictoryB(false);
+      return;
     }
 
     // Déterminer le vainqueur
@@ -571,7 +918,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const champion = updatedMatches.find(m => m.round === 2)?.winner;
     const thirdPlaceMatch = updatedMatches.find(m => m.round === 3);
     const thirdPlaceDone = !thirdPlaceMatch || !!thirdPlaceMatch.winner;
-    if (champion && thirdPlaceDone && onComplete) {
+    if (champion && thirdPlaceDone && onComplete && !playAllPositions) {
       const finalResults = calculateFinalResults(updatedMatches);
       onComplete(finalResults);
     }
@@ -584,8 +931,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     setVictoryB(false);
   };
 
-  const openScoreModal = (match: TableauMatch) => {
+  const openScoreModal = (match: TableauMatch, consolationId?: string) => {
     setEditingMatch(match.id);
+    setEditingConsolationId(consolationId ?? null);
     setEditScoreA(match.scoreA?.toString() || '');
     setEditScoreB(match.scoreB?.toString() || '');
     setVictoryA(false);
@@ -611,6 +959,23 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
 
   const handleSpecialStatus = (status: 'abandon' | 'forfait' | 'exclusion') => {
     if (!editingMatch) return;
+
+    // Si c'est un match de consolation
+    if (editingConsolationId) {
+      const bracket = consolationBrackets.find(b => b.id === editingConsolationId);
+      const match = bracket?.matches.find(m => m.id === editingMatch);
+      if (bracket && match) {
+        let winner: Fencer | null = null;
+        if (status === 'exclusion') {
+          winner = match.fencerA && match.fencerB ? match.fencerB : match.fencerA || match.fencerB;
+        }
+        updateConsolationMatch(editingConsolationId, editingMatch, match.scoreA ?? 0, match.scoreB ?? 0, winner);
+      }
+      setShowScoreModal(false);
+      setEditingMatch(null);
+      setEditingConsolationId(null);
+      return;
+    }
 
     const match = matches.find(m => m.id === editingMatch);
     if (!match) return;
@@ -944,7 +1309,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     rounds.push(r);
     r = r / 2;
   }
-  if (thirdPlaceMatch && tableauSize >= 4) {
+  if ((thirdPlaceMatch || playAllPositions) && tableauSize >= 4) {
     const finalIndex = rounds.indexOf(2);
     if (finalIndex !== -1) {
       rounds.splice(finalIndex, 0, 3);
@@ -1271,19 +1636,111 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         ) : pyramidViewMode ? (
           <Bracket matches={convertToBracketMatches()} tableSize={tableauSize} />
         ) : (
-          <div style={{ display: 'flex', gap: '1rem', overflowX: 'auto' }}>
-            {rounds.map(round => renderRound(round))}
-          </div>
+          <>
+            {playAllPositions && matches.some(m => m.round === tableauSize * 2) && (
+              <div style={{ marginBottom: '1rem', padding: '0.75rem', background: '#eff6ff', borderRadius: '8px', border: '1px solid #bfdbfe' }}>
+                <div style={{ fontWeight: 600, marginBottom: '0.5rem', color: '#1e40af' }}>Barrages</div>
+                <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                  {matches.filter(m => m.round === tableauSize * 2).sort((a, b) => a.position - b.position).map(match => (
+                    <MatchCard
+                      key={match.id}
+                      match={match}
+                      viewMode="full"
+                      baseMatchHeight={BASE_MATCH_HEIGHT}
+                      onMatchClick={openScoreModal}
+                      onArenaClick={id => { setSelectedMatchForArena(id); setShowArenaModal(true); }}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: '1rem', overflowX: 'auto' }}>
+              {rounds.map(round => renderRound(round))}
+            </div>
+          </>
         )}
       </div>
 
       <SeedingTable ranking={ranking} tableauSize={tableauSize} />
 
+      {/* Brackets de consolation (mode Jouer toutes les places) */}
+      {playAllPositions && consolationBrackets.length > 0 && (
+        <div style={{ marginTop: '1.5rem' }}>
+          {consolationBrackets
+            .sort((a, b) => a.firstPlace - b.firstPlace)
+            .map(bracket => {
+              const finalM = bracket.matches.find(m => m.round === 2);
+              const bracketRounds: number[] = [];
+              let r = bracket.size;
+              while (r >= 2) { bracketRounds.push(r); r = r / 2; }
+              if (bracket.matches.some(m => m.round === 3)) {
+                const fi = bracketRounds.indexOf(2);
+                if (fi !== -1) bracketRounds.splice(fi, 0, 3);
+              }
+              return (
+                <div
+                  key={bracket.id}
+                  style={{
+                    background: '#f9fafb',
+                    borderRadius: '8px',
+                    padding: '1rem',
+                    marginBottom: '1rem',
+                    border: '1px solid #e5e7eb',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+                    <h3 style={{ margin: 0, fontSize: '1rem', fontWeight: 600, color: '#374151' }}>
+                      🥋 {bracket.name}
+                    </h3>
+                    {bracket.isComplete && (
+                      <span style={{ background: '#d1fae5', color: '#065f46', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 500 }}>
+                        Terminé
+                      </span>
+                    )}
+                    {finalM?.winner && (
+                      <span style={{ background: '#fef3c7', padding: '0.25rem 0.75rem', borderRadius: '8px', fontSize: '0.875rem', fontWeight: 600 }}>
+                        🏆 {finalM.winner.lastName} {finalM.winner.firstName}
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: '1rem', overflowX: 'auto' }}>
+                    {bracketRounds.map(round => {
+                      const roundMatches = bracket.matches.filter(m => m.round === round).sort((a, b) => a.position - b.position);
+                      const roundName = round === 3 ? 'Petite finale' : round === 2 ? 'Finale' : round === 4 ? 'Demi-finales' : round === 8 ? 'Quarts' : `Tableau de ${round}`;
+                      return (
+                        <div key={round} style={{ display: 'flex', flexDirection: 'column', minWidth: '200px' }}>
+                          <div style={{ textAlign: 'center', fontWeight: 600, marginBottom: '0.5rem', color: '#374151', fontSize: '0.875rem' }}>
+                            {roundName}
+                          </div>
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                            {roundMatches.map(match => (
+                              <MatchCard
+                                key={match.id}
+                                match={match}
+                                viewMode="full"
+                                baseMatchHeight={BASE_MATCH_HEIGHT}
+                                onMatchClick={m => openScoreModal(m, bracket.id)}
+                                onArenaClick={() => {}}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+      )}
+
       {/* Score Modal */}
       {(() => {
         if (!showScoreModal || !editingMatch) return null;
 
-        const match = matches.find(m => m.id === editingMatch);
+        const match = editingConsolationId
+          ? consolationBrackets.find(b => b.id === editingConsolationId)?.matches.find(m => m.id === editingMatch)
+          : matches.find(m => m.id === editingMatch);
         if (!match) return null;
 
         const scoreModal = (

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -571,6 +571,7 @@ export interface CompetitionSettings {
   questConfig?: QuestPhaseConfig; // Configuration du Tour Quest (Sabre Laser uniquement)
   refereeFeatureEnabled?: boolean; // Activer la gestion des arbitres sur arènes et saisie distante
   customFormula?: CustomFormulaConfig; // Formule à la carte (arme CUSTOM uniquement)
+  playAllPositions?: boolean; // Jouer toutes les places (tableaux de classement)
 }
 
 export interface Phase extends BaseEntity {


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Nouvelle option `playAllPositions` dans `CompetitionSettings` — checkbox dans les propriétés de compétition
- Quand activée, le tableau principal utilise la plus grande puissance de 2 ≤ N participants (au lieu de la plus petite ≥ N), avec des matchs de **barrages** pour les fencers en excès
- Après chaque round du tableau (≥ quarts de finale), les perdants forment automatiquement un **sous-tableau de classement** (Places 5–8, 9–16, 13–16, etc.) séded selon le classement de poules
- Petite finale forcée dans chaque sous-tableau
- Saisie des scores directement dans les brackets de consolation via le même modal que le tableau principal

## Fichiers modifiés

| Fichier | Changement |
|---|---|
| `src/shared/types/index.ts` | `playAllPositions?: boolean` dans `CompetitionSettings` |
| `src/renderer/components/CompetitionPropertiesModal.tsx` | Checkbox + state |
| `src/renderer/components/CompetitionView.tsx` | Passe le prop à `TableauView` |
| `src/renderer/components/TableauView.tsx` | Logique complète (barrages, consolation brackets, rendu) |

## Plan de test

- [ ] Créer une compétition à 18 tireurs, activer "Jouer toutes les places"
- [ ] Vérifier 2 matchs de barrages (seeds 15 vs 18, 16 vs 17)
- [ ] Jouer les barrages → bracket 17–18 apparaît avec les 2 perdants
- [ ] Jouer le 1er tour du tableau → bracket 9–16 apparaît avec 8 fencers
- [ ] Jouer les QF → bracket 5–8 apparaît avec 4 fencers
- [ ] Jouer les QF du bracket 9–16 → bracket 13–16 apparaît
- [ ] Vérifier que les SF restent dans leur bracket (petite finale)
- [ ] Compléter tous les brackets → classement 1–18 sans trou ni ex-aequo

## Limitation V1

Les brackets de consolation sont stockés en état React interne (non persistés) — une actualisation de page les efface. À adresser en V2 en sérialisant les matches dans le parent.

https://claude.ai/code/session_01NzeWHyWLNiRuzwct1LkK1Y
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzeWHyWLNiRuzwct1LkK1Y)_