### PR TITLE
fix: use versioned tag for GitHub release (fix tag creation blocked)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,25 +314,27 @@ jobs:
       - name: List downloaded files
         run: find builds -type f
 
-      - name: Delete all existing releases
+      - name: Delete old releases (keep last 3)
         run: |
-          # Supprimer toutes les releases pour ne conserver que la nouvelle
           tags=$(gh release list --repo "${{ github.repository }}" --json tagName -q '.[].tagName' 2>/dev/null || true)
+          count=0
           if [ -n "$tags" ]; then
             echo "$tags" | while read -r tag; do
-              echo "Suppression de la release: $tag"
-              gh release delete "$tag" --repo "${{ github.repository }}" --yes --cleanup-tag 2>/dev/null || true
+              count=$((count + 1))
+              if [ $count -gt 3 ]; then
+                echo "Suppression de la release: $tag"
+                gh release delete "$tag" --repo "${{ github.repository }}" --yes --cleanup-tag 2>/dev/null || true
+              fi
             done
           fi
-          # Nettoyer le tag 'latest' orphelin s'il reste
-          gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/latest" 2>/dev/null || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
+          tag_name: 'v${{ needs.increment-version.outputs.version }}-build.${{ needs.increment-version.outputs.build }}'
+          make_latest: true
           name: '🚀 BellePoule Modern v${{ needs.increment-version.outputs.version }} Build #${{ needs.increment-version.outputs.build }}'
           body: |
             ## BellePoule Modern


### PR DESCRIPTION
## Problème

Le tag `latest` est bloqué par une règle dépôt (immutable tag + creation restricted) :
```
Cannot create ref due to creations being restricted.
tag_name was used by an immutable release
```

## Fix

- `tag_name: latest` → `tag_name: v{version}-build.{build}` (ex: `v1.0.3-build.829`)
- Ajout `make_latest: true` pour marquer la release comme "latest" sur GitHub
- Ne plus supprimer toutes les releases — garder les 3 dernières

https://claude.ai/code/session_018FrnTWEYDVQ6FGQbkrXoSs

---
_Generated by [Claude Code](https://claude.ai/code/session_018FrnTWEYDVQ6FGQbkrXoSs)_