### PR TITLE
fix: bloquer modification match après signature poule (vue Matches)

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -1267,7 +1267,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
               return (
                 <div
                   key={index}
-                  onClick={() => !isAbandonMatch && openScoreModal(index)}
+                  onClick={() => !isAbandonMatch && !isLocked && openScoreModal(index)}
                   style={{
                     display: 'flex',
                     alignItems: 'center',
@@ -1279,7 +1279,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
                         ? '#f0fdf4'
                         : '#fef2f2',
                     borderRadius: '6px',
-                    cursor: isAbandonMatch ? 'not-allowed' : 'pointer',
+                    cursor: isAbandonMatch || isLocked ? 'not-allowed' : 'pointer',
                     border: isAbandonMatch ? '1px dashed #9ca3af' : '1px solid #e5e7eb',
                     opacity: isAbandonMatch ? 0.5 : 1,
                   }}
@@ -1391,7 +1391,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
                 <span style={{ flex: 1, textAlign: 'center', color: '#6b7280', textDecoration: 'line-through' }}>
                   {match.fencerA?.lastName} vs {match.fencerB?.lastName}
                 </span>
-                {onMatchReset && (
+                {!isLocked && onMatchReset && (
                   <button
                     onClick={() => onMatchReset(index)}
                     title="Relancer ce match"


### PR DESCRIPTION
## Bug

Vue "Matches" permettait de modifier/supprimer des résultats après clôture et signature de la poule.

## Cause

`PoolView.tsx` — deux endroits sans vérification `isLocked` :
- `onClick` sur match terminé → ouvrait le modal de saisie
- Bouton "Relancer" sur match annulé → pas de garde

## Fix

- `onClick` match terminé : `!isAbandonMatch && !isLocked`
- Curseur : `isAbandonMatch || isLocked ? 'not-allowed' : 'pointer'`
- Bouton relancer match annulé : `!isLocked && onMatchReset`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TB5yTFVrNWJ53VHyrvArHH)_