### PR TITLE
feat(ui): header glassmorphism, barre de progression, confetti victoire

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -9,6 +9,7 @@ import { logger, LogCategory } from '@shared/services/logger';
 import { RankingImportResult } from '../../shared/utils/fileParser';
 import FencerList from './FencerList';
 import PoolView from './PoolView';
+import Confetti from './Confetti';
 import TableauView, { TableauMatch, FinalResult, propagateWinners, ConsolationBracket } from './TableauView';
 import PoolRankingView from './PoolRankingView';
 import ResultsView from './ResultsView';
@@ -808,145 +809,152 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
   const poolsNextAction = getPoolsNextAction();
 
+  // Confetti + menu état
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [showActionsMenu, setShowActionsMenu] = useState(false);
+  const prevAllPoolsComplete = useRef(false);
+  const prevChampion = useRef<string | null>(null);
+  const actionsMenuRef = useRef<HTMLDivElement>(null);
+
+  // Détecter complétion des poules → confetti
+  useEffect(() => {
+    const allDone = canAdvanceFromPools && pools.length > 0;
+    if (allDone && !prevAllPoolsComplete.current) {
+      setShowConfetti(true);
+      setTimeout(() => setShowConfetti(false), 3200);
+    }
+    prevAllPoolsComplete.current = allDone;
+  }, [canAdvanceFromPools, pools.length]);
+
+  // Fermer le menu actions au clic extérieur
+  useEffect(() => {
+    if (!showActionsMenu) return;
+    const handler = (e: MouseEvent) => {
+      if (actionsMenuRef.current && !actionsMenuRef.current.contains(e.target as Node)) {
+        setShowActionsMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showActionsMenu]);
+
+  // Calcul progression matchs
+  const matchProgress = useMemo(() => {
+    if (pools.length === 0 && tableauMatches.length === 0) return null;
+    if (pools.length > 0) {
+      const total = pools.reduce((s, p) => s + p.matches.length, 0);
+      const done = pools.reduce((s, p) => s + p.matches.filter(m => m.status === MatchStatus.FINISHED).length, 0);
+      return { done, total, label: 'poules' };
+    }
+    if (tableauMatches.length > 0) {
+      const total = tableauMatches.filter(m => m.fencerA && m.fencerB).length;
+      const done = tableauMatches.filter(m => m.status === MatchStatus.FINISHED).length;
+      return { done, total, label: 'tableau' };
+    }
+    return null;
+  }, [pools, tableauMatches]);
+
   return (
     <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' }}>
-      {/* Header */}
-      <div
-        style={{
-          padding: '1rem',
-          background: competition.color,
-          color: 'white',
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
-        <div>
-          <h1 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.25rem' }}>
-            {competition.title}
-          </h1>
-          <p style={{ opacity: 0.9, fontSize: '0.875rem' }}>
-            {new Date(competition.date).toLocaleDateString(language === 'zh-HK' ? 'zh-HK' : language, {
-              weekday: 'long',
-              day: 'numeric',
-              month: 'long',
-              year: 'numeric',
-            })}
-            {competition.location && ` • ${competition.location}`}
-          </p>
-        </div>
-        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-          <span className="badge" style={{ background: 'rgba(255,255,255,0.2)' }}>
-            {fencers.length} {t('fencer.label')}
-          </span>
-          <span className="badge" style={{ background: 'rgba(255,255,255,0.2)' }}>
-            {getCheckedInFencers().length} {t('fencer.present_label')}
-          </span>
-          <button
-            onClick={() => setShowFencerComparison(true)}
-            style={{
-              background: 'rgba(255,255,255,0.2)',
-              border: 'none',
-              color: 'white',
-              padding: '0.5rem 1rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-            }}
-          >
-            ⚔️ {t('competition.comparisons')}
-          </button>
-          <button
-            onClick={() => setShowAnalytics(true)}
-            style={{
-              background: 'rgba(255,255,255,0.2)',
-              border: 'none',
-              color: 'white',
-              padding: '0.5rem 1rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-            }}
-          >
-            📊 {t('competition.analytics')}
-          </button>
-          <button
-            onClick={() => setShowQRCode(true)}
-            style={{
-              background: 'rgba(255,255,255,0.2)',
-              border: 'none',
-              color: 'white',
-              padding: '0.5rem 1rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-            }}
-          >
-            📱 Partager
-          </button>
-          {currentPhase === 'pools' && pools.length > 0 && (
-            <>
+      <Confetti active={showConfetti} />
+      {/* Header — glassmorphism redesign */}
+      <div className="comp-header" style={{ '--comp-color': competition.color } as React.CSSProperties}>
+        <div className="comp-header-bg" />
+        <div className="comp-header-content">
+          {/* Infos */}
+          <div className="comp-header-info">
+            <div className="comp-header-pills">
+              <span className="comp-header-pill">{competition.weapon}</span>
+              <span className="comp-header-pill">{competition.category}</span>
+              <span className="comp-header-pill">{competition.gender}</span>
+            </div>
+            <h1 className="comp-header-title">{competition.title}</h1>
+            <p className="comp-header-meta">
+              {new Date(competition.date).toLocaleDateString(language === 'zh-HK' ? 'zh-HK' : language, {
+                weekday: 'long', day: 'numeric', month: 'long', year: 'numeric',
+              })}
+              {competition.location && ` · ${competition.location}`}
+            </p>
+          </div>
+
+          {/* Stats + actions */}
+          <div className="comp-header-right">
+            {/* Stats */}
+            <div className="comp-header-stats">
+              <div className="comp-stat">
+                <span className="comp-stat-value">{fencers.length}</span>
+                <span className="comp-stat-label">{t('fencer.label')}</span>
+              </div>
+              <div className="comp-stat-sep" />
+              <div className="comp-stat">
+                <span className="comp-stat-value">{getCheckedInFencers().length}</span>
+                <span className="comp-stat-label">{t('fencer.present_label')}</span>
+              </div>
+              {matchProgress && (
+                <>
+                  <div className="comp-stat-sep" />
+                  <div className="comp-stat">
+                    <span className="comp-stat-value">{matchProgress.done}/{matchProgress.total}</span>
+                    <span className="comp-stat-label">matchs</span>
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Menu actions ⋯ */}
+            <div className="comp-header-actions" ref={actionsMenuRef}>
               <button
-                onClick={() => setShowPresentation(true)}
-                style={{
-                  background: 'rgba(255,255,255,0.2)',
-                  border: 'none',
-                  color: 'white',
-                  padding: '0.5rem 1rem',
-                  borderRadius: '6px',
-                  cursor: 'pointer',
-                  fontSize: '0.875rem',
-                }}
+                className="comp-header-menu-btn"
+                onClick={() => setShowActionsMenu(v => !v)}
+                title="Actions"
               >
-                🖥️ Mode Présentation
+                ⋯
               </button>
-              <button
-                onClick={() => setShowKiosk(true)}
-                style={{
-                  background: 'rgba(255,255,255,0.2)',
-                  border: 'none',
-                  color: 'white',
-                  padding: '0.5rem 1rem',
-                  borderRadius: '6px',
-                  cursor: 'pointer',
-                  fontSize: '0.875rem',
-                }}
-              >
-                📱 Mode Kiosk
-              </button>
-            </>
-          )}
-          {(pools.length > 0 || tableauMatches.length > 0) && (
-            <button
-              onClick={() => setShowKioskDisplay(true)}
-              style={{
-                background: 'rgba(255,255,255,0.2)',
-                border: 'none',
-                color: 'white',
-                padding: '0.5rem 1rem',
-                borderRadius: '6px',
-                cursor: 'pointer',
-                fontSize: '0.875rem',
-              }}
-            >
-              🖥️ Kiosk Public
-            </button>
-          )}
-          <button
-            onClick={() => setShowPropertiesModal(true)}
-            style={{
-              background: 'rgba(255,255,255,0.2)',
-              border: 'none',
-              color: 'white',
-              padding: '0.5rem 1rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-            }}
-          >
-            ⚙️ Propriétés
-          </button>
+              {showActionsMenu && (
+                <div className="comp-header-dropdown">
+                  <button className="comp-header-dropdown-item" onClick={() => { setShowFencerComparison(true); setShowActionsMenu(false); }}>
+                    ⚔️ {t('competition.comparisons')}
+                  </button>
+                  <button className="comp-header-dropdown-item" onClick={() => { setShowAnalytics(true); setShowActionsMenu(false); }}>
+                    📊 {t('competition.analytics')}
+                  </button>
+                  <button className="comp-header-dropdown-item" onClick={() => { setShowQRCode(true); setShowActionsMenu(false); }}>
+                    📱 Partager
+                  </button>
+                  {currentPhase === 'pools' && pools.length > 0 && (
+                    <>
+                      <button className="comp-header-dropdown-item" onClick={() => { setShowPresentation(true); setShowActionsMenu(false); }}>
+                        🖥️ Mode Présentation
+                      </button>
+                      <button className="comp-header-dropdown-item" onClick={() => { setShowKiosk(true); setShowActionsMenu(false); }}>
+                        📱 Mode Kiosk
+                      </button>
+                    </>
+                  )}
+                  {(pools.length > 0 || tableauMatches.length > 0) && (
+                    <button className="comp-header-dropdown-item" onClick={() => { setShowKioskDisplay(true); setShowActionsMenu(false); }}>
+                      🖥️ Kiosk Public
+                    </button>
+                  )}
+                  <div className="comp-header-dropdown-sep" />
+                  <button className="comp-header-dropdown-item" onClick={() => { setShowPropertiesModal(true); setShowActionsMenu(false); }}>
+                    ⚙️ Propriétés
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
+
+        {/* Barre de progression matchs */}
+        {matchProgress && matchProgress.total > 0 && (
+          <div className="comp-header-progress">
+            <div
+              className="comp-header-progress-fill"
+              style={{ width: `${(matchProgress.done / matchProgress.total) * 100}%` }}
+            />
+          </div>
+        )}
       </div>
 
       {/* Navigation */}

--- a/src/renderer/components/Confetti.tsx
+++ b/src/renderer/components/Confetti.tsx
@@ -1,0 +1,147 @@
+/**
+ * BellePoule Modern — Confetti Animation
+ * Triggered on pool completion and tournament winner
+ * Licensed under GPL-3.0
+ */
+
+import React, { useEffect, useRef, useCallback } from 'react';
+
+interface ConfettiProps {
+  active: boolean;
+  duration?: number;
+  particleCount?: number;
+  origin?: { x: number; y: number };
+}
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  color: string;
+  shape: 'rect' | 'circle';
+  size: number;
+  rotation: number;
+  rotationSpeed: number;
+  opacity: number;
+  decay: number;
+}
+
+const COLORS = [
+  '#3B5BDB', '#6B84E8', '#F59E0B', '#10B981',
+  '#EF4444', '#8B5CF6', '#EC4899', '#14B8A6',
+  '#F97316', '#FACC15',
+];
+
+const Confetti: React.FC<ConfettiProps> = ({
+  active,
+  duration = 3000,
+  particleCount = 160,
+  origin = { x: 0.5, y: 0.3 },
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animRef = useRef<number>(0);
+  const particlesRef = useRef<Particle[]>([]);
+
+  const createParticles = useCallback((canvas: HTMLCanvasElement): Particle[] => {
+    const cx = canvas.width * origin.x;
+    const cy = canvas.height * origin.y;
+    return Array.from({ length: particleCount }, () => {
+      const angle = (Math.random() * Math.PI * 2);
+      const speed = 4 + Math.random() * 10;
+      return {
+        x: cx,
+        y: cy,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - 6,
+        color: COLORS[Math.floor(Math.random() * COLORS.length)],
+        shape: Math.random() > 0.4 ? 'rect' : 'circle',
+        size: 4 + Math.random() * 8,
+        rotation: Math.random() * Math.PI * 2,
+        rotationSpeed: (Math.random() - 0.5) * 0.3,
+        opacity: 1,
+        decay: 0.012 + Math.random() * 0.008,
+      };
+    });
+  }, [origin, particleCount]);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+
+    particlesRef.current = createParticles(canvas);
+
+    const tick = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      particlesRef.current = particlesRef.current.filter(p => p.opacity > 0.02);
+
+      for (const p of particlesRef.current) {
+        p.x += p.vx;
+        p.y += p.vy;
+        p.vy += 0.25; // gravity
+        p.vx *= 0.99; // air resistance
+        p.rotation += p.rotationSpeed;
+        p.opacity -= p.decay;
+
+        ctx.save();
+        ctx.globalAlpha = Math.max(0, p.opacity);
+        ctx.translate(p.x, p.y);
+        ctx.rotate(p.rotation);
+        ctx.fillStyle = p.color;
+
+        if (p.shape === 'rect') {
+          ctx.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2);
+        } else {
+          ctx.beginPath();
+          ctx.arc(0, 0, p.size / 2, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        ctx.restore();
+      }
+
+      if (particlesRef.current.length > 0) {
+        animRef.current = requestAnimationFrame(tick);
+      } else {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+      }
+    };
+
+    animRef.current = requestAnimationFrame(tick);
+
+    const timer = setTimeout(() => {
+      cancelAnimationFrame(animRef.current);
+      particlesRef.current = [];
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    }, duration);
+
+    return () => {
+      cancelAnimationFrame(animRef.current);
+      clearTimeout(timer);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    };
+  }, [active, duration, createParticles]);
+
+  if (!active) return null;
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        pointerEvents: 'none',
+        zIndex: 9999,
+      }}
+    />
+  );
+};
+
+export default Confetti;

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -15,6 +15,7 @@ import { useColumnVisibility, POOL_COLUMNS, ColumnId } from '../hooks/useColumnV
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import { useHistory } from '../hooks/useHistory';
 import PoolScoreMatrix from './pool/PoolScoreMatrix';
+import Confetti from './Confetti';
 
 interface PoolViewProps {
   pool: Pool;
@@ -65,6 +66,16 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const [signedFencerIds, setSignedFencerIds] = useState<string[]>([]);
 
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
+  const [showPoolConfetti, setShowPoolConfetti] = useState(false);
+  const prevIsComplete = useRef(pool.isComplete);
+
+  useEffect(() => {
+    if (pool.isComplete && !prevIsComplete.current) {
+      setShowPoolConfetti(true);
+      setTimeout(() => setShowPoolConfetti(false), 3000);
+    }
+    prevIsComplete.current = pool.isComplete;
+  }, [pool.isComplete]);
 
   const isLaserSabre = weapon === Weapon.LASER;
   const isLocked = pool.fencers.length > 0 && signedFencerIds.filter(id => pool.fencers.some(f => f.id === id)).length >= pool.fencers.length;
@@ -1429,6 +1440,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
 
   return (
     <div className="card">
+      <Confetti active={showPoolConfetti} particleCount={100} origin={{ x: 0.5, y: 0.5 }} />
       {isLocked && (
         <div style={{
           background: '#fef2f2',

--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -917,3 +917,231 @@ select:focus {
   background: var(--color-bg);
   border-color: var(--color-border-dark);
 }
+
+/* ============================================================
+   COMPETITION HEADER — glassmorphism redesign
+   ============================================================ */
+
+.comp-header {
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.comp-header-bg {
+  position: absolute;
+  inset: 0;
+  background: var(--comp-color, #3B5BDB);
+  /* Rich gradient overlay */
+}
+
+.comp-header-bg::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.15) 60%, rgba(255,255,255,0.04) 100%);
+}
+
+.comp-header-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.25rem 1.5rem 1rem;
+  color: #fff;
+}
+
+.comp-header-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.comp-header-pills {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+.comp-header-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.comp-header-title {
+  font-size: 1.625rem;
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  line-height: 1.2;
+  color: #fff;
+  margin: 0;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.25);
+}
+
+.comp-header-meta {
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.comp-header-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+/* Stats cluster */
+.comp-header-stats {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: var(--radius-lg);
+  padding: 0.5rem 1rem;
+}
+
+.comp-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0 0.625rem;
+}
+
+.comp-stat-value {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1;
+}
+
+.comp-stat-label {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.comp-stat-sep {
+  width: 1px;
+  height: 2rem;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* Actions dropdown */
+.comp-header-actions {
+  position: relative;
+}
+
+.comp-header-menu-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(8px);
+  color: #fff;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--duration-fast) ease;
+  letter-spacing: 0;
+}
+
+.comp-header-menu-btn:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.comp-header-dropdown {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  min-width: 200px;
+  overflow: hidden;
+  z-index: 500;
+  animation: modal-in 0.2s var(--ease-spring);
+}
+
+.comp-header-dropdown-item {
+  width: 100%;
+  padding: 0.625rem 1rem;
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background var(--duration-fast) ease;
+}
+
+.comp-header-dropdown-item:hover {
+  background: var(--color-bg);
+}
+
+.comp-header-dropdown-sep {
+  height: 1px;
+  background: var(--color-border);
+  margin: 0.25rem 0;
+}
+
+/* Progress bar */
+.comp-header-progress {
+  position: relative;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.15);
+  z-index: 1;
+}
+
+.comp-header-progress-fill {
+  height: 100%;
+  background: rgba(255, 255, 255, 0.85);
+  transition: width 0.6s var(--ease-out);
+  border-radius: 0 2px 2px 0;
+  box-shadow: 0 0 8px rgba(255,255,255,0.5);
+}
+
+/* Dark mode */
+.theme-dark .comp-header-dropdown {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+}
+
+.theme-dark .comp-header-dropdown-item:hover {
+  background: var(--color-surface-2);
+}
+
+.theme-dark .comp-header-dropdown-sep {
+  background: var(--color-border);
+}


### PR DESCRIPTION
## Résumé

### Header compétition redesigné
- Background `competition.color` avec overlay gradient multi-couche (`rgba(0,0,0,0.35)` → transparent)
- Glassmorphism sur les pills arme/catégorie/genre et le cluster de stats
- Titre en `1.625rem / 800 / letter-spacing -0.035em` avec text-shadow
- Cluster stats (tireurs / présents / matchs) dans un bloc frosted glass
- Boutons secondaires collapsés dans un menu **⋯** dropdown (animation spring, fermeture au clic extérieur)

### Barre de progression matchs
- Barre 4px en bas du header : `matchs joués / total`
- Transition `width` smooth 0.6s
- Glow blanc + s'adapte automatiquement poules ou tableau

### Confetti 🎊
- `Confetti.tsx` : canvas léger, zero dépendance, 160 particules (rect + circle)
- Physique : gravité 0.25, friction air 0.99, rotation individuelle, decay opacity
- Couleurs : palette BellePoule (bleu, amber, vert, violet…)
- **Trigger 1** : quand une poule individuelle est complétée (`pool.isComplete`)
- **Trigger 2** : quand toutes les poules sont terminées (`canAdvanceFromPools`)

## Test
- [ ] Header : gradient visible, pills, cluster stats
- [ ] Menu ⋯ : ouvre/ferme, toutes les actions fonctionnent
- [ ] Barre progression : visible dès qu'il y a des poules/tableau, avance à chaque score
- [ ] Confetti : déclenché à la fin d'une poule (pas en boucle)
- [ ] Dark mode : dropdown correct

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGUUdwR4rnqVGFNmVUL79A)_