### PR TITLE
feat(ui): command palette, theme toggle rapide, badges de phase

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,12 +3,13 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useEffect, useCallback } from 'react';
-import { Competition } from '../shared/types';
+import React, { useEffect, useCallback, useState } from 'react';
+import { Competition, PhaseType } from '../shared/types';
 import type { CompetitionCreateData } from '../shared/types/preload';
 import { logger, LogCategory } from '@shared/services/logger';
 import CompetitionList from './components/CompetitionList';
 import CompetitionView from './components/CompetitionView';
+import CommandPalette from './components/CommandPalette';
 import NewCompetitionModal from './components/NewCompetitionModal';
 import ReportIssueModal from './components/ReportIssueModal';
 import UpdateNotification from './components/UpdateNotification';
@@ -16,14 +17,26 @@ import SettingsModal from './components/SettingsModal';
 import DTCallNotification from './components/DTCallNotification';
 import { ToastProvider, useToast } from './components/Toast';
 import { ConfirmProvider, useConfirm } from './components/ConfirmDialog';
-import { TranslationProvider, useTranslation } from './contexts/TranslationContext';
+import { TranslationProvider, useTranslation, Theme } from './contexts/TranslationContext';
 import { ErrorBoundary, CompetitionErrorBoundary } from './components/ErrorBoundary';
 import { useAppState } from './hooks/useAppState';
 
+const PHASE_BADGE: Record<string, { label: string; cls: string }> = {
+  [PhaseType.CHECKIN]: { label: 'Appel', cls: 'badge-checkin' },
+  [PhaseType.POOL]: { label: 'Poules', cls: 'badge-pool' },
+  [PhaseType.QUEST]: { label: 'Quest', cls: 'badge-pool' },
+  [PhaseType.DIRECT_ELIMINATION]: { label: 'Tableau', cls: 'badge-tableau' },
+  [PhaseType.CLASSIFICATION]: { label: 'Résultats', cls: 'badge-results' },
+};
+
+const THEME_ICONS: Record<string, string> = { default: '🌓', light: '☀️', dark: '🌙' };
+const THEME_CYCLE: Theme[] = ['default', 'light', 'dark'];
+
 const AppContent: React.FC = () => {
-  const { t, isLoading: translationLoading } = useTranslation();
+  const { t, isLoading: translationLoading, theme, changeTheme } = useTranslation();
   const { showToast } = useToast();
   const { confirm } = useConfirm();
+  const [showCommandPalette, setShowCommandPalette] = useState(false);
 
   const {
     view,
@@ -96,6 +109,18 @@ const AppContent: React.FC = () => {
         window.electronAPI.removeAllListeners('autosave:failed');
       }
     };
+  }, []);
+
+  // Ctrl+K → command palette
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        setShowCommandPalette(prev => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
   }, []);
 
   // Sync logo from disk to localStorage so PDF exports always find it
@@ -302,6 +327,16 @@ const AppContent: React.FC = () => {
               </button>
             )}
             <button
+              className="btn-theme-toggle"
+              onClick={() => {
+                const next = THEME_CYCLE[(THEME_CYCLE.indexOf(theme) + 1) % THEME_CYCLE.length];
+                changeTheme(next);
+              }}
+              title={`Thème : ${theme}`}
+            >
+              {THEME_ICONS[theme]}
+            </button>
+            <button
               className="btn btn-secondary"
               onClick={() => setShowSettingsModal(true)}
               title={t('settings.title')}
