### PR TITLE
Import arbitres Engarde + filtre matchs terminés

### DIFF
--- a/src/renderer/components/RefereeManager.tsx
+++ b/src/renderer/components/RefereeManager.tsx
@@ -4,9 +4,10 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { Referee, Match, Pool, Competition } from '../../shared/types';
+import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
+import { Referee, Match, Pool, Competition, MatchStatus } from '../../shared/types';
 import { RefereeManager, RefereeRotationConfig } from '../../shared/services/refereeManager';
+import { parseEngardeRefereeFile } from '../../shared/utils/fileParser';
 
 interface RefereeManagerProps {
   competition: Competition;
@@ -36,6 +37,8 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
   const [activeTab, setActiveTab] = useState<'referees' | 'assignments' | 'history'>('referees');
   const [newReferee, setNewReferee] = useState({ name: '', club: '', license: '', category: '', nationality: 'FRA' });
   const [addError, setAddError] = useState('');
+  const [importStatus, setImportStatus] = useState<{ count: number; errors: string[] } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [historyRows, setHistoryRows] = useState<Array<{
     matchId: string; matchNumber: number; poolName: string | null;
     fencerAName: string; fencerBName: string;
@@ -65,7 +68,7 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
   };
 
   const handleAutoAssign = () => {
-    const newAssignments = manager.assignRefereesToMatches(matches, pools);
+    const newAssignments = manager.assignRefereesToMatches(pendingMatches, pools);
     setAssignments(newAssignments);
     onAssignmentsChange(newAssignments);
     persistAssignments(newAssignments);
@@ -99,6 +102,39 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
     }
     return null;
   };
