### PR TITLE
Fix bugs import arbitres + FFF/TXT round-trip

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -453,8 +453,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         filters: [{ name: 'XML BellePoule', extensions: ['xml', 'cotcot'] }],
       },
       fff: {
-        title: 'Importer une liste FFE',
-        filters: [{ name: 'Fichiers FFE', extensions: ['fff', 'csv', 'txt'] }],
+        title: 'Importer une liste FFE (.fff, .csv, .txt)',
+        filters: [{ name: 'Fichiers FFE / TXT', extensions: ['fff', 'csv', 'txt'] }],
       },
       ranking: {
         title: 'Importer un classement FFE',

--- a/src/renderer/components/RefereeManager.tsx
+++ b/src/renderer/components/RefereeManager.tsx
@@ -108,12 +108,12 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
     if (!file) return;
     const content = await file.text();
     const parsed = parseEngardeRefereeFile(content);
-    let count = 0;
     const errors: string[] = [...parsed.errors];
+    const created: typeof referees = [];
     for (const ref of parsed.referees) {
       try {
         const name = `${ref.firstName} ${ref.lastName}`.trim();
-        const created = await window.electronAPI.db.createReferee(competition.id, {
+        const newRef = await window.electronAPI.db.createReferee(competition.id, {
           name,
           club: ref.club,
           license: ref.license,
@@ -121,13 +121,13 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
           nationality: ref.nationality,
           gender: ref.gender,
         });
-        onRefereesChange([...referees, created]);
-        count++;
+        created.push(newRef);
       } catch (err: any) {
         errors.push(err?.message ?? 'Erreur import');
       }
     }
-    setImportStatus({ count, errors });
+    if (created.length > 0) onRefereesChange([...referees, ...created]);
+    setImportStatus({ count: created.length, errors });
     if (fileInputRef.current) fileInputRef.current.value = '';
   }, [competition.id, referees, onRefereesChange]);
 

--- a/src/shared/utils/fileParser.ts
+++ b/src/shared/utils/fileParser.ts
@@ -142,6 +142,11 @@ function parseTXTLine(line: string, lineNumber: number): Partial<Fencer> | null 
     return null;
   }
 
+  // Sauter le premier champ s'il est purement numérique (colonne N° du format TXT BellePoule)
+  if (/^\d+$/.test(bestParts[0]) && bestParts.length >= 3) {
+    bestParts = bestParts.slice(1);
+  }
+
   const lastName = bestParts[0]?.toUpperCase().trim();
   const firstName = bestParts[1]?.trim();
 
@@ -766,21 +771,20 @@ function parseFFELine(
       region = (parts[9] || '').trim() || undefined;
       club = (parts[10] || '').trim() || undefined;
 
-      // La position finale est dans la section positionInfo (indice 14)
-      // Format: "Position,Statut" (ex: "2,t")
-      const positionField = (parts[14] || '').trim();
-      if (positionField && positionField !== '?') {
-        const parsedRanking = parseInt(positionField);
+      // Le classement FFE est à l'index 11 (4e champ de section2: Licence,Ligue,Club,Classement,...)
+      // NE PAS utiliser parts[14] (position séquentielle "1,t","2,t"...) comme classement
+      const rankingAtIdx11 = (parts[11] || '').trim();
+      if (rankingAtIdx11 && rankingAtIdx11 !== '?') {
+        const parsedRanking = parseInt(rankingAtIdx11);
         if (!isNaN(parsedRanking) && parsedRanking > 0) {
           ranking = parsedRanking;
         }
       }
 
-      // Fallback: si pas de position finale trouvée, chercher dans clubInfo
-      // Le classement est à l'index 10 (4ème position dans section 2: Licence,Ligue,Club,Classement,?,?)
+      // Fallback: certains formats placent le classement en parts[10] (3e champ section2)
       if (ranking === undefined) {
         const rankingField = (parts[10] || '').trim();
-        if (rankingField && rankingField !== '?') {
+        if (rankingField && rankingField !== '?' && !/^[A-Za-zÀ-ÿ]/.test(rankingField)) {
           const parsedRanking = parseInt(rankingField);
           if (!isNaN(parsedRanking) && parsedRanking > 0 && parsedRanking < 10000) {
             ranking = parsedRanking;
@@ -795,10 +799,10 @@ function parseFFELine(
       region = (parts[9] || '').trim() || undefined;
       club = (parts[10] || '').trim() || undefined;
 
-      // Chercher le classement à l'index 10 (4ème position dans section 2: Licence,Ligue,Club,Classement,?,?)
-      const rankingField = (parts[10] || '').trim();
-      if (rankingField && rankingField !== '?') {
-        const parsedRanking = parseInt(rankingField);
+      // Classement à l'index 11 (4e champ section2: Licence,Ligue,Club,Classement,...)
+      const rankingField11 = (parts[11] || '').trim();
+      if (rankingField11 && rankingField11 !== '?') {
+        const parsedRanking = parseInt(rankingField11);
         if (!isNaN(parsedRanking) && parsedRanking > 0 && parsedRanking < 10000) {
           ranking = parsedRanking;
         }


### PR DESCRIPTION
## Bugs corrigés

**Import arbitres (stale closure)**
`handleImportFile` appelait `onRefereesChange([...referees, created])` à chaque itération de boucle — `referees` étant la valeur capturée au moment du rendu, seul le dernier arbitre apparaissait dans la liste (mais tous étaient bien persistés en DB, d'où la visibilité dans le menu déroulant de l'arène). Fix : accumulation dans un tableau local, un seul appel `onRefereesChange([...referees, ...created])` après la boucle.

**Import TXT BellePoule — numéros devenus prénoms**
Le format TXT exporté par BellePoule commence chaque ligne par le numéro du tireur (`1     KIROU   Hadil ...`). `parseTXTLine` le prenait comme `lastName`. Fix : si le premier champ est purement numérique et qu'il reste ≥ 3 champs, le sauter.

**FFF round-trip — classement écrasé par la position séquentielle**
`parseFFELine` (format mixed) lisait `parts[14]` (la position séquentielle `1,t`, `2,t`…) comme classement au lieu de `parts[11]` (4e champ de section2 = classement FFE réel). Fix : lecture depuis `parts[11]`, plus de fallback sur `parts[14]`.

**Label dialogue import**
Le dialogue FFE acceptait déjà `.txt` mais ne le mentionnait pas. Label mis à jour : `Fichiers FFE / TXT`.

https://claude.ai/code/session_01LfTvUzPVKU66XWgzXhiN5h

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfTvUzPVKU66XWgzXhiN5h)_