### PR TITLE
fix(remote): attribution FIFO des matchs DE sur les pistes (#430)

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2490,14 +2490,8 @@ export class RemoteScoreServer {
     if (!toArenaObj.currentMatch) {
       // Arène libre → le match devient le currentMatch visible immédiatement
       this.assignMatchToArena(toArenaId, matchToMove);
-    } else if (toArenaObj.currentMatch.status !== 'in_progress') {
-      // currentMatch non démarré → le déplacer en tête de file, afficher le nouveau
-      const displaced = toArenaObj.currentMatch;
-      const toQueue = this.arenaMatchQueue.get(toArenaId) || [];
-      this.arenaMatchQueue.set(toArenaId, [displaced, ...toQueue]);
-      this.assignMatchToArena(toArenaId, matchToMove);
     } else {
-      // Match en cours → ajouter en fin de file
+      // Arène occupée (match en cours ou non démarré) → ajouter en fin de file (FIFO)
       const toQueue = this.arenaMatchQueue.get(toArenaId) || [];
       this.arenaMatchQueue.set(toArenaId, [...toQueue, matchToMove]);
       this.updateArena(toArenaId, { status: toArenaObj.status });
@@ -3779,7 +3773,7 @@ export class RemoteScoreServer {
     // Build the new DE match list, excluding already-active matches
     const deMatches = matchesFromRenderer
       .filter(m => !m.__poolFencers && m.isTableau && m.fencerA && m.fencerB)
-      .sort((a: any, b: any) => (a.round || 0) - (b.round || 0));
+      .sort((a: any, b: any) => (b.round || 0) - (a.round || 0));
 
     // Replace DE entries in sessionMatches (keep pool matches intact)
     this.sessionMatches = this.sessionMatches.filter((m: any) => !m.isTableau);
@@ -3830,6 +3824,7 @@ export class RemoteScoreServer {
           arena.currentMatch = null;
           arena.status = 'idle';
           arenaEffectivelyFree = true;
+          this.updateArena(arenaId, { status: 'idle', currentMatch: null });
         } else {
           // Cas 2 : score remote ou fast-poule → vérifier le statut effectif
           const scoreUpdate = this.sessionMatchScores.get(arena.currentMatch.id);


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

Corrige 3 sous-bugs de l'issue #430 signalés par Luceriude (commentaire du 20 mai 2026).

- **FIFO sur les pistes** : `updateMatchArena` ne déplace plus le `currentMatch` non-démarré quand un nouveau match est assigné à la même piste. Le nouveau match rejoint la fin de file, le premier assigné reste affiché.
- **Libération après score manuel DT** : `refreshDeMatches` broadcastait l'état interne mis à `idle` sans l'envoyer aux clients. Ajout d'un `updateArena` pour que l'arbitre/kiosque soit notifié immédiatement.
- **Ordre des rounds** : `refreshDeMatches` triait les matchs DE en ordre ascendant (finales en premier) alors que `startSession` utilise l'ordre descendant. Alignement sur DESC pour que les 8es précèdent les quarts.

## Plan de test

- [ ] Assigner combat-1 → Piste 1, puis combat-2 → Piste 1 : combat-1 reste `currentMatch`, combat-2 en file
- [ ] Scorer combat-1 depuis l'UI DT : la piste se libère côté arbitre/kiosque sans attendre la console arbitre
- [ ] Vérifier que les noms affichés correspondent au bon match
- [ ] Vérifier que les 8es de finale précèdent les quarts sur les pistes

**À valider par Luceriude avant merge.**

https://claude.ai/code/session_01MhYhKXxkMmxnwoynmVCLjC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhYhKXxkMmxnwoynmVCLjC)_