+
+  const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const content = await file.text();
+    const parsed = parseEngardeRefereeFile(content);
+    let count = 0;
+    const errors: string[] = [...parsed.errors];
+    for (const ref of parsed.referees) {
+      try {
+        const name = `${ref.firstName} ${ref.lastName}`.trim();
+        const created = await window.electronAPI.db.createReferee(competition.id, {
+          name,
+          club: ref.club,
+          license: ref.license,
+          category: ref.category,
+          nationality: ref.nationality,
+          gender: ref.gender,
+        });
+        onRefereesChange([...referees, created]);
+        count++;
+      } catch (err: any) {
+        errors.push(err?.message ?? 'Erreur import');
+      }
+    }
+    setImportStatus({ count, errors });
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }, [competition.id, referees, onRefereesChange]);
+
+  const pendingMatches = useMemo(
+    () => matches.filter(m => m.status !== MatchStatus.FINISHED && m.status !== MatchStatus.CANCELLED),
+    [matches]
+  );
 
   return (
     <div
@@ -195,6 +231,23 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
             >
               ＋ Ajouter
             </button>
+          </div>
+
+          {/* Import fichier Engarde */}
+          <div style={{ marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <input ref={fileInputRef} type="file" accept=".txt,.csv" style={{ display: 'none' }} onChange={handleImportFile} />
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              style={{ background: '#6d28d9', color: 'white', border: 'none', padding: '0.5rem 1.25rem', borderRadius: '6px', cursor: 'pointer', fontWeight: '500' }}
+            >
+              📂 Importer fichier Engarde
+            </button>
+            {importStatus && (
+              <span style={{ fontSize: '0.875rem', color: importStatus.errors.length ? '#dc2626' : '#166534' }}>
+                {importStatus.count} arbitre(s) importé(s)
+                {importStatus.errors.length > 0 && ` — ${importStatus.errors.length} erreur(s)`}
+              </span>
+            )}
           </div>
 
           {/* Liste arbitres */}
@@ -515,8 +568,11 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
       {/* Match Assignments */}
       <div>
         <h3 style={{ marginBottom: '1rem', color: '#374151' }}>Assignations des Matchs</h3>
+        {pendingMatches.length === 0 && (
+          <p style={{ color: '#6b7280', fontStyle: 'italic' }}>Aucun match en attente d'arbitre.</p>
+        )}
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-          {matches.map(match => {
+          {pendingMatches.map(match => {
             const assignedReferee = assignments.get(match.id);
             const conflictWarning = assignedReferee
               ? getConflictWarning(match, assignedReferee)

--- a/src/shared/utils/fileParser.ts
+++ b/src/shared/utils/fileParser.ts
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import { Fencer, FencerStatus, Gender } from '../types';
+import { Fencer, FencerStatus, Gender, Referee } from '../types';
 import { logger, LogCategory } from '../services/logger';
 
 export interface ImportResult {
@@ -1262,4 +1262,60 @@ function normalizeName(name: string): string {
     .replace(/[\u0300-\u036f]/g, '') // Supprime les accents
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+// ============================================================================
+// Import arbitres Engarde
+// ============================================================================
+
+export interface RefereeImportResult {
+  referees: Array<Omit<Referee, 'id' | 'ref' | 'createdAt' | 'updatedAt' | 'status'>>;
+  errors: string[];
+  skipped: number;
+}
+
+/**
+ * Parse un fichier arbitres au format Engarde (TXT semicolon-separated).
+ * En-tête attendu: nom;prenom;sexe;categorie;club;ligue;nation;date_nais;licence_fie;licence;
+ */
+export function parseEngardeRefereeFile(content: string): RefereeImportResult {
+  const result: RefereeImportResult = { referees: [], errors: [], skipped: 0 };
+
+  let clean = content;
+  if (clean.charCodeAt(0) === 0xfeff) clean = clean.slice(1);
+
+  const lines = clean.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  if (lines.length === 0) {
+    result.errors.push('Fichier vide');
+    return result;
+  }
+
+  // Détecter et sauter l'en-tête
+  const firstLower = lines[0].toLowerCase();
+  const startIdx = firstLower.includes('nom') || firstLower.includes('prenom') || firstLower.includes('sexe') ? 1 : 0;
+
+  for (let i = startIdx; i < lines.length; i++) {
+    const parts = lines[i].split(';');
+    if (parts.length < 2) { result.skipped++; continue; }
+
+    const lastName = parts[0]?.trim() || '';
+    const firstName = parts[1]?.trim() || '';
+    if (!lastName && !firstName) { result.skipped++; continue; }
+
+    const sexe = parts[2]?.trim().toUpperCase();
+    const gender: Gender = sexe === 'M' ? Gender.MALE : Gender.FEMALE;
+    const category = parts[3]?.trim() || undefined;
+    const club = parts[4]?.trim() || undefined;
+    const region = parts[5]?.trim() || undefined;
+    const nationality = parts[6]?.trim() || 'FRA';
+    // date_nais ignoré pour les arbitres
+    // licence_fie = parts[8], licence FFE = parts[9]
+    const licenseFIE = parts[8]?.trim() || '';
+    const licenseFFE = parts[9]?.trim() || '';
+    const license = licenseFFE || licenseFIE || undefined;
+
+    result.referees.push({ lastName, firstName, gender, nationality, club, region, license, category });
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Résumé

- **Import arbitres Engarde** : bouton "📂 Importer fichier Engarde" dans l'onglet Arbitres. Parse le format TXT semicolon (`nom;prenom;sexe;categorie;club;ligue;nation;date_nais;licence_fie;licence`). Détecte et saute l'en-tête automatiquement. Affiche le nombre d'arbitres importés + erreurs éventuelles.
- **Filtre matchs terminés** : l'onglet Assignations n'affiche plus que les matchs `NOT_STARTED` ou `IN_PROGRESS`. L'assignation automatique ne traite également que ces matchs.

## Fichiers modifiés

- `src/shared/utils/fileParser.ts` — `parseEngardeRefereeFile()`
- `src/renderer/components/RefereeManager.tsx` — bouton import + `pendingMatches`

https://claude.ai/code/session_01LfTvUzPVKU66XWgzXhiN5h

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfTvUzPVKU66XWgzXhiN5h)_