### PR TITLE
feat(ui): améliorations UX — couleurs poule, dark mode tablette, haptic, breadcrumb, coach marks

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2210,6 +2210,7 @@
           this.overtimeType = this.overtimeType === 'supplementary'
             ? 'challenger_supplementary'
             : 'challenger';
+          if (navigator.vibrate) navigator.vibrate([200, 100, 200, 100, 200]);
           this.updateSuddenDeathUI();
           this.showNotification(
             '⚡ MORT SUBITE – Les deux tireurs ont 10 pts ! Zone C uniquement.'
@@ -2530,6 +2531,7 @@
           } else {
             this.overtimeType = 'supplementary';
           }
+          if (navigator.vibrate) navigator.vibrate([150, 80, 150, 80, 400]);
           this.timerSeconds = 30;
           this.updateTimerDisplay();
           this.broadcastTimerUpdate();
@@ -2742,6 +2744,8 @@
 
         showFinishModal() {
           if (!this.currentMatch || this.matchStatus !== 'in_progress') return;
+
+          if (navigator.vibrate) navigator.vibrate([100, 60, 100, 60, 600]);
 
           if (this.timerRunning) {
             this.pauseTimer();

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1014,6 +1014,16 @@
         border-color: #7c3aed;
         color: #fff;
       }
+      @media (prefers-color-scheme: dark) {
+        .active-match { background: rgba(30,30,40,0.97); color: #f3f4f6; }
+        .fencer-box { background: #1f2937; color: #f9fafb; }
+        .fencer-box.red-side { background: linear-gradient(135deg, #3b0a0a 0%, #4c1010 100%); }
+        .fencer-box.green-side { background: linear-gradient(135deg, #0a2e1a 0%, #103d22 100%); }
+        .fencer-club { color: #9ca3af; }
+        .modal-content { background: #1f2937; color: #f3f4f6; }
+        .final-score { background: #111827; color: #f3f4f6; }
+        .next-matches-screen { background: rgba(0,0,0,0.5); }
+      }
     </style>
   </head>
   <body>
@@ -1950,6 +1960,7 @@
           }
 
           this.pushHistory('score');
+          if (navigator.vibrate) navigator.vibrate(points === 5 ? 120 : points === 3 ? 80 : 40);
 
           const ef = this._effectiveFencer(fencer);
           const zone = points === 1 ? 'A' : points === 3 ? 'B' : 'C';
@@ -1988,6 +1999,7 @@
           if (this.matchStatus === 'finished') return;
 
           this.pushHistory('card');
+          if (navigator.vibrate) navigator.vibrate(cardType === 'red' ? [100,50,100] : cardType === 'yellow' ? 80 : 40);
 
           const ef = this._effectiveFencer(fencer);
           const cards = ef === 'A' ? this.cardsA : this.cardsB;

--- a/src/renderer/components/CoachMark.tsx
+++ b/src/renderer/components/CoachMark.tsx
@@ -1,0 +1,79 @@
+/**
+ * BellePoule Modern - CoachMark Component
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useEffect, useRef } from 'react';
+
+interface CoachMarkProps {
+  id: string;
+  message: string;
+  position?: 'top' | 'bottom' | 'left' | 'right';
+  children: React.ReactNode;
+}
+
+const CoachMark: React.FC<CoachMarkProps> = ({ id, message, position = 'bottom', children }) => {
+  const key = `bellepoule-coach-${id}`;
+  const [visible, setVisible] = useState(() => localStorage.getItem(key) !== 'seen');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    timerRef.current = setTimeout(() => dismiss(), 6000);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [visible]);
+
+  const dismiss = () => {
+    localStorage.setItem(key, 'seen');
+    setVisible(false);
+  };
+
+  const tooltipStyle: React.CSSProperties = {
+    position: 'absolute',
+    zIndex: 9999,
+    background: '#1e40af',
+    color: 'white',
+    padding: '0.5rem 0.75rem',
+    borderRadius: '0.5rem',
+    fontSize: '0.8rem',
+    whiteSpace: 'nowrap',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+    pointerEvents: 'none',
+    ...(position === 'bottom' ? { top: 'calc(100% + 8px)', left: '50%', transform: 'translateX(-50%)' } :
+        position === 'top'    ? { bottom: 'calc(100% + 8px)', left: '50%', transform: 'translateX(-50%)' } :
+        position === 'right'  ? { left: 'calc(100% + 8px)', top: '50%', transform: 'translateY(-50%)' } :
+                                { right: 'calc(100% + 8px)', top: '50%', transform: 'translateY(-50%)' }),
+  };
+
+  const arrowStyle: React.CSSProperties = {
+    position: 'absolute',
+    width: 0,
+    height: 0,
+    ...(position === 'bottom' ? { bottom: '100%', left: '50%', transform: 'translateX(-50%)', borderLeft: '5px solid transparent', borderRight: '5px solid transparent', borderBottom: '5px solid #1e40af' } :
+        position === 'top'    ? { top: '100%', left: '50%', transform: 'translateX(-50%)', borderLeft: '5px solid transparent', borderRight: '5px solid transparent', borderTop: '5px solid #1e40af' } : {}),
+  };
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-flex' }} onClick={visible ? dismiss : undefined}>
+      {visible && (
+        <span style={{
+          position: 'absolute', inset: '-4px',
+          borderRadius: '0.5rem',
+          border: '2px solid #3b82f6',
+          animation: 'coach-pulse 1.5s ease-in-out infinite',
+          pointerEvents: 'none',
+          zIndex: 9998,
+        }} />
+      )}
+      {children}
+      {visible && (
+        <div style={tooltipStyle}>
+          <span style={arrowStyle} />
+          {message}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CoachMark;

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -13,6 +13,7 @@ import Confetti from './Confetti';
 import TableauView, { TableauMatch, FinalResult, propagateWinners, ConsolationBracket } from './TableauView';
 import PoolRankingView from './PoolRankingView';
 import ResultsView from './ResultsView';
+import CoachMark from './CoachMark';
 import AddFencerModal from './AddFencerModal';
 import CompetitionPropertiesModal from './CompetitionPropertiesModal';
 import ImportModal from './ImportModal';
@@ -903,13 +904,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
             {/* Menu actions ⋯ */}
             <div className="comp-header-actions" ref={actionsMenuRef}>
-              <button
-                className="comp-header-menu-btn"
-                onClick={() => setShowActionsMenu(v => !v)}
-                title="Actions"
-              >
-                ⋯
-              </button>
+              <CoachMark id="actions-menu" message="Comparaison, analytiques, partage QR..." position="left">
+                <button
+                  className="comp-header-menu-btn"
+                  onClick={() => setShowActionsMenu(v => !v)}
+                  title="Actions"
+                >
+                  ⋯
+                </button>
+              </CoachMark>
               {showActionsMenu && (
                 <div className="comp-header-dropdown">
                   <button className="comp-header-dropdown-item" onClick={() => { setShowFencerComparison(true); setShowActionsMenu(false); }}>
@@ -957,6 +960,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         )}
       </div>
 
+      {/* Breadcrumb */}
+      <div style={{ padding: '0.25rem 1rem', fontSize: '0.75rem', color: 'var(--text-muted, #6b7280)', borderBottom: '1px solid var(--border-color, rgba(255,255,255,0.1))', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <span style={{ fontWeight: 500, opacity: 0.7 }}>{competition.title}</span>
+        <span>›</span>
+        <span style={{ fontWeight: 600, color: 'var(--text-primary, #f3f4f6)' }}>
+          {phases.find(p => p.id === currentPhase)?.label ?? currentPhase}
+        </span>
+      </div>
+
       {/* Navigation */}
       <div className="phase-nav">
         {phases.map((phase, index) => (
@@ -990,13 +1002,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             </button>
           )}
           {currentPhase === 'checkin' && (!questEnabled || questConfig?.hasPreliminaryPools) && (
-            <button
-              className="btn btn-primary"
-              onClick={handleGeneratePools}
-              disabled={getCheckedInFencers().length < 4}
-            >
-              Générer les poules →
-            </button>
+            <CoachMark id="generate-pools" message="Cliquez ici après avoir pointé tous vos tireurs" position="bottom">
+              <button
+                className="btn btn-primary"
+                onClick={handleGeneratePools}
+                disabled={getCheckedInFencers().length < 4}
+              >
+                Générer les poules →
+              </button>
+            </CoachMark>
           )}
           {currentPhase === 'pools' && poolsNextAction && (
             <button className="btn btn-primary" onClick={poolsNextAction.action}>

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -430,6 +430,24 @@ const FencerListComponent: React.FC<FencerListProps> = ({
         </div>
       )}
 
+      {fencers.length > 0 && (
+        <div style={{ marginBottom: '1rem' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', color: 'var(--text-muted, #6b7280)', marginBottom: '4px' }}>
+            <span>Pointage</span>
+            <span>{checkedInCount} / {fencers.length}</span>
+          </div>
+          <div style={{ height: '6px', background: 'var(--border-color, #e5e7eb)', borderRadius: '3px', overflow: 'hidden' }}>
+            <div style={{
+              height: '100%',
+              width: fencers.length > 0 ? `${(checkedInCount / fencers.length) * 100}%` : '0%',
+              background: checkedInCount === fencers.length && fencers.length > 0 ? '#22c55e' : '#3b82f6',
+              borderRadius: '3px',
+              transition: 'width 0.4s ease',
+            }} />
+          </div>
+        </div>
+      )}
+
       <div className="card mb-4">
         <div className="card-body flex gap-4">
           <input

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -149,9 +149,27 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
       {fencers.map((rowFencer, rowIndex) => {
         const stats = calculateFencerStats(rowFencer);
         const rankEntry = pool.ranking.find(r => r.fencer.id === rowFencer.id);
+        const rankRatio = (rankEntry?.rank ?? fencers.length) / fencers.length;
+        const rowBg =
+          rankRatio <= 0.7
+            ? 'rgba(16,185,129,0.08)'
+            : rankRatio <= 0.9
+              ? 'rgba(245,158,11,0.10)'
+              : 'rgba(239,68,68,0.08)';
+
+        const fencerMatches = pool.matches.filter(
+          m =>
+            m.status === MatchStatus.FINISHED &&
+            (m.fencerA?.id === rowFencer.id || m.fencerB?.id === rowFencer.id)
+        );
+        const sparkBars = fencerMatches.map(m => {
+          const isA = m.fencerA?.id === rowFencer.id;
+          const won = isA ? m.scoreA?.isVictory : m.scoreB?.isVictory;
+          return won;
+        });
 
         return (
-          <div key={rowFencer.id} className="pool-row">
+          <div key={rowFencer.id} className="pool-row" style={{ backgroundColor: rowBg }}>
             <div
               className="pool-cell pool-cell-header pool-cell-name"
               title={`${rowFencer.firstName} ${rowFencer.lastName}`}
@@ -164,6 +182,20 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                   {rowFencer.firstName}
                 </span>
               </span>
+              {sparkBars.length > 0 && (
+                <svg width="16" height="10" style={{ flexShrink: 0 }} aria-hidden="true">
+                  {sparkBars.map((won, i) => (
+                    <rect
+                      key={i}
+                      x={i * (16 / sparkBars.length)}
+                      y={won ? 0 : 4}
+                      width={Math.max(1, 16 / sparkBars.length - 1)}
+                      height={won ? 10 : 6}
+                      fill={won ? '#22c55e' : '#ef4444'}
+                    />
+                  ))}
+                </svg>
+              )}
               {onFencerChangePool && (
                 <button
                   onClick={e => {

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -2098,3 +2098,8 @@ body {
   background: var(--color-bg) !important;
   border-bottom-color: var(--color-border) !important;
 }
+
+@keyframes coach-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(1.04); }
+}


### PR DESCRIPTION
## Résumé

- **PoolScoreMatrix** : color coding adaptatif par rang (vert qualifié / ambre limite / rouge éliminé) + sparkline V/D inline par tireur
- **referee.html** : mode sombre automatique (`prefers-color-scheme: dark`) + vibrations haptic sur touche (+1/+3/+5), carton, fin de match, temps supplémentaire et mort subite
- **FencerList** : barre de progression de pointage animée
- **CompetitionView** : breadcrumb `Compétition › Phase courante` + coach marks au premier lancement (bouton poules, menu actions)
- **CoachMark** : nouveau composant tooltip pulsant auto-dismiss via localStorage

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQ7h3Q8b7tLhFRmmCE6wRC)_