### PR TITLE
feat(ui): skeleton, onboarding, score flash, drag tabs, search hint

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -37,6 +37,7 @@ const AppContent: React.FC = () => {
   const { showToast } = useToast();
   const { confirm } = useConfirm();
   const [showCommandPalette, setShowCommandPalette] = useState(false);
+  const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
 
   const {
     view,
@@ -299,6 +300,15 @@ const AppContent: React.FC = () => {
             </svg>
             {t('app.title')}
           </div>
+          {/* Ctrl+K hint — clickable */}
+          <button
+            className="header-search-hint"
+            onClick={() => setShowCommandPalette(true)}
+            title="Ouvrir la palette de commandes (Ctrl+K)"
+          >
+            <span>Rechercher…</span>
+            <kbd>Ctrl K</kbd>
+          </button>
           <div className="header-nav">
             {openCompetitions.length > 0 && view === 'competition' && (
               <button
@@ -411,7 +421,25 @@ const AppContent: React.FC = () => {
             {openCompetitions.map(openComp => (
               <div
                 key={openComp.competition.id}
-                className={`tab ${activeTabId === openComp.competition.id ? 'tab-active' : ''}`}
+                className={`tab ${activeTabId === openComp.competition.id ? 'tab-active' : ''} ${draggedTabId === openComp.competition.id ? 'tab-dragging' : ''}`}
+                draggable
+                onDragStart={() => setDraggedTabId(openComp.competition.id)}
+                onDragEnd={() => setDraggedTabId(null)}
+                onDragOver={e => e.preventDefault()}
+                onDrop={e => {
+                  e.preventDefault();
+                  if (!draggedTabId || draggedTabId === openComp.competition.id) return;
+                  setOpenCompetitions(prev => {
+                    const from = prev.findIndex(o => o.competition.id === draggedTabId);
+                    const to = prev.findIndex(o => o.competition.id === openComp.competition.id);
+                    if (from === -1 || to === -1) return prev;
+                    const next = [...prev];
+                    const [moved] = next.splice(from, 1);
+                    next.splice(to, 0, moved);
+                    return next;
+                  });
+                  setDraggedTabId(null);
+                }}
                 onClick={() => handleTabSwitch(openComp.competition.id)}
                 style={{
                   display: 'flex',
@@ -419,18 +447,15 @@ const AppContent: React.FC = () => {
                   gap: '0.5rem',
                   padding: '0.75rem 1rem',
                   borderRadius: '8px 8px 0 0',
-                  cursor: 'pointer',
+                  cursor: 'grab',
                   background: activeTabId === openComp.competition.id ? 'white' : 'transparent',
-                  border:
-                    activeTabId === openComp.competition.id
-                      ? '1px solid #e5e7eb'
-                      : '1px solid transparent',
-                  borderBottom:
-                    activeTabId === openComp.competition.id ? '1px solid white' : 'none',
+                  border: activeTabId === openComp.competition.id ? '1px solid #e5e7eb' : '1px solid transparent',
+                  borderBottom: activeTabId === openComp.competition.id ? '1px solid white' : 'none',
                   marginBottom: activeTabId === openComp.competition.id ? '-1px' : '0',
                   transition: 'all 0.15s ease',
                   position: 'relative',
                   minWidth: '150px',
+                  opacity: draggedTabId === openComp.competition.id ? 0.4 : 1,
                 }}
                 onMouseEnter={e => {
                   if (activeTabId !== openComp.competition.id) {
@@ -443,6 +468,12 @@ const AppContent: React.FC = () => {
                   }
                 }}
               >
+                {/* Dot coloré de la compétition */}
+                <span style={{
+                  width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
+                  background: openComp.competition.color || '#3B5BDB',
+                  boxShadow: `0 0 0 2px ${(openComp.competition.color || '#3B5BDB')}33`,
+                }} />
                 <span
                   style={{
                     fontWeight: activeTabId === openComp.competition.id ? '600' : '400',
@@ -469,25 +500,12 @@ const AppContent: React.FC = () => {
                 <button
                   onClick={e => handleTabClose(openComp.competition.id, e)}
                   style={{
-                    background: 'none',
-                    border: 'none',
-                    color: '#6b7280',
-                    cursor: 'pointer',
-                    padding: '0.125rem',
-                    borderRadius: '3px',
-                    fontSize: '0.75rem',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
+                    background: 'none', border: 'none', color: '#6b7280',
+                    cursor: 'pointer', padding: '0.125rem', borderRadius: '3px',
+                    fontSize: '0.75rem', display: 'flex', alignItems: 'center', justifyContent: 'center',
                   }}
-                  onMouseEnter={e => {
-                    e.currentTarget.style.background = '#e5e7eb';
-                    e.currentTarget.style.color = '#374151';
-                  }}
-                  onMouseLeave={e => {
-                    e.currentTarget.style.background = 'none';
-                    e.currentTarget.style.color = '#6b7280';
-                  }}
+                  onMouseEnter={e => { e.currentTarget.style.background = '#e5e7eb'; e.currentTarget.style.color = '#374151'; }}
+                  onMouseLeave={e => { e.currentTarget.style.background = 'none'; e.currentTarget.style.color = '#6b7280'; }}
                   title={t('app.close_tab')}
                 >
                   ×

--- a/src/renderer/components/CompetitionList.tsx
+++ b/src/renderer/components/CompetitionList.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { Competition, Weapon, Gender, Category } from '../../shared/types';
 import { useTranslation } from '../hooks/useTranslation';
 import { usePagination } from '../hooks/usePagination';
+import { CompetitionCardSkeleton, SkeletonStyles } from './Skeleton';
 
 interface CompetitionListProps {
   competitions: Competition[];
@@ -45,15 +46,14 @@ const CompetitionListComponent: React.FC<CompetitionListProps> = ({
   if (isLoading) {
     return (
       <div className="content">
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            minHeight: '50vh',
-          }}
-        >
-          <div className="text-muted">{t('messages.loading')}</div>
+        <SkeletonStyles />
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="page-title">{t('app.title')}</h1>
+        </div>
+        <div className="competition-grid">
+          {[1, 2, 3, 4, 5, 6].map(i => (
+            <CompetitionCardSkeleton key={i} />
+          ))}
         </div>
       </div>
     );
@@ -62,32 +62,60 @@ const CompetitionListComponent: React.FC<CompetitionListProps> = ({
   if (competitions.length === 0) {
     return (
       <div className="content">
-        <div className="flex justify-between items-center mb-4">
-          <h1 className="page-title">{t('app.title')}</h1>
-          <button className="btn btn-primary btn-lg" onClick={onNewCompetition}>
-            + {t('menu.new_competition')}
-          </button>
-        </div>
-
         <div
           style={{
             display: 'flex',
-            justifyContent: 'center',
+            flexDirection: 'column',
             alignItems: 'center',
-            minHeight: '50vh',
+            justifyContent: 'center',
+            minHeight: '70vh',
+            gap: '3rem',
           }}
         >
-          <div className="empty-state">
-            <div className="empty-state-icon">🤺</div>
-            <h2 className="empty-state-title">{t('messages.no_competitions')}</h2>
-            <p className="empty-state-description">
-              {t('messages.no_competitions')} {t('messages.create_competition')} &quot;+{' '}
-              {t('menu.new_competition')}&quot;.
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontSize: '3.5rem', marginBottom: '1rem' }}>🤺</div>
+            <h1 style={{ fontSize: '1.75rem', fontWeight: 700, letterSpacing: '-0.03em', marginBottom: '0.5rem' }}>
+              Bienvenue sur BellePoule
+            </h1>
+            <p style={{ color: 'var(--color-text-light)', fontSize: '1rem', maxWidth: '36ch', margin: '0 auto' }}>
+              Gérez vos compétitions d&apos;escrime de l&apos;appel au podium.
             </p>
-            <button className="btn btn-primary btn-lg" onClick={onNewCompetition}>
-              + {t('menu.new_competition')}
-            </button>
           </div>
+
+          <div style={{ display: 'flex', gap: '1rem', alignItems: 'flex-start' }}>
+            {[
+              { step: '1', icon: '🏆', label: 'Créer', desc: 'une compétition' },
+              { step: '2', icon: '🤺', label: 'Ajouter', desc: 'les tireurs' },
+              { step: '3', icon: '🎯', label: 'Générer', desc: 'les poules' },
+              { step: '4', icon: '🏅', label: 'Publier', desc: 'les résultats' },
+            ].map(({ step, icon, label, desc }) => (
+              <div key={step} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.5rem', width: 100 }}>
+                <div style={{
+                  width: 48, height: 48, borderRadius: '50%',
+                  background: 'var(--color-primary)', color: '#fff',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: '1.25rem', fontWeight: 700, boxShadow: '0 4px 12px var(--color-primary-glow)',
+                }}>
+                  {icon}
+                </div>
+                <div style={{ fontSize: '0.6875rem', fontWeight: 700, color: 'var(--color-text-muted)', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+                  Étape {step}
+                </div>
+                <div style={{ textAlign: 'center', fontSize: '0.8125rem', fontWeight: 600 }}>{label}</div>
+                <div style={{ textAlign: 'center', fontSize: '0.75rem', color: 'var(--color-text-light)' }}>{desc}</div>
+              </div>
+            )).reduce<React.ReactNode[]>((acc, el, i) => {
+              if (i > 0) acc.push(
+                <div key={`arrow-${i}`} style={{ color: 'var(--color-border-dark)', marginTop: '1rem', fontSize: '1.25rem' }}>→</div>
+              );
+              acc.push(el);
+              return acc;
+            }, [])}
+          </div>
+
+          <button className="btn btn-primary btn-lg" onClick={onNewCompetition} style={{ padding: '0.75rem 2rem' }}>
+            + {t('menu.new_competition')}
+          </button>
         </div>
       </div>
     );
@@ -119,41 +147,35 @@ const CompetitionListComponent: React.FC<CompetitionListProps> = ({
             onClick={() => onSelect(competition)}
             style={{ '--card-accent': competition.color || '#3B5BDB' } as React.CSSProperties}
           >
-            <div className="card-body">
-              <div className="card-header">
-                <h3 className="card-title">{competition.title}</h3>
-                <div className="card-actions">
-                  <button
-                    className="btn btn-icon btn-secondary"
-                    onClick={e => {
-                      e.stopPropagation();
-                      onDelete(competition.id);
-                    }}
-                    title={t('actions.delete')}
-                  >
-                    🗑️
-                  </button>
+            <div className="comp-card-inner">
+              <div className="comp-card-top">
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <h3 className="comp-card-title">{competition.title}</h3>
+                  <p className="comp-card-date">{formatDate(competition.date)}</p>
                 </div>
+                <button
+                  className="btn btn-icon btn-secondary comp-card-delete"
+                  onClick={e => { e.stopPropagation(); onDelete(competition.id); }}
+                  title={t('actions.delete')}
+                >
+                  🗑️
+                </button>
               </div>
 
-              <div className="card-content">
-                <div className="card-meta">
-                  <div className="meta-item">
-                    <span className="meta-label">{t('competition.date')}:</span>
-                    <span>{formatDate(competition.date)}</span>
-                  </div>
-                  <div className="meta-item">
-                    <span className="meta-label">{t('competition.location')}:</span>
-                    <span>{competition.location || t('actions.default')}</span>
-                  </div>
-                  <div className="meta-item">
-                    <span className="meta-label">{t('competition.weapon')}:</span>
-                    <span>{competition.weapon}</span>
-                  </div>
-                </div>
-                <div className="card-footer">
-                  <span className="card-status">{t('actions.view')} →</span>
-                </div>
+              <div className="comp-card-pills">
+                <span className="comp-pill">{competition.weapon}</span>
+                <span className="comp-pill">{competition.category}</span>
+                <span className="comp-pill">{competition.gender}</span>
+                {competition.location && (
+                  <span className="comp-pill comp-pill-location">📍 {competition.location}</span>
+                )}
+              </div>
+
+              <div className="comp-card-footer">
+                <span className="comp-card-fencers">
+                  🤺 {competition.fencers.length} tireurs
+                </span>
+                <span className="comp-card-open">Ouvrir →</span>
               </div>
             </div>
           </div>

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Pool, Fencer, Score, MatchStatus, FencerStatus } from '../../../shared/types';
 import { formatRatio, formatIndex } from '../../../shared/utils/poolCalculations';
 import { ColumnId } from '../../hooks/useColumnVisibility';
@@ -25,6 +25,22 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
   isLocked = false,
 }) => {
   const fencers = pool.fencers;
+  const [flashCell, setFlashCell] = useState<string | null>(null);
+  const prevMatchesRef = useRef<typeof pool.matches>(pool.matches);
+
+  useEffect(() => {
+    const prev = prevMatchesRef.current;
+    for (const match of pool.matches) {
+      const old = prev.find(m => m.id === match.id);
+      if (old && match.status === MatchStatus.FINISHED && old.status !== MatchStatus.FINISHED) {
+        const key = `${match.fencerA?.id}-${match.fencerB?.id}`;
+        setFlashCell(key);
+        setTimeout(() => setFlashCell(null), 900);
+        break;
+      }
+    }
+    prevMatchesRef.current = pool.matches;
+  }, [pool.matches]);
 
   const getScore = (fencerA: Fencer, fencerB: Fencer): Score | null => {
     const match = pool.matches.find(
@@ -211,10 +227,14 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                   : 'pool-cell-defeat'
                 : 'pool-cell-editable';
 
+              const cellKey = `${rowFencer.id}-${colFencer.id}`;
+              const mirrorKey = `${colFencer.id}-${rowFencer.id}`;
+              const isFlashing = flashCell === cellKey || flashCell === mirrorKey;
+
               return (
                 <div
                   key={colIndex}
-                  className={`pool-cell ${cellClass}`}
+                  className={`pool-cell ${cellClass} ${isFlashing ? 'pool-cell-flash' : ''}`}
                   onClick={() => !isLocked && onCellClick(rowFencer, colFencer)}
                   style={{ cursor: isLocked ? 'default' : 'pointer', position: 'relative' }}
                 >

--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -708,3 +708,212 @@ select:focus {
 .competition-grid .competition-card:nth-child(4) { animation-delay: 120ms; }
 .competition-grid .competition-card:nth-child(5) { animation-delay: 160ms; }
 .competition-grid .competition-card:nth-child(6) { animation-delay: 200ms; }
+
+/* ============================================================
+   COMPETITION CARDS — inner layout
+   ============================================================ */
+
+.comp-card-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 1.25rem;
+}
+
+.comp-card-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.comp-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  line-height: 1.3;
+  margin: 0 0 0.25rem;
+}
+
+.comp-card-date {
+  font-size: 0.75rem;
+  color: var(--color-text-light);
+  margin: 0;
+}
+
+.comp-card-delete {
+  opacity: 0;
+  transition: opacity var(--duration-fast) ease;
+  flex-shrink: 0;
+}
+
+.competition-card:hover .comp-card-delete {
+  opacity: 1;
+}
+
+.comp-card-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.comp-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1875rem 0.5625rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border-radius: var(--radius-full);
+  background: var(--color-bg);
+  color: var(--color-text-light);
+  border: 1px solid var(--color-border);
+}
+
+.comp-pill-location {
+  background: transparent;
+}
+
+.comp-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.comp-card-fencers {
+  font-size: 0.8125rem;
+  color: var(--color-text-light);
+  font-weight: 500;
+}
+
+.comp-card-open {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  transition: gap var(--duration-fast) ease;
+}
+
+.competition-card:hover .comp-card-open {
+  letter-spacing: 0.02em;
+}
+
+/* ============================================================
+   HEADER SEARCH HINT (Ctrl+K)
+   ============================================================ */
+
+.header-search-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.875rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+  font-family: var(--font-sans);
+  transition: all var(--duration-fast) ease;
+  margin: 0 auto 0 1rem;
+  min-width: 180px;
+}
+
+.header-search-hint:hover {
+  background: var(--color-surface);
+  border-color: var(--color-border-dark);
+  color: var(--color-text-light);
+}
+
+.header-search-hint span {
+  flex: 1;
+  text-align: left;
+}
+
+.header-search-hint kbd {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-dark);
+  border-radius: 4px;
+  padding: 0.0625rem 0.3125rem;
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+/* ============================================================
+   POOL CELL FLASH ANIMATION
+   ============================================================ */
+
+@keyframes pool-flash {
+  0%   { box-shadow: inset 0 0 0 2px var(--color-primary); }
+  40%  { box-shadow: inset 0 0 0 2px var(--color-primary); background: rgba(59,91,219,0.15); }
+  100% { box-shadow: inset 0 0 0 0px transparent; }
+}
+
+.pool-cell-flash {
+  animation: pool-flash 0.9s var(--ease-out) forwards;
+}
+
+/* ============================================================
+   PHASE CONTENT TRANSITION
+   ============================================================ */
+
+@keyframes phase-enter {
+  from { opacity: 0; transform: translateX(8px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+.content {
+  animation: phase-enter var(--duration-slow) var(--ease-out) both;
+}
+
+/* ============================================================
+   SKELETON — shimmer keyframe (from Skeleton.tsx inline)
+   ============================================================ */
+
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.theme-dark [style*="shimmer"] {
+  background: linear-gradient(90deg, #2a2826 25%, #333028 50%, #2a2826 75%) !important;
+}
+
+/* ============================================================
+   TAB DRAGGING
+   ============================================================ */
+
+.tab-dragging {
+  opacity: 0.4 !important;
+}
+
+/* ============================================================
+   SKELETON CARDS — dark mode
+   ============================================================ */
+
+.theme-dark .comp-pill {
+  background: var(--color-surface-2);
+  border-color: var(--color-border);
+  color: var(--color-text-muted);
+}
+
+.theme-dark .comp-card-footer {
+  border-top-color: var(--color-border);
+}
+
+.theme-dark .header-search-hint {
+  background: var(--color-surface-2);
+  border-color: var(--color-border);
+}
+
+.theme-dark .header-search-hint:hover {
+  background: var(--color-border);
+}
+
+.theme-dark .header-search-hint kbd {
+  background: var(--color-bg);
+  border-color: var(--color-border-dark);
+}


### PR DESCRIPTION
## Ce qui change

### Skeleton loaders
- Chargement → 6 cards shimmer au lieu de "Chargement…"
- Animation shimmer CSS (gradient qui glisse)

### Empty state onboarding visuel
- 4 étapes avec icônes : Créer → Ajouter → Poules → Podium
- Flèches entre les étapes, bouton CTA centré

### Cards compétitions refaites
- Pills colorées : arme / catégorie / genre / lieu
- Footer avec compteur de tireurs
- Bouton supprimer visible uniquement au hover
- Barre accent couleur en top (déjà fait PR précédent)

### Header search hint
- Barre "Rechercher…" `Ctrl K` cliquable au centre du header
- Style frosted, s'ouvre la command palette au clic

### Dot coloré dans les onglets
- Petit cercle de la couleur de la compétition avant le titre
- Avec glow ring subtil

### Drag-and-drop des onglets
- Glisser-déposer pour réordonner les compétitions ouvertes
- Onglet draggé devient transparent (opacity 0.4)

### Score flash animation
- Quand un score est enregistré dans la grille de poule, la cellule flashe en bleu 900ms
- Détection via comparaison `pool.matches` prev/next avec `useRef`

## Test
- [ ] Chargement initial : voir les skeleton cards s'afficher
- [ ] App sans compétitions : voir l'onboarding avec les 4 étapes
- [ ] Cards : pills, footer, delete au hover seulement
- [ ] Ctrl+K et clic sur la barre de recherche → ouvre la palette
- [ ] Onglets : dot coloré visible, drag-and-drop fonctionnel
- [ ] Saisir un score dans une poule → flash bleu sur la cellule

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGUUdwR4rnqVGFNmVUL79A)_