### PR TITLE
feat(ui): transition phases, stats bar, tooltips glassmorphism, MatchCard redesign

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1006,8 +1006,47 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         </div>
       </div>
 
-      {/* Content */}
-      <div style={{ flex: 1, overflow: 'auto' }}>
+      {/* Stats bar */}
+      {(pools.length > 0 || tableauMatches.length > 0 || fencers.length > 0) && (
+        <div className="comp-stats-bar">
+          <div className="comp-stats-bar-item">
+            <span className="comp-stats-bar-icon">🤺</span>
+            <span>{getCheckedInFencers().length}/{fencers.length} tireurs</span>
+          </div>
+          {pools.length > 0 && (
+            <>
+              <div className="comp-stats-bar-sep" />
+              <div className="comp-stats-bar-item">
+                <span className="comp-stats-bar-icon">🎯</span>
+                <span>{pools.filter(p => p.isComplete).length}/{pools.length} poules</span>
+              </div>
+              <div className="comp-stats-bar-sep" />
+              <div className="comp-stats-bar-item">
+                <span className="comp-stats-bar-icon">⚡</span>
+                <span>
+                  {pools.reduce((s, p) => s + p.matches.filter(m => m.status === MatchStatus.FINISHED).length, 0)}/
+                  {pools.reduce((s, p) => s + p.matches.length, 0)} matchs
+                </span>
+              </div>
+            </>
+          )}
+          {tableauMatches.length > 0 && (
+            <>
+              <div className="comp-stats-bar-sep" />
+              <div className="comp-stats-bar-item">
+                <span className="comp-stats-bar-icon">🏆</span>
+                <span>
+                  {tableauMatches.filter(m => m.status === MatchStatus.FINISHED).length}/
+                  {tableauMatches.filter(m => m.fencerA && m.fencerB).length} tableau
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Content — keyed pour animation de transition */}
+      <div key={currentPhase} className="phase-content" style={{ flex: 1, overflow: 'auto' }}>
         {currentPhase === 'checkin' && (
           <FencerList
             fencers={fencers}

--- a/src/renderer/components/Tooltip.tsx
+++ b/src/renderer/components/Tooltip.tsx
@@ -72,21 +72,28 @@ export const Tooltip: React.FC<TooltipProps> = ({
     };
   }, []);
 
+  const BG = 'rgba(26, 25, 22, 0.82)';
+  const ARROW_SIZE = 5;
+
   const getTooltipStyle = (): React.CSSProperties => {
     const base: React.CSSProperties = {
       position: 'fixed',
-      backgroundColor: '#1f2937',
-      color: 'white',
-      padding: '8px 12px',
-      borderRadius: '6px',
-      fontSize: '13px',
+      background: BG,
+      backdropFilter: 'blur(12px) saturate(160%)',
+      WebkitBackdropFilter: 'blur(12px) saturate(160%)',
+      color: 'rgba(255,255,255,0.92)',
+      padding: '6px 10px',
+      borderRadius: '8px',
+      fontSize: '12px',
+      fontWeight: 500,
+      letterSpacing: '-0.01em',
       whiteSpace: 'nowrap',
       zIndex: 9999,
       pointerEvents: 'none',
       opacity: isVisible ? 1 : 0,
-      transform: isVisible ? 'translate(-50%, -50%) scale(1)' : 'translate(-50%, -50%) scale(0.9)',
-      transition: 'opacity 0.2s, transform 0.2s',
-      boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+      transition: 'opacity 0.15s ease, transform 0.15s ease',
+      boxShadow: '0 4px 16px rgba(0,0,0,0.25), 0 0 0 1px rgba(255,255,255,0.08)',
+      border: '1px solid rgba(255,255,255,0.12)',
     };
 
     switch (position) {
@@ -95,28 +102,32 @@ export const Tooltip: React.FC<TooltipProps> = ({
           ...base,
           left: coords.x,
           top: coords.y - 20,
-          transform: `translate(-50%, -100%) scale(${isVisible ? 1 : 0.9})`,
+          transform: `translate(-50%, -100%) scale(${isVisible ? 1 : 0.92})`,
+          transformOrigin: 'bottom center',
         };
       case 'bottom':
         return {
           ...base,
           left: coords.x,
           top: coords.y + 20,
-          transform: `translate(-50%, 0) scale(${isVisible ? 1 : 0.9})`,
+          transform: `translate(-50%, 0) scale(${isVisible ? 1 : 0.92})`,
+          transformOrigin: 'top center',
         };
       case 'left':
         return {
           ...base,
           left: coords.x - 20,
           top: coords.y,
-          transform: `translate(-100%, -50%) scale(${isVisible ? 1 : 0.9})`,
+          transform: `translate(-100%, -50%) scale(${isVisible ? 1 : 0.92})`,
+          transformOrigin: 'right center',
         };
       case 'right':
         return {
           ...base,
           left: coords.x + 20,
           top: coords.y,
-          transform: `translate(0, -50%) scale(${isVisible ? 1 : 0.9})`,
+          transform: `translate(0, -50%) scale(${isVisible ? 1 : 0.92})`,
+          transformOrigin: 'left center',
         };
       default:
         return base;
@@ -131,41 +142,41 @@ export const Tooltip: React.FC<TooltipProps> = ({
       borderStyle: 'solid',
       zIndex: 9999,
       opacity: isVisible ? 1 : 0,
-      transition: 'opacity 0.2s',
+      transition: 'opacity 0.15s ease',
     };
 
     switch (position) {
       case 'top':
         return {
           ...base,
-          left: coords.x - 5,
+          left: coords.x - ARROW_SIZE,
           top: coords.y - 20,
-          borderWidth: '5px 5px 0 5px',
-          borderColor: '#1f2937 transparent transparent transparent',
+          borderWidth: `${ARROW_SIZE}px ${ARROW_SIZE}px 0 ${ARROW_SIZE}px`,
+          borderColor: `${BG} transparent transparent transparent`,
         };
       case 'bottom':
         return {
           ...base,
-          left: coords.x - 5,
+          left: coords.x - ARROW_SIZE,
           top: coords.y + 20,
-          borderWidth: '0 5px 5px 5px',
-          borderColor: 'transparent transparent #1f2937 transparent',
+          borderWidth: `0 ${ARROW_SIZE}px ${ARROW_SIZE}px ${ARROW_SIZE}px`,
+          borderColor: `transparent transparent ${BG} transparent`,
         };
       case 'left':
         return {
           ...base,
           left: coords.x - 20,
-          top: coords.y - 5,
-          borderWidth: '5px 0 5px 5px',
-          borderColor: 'transparent transparent transparent #1f2937',
+          top: coords.y - ARROW_SIZE,
+          borderWidth: `${ARROW_SIZE}px 0 ${ARROW_SIZE}px ${ARROW_SIZE}px`,
+          borderColor: `transparent transparent transparent ${BG}`,
         };
       case 'right':
         return {
           ...base,
           left: coords.x + 20,
-          top: coords.y - 5,
-          borderWidth: '5px 5px 5px 0',
-          borderColor: 'transparent #1f2937 transparent transparent',
+          top: coords.y - ARROW_SIZE,
+          borderWidth: `${ARROW_SIZE}px ${ARROW_SIZE}px ${ARROW_SIZE}px 0`,
+          borderColor: `transparent ${BG} transparent transparent`,
         };
       default:
         return base;

--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -24,159 +24,90 @@ const MatchCard: React.FC<MatchCardProps> = ({
   const hasScore = match.scoreA !== null && match.scoreB !== null;
   const isMatchComplete = match.winner !== null;
 
+  const winnerA = match.winner?.id === match.fencerA?.id;
+  const winnerB = match.winner?.id === match.fencerB?.id;
+
   const handleArenaClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     onArenaClick(match.id);
   };
 
+  const fencerName = (f: typeof match.fencerA) =>
+    f ? `${f.lastName} ${f.firstName.charAt(0)}.` : '—';
+
+  const posStyle: React.CSSProperties =
+    verticalPosition !== undefined
+      ? {
+          position: 'absolute' as const,
+          top: `${verticalPosition}px`,
+          left: 0,
+          right: 0,
+          height: `${BASE_MATCH_HEIGHT}px`,
+          overflow: 'hidden',
+        }
+      : { position: 'relative' as const, marginBottom: '0.375rem' };
+
   return (
     <div
-      key={match.id}
-      style={{
-        border: '1px solid #e5e7eb',
-        borderRadius: '4px',
-        padding: '0.5rem',
-        background: match.winner ? '#f0fdf4' : 'white',
-        minWidth: '180px',
-        cursor: canEdit ? 'pointer' : 'default',
-        ...(verticalPosition !== undefined
-          ? {
-              position: 'absolute' as const,
-              top: `${verticalPosition}px`,
-              left: 0,
-              right: 0,
-              height: `${BASE_MATCH_HEIGHT}px`,
-              overflow: 'hidden',
-            }
-          : { position: 'relative' as const, marginBottom: '0.25rem' }),
-      }}
-      onClick={() => {
-        if (canEdit) onMatchClick(match);
-      }}
+      className={`match-card ${canEdit ? 'match-card-clickable' : ''} ${isMatchComplete ? 'match-card-done' : ''}`}
+      style={posStyle}
+      onClick={() => canEdit && onMatchClick(match)}
     >
+      {/* Arena badge */}
       {canEdit && !isMatchComplete && (
         <button
+          className={`match-arena-btn ${match.arena ? 'match-arena-btn-active' : ''}`}
           onClick={handleArenaClick}
-          style={{
-            position: 'absolute',
-            top: '4px',
-            right: '4px',
-            background: match.arena ? '#10b981' : '#e5e7eb',
-            color: match.arena ? 'white' : '#6b7280',
-            border: 'none',
-            borderRadius: '4px',
-            padding: '2px 6px',
-            fontSize: '0.625rem',
-            cursor: 'pointer',
-            fontWeight: '500',
-          }}
-          title={match.arena ? `Piste ${match.arena}` : 'Assigner à une piste'}
+          title={match.arena ? `Piste ${match.arena}` : 'Assigner une piste'}
         >
           {match.arena ? `P${match.arena}` : '+P'}
         </button>
       )}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          padding: '0.25rem',
-          background: match.winner === match.fencerA ? '#dcfce7' : 'transparent',
-          borderRadius: '2px',
-        }}
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.125rem' }}>
-          <span
-            style={{
-              fontSize: '0.875rem',
-              fontWeight: match.winner === match.fencerA ? '600' : '400',
-            }}
-          >
-            {match.fencerA
-              ? `${match.fencerA.lastName} ${match.fencerA.firstName.charAt(0)}.`
-              : '-'}
-          </span>
-          {match.fencerA && (
-            <span style={{ fontSize: '0.625rem', color: '#6b7280' }}>
-              {match.fencerA.birthDate && `${new Date(match.fencerA.birthDate).getFullYear()}`}
-              {match.fencerA.ranking && ` • #${match.fencerA.ranking}`}
-            </span>
+
+      {/* Fencer A */}
+      <div className={`match-fencer ${winnerA ? 'match-fencer-winner' : ''} ${!match.fencerA ? 'match-fencer-empty' : ''}`}>
+        <div className="match-fencer-info">
+          {winnerA && <span className="match-winner-crown">🥇</span>}
+          <span className="match-fencer-name">{fencerName(match.fencerA)}</span>
+          {match.fencerA?.ranking && (
+            <span className="match-fencer-seed">#{match.fencerA.ranking}</span>
           )}
         </div>
-        <span style={{ fontWeight: '600' }}>{match.scoreA !== null ? match.scoreA : ''}</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          padding: '0.25rem',
-          background: match.winner === match.fencerB ? '#dcfce7' : 'transparent',
-          borderRadius: '2px',
-        }}
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.125rem' }}>
-          <span
-            style={{
-              fontSize: '0.875rem',
-              fontWeight: match.winner === match.fencerB ? '600' : '400',
-            }}
-          >
-            {match.fencerB
-              ? `${match.fencerB.lastName} ${match.fencerB.firstName.charAt(0)}.`
-              : '-'}
+        {hasScore && (
+          <span className={`match-score ${winnerA ? 'match-score-winner' : 'match-score-loser'}`}>
+            {match.scoreA}
           </span>
-          {match.fencerB && (
-            <span style={{ fontSize: '0.625rem', color: '#6b7280' }}>
-              {match.fencerB.birthDate && `${new Date(match.fencerB.birthDate).getFullYear()}`}
-              {match.fencerB.ranking && ` • #${match.fencerB.ranking}`}
-            </span>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="match-divider" />
+
+      {/* Fencer B */}
+      <div className={`match-fencer ${winnerB ? 'match-fencer-winner' : ''} ${!match.fencerB ? 'match-fencer-empty' : ''}`}>
+        <div className="match-fencer-info">
+          {winnerB && <span className="match-winner-crown">🥇</span>}
+          <span className="match-fencer-name">{fencerName(match.fencerB)}</span>
+          {match.fencerB?.ranking && (
+            <span className="match-fencer-seed">#{match.fencerB.ranking}</span>
           )}
         </div>
-        <span style={{ fontWeight: '600' }}>{match.scoreB !== null ? match.scoreB : ''}</span>
+        {hasScore && (
+          <span className={`match-score ${winnerB ? 'match-score-winner' : 'match-score-loser'}`}>
+            {match.scoreB}
+          </span>
+        )}
       </div>
+
+      {/* Bye */}
       {match.isBye && (
-        <div
-          style={{
-            fontSize: '0.75rem',
-            color: '#6b7280',
-            textAlign: 'center',
-            marginTop: '0.25rem',
-          }}
-        >
-          Exempt
-        </div>
+        <div className="match-bye">Exempt</div>
       )}
-      {canEdit && !hasScore && viewMode !== 'full' && (
-        <div
-          style={{
-            width: '100%',
-            marginTop: '0.5rem',
-            padding: '0.25rem',
-            fontSize: '0.75rem',
-            background: '#3b82f6',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            textAlign: 'center',
-          }}
-        >
-          Saisir score
-        </div>
-      )}
-      {canEdit && hasScore && viewMode !== 'full' && (
-        <div
-          style={{
-            width: '100%',
-            marginTop: '0.5rem',
-            padding: '0.25rem',
-            fontSize: '0.75rem',
-            background: '#f59e0b',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            textAlign: 'center',
-          }}
-        >
-          Modifier score
+
+      {/* CTA bar */}
+      {canEdit && viewMode !== 'full' && (
+        <div className={`match-cta ${hasScore ? 'match-cta-edit' : 'match-cta-enter'}`}>
+          {hasScore ? '✏️ Modifier' : '➕ Saisir score'}
         </div>
       )}
     </div>

--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -1145,3 +1145,239 @@ select:focus {
 .theme-dark .comp-header-dropdown-sep {
   background: var(--color-border);
 }
+
+/* ============================================================
+   PHASE TRANSITION ANIMATION
+   ============================================================ */
+
+@keyframes phase-slide-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.phase-content {
+  animation: phase-slide-in var(--duration-slow) var(--ease-out) both;
+}
+
+/* ============================================================
+   COMPETITION STATS BAR
+   ============================================================ */
+
+.comp-stats-bar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  padding: 0 1.25rem;
+  height: 36px;
+  background: var(--color-surface-2);
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-light);
+  flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.comp-stats-bar::-webkit-scrollbar { display: none; }
+
+.comp-stats-bar-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0 0.875rem;
+  white-space: nowrap;
+}
+
+.comp-stats-bar-icon {
+  font-size: 0.875rem;
+}
+
+.comp-stats-bar-sep {
+  width: 1px;
+  height: 16px;
+  background: var(--color-border);
+  flex-shrink: 0;
+}
+
+.theme-dark .comp-stats-bar {
+  background: var(--color-surface-2);
+  border-bottom-color: var(--color-border);
+}
+
+/* ============================================================
+   MATCH CARD — tableau redesign
+   ============================================================ */
+
+.match-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  min-width: 190px;
+  box-shadow: var(--shadow-sm);
+  transition:
+    box-shadow var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    transform var(--duration-fast) ease;
+}
+
+.match-card-clickable {
+  cursor: pointer;
+}
+
+.match-card-clickable:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--color-primary);
+  transform: translateY(-1px);
+}
+
+.match-card-done {
+  border-color: var(--color-border);
+}
+
+.match-fencer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.4375rem 0.625rem;
+  gap: 0.5rem;
+  min-height: 36px;
+  transition: background var(--duration-fast) ease;
+}
+
+.match-fencer-winner {
+  background: rgba(13, 148, 136, 0.1);
+}
+
+.match-fencer-empty {
+  opacity: 0.4;
+}
+
+.match-fencer-info {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.match-winner-crown {
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.match-fencer-name {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--color-text);
+}
+
+.match-fencer-winner .match-fencer-name {
+  font-weight: 700;
+  color: var(--color-success);
+}
+
+.match-fencer-seed {
+  font-size: 0.625rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  background: var(--color-bg);
+  padding: 0.0625rem 0.25rem;
+  border-radius: var(--radius-sm);
+}
+
+.match-score {
+  font-size: 1rem;
+  font-weight: 700;
+  min-width: 1.5rem;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.match-score-winner {
+  color: var(--color-success);
+}
+
+.match-score-loser {
+  color: var(--color-text-muted);
+}
+
+.match-divider {
+  height: 1px;
+  background: var(--color-border);
+  margin: 0;
+}
+
+.match-arena-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  padding: 2px 6px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  background: var(--color-border);
+  color: var(--color-text-muted);
+  transition: background var(--duration-fast) ease;
+  letter-spacing: 0.03em;
+}
+
+.match-arena-btn-active {
+  background: var(--color-success);
+  color: #fff;
+}
+
+.match-arena-btn:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.match-bye {
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+.match-cta {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-align: center;
+  border-top: 1px solid var(--color-border);
+}
+
+.match-cta-enter {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.match-cta-edit {
+  background: var(--color-surface-2);
+  color: var(--color-text-light);
+}
+
+/* Dark mode */
+.theme-dark .match-fencer-winner {
+  background: rgba(13, 148, 136, 0.18);
+}
+
+.theme-dark .match-fencer-winner .match-fencer-name {
+  color: #2DD4BF;
+}
+
+.theme-dark .match-score-winner {
+  color: #2DD4BF;
+}
+
+.theme-dark .match-arena-btn {
+  background: var(--color-border);
+  color: var(--color-text-muted);
+}


### PR DESCRIPTION
## Résumé

### Animation transition entre phases
- `key={currentPhase}` sur le wrapper de contenu → React remonte le composant à chaque changement
- `@keyframes phase-slide-in` : fade + translateY(6px → 0), 350ms ease-out

### Barre de stats persistante
- Barre 36px entre phase-nav et contenu, toujours visible
- Affiche : tireurs présents/total · poules complètes/total · matchs joués/total
- S'adapte automatiquement (poules ou tableau selon contexte)

### Tooltips glassmorphism
- `backdrop-filter: blur(12px)` + fond `rgba(26,25,22,0.82)`
- Border `rgba(255,255,255,0.12)` + box-shadow multicouche
- Animation scale spring (0.92 → 1) au lieu du scale basique
- Flèche cohérente avec le nouveau fond

### MatchCard redesign (tableau)
- Vainqueur : fond teal `rgba(13,148,136,0.1)`, texte teal, score coloré
- Perdant : score en `text-muted`
- Badge seed `#X` avec fond pill
- Hover : lift + border primary + shadow
- Arena btn : styles design tokens, vert quand assigné
- CTA bar : bleu pour "Saisir score", gris pour "Modifier"
- Dark mode complet

## Test
- [ ] Changer de phase → voir le slide-in
- [ ] Stats bar visible dès qu'il y a des poules
- [ ] Survol d'un élément avec Tooltip → glassmorphism visible
- [ ] Vue tableau pending : MatchCards redesignées, winner teal
- [ ] Dark mode : tout cohérent

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGUUdwR4rnqVGFNmVUL79A)_