### PR TITLE
fix(build): TableauMatch.status n'existe pas → utiliser .winner !== null

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -848,7 +848,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     }
     if (tableauMatches.length > 0) {
       const total = tableauMatches.filter(m => m.fencerA && m.fencerB).length;
-      const done = tableauMatches.filter(m => m.status === MatchStatus.FINISHED).length;
+      const done = tableauMatches.filter(m => m.winner !== null).length;
       return { done, total, label: 'tableau' };
     }
     return null;

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1036,7 +1036,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               <div className="comp-stats-bar-item">
                 <span className="comp-stats-bar-icon">🏆</span>
                 <span>
-                  {tableauMatches.filter(m => m.status === MatchStatus.FINISHED).length}/
+                  {tableauMatches.filter(m => m.winner !== null).length}/
                   {tableauMatches.filter(m => m.fencerA && m.fencerB).length} tableau
                 </span>
               </div>


### PR DESCRIPTION
## Fix

Erreur de build CI :

```
error TS2339: Property 'status' does not exist on type 'TableauMatch'
```

`TableauMatch` n'a pas de propriété `status` — il utilise `winner: Fencer | null` pour indiquer si un match est terminé.

**Correction** : `m.status === MatchStatus.FINISHED` → `m.winner !== null` dans le calcul de progression du tableau (stats bar).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGUUdwR4rnqVGFNmVUL79A)_