### PR TITLE
Persist remote arena count, default to pool count

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -148,10 +148,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     showToast,
   });
 
-  // Synchroniser le nombre d'arènes avec le nombre de poules (seed initial uniquement)
+  // Synchroniser le nombre d'arènes avec le nombre de poules (seed initial uniquement, pas de valeur restaurée)
   useEffect(() => {
-    if (pools.length > 0 && remoteArenaCount === 1) setRemoteArenaCount(pools.length);
-  }, [pools.length]);
+    if (!isLoaded) return;
+    if (pools.length > 0 && remoteArenaCount === 1 && !restoredState?.remoteArenaCount) {
+      setRemoteArenaCount(pools.length);
+    }
+  }, [isLoaded, pools.length]);
 
   const poolPrepParams = useMemo(() => ({
     poolCount: pools.length,
@@ -170,6 +173,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     tableauMatches,
     finalResults,
     skipPoolPhase,
+    remoteArenaCount,
     poolPrepParams,
   });
 
@@ -202,6 +206,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         setMaxFencersPerPool(restoredState.poolPrepParams.maxFencersPerPool);
       }
       if (restoredState.skipPoolPhase) setSkipPoolPhase(restoredState.skipPoolPhase);
+      if (restoredState.remoteArenaCount != null) setRemoteArenaCount(restoredState.remoteArenaCount);
     }
   }, [restoredState, isLoaded]);
 

--- a/src/renderer/hooks/useCompetitionSession.ts
+++ b/src/renderer/hooks/useCompetitionSession.ts
@@ -20,6 +20,7 @@ interface SessionState {
   finalResults: FinalResult[];
   currentPoolRound: number;
   skipPoolPhase: boolean;
+  remoteArenaCount?: number;
   poolPrepParams: {
     poolCount: number;
     minFencersPerPool: number;
@@ -42,6 +43,7 @@ interface UseCompetitionSessionProps {
   tableauMatches: TableauMatch[];
   finalResults: FinalResult[];
   skipPoolPhase: boolean;
+  remoteArenaCount: number;
   poolPrepParams: {
     poolCount: number;
     minFencersPerPool: number;
@@ -99,6 +101,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
       finalResults: p.finalResults,
       currentPoolRound: p.currentPoolRound,
       skipPoolPhase: p.skipPoolPhase,
+      remoteArenaCount: p.remoteArenaCount,
       poolPrepParams: {
         poolCount: p.poolPrepParams?.poolCount || 0,
         minFencersPerPool: p.poolPrepParams?.minFencersPerPool || 5,
@@ -140,6 +143,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
           finalResults: typedState.finalResults || [],
           currentPoolRound: typedState.uiState?.currentPoolRound || 1,
           skipPoolPhase: typedState.skipPoolPhase ?? false,
+          remoteArenaCount: typedState.remoteArenaCount,
           poolPrepParams: typedState.poolPrepParams || {
             poolCount: 0,
             minFencersPerPool: 5,
@@ -182,6 +186,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
         finalResults: p.finalResults,
         currentPoolRound: p.currentPoolRound,
         skipPoolPhase: p.skipPoolPhase,
+        remoteArenaCount: p.remoteArenaCount,
         poolPrepParams: p.poolPrepParams,
         uiState: {
           currentPhase: p.currentPhase,
@@ -219,6 +224,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
     props.tableauMatches,
     props.finalResults,
     props.skipPoolPhase,
+    props.remoteArenaCount,
     props.poolPrepParams,
     saveState,
   ]);


### PR DESCRIPTION
## Summary
- `remoteArenaCount` ajouté dans `SessionState` → sauvegardé en DB à chaque changement et à la fermeture
- Restauré au redémarrage via `useCompetitionSession` + `CompetitionView`
- Par défaut = `pools.length` quand aucune valeur persistée n'existe

## Test plan
- [ ] Générer des poules → vérifier que le nombre de pistes = nombre de poules
- [ ] Modifier le nombre de pistes manuellement → redémarrer l'app → vérifier que la valeur est conservée
- [ ] Nouvelle compétition sans historique → vérifier fallback sur `pools.length`

https://claude.ai/code/session_01Kifk6jJiyKuomYXfEf1UNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kifk6jJiyKuomYXfEf1UNw)_