### PR TITLE
fix(remote): matchs tableau invisibles sur tablettes après transition poule→DE

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1058,14 +1058,18 @@ export class RemoteScoreServer {
 
         const arena = this.arenas.get(arenaId);
 
-        // Si l'arène a un pool associé, retourner TOUS les matchs en attente du pool
-        // (pas seulement le match courant) pour que l'arbitre voie les prochains matchs.
+        // Si l'arène a un pool associé, retourner les matchs NON TERMINÉS du pool.
+        // On exclut les matchs finis pour que, en fin de poule, le fallthrough
+        // atteigne la file d'attente DE (Tier 3) au lieu de bloquer dessus.
         const currentPoolId = arena?.currentMatch?.poolId;
         if (currentPoolId && this.sessionMatches.length > 0) {
           const rawPoolMatches = this.sessionMatches
             .filter((m: any) => {
               const matchPoolId = m.poolId || m.pool?.id || `pool-${m.poolNumber || m.number}`;
-              return matchPoolId === currentPoolId;
+              if (matchPoolId !== currentPoolId) return false;
+              const scoreUpdate = this.sessionMatchScores.get(m.id);
+              const effectiveStatus = scoreUpdate?.status ?? m.status;
+              return effectiveStatus !== MatchStatus.FINISHED;
             })
             .map((m: any) => {
               const scoreUpdate = this.sessionMatchScores.get(m.id);
@@ -1073,15 +1077,16 @@ export class RemoteScoreServer {
             });
           const poolMatches = this.applySmartMatchOrder(rawPoolMatches as Match[]);
           console.log(
-            `[RemoteScoreServer] ${poolMatches.length} matchs de pool pour arène ${arenaId} (pool ${currentPoolId})`
+            `[RemoteScoreServer] ${poolMatches.length} matchs de pool non terminés pour arène ${arenaId} (pool ${currentPoolId})`
           );
           if (poolMatches.length > 0) {
             return res.json({ matches: poolMatches, poolId: currentPoolId, poolName: null });
           }
         }
 
-        // Fallback: match courant seul
-        if (arena?.currentMatch) {
+        // Fallback: match courant seul — ignoré s'il est terminé pour éviter
+        // de bloquer l'accès à la file d'attente DE (Tier 3).
+        if (arena?.currentMatch && arena.currentMatch.status !== MatchStatus.FINISHED) {
           console.log(
             `[RemoteScoreServer] Fallback match courant pour arène ${arenaId}: ${arena.currentMatch.id}`
           );


### PR DESCRIPTION
## Problème

Au passage poule → tableau, les tablettes d'arbitrage affichaient « Tous les matchs de cette arène sont terminés » alors que les matchs DE étaient bien assignés aux pistes (badges P2/P3 visibles sur le PC).

## Cause racine

`/api/arenas/:arenaId/matches` a trois niveaux de priorité :

1. **Tier 1** – matchs du pool associé à `arena.currentMatch.poolId`
2. **Tier 2** – `arena.currentMatch` seul (fallback)
3. **Tier 3** – file d'attente DE (`arenaMatchQueue`)

En fin de poule, `arena.currentMatch.poolId` est encore défini. Le Tier 1 renvoyait **tous** les matchs de la poule (status `finished`). La tablette filtrait côté client pour `not_started | in_progress` → liste vide → message « terminés ». Le Tier 3 avec les vrais matchs DE n'était jamais atteint.

## Correction

- **Tier 1** : exclure les matchs `FINISHED` du filtre. Si toute la poule est terminée, `poolMatches.length === 0` → fallthrough naturel.
- **Tier 2** : ignorer `currentMatch` s'il est `FINISHED` → idem, fallthrough vers Tier 3.

La file DE est ainsi atteinte dès que la poule est complète.

https://claude.ai/code/session_01TNTa6hZzLxoHRzvR7Z5iou

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNTa6hZzLxoHRzvR7Z5iou)_