### PR TITLE
fix: TS2448 useCompetitionSession déclaré après utilisation

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -148,14 +148,6 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     showToast,
   });
 
-  // Synchroniser le nombre d'arènes avec le nombre de poules (seed initial uniquement, pas de valeur restaurée)
-  useEffect(() => {
-    if (!isLoaded) return;
-    if (pools.length > 0 && remoteArenaCount === 1 && !restoredState?.remoteArenaCount) {
-      setRemoteArenaCount(pools.length);
-    }
-  }, [isLoaded, pools.length]);
-
   const poolPrepParams = useMemo(() => ({
     poolCount: pools.length,
     minFencersPerPool,
@@ -176,6 +168,14 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     remoteArenaCount,
     poolPrepParams,
   });
+
+  // Synchroniser le nombre d'arènes avec le nombre de poules (seed initial uniquement, pas de valeur restaurée)
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (pools.length > 0 && remoteArenaCount === 1 && !restoredState?.remoteArenaCount) {
+      setRemoteArenaCount(pools.length);
+    }
+  }, [isLoaded, pools.length]);
 
   // Restaurer l'état au chargement
   useEffect(() => {


### PR DESCRIPTION
## Problème

`build:ci` échoue avec :
```
TS2448: Block-scoped variable 'isLoaded' used before its declaration.
TS2454: Variable 'isLoaded' is used before being assigned.
```

## Cause

Dans `CompetitionView.tsx`, le `useEffect` qui référence `isLoaded` et `restoredState` était placé **avant** l'appel à `useCompetitionSession` qui les déclare.

## Fix

Déplacement de `poolPrepParams` (useMemo) et `useCompetitionSession` avant le `useEffect` dépendant.

https://claude.ai/code/session_01P98aZd9gEdS9X9a9ZSR8cx

---
_Generated by [Claude Code](https://claude.ai/code/session_01P98aZd9gEdS9X9a9ZSR8cx)_