### PR TITLE
feat: ajout tireur en milieu de compétition (issue #431)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1401,6 +1401,34 @@ export class DatabaseManager {
     this.save();
   }
 
+  public addFencerToPoolMidCompetition(poolId: string, fencerId: string, maxScore: number): Pool {
+    if (!this.db) throw new Error('Database not open');
+    const existingFencers = this.getPoolFencers(poolId);
+    if (existingFencers.some(f => f.id === fencerId)) {
+      throw new Error('Fencer already in this pool');
+    }
+    const nextPosition = existingFencers.length;
+    this.addFencerToPool(poolId, fencerId, nextPosition);
+
+    const maxNumRow = this.db.exec(
+      `SELECT COALESCE(MAX(number), 0) AS max_num FROM matches WHERE pool_id = '${poolId}'`
+    );
+    let nextMatchNumber: number =
+      (maxNumRow[0]?.values[0]?.[0] as number | null) ?? 0;
+
+    for (const existing of existingFencers) {
+      nextMatchNumber += 1;
+      this.createMatch(
+        { number: nextMatchNumber, fencerA: { id: fencerId } as any, fencerB: { id: existing.id } as any, maxScore },
+        poolId
+      );
+    }
+    this.save();
+    return this.getPoolsByPhase(
+      (this.db.exec(`SELECT phase_id FROM pools WHERE id = '${poolId}'`)[0]?.values[0]?.[0] as string)
+    ).find(p => p.id === poolId)!;
+  }
+
   public getPoolsByPhase(phaseId: string): Pool[] {
     if (!this.db) throw new Error('Database not open');
     const results: Pool[] = [];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1033,6 +1033,9 @@ ipcMain.handle('db:clearPoolsForPhase', async (_, phaseId) => {
 ipcMain.handle('db:addFencerToPool', async (_, poolId, fencerId, position) => {
   return db.addFencerToPool(poolId, fencerId, position);
 });
+ipcMain.handle('db:addFencerToPoolMidCompetition', async (_, poolId, fencerId, maxScore) => {
+  return db.addFencerToPoolMidCompetition(poolId, fencerId, maxScore ?? 5);
+});
 ipcMain.handle('db:getPoolFencers', async (_, poolId) => {
   return db.getPoolFencers(poolId);
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -170,6 +170,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
       }
       return ipcRenderer.invoke('db:addFencerToPool', poolId, fencerId, position);
     },
+    addFencerToPoolMidCompetition: (poolId: string, fencerId: string, maxScore?: number) => {
+      if (!poolId || typeof poolId !== 'string') {
+        throw new Error('Pool ID is required and must be a string');
+      }
+      if (!fencerId || typeof fencerId !== 'string') {
+        throw new Error('Fencer ID is required and must be a string');
+      }
+      return ipcRenderer.invoke('db:addFencerToPoolMidCompetition', poolId, fencerId, maxScore);
+    },
     getPoolFencers: (poolId: string) => {
       if (!poolId || typeof poolId !== 'string') {
         throw new Error('Pool ID is required and must be a string');

--- a/src/renderer/components/AddFencerToPoolModal.tsx
+++ b/src/renderer/components/AddFencerToPoolModal.tsx
@@ -1,0 +1,190 @@
+/**
+ * BellePoule Modern - Add Fencer To Pool Modal
+ * Allows adding an unassigned fencer to a pool mid-competition
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useEffect, useMemo } from 'react';
+import { Fencer, Pool } from '../../shared/types';
+
+interface AddFencerToPoolModalProps {
+  pool: Pool;
+  competitionId: string;
+  maxScore?: number;
+  onConfirm: (updatedPool: Pool) => void;
+  onClose: () => void;
+}
+
+const AddFencerToPoolModal: React.FC<AddFencerToPoolModalProps> = ({
+  pool,
+  competitionId,
+  maxScore = 5,
+  onConfirm,
+  onClose,
+}) => {
+  const [allFencers, setAllFencers] = useState<Fencer[]>([]);
+  const [allPoolFencerIds, setAllPoolFencerIds] = useState<Set<string>>(new Set());
+  const [search, setSearch] = useState('');
+  const [selectedFencer, setSelectedFencer] = useState<Fencer | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      window.electronAPI.db.getFencersByCompetition(competitionId),
+      window.electronAPI.db.getPhasesByCompetition(competitionId).then(phases =>
+        Promise.all(
+          phases
+            .filter((p: { type: string }) => p.type === 'pool')
+            .map((p: { id: string }) => window.electronAPI.db.getPoolFencers(p.id))
+        )
+      ),
+    ]).then(([fencers, poolFencerArrays]) => {
+      setAllFencers(fencers);
+      const ids = new Set<string>();
+      for (const arr of poolFencerArrays) {
+        for (const f of arr as Fencer[]) ids.add(f.id);
+      }
+      setAllPoolFencerIds(ids);
+    });
+  }, [competitionId]);
+
+  const available = useMemo(() => {
+    const poolFencerIds = new Set(pool.fencers.map(f => f.id));
+    const q = search.toLowerCase();
+    return allFencers.filter(
+      f =>
+        !poolFencerIds.has(f.id) &&
+        !allPoolFencerIds.has(f.id) &&
+        (`${f.firstName} ${f.lastName}`.toLowerCase().includes(q) ||
+          f.lastName.toLowerCase().includes(q))
+    );
+  }, [allFencers, allPoolFencerIds, pool.fencers, search]);
+
+  const handleAdd = async () => {
+    if (!selectedFencer) return;
+    setIsLoading(true);
+    try {
+      const updatedPool = await window.electronAPI.db.addFencerToPoolMidCompetition(
+        pool.id,
+        selectedFencer.id,
+        maxScore
+      );
+      onConfirm(updatedPool);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '420px' }}>
+        <div className="modal-header">
+          <h2>Ajouter un tireur – Poule {pool.number}</h2>
+          <button className="btn-close" onClick={onClose}>&times;</button>
+        </div>
+
+        <div className="modal-body">
+          <div
+            style={{
+              padding: '0.75rem',
+              background: '#fef3c7',
+              borderRadius: '6px',
+              marginBottom: '1rem',
+              color: '#92400e',
+              fontSize: '0.875rem',
+            }}
+          >
+            ⚠️ <strong>Opération de sauvetage :</strong> le tireur sera ajouté sans rééquilibrage.
+            Des matchs contre tous les tireurs présents seront créés.
+          </div>
+
+          <input
+            type="text"
+            placeholder="Rechercher par nom…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            autoFocus
+            style={{
+              width: '100%',
+              padding: '0.5rem 0.75rem',
+              border: '1px solid #d1d5db',
+              borderRadius: '6px',
+              marginBottom: '0.75rem',
+              fontSize: '0.875rem',
+              boxSizing: 'border-box',
+            }}
+          />
+
+          <div
+            style={{
+              maxHeight: '240px',
+              overflowY: 'auto',
+              border: '1px solid #e5e7eb',
+              borderRadius: '6px',
+            }}
+          >
+            {available.length === 0 ? (
+              <div
+                style={{
+                  padding: '1rem',
+                  textAlign: 'center',
+                  color: '#6b7280',
+                  fontSize: '0.875rem',
+                }}
+              >
+                Aucun tireur disponible
+              </div>
+            ) : (
+              available.map(f => {
+                const isSelected = selectedFencer?.id === f.id;
+                return (
+                  <div
+                    key={f.id}
+                    onClick={() => setSelectedFencer(isSelected ? null : f)}
+                    style={{
+                      padding: '0.6rem 0.75rem',
+                      cursor: 'pointer',
+                      background: isSelected ? '#eff6ff' : 'transparent',
+                      borderBottom: '1px solid #f3f4f6',
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                    onMouseEnter={e => {
+                      if (!isSelected) (e.currentTarget as HTMLDivElement).style.background = '#f9fafb';
+                    }}
+                    onMouseLeave={e => {
+                      if (!isSelected) (e.currentTarget as HTMLDivElement).style.background = 'transparent';
+                    }}
+                  >
+                    <span style={{ fontWeight: isSelected ? 600 : 400 }}>
+                      {f.lastName} {f.firstName}
+                    </span>
+                    {f.club && (
+                      <span style={{ fontSize: '0.75rem', color: '#9ca3af' }}>{f.club}</span>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn btn-secondary" onClick={onClose}>
+            Annuler
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleAdd}
+            disabled={!selectedFencer || isLoading}
+          >
+            {isLoading ? 'Ajout…' : 'Ajouter le tireur'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddFencerToPoolModal;

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1142,6 +1142,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                         weapon={competition.weapon}
                         competitionName={competition.title}
                         maxScore={poolMaxScore}
+                        competitionId={competition.id}
                         onScoreUpdate={(matchIndex, scoreA, scoreB, winner, specialStatus) =>
                           updateScore(poolIndex, matchIndex, scoreA, scoreB, winner, specialStatus)
                         }
@@ -1169,6 +1170,11 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                           ) {
                             handleFencerForfeit(fencerId, status);
                           }
+                        }}
+                        onFencerAdded={updatedPool => {
+                          setPools(prev =>
+                            prev.map(p => (p.id === updatedPool.id ? updatedPool : p))
+                          );
                         }}
                       />
                     </div>

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -16,12 +16,14 @@ import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTem
 import { useHistory } from '../hooks/useHistory';
 import PoolScoreMatrix from './pool/PoolScoreMatrix';
 import Confetti from './Confetti';
+import AddFencerToPoolModal from './AddFencerToPoolModal';
 
 interface PoolViewProps {
   pool: Pool;
   maxScore?: number;
   weapon?: Weapon;
   competitionName?: string;
+  competitionId?: string;
   onScoreUpdate: (
     matchIndex: number,
     scoreA: number,
@@ -33,6 +35,7 @@ interface PoolViewProps {
   onMatchCancel?: (matchIndex: number) => void;
   onFencerChangePool?: (fencer: Fencer) => void;
   onFencerStatusChange?: (fencerId: string, status: 'abandon' | 'forfait' | 'exclusion') => void;
+  onFencerAdded?: (updatedPool: Pool) => void;
 }
 
 type ViewMode = 'grid' | 'matches';
@@ -42,11 +45,13 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   maxScore = 5,
   weapon,
   competitionName,
+  competitionId,
   onScoreUpdate,
   onMatchReset,
   onMatchCancel,
   onFencerChangePool,
   onFencerStatusChange,
+  onFencerAdded,
 }) => {
   const { showToast } = useToast();
   const { confirm } = useConfirm();
@@ -67,6 +72,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
 
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
   const [showPoolConfetti, setShowPoolConfetti] = useState(false);
+  const [showAddFencerModal, setShowAddFencerModal] = useState(false);
   const prevIsComplete = useRef(pool.isComplete);
 
   useEffect(() => {
@@ -1439,6 +1445,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   );
 
   return (
+    <>
     <div className="card">
       <Confetti active={showPoolConfetti} particleCount={100} origin={{ x: 0.5, y: 0.5 }} />
       {isLocked && (
@@ -1556,6 +1563,23 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           >
             📄 PDF
           </button>
+          {competitionId && (
+            <button
+              onClick={() => setShowAddFencerModal(true)}
+              style={{
+                padding: '0.375rem 0.75rem',
+                fontSize: '0.75rem',
+                background: '#e5e7eb',
+                color: '#374151',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+              }}
+              title="Ajouter un tireur à cette poule"
+            >
+              ➕ Tireur
+            </button>
+          )}
           <div style={{ position: 'relative' }} ref={columnMenuRef}>
             <button
               onClick={() => setShowColumnMenu(!showColumnMenu)}
@@ -1670,6 +1694,19 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         {renderScoreModal()}
       </div>
     </div>
+    {showAddFencerModal && competitionId && (
+      <AddFencerToPoolModal
+        pool={pool}
+        competitionId={competitionId}
+        maxScore={maxScore}
+        onConfirm={updatedPool => {
+          setShowAddFencerModal(false);
+          onFencerAdded?.(updatedPool);
+        }}
+        onClose={() => setShowAddFencerModal(false)}
+      />
+    )}
+    </>
   );
 };
 

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -480,6 +480,7 @@ export interface DatabaseAPI {
   createPool: (phaseId: string, number: number, poolId?: string) => Promise<Pool>;
   clearPoolsForPhase: (phaseId: string) => Promise<void>;
   addFencerToPool: (poolId: string, fencerId: string, position: number) => Promise<void>;
+  addFencerToPoolMidCompetition: (poolId: string, fencerId: string, maxScore?: number) => Promise<Pool>;
   getPoolFencers: (poolId: string) => Promise<Fencer[]>;
   getPoolsByPhase: (phaseId: string) => Promise<Pool[]>;
   updatePool: (pool: Pool) => Promise<void>;


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

Closes #431

- **DB** : nouvelle méthode `addFencerToPoolMidCompetition` — insère le tireur dans la poule et génère les matchs manquants (vs chaque tireur déjà présent) sans toucher aux matchs existants
- **IPC** : handler `db:addFencerToPoolMidCompetition` + bridge preload + type `DatabaseAPI`
- **Modal** `AddFencerToPoolModal` : liste les tireurs inscrits non encore affectés à une poule, recherche par nom, avertissement "opération de sauvetage"
- **PoolView** : bouton `➕ Tireur` visible quand `competitionId` est fourni
- **CompetitionView** : passe `competitionId` et `onFencerAdded` à chaque `PoolView`

## Plan de test

- [ ] Créer une compétition, ajouter des tireurs, générer des poules et démarrer la phase poules
- [ ] Ouvrir une poule → cliquer `➕ Tireur` → vérifier que seuls les tireurs non affectés apparaissent
- [ ] Sélectionner un tireur → cliquer "Ajouter le tireur"
- [ ] Vérifier que le tireur apparaît dans la poule avec ses matchs contre tous les autres
- [ ] Vérifier que les matchs déjà joués ne sont pas modifiés
- [ ] Vérifier qu'un tireur déjà dans une poule n'apparaît pas dans la liste

https://claude.ai/code/session_01EXRdfyVXmK2wu3JE6AhLwj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXRdfyVXmK2wu3JE6AhLwj)_