### PR TITLE
fix: persistance de l'assignation des arbitres

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -974,6 +974,7 @@ export class DatabaseManager {
       poolId: row.pool_id as string,
       tableId: row.table_id as string,
       round: row.round as number,
+      referee: row.referee_id ? (this.getReferee(row.referee_id as string) ?? undefined) : undefined,
       createdAt: new Date(row.created_at as string),
       updatedAt: new Date(row.updated_at as string),
     };
@@ -1020,6 +1021,23 @@ export class DatabaseManager {
       fStmt.free();
     }
 
+    // Batch-fetch referees referenced by these matches
+    const refereeIds = new Set<string>();
+    for (const row of matchRows) {
+      if (row.referee_id) refereeIds.add(row.referee_id as string);
+    }
+    const refereesById = new Map<string, Referee>();
+    if (refereeIds.size > 0) {
+      const placeholders = Array.from({ length: refereeIds.size }, () => '?').join(',');
+      const rStmt = this.db.prepare(`SELECT * FROM referees WHERE id IN (${placeholders})`);
+      rStmt.bind(Array.from(refereeIds));
+      while (rStmt.step()) {
+        const rRow = rStmt.getAsObject();
+        refereesById.set(rRow.id as string, this.rowToReferee(rRow));
+      }
+      rStmt.free();
+    }
+
     return matchRows.map(row => ({
       id: row.id as string,
       number: row.number as number,
@@ -1032,6 +1050,7 @@ export class DatabaseManager {
       poolId: row.pool_id as string,
       tableId: row.table_id as string,
       round: row.round as number,
+      referee: row.referee_id ? (refereesById.get(row.referee_id as string) ?? undefined) : undefined,
       createdAt: new Date(row.created_at as string),
       updatedAt: new Date(row.updated_at as string),
     }));

--- a/src/renderer/components/RefereeManager.tsx
+++ b/src/renderer/components/RefereeManager.tsx
@@ -54,6 +54,14 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
   }, [competition.id]);
 
   useEffect(() => {
+    const initial = new Map<string, Referee>();
+    for (const m of matches) {
+      if (m.referee) initial.set(m.id, m.referee);
+    }
+    setAssignments(initial);
+  }, [matches]);
+
+  useEffect(() => {
     if (activeTab === 'history') loadHistory();
   }, [activeTab, loadHistory]);
 


### PR DESCRIPTION
## Problème

L'assignation des arbitres disparaissait dès qu'on quittait l'onglet Arbitres, et les matchs ne voyaient jamais l'arbitre assigné même après rechargement.

## Cause racine (3 bugs)

1. **`getMatch()` et `getMatchesByPool()`** ne retournaient pas le champ `referee_id` de la DB → les objets `Match` n'avaient jamais de champ `referee`, même si la valeur était bien sauvegardée en base.
2. **`RefereeManager`** initialisait la Map `assignments` à vide sans jamais lire les assignations existantes dans les props `matches`.
3. `onAssignmentsChange={() => {}}` était un no-op (mineur, hors scope de ce fix).

## Corrections

- `src/database/index.ts` : `getMatch()` joint maintenant la table `referees` pour retourner l'objet `referee`. `getMatchesByPool()` fait un batch-fetch des referees (même pattern que les fencers déjà en place).
- `src/renderer/components/RefereeManager.tsx` : ajout d'un `useEffect` qui initialise `assignments` depuis les matchs passés en props au montage du composant.

https://claude.ai/code/session_01Gc2UAPG9HZ448P9rLsVEhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc2UAPG9HZ448P9rLsVEhT)_