@@ -423,6 +458,13 @@ const AppContent: React.FC = () => {
                   {openComp.isDirty && (
                     <span style={{ color: '#ef4444', marginLeft: '0.25rem' }}>●</span>
                   )}
+                  {(() => {
+                    const phase = openComp.competition.phases?.[openComp.competition.currentPhaseIndex];
+                    const badge = phase ? PHASE_BADGE[phase.type] : null;
+                    return badge ? (
+                      <span className={`tab-phase-badge ${badge.cls}`}>{badge.label}</span>
+                    ) : null;
+                  })()}
                 </span>
                 <button
                   onClick={e => handleTabClose(openComp.competition.id, e)}
@@ -501,6 +543,25 @@ const AppContent: React.FC = () => {
 
         {showSettingsModal && (
           <SettingsModal onClose={() => setShowSettingsModal(false)} onSave={handleSettingsSave} />
+        )}
+
+        {showCommandPalette && (
+          <CommandPalette
+            competitions={competitions}
+            onClose={() => setShowCommandPalette(false)}
+            onSelectCompetition={id => {
+              setShowCommandPalette(false);
+              handleTabSwitch(id);
+            }}
+            onNewCompetition={() => {
+              setShowCommandPalette(false);
+              setShowNewCompetitionModal(true);
+            }}
+            onOpenSettings={() => {
+              setShowCommandPalette(false);
+              setShowSettingsModal(true);
+            }}
+          />
         )}
       </div>
     </>

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -1,0 +1,172 @@
+/**
+ * BellePoule Modern - Command Palette (Ctrl+K)
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Competition } from '../../shared/types';
+import { useTranslation } from '../contexts/TranslationContext';
+
+interface Command {
+  id: string;
+  label: string;
+  description?: string;
+  icon: string;
+  action: () => void;
+  keywords?: string[];
+}
+
+interface CommandPaletteProps {
+  competitions: Competition[];
+  onClose: () => void;
+  onSelectCompetition: (id: string) => void;
+  onNewCompetition: () => void;
+  onOpenSettings: () => void;
+}
+
+const CommandPalette: React.FC<CommandPaletteProps> = ({
+  competitions,
+  onClose,
+  onSelectCompetition,
+  onNewCompetition,
+  onOpenSettings,
+}) => {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const staticCommands: Command[] = [
+    {
+      id: 'new-competition',
+      label: t('menu.new_competition'),
+      icon: '➕',
+      action: () => { onClose(); onNewCompetition(); },
+      keywords: ['new', 'nouveau', 'creer', 'create'],
+    },
+    {
+      id: 'settings',
+      label: t('settings.title'),
+      icon: '⚙️',
+      action: () => { onClose(); onOpenSettings(); },
+      keywords: ['settings', 'parametres', 'config', 'theme', 'langue'],
+    },
+  ];
+
+  const competitionCommands: Command[] = competitions.map(c => ({
+    id: `comp-${c.id}`,
+    label: c.title,
+    description: `${c.weapon} · ${c.category} · ${c.fencers.length} tireurs`,
+    icon: '🏆',
+    action: () => { onClose(); onSelectCompetition(c.id); },
+    keywords: [c.title.toLowerCase(), c.weapon, c.category],
+  }));
+
+  const allCommands = [...staticCommands, ...competitionCommands];
+
+  const filtered = query.trim()
+    ? allCommands.filter(cmd => {
+        const q = query.toLowerCase();
+        return (
+          cmd.label.toLowerCase().includes(q) ||
+          cmd.description?.toLowerCase().includes(q) ||
+          cmd.keywords?.some(k => k.includes(q))
+        );
+      })
+    : allCommands;
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex(i => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex(i => Math.max(i - 1, 0));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        filtered[selectedIndex]?.action();
+      } else if (e.key === 'Escape') {
+        onClose();
+      }
+    },
+    [filtered, selectedIndex, onClose]
+  );
+
+  useEffect(() => {
+    const item = listRef.current?.children[selectedIndex] as HTMLElement;
+    item?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  return (
+    <div className="command-palette-backdrop" onClick={onClose}>
+      <div
+        className="command-palette"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-label="Command palette"
+      >
+        <div className="command-palette-search">
+          <span className="command-palette-search-icon">⌘</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Rechercher une compétition ou une action…"
+            className="command-palette-input"
+            aria-label="Search commands"
+          />
+          {query && (
+            <button className="command-palette-clear" onClick={() => setQuery('')}>
+              ✕
+            </button>
+          )}
+        </div>
+
+        <div ref={listRef} className="command-palette-list" role="listbox">
+          {filtered.length === 0 ? (
+            <div className="command-palette-empty">Aucun résultat</div>
+          ) : (
+            filtered.map((cmd, i) => (
+              <div
+                key={cmd.id}
+                className={`command-palette-item ${i === selectedIndex ? 'command-palette-item-selected' : ''}`}
+                onClick={cmd.action}
+                onMouseEnter={() => setSelectedIndex(i)}
+                role="option"
+                aria-selected={i === selectedIndex}
+              >
+                <span className="command-palette-item-icon">{cmd.icon}</span>
+                <span className="command-palette-item-content">
+                  <span className="command-palette-item-label">{cmd.label}</span>
+                  {cmd.description && (
+                    <span className="command-palette-item-description">{cmd.description}</span>
+                  )}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="command-palette-footer">
+          <span><kbd>↑↓</kbd> naviguer</span>
+          <span><kbd>↵</kbd> sélectionner</span>
+          <span><kbd>Esc</kbd> fermer</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CommandPalette;

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -1871,3 +1871,230 @@ body {
   border-color: #ef4444;
   color: #fff;
 }
+
+/* ============================================================
+   Command Palette
+   ============================================================ */
+
+.command-palette-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(4px);
+  z-index: 9000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.command-palette {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg), 0 0 0 1px rgba(0,0,0,0.05);
+  width: 560px;
+  max-width: calc(100vw - 2rem);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 60vh;
+}
+
+.command-palette-search {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.command-palette-search-icon {
+  font-size: 1rem;
+  color: var(--color-text-light);
+  flex-shrink: 0;
+}
+
+.command-palette-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+}
+
+.command-palette-input::placeholder {
+  color: var(--color-text-light);
+}
+
+.command-palette-clear {
+  background: none;
+  border: none;
+  color: var(--color-text-light);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--radius-sm);
+  line-height: 1;
+}
+
+.command-palette-clear:hover {
+  background: var(--color-border);
+  color: var(--color-text);
+}
+
+.command-palette-list {
+  overflow-y: auto;
+  flex: 1;
+  padding: 0.375rem;
+}
+
+.command-palette-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.command-palette-item:hover,
+.command-palette-item-selected {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.command-palette-item-selected .command-palette-item-description {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.command-palette-item-icon {
+  font-size: 1.125rem;
+  flex-shrink: 0;
+  width: 1.5rem;
+  text-align: center;
+}
+
+.command-palette-item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.command-palette-item-label {
+  font-size: 0.9375rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette-item-description {
+  font-size: 0.75rem;
+  color: var(--color-text-light);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette-empty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-light);
+  font-size: 0.875rem;
+}
+
+.command-palette-footer {
+  display: flex;
+  gap: 1.25rem;
+  padding: 0.625rem 1rem;
+  border-top: 1px solid var(--color-border);
+  font-size: 0.75rem;
+  color: var(--color-text-light);
+}
+
+.command-palette-footer kbd {
+  background: var(--color-border);
+  border: 1px solid var(--color-border-dark, #9ca3af);
+  border-radius: 3px;
+  padding: 0.0625rem 0.3125rem;
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  color: var(--color-text);
+}
+
+/* ============================================================
+   Theme Toggle Button
+   ============================================================ */
+
+.btn-theme-toggle {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 1.125rem;
+  padding: 0.375rem 0.5rem;
+  line-height: 1;
+  transition: background 0.15s ease, border-color 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-theme-toggle:hover {
+  background: var(--color-border);
+}
+
+/* ============================================================
+   Tab Phase Badge
+   ============================================================ */
+
+.tab-phase-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 999px;
+  background: var(--color-primary);
+  color: #fff;
+  margin-left: 0.25rem;
+  vertical-align: middle;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.tab-phase-badge.badge-checkin { background: #6b7280; }
+.tab-phase-badge.badge-pool    { background: #3b82f6; }
+.tab-phase-badge.badge-ranking { background: #8b5cf6; }
+.tab-phase-badge.badge-tableau { background: #f59e0b; color: #1f2937; }
+.tab-phase-badge.badge-results { background: #10b981; }
+
+/* ============================================================
+   Tab dark mode tokens (replace hardcoded colors)
+   ============================================================ */
+
+.tab {
+  color: var(--color-text-light);
+}
+
+.tab:hover:not(.tab-active) {
+  background: var(--color-border) !important;
+}
+
+.tab-active {
+  background: var(--color-surface) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-text) !important;
+}
+
+.tabs-container {
+  background: var(--color-bg) !important;
+  border-bottom-color: var(--color-border) !important;
+}


### PR DESCRIPTION
## Résumé

- **Command palette (Ctrl+K)** — recherche instantanée de compétitions + actions (nouvelle compétition, settings). Navigation clavier ↑↓↵, fermeture Esc.
- **Theme toggle rapide** — bouton 🌓/☀️/🌙 dans le header pour cycler default→light→dark sans ouvrir les settings.
- **Badges de phase sur les onglets** — badge coloré (Appel / Poules / Tableau / Résultats…) indiquant la phase courante de chaque compétition ouverte.
- **Dark mode onglets** — remplacement des couleurs hardcodées par des tokens CSS (`var(--color-surface)`, `var(--color-border)`) pour que les onglets respectent le thème.

## Test

- [ ] Ctrl+K ouvre la palette, Esc ferme
- [ ] Recherche filtre compétitions et actions
- [ ] Entrée/clic navigue vers la compétition
- [ ] Bouton thème dans le header cycle les 3 modes
- [ ] Badge de phase visible sur les onglets de compétition
- [ ] Onglets lisibles en dark mode

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGUUdwR4rnqVGFNmVUL79A)_