### PR TITLE
fix(remote): tablettes vides en tableau après fast-poule (statut périmé)

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1084,27 +1084,36 @@ export class RemoteScoreServer {
           }
         }
 
-        // Fallback: match courant seul — ignoré s'il est terminé pour éviter
-        // de bloquer l'accès à la file d'attente DE (Tier 3).
-        if (arena?.currentMatch && arena.currentMatch.status !== MatchStatus.FINISHED) {
-          console.log(
-            `[RemoteScoreServer] Fallback match courant pour arène ${arenaId}: ${arena.currentMatch.id}`
-          );
-          return res.json({
-            matches: [
-              {
-                id: arena.currentMatch.id,
-                poolId: arena.currentMatch.poolId,
-                fencerA: arena.currentMatch.fencerA,
-                fencerB: arena.currentMatch.fencerB,
-                scoreA: arena.currentMatch.scoreA,
-                scoreB: arena.currentMatch.scoreB,
-                status: arena.currentMatch.status,
-              },
-            ],
-            poolId: null,
-            poolName: null,
-          });
+        // Fallback: match courant seul.
+        // On utilise sessionMatches comme source de vérité pour le statut : en "fast poule",
+        // les scores sont saisis via l'UI principale sans passer par finishArenaMatch, donc
+        // arena.currentMatch.status reste 'not_started' en mémoire alors que le match est
+        // réellement terminé dans sessionMatches.
+        if (arena?.currentMatch) {
+          const scoreUpdate = this.sessionMatchScores.get(arena.currentMatch.id);
+          const inSession = this.sessionMatches.find((m: any) => m.id === arena.currentMatch!.id);
+          const effectiveStatus =
+            scoreUpdate?.status ?? inSession?.status ?? arena.currentMatch.status;
+          if (effectiveStatus !== MatchStatus.FINISHED) {
+            console.log(
+              `[RemoteScoreServer] Fallback match courant pour arène ${arenaId}: ${arena.currentMatch.id}`
+            );
+            return res.json({
+              matches: [
+                {
+                  id: arena.currentMatch.id,
+                  poolId: arena.currentMatch.poolId,
+                  fencerA: arena.currentMatch.fencerA,
+                  fencerB: arena.currentMatch.fencerB,
+                  scoreA: arena.currentMatch.scoreA,
+                  scoreB: arena.currentMatch.scoreB,
+                  status: effectiveStatus,
+                },
+              ],
+              poolId: null,
+              poolName: null,
+            });
+          }
         }
 
         // File d'attente DE
@@ -3721,7 +3730,24 @@ export class RemoteScoreServer {
       const arena = this.arenas.get(arenaId);
       if (!arena) continue;
       const existing = this.arenaMatchQueue.get(arenaId) || [];
-      if (!arena.currentMatch && queue.length > 0) {
+
+      // Déterminer si l'arène est effectivement libre : en fast-poule les scores sont
+      // saisis via l'UI principale, donc arena.currentMatch.status reste 'not_started'
+      // alors que le match est terminé dans sessionMatches. On vérifie sessionMatches.
+      let arenaEffectivelyFree = !arena.currentMatch;
+      if (!arenaEffectivelyFree && arena.currentMatch) {
+        const scoreUpdate = this.sessionMatchScores.get(arena.currentMatch.id);
+        const inSession = this.sessionMatches.find((m: any) => m.id === arena.currentMatch!.id);
+        const effectiveStatus =
+          scoreUpdate?.status ?? inSession?.status ?? arena.currentMatch.status;
+        if (effectiveStatus === MatchStatus.FINISHED) {
+          arena.currentMatch = null;
+          arena.status = 'idle';
+          arenaEffectivelyFree = true;
+        }
+      }
+
+      if (arenaEffectivelyFree && queue.length > 0) {
         this.assignMatchToArena(arenaId, queue[0]);
         this.arenaMatchQueue.set(arenaId, [...existing, ...queue.slice(1)]);
       } else {


### PR DESCRIPTION
## Diagnostic complet

En **fast poule** (scores saisis via l'UI principale), les matchs n'utilisent pas `finishArenaMatch`. Résultat : `arena.currentMatch.status` reste `'not_started'` en mémoire serveur alors que le match est `'finished'` dans `sessionMatches`.

### Chemin d'exécution bugué

1. Poule terminée → `arena.currentMatch.poolId` encore défini, `status = 'not_started'`
2. `refreshDeMatches` appelé → `!arena.currentMatch` est **false** → matchs DE mis en queue
3. Tablette poll `/api/arenas/:arenaId/matches` :
   - **Tier 1** (pool) : retournait TOUS les matchs de la poule y compris finis → client filtrait `not_started|in_progress` → **vide**
   - **Tier 2** (currentMatch fallback) : `status !== FINISHED` → TRUE (statut périmé `'not_started'`) → retournait le vieux match de poule
   - **Tier 3** (file DE) : jamais atteint

## Corrections

### 1. API `/api/arenas/:arenaId/matches`
- **Tier 1** : filtre les matchs avec `effectiveStatus` (`sessionMatchScores` → `sessionMatches`) au lieu du statut brut
- **Tier 2** : utilise le même `effectiveStatus` pour décider si le `currentMatch` est terminé (source de vérité = `sessionMatches`, pas `arena.currentMatch.status`)

### 2. `refreshDeMatches`
Avant d'assigner les matchs DE, vérifie le statut effectif de `arena.currentMatch`. Si le match de poule est terminé dans `sessionMatches` (même si `status` mémoire est `'not_started'`) :
- `arena.currentMatch = null`
- Assign direct du premier match DE via `assignMatchToArena` → **push Socket.IO immédiat** aux tablettes

Sans ce fix, les tablettes devaient recharger manuellement pour voir les matchs DE.

https://claude.ai/code/session_01TNTa6hZzLxoHRzvR7Z5iou

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNTa6hZzLxoHRzvR7Z5iou)_