### PR TITLE
fix(remote): syncPoolMatches actif même hors onglet remote

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1215,7 +1215,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
           />
         )}
 
-        {currentPhase === 'remote' && (
+        <div style={{ display: currentPhase === 'remote' ? '' : 'none' }}>
           <RemoteScoreManager
             competition={competition}
             pools={pools}
@@ -1226,7 +1226,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onStopRemote={() => setIsRemoteActive(false)}
             isRemoteActive={isRemoteActive}
           />
-        )}
+        </div>
 
         {currentPhase === 'logs' && (
           <ScoreAuditLog competitionId={competition.id} />


### PR DESCRIPTION
## Problème

Quand l'utilisateur utilisait le remplissage auto depuis l'onglet poule, les scores n'étaient pas synchronisés sur `/arene{N}/poule` → les signatures restaient indisponibles.

**Cause racine** : `RemoteScoreManager` était monté conditionnellement (`currentPhase === 'remote'`). Son `useEffect` qui appelle `syncPoolMatches` (broadcast Socket.IO vers les tablettes) était donc inactif quand l'utilisateur se trouvait sur l'onglet poule.

## Fix

Toujours monter `RemoteScoreManager` (masqué via `display:none` hors onglet remote) pour que l'effet `syncPoolMatches` reste actif quel que soit l'onglet courant.

```diff
- {currentPhase === 'remote' && (
-   <RemoteScoreManager ... />
- )}
+ <div style={{ display: currentPhase === 'remote' ? '' : 'none' }}>
+   <RemoteScoreManager ... />
+ </div>
```

## Impact

- Remplissage auto → pool.html reçoit le update Socket.IO → `isComplete: true` → boutons signature activés ✓
- Score manuel depuis PoolView → même correction s'applique ✓
- Aucun changement de comportement quand l'utilisateur est sur l'onglet remote ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01K98K8XsPZCLkJ3CC9rmzt3)_