### PR TITLE
refactor: découpe TableauView + React.memo composants manquants

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,18 +3,18 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useEffect, useCallback, useState } from 'react';
+import React, { useEffect, useCallback, useState, Suspense } from 'react';
 import { Competition, PhaseType } from '../shared/types';
 import type { CompetitionCreateData } from '../shared/types/preload';
 import { logger, LogCategory } from '@shared/services/logger';
 import CompetitionList from './components/CompetitionList';
 import CompetitionView from './components/CompetitionView';
-import CommandPalette from './components/CommandPalette';
-import NewCompetitionModal from './components/NewCompetitionModal';
-import ReportIssueModal from './components/ReportIssueModal';
-import UpdateNotification from './components/UpdateNotification';
-import SettingsModal from './components/SettingsModal';
-import DTCallNotification from './components/DTCallNotification';
+const CommandPalette = React.lazy(() => import('./components/CommandPalette'));
+const NewCompetitionModal = React.lazy(() => import('./components/NewCompetitionModal'));
+const ReportIssueModal = React.lazy(() => import('./components/ReportIssueModal'));
+const SettingsModal = React.lazy(() => import('./components/SettingsModal'));
+const DTCallNotification = React.lazy(() => import('./components/DTCallNotification'));
+const UpdateNotification = React.lazy(() => import('./components/UpdateNotification'));
 import { ToastProvider, useToast } from './components/Toast';
 import { ConfirmProvider, useConfirm } from './components/ConfirmDialog';
 import { TranslationProvider, useTranslation, Theme } from './contexts/TranslationContext';
@@ -280,8 +280,8 @@ const AppContent: React.FC = () => {
 
   return (
     <>
-      <UpdateNotification />
-      <DTCallNotification />
+      <Suspense fallback={null}><UpdateNotification /></Suspense>
+      <Suspense fallback={null}><DTCallNotification /></Suspense>
       <div className="app">
         <header className="header">
           <div className="header-title">
@@ -549,37 +549,45 @@ const AppContent: React.FC = () => {
         </main>
 
         {showNewCompetitionModal && (
-          <NewCompetitionModal
-            onClose={() => setShowNewCompetitionModal(false)}
-            onCreate={handleCreateCompetition}
-          />
+          <Suspense fallback={null}>
+            <NewCompetitionModal
+              onClose={() => setShowNewCompetitionModal(false)}
+              onCreate={handleCreateCompetition}
+            />
+          </Suspense>
         )}
 
         {showReportIssueModal && (
-          <ReportIssueModal onClose={() => setShowReportIssueModal(false)} />
+          <Suspense fallback={null}>
+            <ReportIssueModal onClose={() => setShowReportIssueModal(false)} />
+          </Suspense>
         )}
 
         {showSettingsModal && (
-          <SettingsModal onClose={() => setShowSettingsModal(false)} onSave={handleSettingsSave} />
+          <Suspense fallback={null}>
+            <SettingsModal onClose={() => setShowSettingsModal(false)} onSave={handleSettingsSave} />
+          </Suspense>
         )}
 
         {showCommandPalette && (
-          <CommandPalette
-            competitions={competitions}
-            onClose={() => setShowCommandPalette(false)}
-            onSelectCompetition={id => {
-              setShowCommandPalette(false);
-              handleTabSwitch(id);
-            }}
-            onNewCompetition={() => {
-              setShowCommandPalette(false);
-              setShowNewCompetitionModal(true);
-            }}
-            onOpenSettings={() => {
-              setShowCommandPalette(false);
-              setShowSettingsModal(true);
-            }}
-          />
+          <Suspense fallback={null}>
+            <CommandPalette
+              competitions={competitions}
+              onClose={() => setShowCommandPalette(false)}
+              onSelectCompetition={id => {
+                setShowCommandPalette(false);
+                handleTabSwitch(id);
+              }}
+              onNewCompetition={() => {
+                setShowCommandPalette(false);
+                setShowNewCompetitionModal(true);
+              }}
+              onOpenSettings={() => {
+                setShowCommandPalette(false);
+                setShowSettingsModal(true);
+              }}
+            />
+          </Suspense>
         )}
       </div>
     </>

--- a/src/renderer/components/CardModal.tsx
+++ b/src/renderer/components/CardModal.tsx
@@ -23,7 +23,7 @@ interface CardModalProps {
   opponentName: string;
 }
 
-export const CardModal: React.FC<CardModalProps> = ({
+const CardModal_: React.FC<CardModalProps> = ({
   isOpen,
   onClose,
   onConfirm,
@@ -195,4 +195,5 @@ export const CardModal: React.FC<CardModalProps> = ({
   );
 };
 
-export default React.memo(CardModal);
+export const CardModal = React.memo(CardModal_);
+export default CardModal;

--- a/src/renderer/components/DashboardComponents.tsx
+++ b/src/renderer/components/DashboardComponents.tsx
@@ -15,7 +15,7 @@ interface StatCardProps {
   color: 'blue' | 'green' | 'orange' | 'purple' | 'red';
 }
 
-export const ModernStatCard: React.FC<StatCardProps> = ({ title, value, icon, trend, color }) => {
+const ModernStatCard_: React.FC<StatCardProps> = ({ title, value, icon, trend, color }) => {
   const colors = {
     blue: { bg: '#eff6ff', icon: '#3b82f6', text: '#1e40af' },
     green: { bg: '#f0fdf4', icon: '#10b981', text: '#065f46' },
@@ -87,7 +87,7 @@ interface TimelineItem {
   color: string;
 }
 
-export const ActivityTimeline: React.FC<{ items: TimelineItem[] }> = ({ items }) => {
+const ActivityTimeline_: React.FC<{ items: TimelineItem[] }> = ({ items }) => {
   return (
     <div style={{ padding: '20px' }}>
       {items.map((item, index) => (
@@ -141,7 +141,7 @@ export const ActivityTimeline: React.FC<{ items: TimelineItem[] }> = ({ items })
 };
 
 // Mini Chart (Sparkline)
-export const Sparkline: React.FC<{
+const Sparkline_: React.FC<{
   data: number[];
   color?: string;
   height?: number;
@@ -173,7 +173,7 @@ export const Sparkline: React.FC<{
 };
 
 // Comparison Bar
-export const ComparisonBar: React.FC<{
+const ComparisonBar_: React.FC<{
   label: string;
   valueA: number;
   valueB: number;
@@ -244,7 +244,7 @@ export const ComparisonBar: React.FC<{
 };
 
 // Leaderboard Item
-export const LeaderboardItem: React.FC<{
+const LeaderboardItem_: React.FC<{
   rank: number;
   name: string;
   score: number;
@@ -344,7 +344,7 @@ export const LeaderboardItem: React.FC<{
 };
 
 // Empty State Illustration
-export const EmptyState: React.FC<{
+const EmptyState_: React.FC<{
   icon: string;
   title: string;
   description: string;
@@ -412,7 +412,7 @@ export const EmptyState: React.FC<{
 };
 
 // Weather/Condition Widget
-export const ConditionWidget: React.FC<{
+const ConditionWidget_: React.FC<{
   condition: 'excellent' | 'good' | 'fair' | 'poor';
   label: string;
   value: string;
@@ -464,6 +464,14 @@ export const ConditionWidget: React.FC<{
     </div>
   );
 };
+
+export const ModernStatCard = React.memo(ModernStatCard_);
+export const ActivityTimeline = React.memo(ActivityTimeline_);
+export const Sparkline = React.memo(Sparkline_);
+export const ComparisonBar = React.memo(ComparisonBar_);
+export const LeaderboardItem = React.memo(LeaderboardItem_);
+export const EmptyState = React.memo(EmptyState_);
+export const ConditionWidget = React.memo(ConditionWidget_);
 
 export default {
   ModernStatCard,

--- a/src/renderer/components/EnhancedToast.tsx
+++ b/src/renderer/components/EnhancedToast.tsx
@@ -36,7 +36,7 @@ export const useToast = () => {
   return context;
 };
 
-export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+const ToastProvider_: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   const addToast = (toast: Omit<Toast, 'id'>) => {
@@ -256,3 +256,4 @@ export const useToastHelpers = () => {
     ) => addToast({ type: 'info', title, message, ...options }),
   };
 };
+export const ToastProvider = React.memo(ToastProvider_);

--- a/src/renderer/components/LiveDashboard.tsx
+++ b/src/renderer/components/LiveDashboard.tsx
@@ -271,7 +271,7 @@ export const LiveDashboard: React.FC<LiveDashboardProps> = ({
 };
 
 // Live Match Card Component
-const LiveMatchCard: React.FC<{ match: Match; index: number }> = ({ match, index }) => {
+const LiveMatchCard_: React.FC<{ match: Match; index: number }> = ({ match, index }) => {
   const [elapsed, setElapsed] = useState(0);
 
   useEffect(() => {
@@ -351,7 +351,7 @@ const LiveMatchCard: React.FC<{ match: Match; index: number }> = ({ match, index
 };
 
 // Pool Results Card Component
-const PoolResultsCard: React.FC<{ pool: Pool; isLaserSabre?: boolean }> = ({
+const PoolResultsCard_: React.FC<{ pool: Pool; isLaserSabre?: boolean }> = ({
   pool,
   isLaserSabre = false,
 }) => {
@@ -531,7 +531,7 @@ const PoolResultsCard: React.FC<{ pool: Pool; isLaserSabre?: boolean }> = ({
 };
 
 // Tableau View Component
-const TableauView: React.FC<{ matches: Match[] }> = ({ matches }) => {
+const TableauView_: React.FC<{ matches: Match[] }> = ({ matches }) => {
   const rounds = [128, 64, 32, 16, 8, 4, 2, 1];
 
   return (
@@ -641,7 +641,7 @@ const TableauView: React.FC<{ matches: Match[] }> = ({ matches }) => {
 };
 
 // Final Ranking View
-const FinalRankingView: React.FC<{ results: any[] }> = ({ results }) => {
+const FinalRankingView_: React.FC<{ results: any[] }> = ({ results }) => {
   return (
     <div
       style={{
@@ -737,5 +737,10 @@ const FinalRankingView: React.FC<{ results: any[] }> = ({ results }) => {
     </div>
   );
 };
+
+const LiveMatchCard = React.memo(LiveMatchCard_);
+const PoolResultsCard = React.memo(PoolResultsCard_);
+const TableauView = React.memo(TableauView_);
+const FinalRankingView = React.memo(FinalRankingView_);
 
 export default React.memo(LiveDashboard);

--- a/src/renderer/components/ModernVisualComponents.tsx
+++ b/src/renderer/components/ModernVisualComponents.tsx
@@ -5,7 +5,7 @@ interface ThemeToggleProps {
   onToggle: () => void;
 }
 
-export const ModernThemeToggle: React.FC<ThemeToggleProps> = ({ isDark, onToggle }) => {
+const ModernThemeToggle_: React.FC<ThemeToggleProps> = ({ isDark, onToggle }) => {
   return (
     <button
       onClick={onToggle}
@@ -72,7 +72,7 @@ export const ModernThemeToggle: React.FC<ThemeToggleProps> = ({ isDark, onToggle
 };
 
 // Glassmorphism Card
-export const GlassCard: React.FC<{ children: React.ReactNode; style?: React.CSSProperties }> = ({
+const GlassCard_: React.FC<{ children: React.ReactNode; style?: React.CSSProperties }> = ({
   children,
   style,
 }) => {
@@ -94,7 +94,7 @@ export const GlassCard: React.FC<{ children: React.ReactNode; style?: React.CSSP
 };
 
 // Animated Counter
-export const AnimatedCounter: React.FC<{ value: number; duration?: number }> = ({
+const AnimatedCounter_: React.FC<{ value: number; duration?: number }> = ({
   value,
   duration = 1000,
 }) => {
@@ -134,7 +134,7 @@ export const AnimatedCounter: React.FC<{ value: number; duration?: number }> = (
 };
 
 // Ripple Button
-export const RippleButton: React.FC<
+const RippleButton_: React.FC<
   React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: 'primary' | 'secondary' | 'danger' }
 > = ({ children, variant = 'primary', style, ...props }) => {
   const [ripples, setRipples] = React.useState<{ x: number; y: number; id: number }[]>([]);
@@ -219,7 +219,7 @@ export const RippleButton: React.FC<
 };
 
 // Gradient Text
-export const GradientText: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const GradientText_: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <span
       style={{
@@ -236,7 +236,7 @@ export const GradientText: React.FC<{ children: React.ReactNode }> = ({ children
 };
 
 // Status Badge
-export const StatusBadge: React.FC<{
+const StatusBadge_: React.FC<{
   status: 'success' | 'warning' | 'error' | 'info' | 'neutral';
   children: React.ReactNode;
   pulse?: boolean;
@@ -289,7 +289,7 @@ export const StatusBadge: React.FC<{
 };
 
 // Floating Action Button
-export const FloatingActionButton: React.FC<{
+const FloatingActionButton_: React.FC<{
   icon: string;
   onClick: () => void;
   label?: string;
@@ -333,7 +333,7 @@ export const FloatingActionButton: React.FC<{
 };
 
 // Progress Ring
-export const ProgressRing: React.FC<{
+const ProgressRing_: React.FC<{
   progress: number;
   size?: number;
   strokeWidth?: number;
@@ -385,7 +385,7 @@ export const ProgressRing: React.FC<{
 };
 
 // Hover Card
-export const HoverCard: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const HoverCard_: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <div
       style={{
@@ -413,7 +413,7 @@ export const HoverCard: React.FC<{ children: React.ReactNode }> = ({ children })
 };
 
 // Confetti Celebration
-export const Confetti: React.FC<{ trigger: boolean }> = ({ trigger }) => {
+const Confetti_: React.FC<{ trigger: boolean }> = ({ trigger }) => {
   const [particles, setParticles] = React.useState<
     Array<{
       id: number;
@@ -482,6 +482,17 @@ export const Confetti: React.FC<{ trigger: boolean }> = ({ trigger }) => {
     </div>
   );
 };
+
+export const ModernThemeToggle = React.memo(ModernThemeToggle_);
+export const GlassCard = React.memo(GlassCard_);
+export const AnimatedCounter = React.memo(AnimatedCounter_);
+export const RippleButton = React.memo(RippleButton_);
+export const GradientText = React.memo(GradientText_);
+export const StatusBadge = React.memo(StatusBadge_);
+export const FloatingActionButton = React.memo(FloatingActionButton_);
+export const ProgressRing = React.memo(ProgressRing_);
+export const HoverCard = React.memo(HoverCard_);
+export const Confetti = React.memo(Confetti_);
 
 export default {
   ModernThemeToggle,

--- a/src/renderer/components/OfflineStatus.tsx
+++ b/src/renderer/components/OfflineStatus.tsx
@@ -14,7 +14,7 @@ interface OfflineStatusProps {
   className?: string;
 }
 
-export const OfflineStatus: React.FC<OfflineStatusProps> = ({ className = '' }) => {
+const OfflineStatus_: React.FC<OfflineStatusProps> = ({ className = '' }) => {
   const [isOnline, setIsOnline] = useState(true);
   const [isSyncing, setIsSyncing] = useState(false);
   const [syncStatus, setSyncStatus] = useState({
@@ -217,3 +217,4 @@ export const OfflineStatus: React.FC<OfflineStatusProps> = ({ className = '' }) 
     </>
   );
 };
+export const OfflineStatus = React.memo(OfflineStatus_);

--- a/src/renderer/components/Skeleton.tsx
+++ b/src/renderer/components/Skeleton.tsx
@@ -14,7 +14,7 @@ interface SkeletonProps {
   style?: React.CSSProperties;
 }
 
-export const Skeleton: React.FC<SkeletonProps> = ({
+const Skeleton_: React.FC<SkeletonProps> = ({
   width = '100%',
   height = '20px',
   borderRadius = '4px',
@@ -39,7 +39,7 @@ export const Skeleton: React.FC<SkeletonProps> = ({
 };
 
 // Competition Card Skeleton
-export const CompetitionCardSkeleton: React.FC = () => {
+const CompetitionCardSkeleton_: React.FC = () => {
   return (
     <div
       style={{
@@ -66,7 +66,7 @@ export const CompetitionCardSkeleton: React.FC = () => {
 };
 
 // Pool View Skeleton
-export const PoolViewSkeleton: React.FC = () => {
+const PoolViewSkeleton_: React.FC = () => {
   return (
     <div style={{ padding: '20px' }}>
       <div style={{ marginBottom: '24px' }}>
@@ -113,7 +113,7 @@ export const PoolViewSkeleton: React.FC = () => {
 };
 
 // Table Row Skeleton
-export const TableRowSkeleton: React.FC<{ columns?: number }> = ({ columns = 5 }) => {
+const TableRowSkeleton_: React.FC<{ columns?: number }> = ({ columns = 5 }) => {
   return (
     <div
       style={{
@@ -133,7 +133,7 @@ export const TableRowSkeleton: React.FC<{ columns?: number }> = ({ columns = 5 }
 };
 
 // Stats Card Skeleton
-export const StatsCardSkeleton: React.FC = () => {
+const StatsCardSkeleton_: React.FC = () => {
   return (
     <div
       style={{
@@ -156,7 +156,7 @@ export const StatsCardSkeleton: React.FC = () => {
 };
 
 // Add shimmer keyframes to global styles
-export const SkeletonStyles: React.FC = () => (
+const SkeletonStyles_: React.FC = () => (
   <style>{`
     @keyframes shimmer {
       0% {
@@ -168,6 +168,13 @@ export const SkeletonStyles: React.FC = () => (
     }
   `}</style>
 );
+
+export const Skeleton = React.memo(Skeleton_);
+export const CompetitionCardSkeleton = React.memo(CompetitionCardSkeleton_);
+export const PoolViewSkeleton = React.memo(PoolViewSkeleton_);
+export const TableRowSkeleton = React.memo(TableRowSkeleton_);
+export const StatsCardSkeleton = React.memo(StatsCardSkeleton_);
+export const SkeletonStyles = React.memo(SkeletonStyles_);
 
 export default {
   Skeleton,

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -13,6 +13,9 @@ import { exportTableauToPDF, printTableauHTML, MAX_MATCHES_PER_PAGE_TABLEAU } fr
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import MatchCard from './tableau/MatchCard';
 import SeedingTable from './tableau/SeedingTable';
+import TableauScoreModal from './tableau/TableauScoreModal';
+import TableauPendingSection from './tableau/TableauPendingSection';
+import TableauToolbar from './tableau/TableauToolbar';
 
 interface BracketMatch {
   id: string;
@@ -1444,161 +1447,21 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
 
   return (
     <div style={{ padding: '1rem' }}>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: '1rem',
-        }}
-      >
-        <h2 style={{ fontSize: '1.25rem', fontWeight: '600' }}>
-          Tableau de {tableauSize} - {ranking.length} qualifiés
-        </h2>
-        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-          {arenaCount > 0 && (
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.4rem',
-                fontSize: '0.875rem',
-                color: '#374151',
-                cursor: 'pointer',
-                padding: '0.5rem 0.75rem',
-                background: autoAssignArenas ? '#eff6ff' : '#f3f4f6',
-                border: `1px solid ${autoAssignArenas ? '#3b82f6' : '#d1d5db'}`,
-                borderRadius: '6px',
-                userSelect: 'none',
-              }}
-              title="Assigne automatiquement les matchs aux arènes disponibles en round-robin"
-            >
-              <input
-                type="checkbox"
-                checked={autoAssignArenas}
-                onChange={e => handleAutoAssignToggle(e.target.checked)}
-                style={{ cursor: 'pointer' }}
-              />
-              <span>🏟️ Assignation auto</span>
-            </label>
-          )}
-          <button
-            onClick={handleAutoFillScores}
-            style={{
-              background: '#f59e0b',
-              color: 'white',
-              border: 'none',
-              padding: '0.5rem 1rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-              fontWeight: '500',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.25rem',
-            }}
-          >
-            🎲 Remplir auto
-          </button>
-          <button
-            onClick={() => setViewMode(viewMode === 'full' ? 'pending' : 'full')}
-            style={{
-              background: viewMode === 'pending' ? '#3b82f6' : '#e5e7eb',
-              color: viewMode === 'pending' ? 'white' : '#374151',
-              border: 'none',
-              padding: '0.5rem 0.75rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-              fontWeight: '500',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.25rem',
-            }}
-            title={
-              viewMode === 'full'
-                ? 'Afficher les matches en attente'
-                : 'Afficher le tableau complet'
-            }
-          >
-            {viewMode === 'full' ? '📋 Matchs en attente' : '📊 Tableau complet'}
-          </button>
-          <button
-            onClick={() => setPyramidViewMode(!pyramidViewMode)}
-            style={{
-              background: pyramidViewMode ? '#8b5cf6' : '#e5e7eb',
-              color: pyramidViewMode ? 'white' : '#374151',
-              border: 'none',
-              padding: '0.5rem 0.75rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-              fontWeight: '500',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.25rem',
-            }}
-            title={pyramidViewMode ? 'Vue tableau' : 'Vue pyramidale'}
-          >
-            {pyramidViewMode ? '🔲 Tableau' : '🔺 Pyramide'}
-          </button>
-          <button
-            onClick={() => { setPdfMode('print'); setShowPdfModal(true); }}
-            style={{
-              background: '#6366f1',
-              color: 'white',
-              border: 'none',
-              padding: '0.5rem 0.75rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-              fontWeight: '500',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.25rem',
-            }}
-            title="Imprimer les feuilles de match"
-          >
-            🖨️ Imprimer
-          </button>
-          <button
-            onClick={() => { setPdfMode('pdf'); setShowPdfModal(true); }}
-            style={{
-              background: '#10b981',
-              color: 'white',
-              border: 'none',
-              padding: '0.5rem 0.75rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-              fontWeight: '500',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.25rem',
-            }}
-            title="Exporter les feuilles de match en PDF"
-          >
-            📄 Export PDF
-          </button>
-          {champion && (
-            <div
-              style={{
-                background: '#fef3c7',
-                padding: '0.5rem 1rem',
-                borderRadius: '8px',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.5rem',
-              }}
-            >
-              <span style={{ fontSize: '1.5rem' }}>🏆</span>
-              <span style={{ fontWeight: '600' }}>
-                {champion.lastName} {champion.firstName}
-              </span>
-            </div>
-          )}
-        </div>
-      </div>
+      <TableauToolbar
+        tableauSize={tableauSize}
+        rankingCount={ranking.length}
+        arenaCount={arenaCount}
+        autoAssignArenas={autoAssignArenas}
+        onAutoAssignToggle={handleAutoAssignToggle}
+        onAutoFillScores={handleAutoFillScores}
+        viewMode={viewMode}
+        onViewModeToggle={() => setViewMode(viewMode === 'full' ? 'pending' : 'full')}
+        pyramidViewMode={pyramidViewMode}
+        onPyramidViewModeToggle={() => setPyramidViewMode(!pyramidViewMode)}
+        onPrintClick={() => { setPdfMode('print'); setShowPdfModal(true); }}
+        onExportPdfClick={() => { setPdfMode('pdf'); setShowPdfModal(true); }}
+        champion={champion}
+      />
 
       <div
         style={{
@@ -1633,7 +1496,16 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                   {pendingOrder === 'asc' ? '🔼 Croissant' : '🔽 Décroissant'}
                 </button>
               </div>
-              {pendingViewRounds.map(round => renderPendingSection(round))}
+              {pendingViewRounds.map(round => (
+                <TableauPendingSection
+                  key={round}
+                  round={round}
+                  matches={matches}
+                  isExpanded={expandedRounds.has(round)}
+                  onToggle={toggleRoundExpansion}
+                  renderMatch={renderMatch}
+                />
+              ))}
 
               <div
                 style={{
@@ -1788,223 +1660,27 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
       )}
 
       {/* Score Modal */}
-      {(() => {
-        if (!showScoreModal || !editingMatch) return null;
-
+      {showScoreModal && editingMatch && (() => {
         const match = editingConsolationId
           ? consolationBrackets.find(b => b.id === editingConsolationId)?.matches.find(m => m.id === editingMatch)
           : matches.find(m => m.id === editingMatch);
         if (!match) return null;
-
-        const scoreModal = (
-          <div className="modal-overlay" onClick={() => setShowScoreModal(false)}>
-            <div
-              ref={modalRef}
-              className="modal resizable"
-              style={{
-                maxWidth: '900px',
-                width: '95%',
-                minHeight: '400px',
-              }}
-              onClick={e => e.stopPropagation()}
-            >
-              <div className="modal-header" style={{ cursor: 'move' }}>
-                <h3 className="modal-title">{getRoundName(match.round)} - Saisie rapide</h3>
-              </div>
-              <div className="modal-body" style={{ padding: '2rem' }}>
-                {/* Ligne unique avec les deux tireurs côte à côte */}
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: '1.5rem',
-                    marginBottom: '1.5rem',
-                  }}
-                >
-                  {/* Tireur A */}
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'flex-end',
-                      flex: 1,
-                      minWidth: '200px',
-                    }}
-                  >
-                    <div style={{ fontSize: '1.5rem', fontWeight: 600, textAlign: 'right' }}>
-                      {match.fencerA?.lastName}
-                    </div>
-                    <div style={{ fontSize: '1rem', color: '#6b7280', textAlign: 'right' }}>
-                      {match.fencerA?.firstName} {match.fencerA?.club && `(${match.fencerA.club})`}
-                    </div>
-                  </div>
-
-                  {/* Input Score A */}
-                  <input
-                    type="number"
-                    className="form-input"
-                    style={{
-                      width: '120px',
-                      textAlign: 'center',
-                      fontSize: '3rem',
-                      padding: '0.75rem',
-                      borderColor:
-                        (parseInt(editScoreA, 10) || 0) > (isUnlimitedScore ? 999 : maxScore)
-                          ? '#ef4444'
-                          : undefined,
-                      borderWidth:
-                        (parseInt(editScoreA, 10) || 0) > (isUnlimitedScore ? 999 : maxScore)
-                          ? '2px'
-                          : undefined,
-                    }}
-                    value={editScoreA}
-                    onChange={e => setEditScoreA(e.target.value)}
-                    min="0"
-                    max={isUnlimitedScore ? undefined : maxScore}
-                    autoFocus
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault();
-                        handleScoreSubmit();
-                      } else if (e.key === 'Tab' && !e.shiftKey) {
-                        e.preventDefault();
-                        const modalBody = e.currentTarget.closest('.modal-body');
-                        if (modalBody) {
-                          const inputs = modalBody.querySelectorAll('input[type="number"]');
-                          if (inputs.length > 1) {
-                            const nextInput = inputs[1] as HTMLInputElement;
-                            nextInput.focus();
-                            nextInput.select();
-                          }
-                        }
-                      }
-                    }}
-                  />
-
-                  {/* Séparateur */}
-                  <span style={{ fontSize: '3rem', fontWeight: 'bold', color: '#9ca3af' }}>:</span>
-
-                  {/* Input Score B */}
-                  <input
-                    type="number"
-                    className="form-input"
-                    style={{
-                      width: '120px',
-                      textAlign: 'center',
-                      fontSize: '3rem',
-                      padding: '0.75rem',
-                      borderColor:
-                        (parseInt(editScoreB, 10) || 0) > (isUnlimitedScore ? 999 : maxScore)
-                          ? '#ef4444'
-                          : undefined,
-                      borderWidth:
-                        (parseInt(editScoreB, 10) || 0) > (isUnlimitedScore ? 999 : maxScore)
-                          ? '2px'
-                          : undefined,
-                    }}
-                    value={editScoreB}
-                    onChange={e => setEditScoreB(e.target.value)}
-                    min="0"
-                    max={isUnlimitedScore ? undefined : maxScore}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault();
-                        handleScoreSubmit();
-                      } else if (e.key === 'Tab' && e.shiftKey) {
-                        e.preventDefault();
-                        const modalBody = e.currentTarget.closest('.modal-body');
-                        if (modalBody) {
-                          const inputs = modalBody.querySelectorAll('input[type="number"]');
-                          if (inputs.length > 0) {
-                            const prevInput = inputs[0] as HTMLInputElement;
-                            prevInput.focus();
-                            prevInput.select();
-                          }
-                        }
-                      }
-                    }}
-                  />
-
-                  {/* Tireur B */}
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'flex-start',
-                      flex: 1,
-                      minWidth: '200px',
-                    }}
-                  >
-                    <div style={{ fontSize: '1.5rem', fontWeight: 600, textAlign: 'left' }}>
-                      {match.fencerB?.lastName}
-                    </div>
-                    <div style={{ fontSize: '1rem', color: '#6b7280', textAlign: 'left' }}>
-                      {match.fencerB?.firstName} {match.fencerB?.club && `(${match.fencerB.club})`}
-                    </div>
-                  </div>
-                </div>
-
-                {/* Info score max */}
-                {!isUnlimitedScore && maxScore > 0 && (
-                  <p
-                    className="text-sm text-muted"
-                    style={{ textAlign: 'center', marginBottom: '1rem', fontSize: '1rem' }}
-                  >
-                    💡 Score maximum : {maxScore} touches
-                  </p>
-                )}
-
-                {/* Boutons spéciaux sur une ligne */}
-                <div
-                  style={{
-                    display: 'flex',
-                    gap: '0.5rem',
-                    justifyContent: 'center',
-                    borderTop: '1px solid #e5e7eb',
-                    paddingTop: '1rem',
-                    marginTop: '1rem',
-                  }}
-                >
-                  <button
-                    className="btn btn-warning"
-                    onClick={() => handleSpecialStatus('abandon')}
-                    style={{ fontSize: '0.8rem', padding: '0.4rem 0.75rem' }}
-                  >
-                    🚴 Abandon
-                  </button>
-                  <button
-                    className="btn btn-warning"
-                    onClick={() => handleSpecialStatus('forfait')}
-                    style={{ fontSize: '0.8rem', padding: '0.4rem 0.75rem' }}
-                  >
-                    📋 Forfait
-                  </button>
-                  <button
-                    className="btn btn-danger"
-                    onClick={() => handleSpecialStatus('exclusion')}
-                    style={{ fontSize: '0.8rem', padding: '0.4rem 0.75rem' }}
-                  >
-                    🚫 Exclusion
-                  </button>
-                </div>
-              </div>
-              <div
-                className="modal-footer"
-                style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}
-              >
-                <button className="btn btn-secondary" onClick={() => setShowScoreModal(false)}>
-                  Annuler
-                </button>
-                <button className="btn btn-primary" onClick={handleScoreSubmit}>
-                  Valider
-                </button>
-              </div>
-            </div>
-          </div>
+        return (
+          <TableauScoreModal
+            match={match}
+            editScoreA={editScoreA}
+            setEditScoreA={setEditScoreA}
+            editScoreB={editScoreB}
+            setEditScoreB={setEditScoreB}
+            maxScore={maxScore}
+            isUnlimitedScore={isUnlimitedScore}
+            modalRef={modalRef}
+            onClose={() => setShowScoreModal(false)}
+            onSubmit={handleScoreSubmit}
+            onSpecialStatus={handleSpecialStatus}
+            getRoundName={getRoundName}
+          />
         );
-
-        return scoreModal;
       })()}
 
       {showPdfModal && (

--- a/src/renderer/components/tableau/TableauPendingSection.tsx
+++ b/src/renderer/components/tableau/TableauPendingSection.tsx
@@ -1,0 +1,74 @@
+/**
+ * BellePoule Modern - TableauPendingSection
+ * Section repliable d'un round dans la vue "Matchs en attente"
+ * Licensed under GPL-3.0
+ */
+
+import React from 'react';
+import { TableauMatch } from '../TableauView';
+
+interface TableauPendingSectionProps {
+  round: number;
+  matches: TableauMatch[];
+  isExpanded: boolean;
+  onToggle: (round: number) => void;
+  renderMatch: (match: TableauMatch) => React.ReactNode;
+}
+
+const TableauPendingSectionComponent: React.FC<TableauPendingSectionProps> = ({
+  round,
+  matches,
+  isExpanded,
+  onToggle,
+  renderMatch,
+}) => {
+  const roundMatches = matches
+    .filter(m => m.round === round)
+    .sort((a, b) => a.position - b.position);
+  const roundName = round === 3 ? 'Petite Finale' : `Tableau de ${round}`;
+
+  return (
+    <div
+      style={{
+        background: 'white',
+        borderRadius: '8px',
+        marginBottom: '0.5rem',
+        overflow: 'hidden',
+        border: '1px solid #e5e7eb',
+      }}
+    >
+      <div
+        onClick={() => onToggle(round)}
+        style={{
+          padding: '0.75rem 1rem',
+          background: '#f3f4f6',
+          cursor: 'pointer',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          userSelect: 'none',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span style={{ fontSize: '1rem' }}>{isExpanded ? '▼' : '▶'}</span>
+          <span style={{ fontWeight: '600', color: '#374151' }}>{roundName}</span>
+        </div>
+        <span style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+          {roundMatches.length} match{roundMatches.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+      {isExpanded && (
+        <div style={{ padding: '0.5rem' }}>
+          {roundMatches.map(match => (
+            <div key={match.id} style={{ marginBottom: '0.5rem' }}>
+              {renderMatch(match)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TableauPendingSection = React.memo(TableauPendingSectionComponent);
+export default TableauPendingSection;

--- a/src/renderer/components/tableau/TableauScoreModal.tsx
+++ b/src/renderer/components/tableau/TableauScoreModal.tsx
@@ -1,0 +1,249 @@
+/**
+ * BellePoule Modern - TableauScoreModal
+ * Modale de saisie rapide du score d'un match de tableau
+ * Licensed under GPL-3.0
+ */
+
+import React from 'react';
+import { TableauMatch } from '../TableauView';
+
+interface TableauScoreModalProps {
+  match: TableauMatch;
+  editScoreA: string;
+  setEditScoreA: (v: string) => void;
+  editScoreB: string;
+  setEditScoreB: (v: string) => void;
+  maxScore: number;
+  isUnlimitedScore: boolean;
+  modalRef: React.RefObject<HTMLDivElement>;
+  onClose: () => void;
+  onSubmit: () => void;
+  onSpecialStatus: (status: 'abandon' | 'forfait' | 'exclusion') => void;
+  getRoundName: (round: number) => string;
+}
+
+const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
+  match,
+  editScoreA,
+  setEditScoreA,
+  editScoreB,
+  setEditScoreB,
+  maxScore,
+  isUnlimitedScore,
+  modalRef,
+  onClose,
+  onSubmit,
+  onSpecialStatus,
+  getRoundName,
+}) => {
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        ref={modalRef}
+        className="modal resizable"
+        style={{
+          maxWidth: '900px',
+          width: '95%',
+          minHeight: '400px',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="modal-header" style={{ cursor: 'move' }}>
+          <h3 className="modal-title">{getRoundName(match.round)} - Saisie rapide</h3>
+        </div>
+        <div className="modal-body" style={{ padding: '2rem' }}>
+          {/* Ligne unique avec les deux tireurs côte à côte */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '1.5rem',
+              marginBottom: '1.5rem',
+            }}
+          >
+            {/* Tireur A */}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-end',
+                flex: 1,
+                minWidth: '200px',
+              }}
+            >
+              <div style={{ fontSize: '1.5rem', fontWeight: 600, textAlign: 'right' }}>
+                {match.fencerA?.lastName}
+              </div>
+              <div style={{ fontSize: '1rem', color: '#6b7280', textAlign: 'right' }}>
+                {match.fencerA?.firstName} {match.fencerA?.club && `(${match.fencerA.club})`}
+              </div>
+            </div>
+
+            {/* Input Score A */}
+            <input
+              type="number"
+              className="form-input"
+              style={{
+                width: '120px',
+                textAlign: 'center',
+                fontSize: '3rem',
+                padding: '0.75rem',
+                borderColor:
+                  (parseInt(editScoreA, 10) || 0) > (isUnlimitedScore ? 999 : maxScore)
+                    ? '#ef4444'
+                    : undefined,
+                borderWidth:
+                  (parseInt(editScoreA, 10) || 0) > (isUnlimitedScore ? 999 : maxScore)
+                    ? '2px'
+                    : undefined,
+              }}
+              value={editScoreA}
+              onChange={e => setEditScoreA(e.target.value)}
+              min="0"
+              max={isUnlimitedScore ? undefined : maxScore}
+              autoFocus
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  onSubmit();
+                } else if (e.key === 'Tab' && !e.shiftKey) {
+                  e.preventDefault();
+                  const modalBody = e.currentTarget.closest('.modal-body');
+                  if (modalBody) {
+                    const inputs = modalBody.querySelectorAll('input[type="number"]');
+                    if (inputs.length > 1) {
+                      const nextInput = inputs[1] as HTMLInputElement;
+                      nextInput.focus();
+                      nextInput.select();
+                    }
+                  }
+                }
+              }}
+            />
+
+            {/* Séparateur */}
+            <span style={{ fontSize: '3rem', fontWeight: 'bold', color: '#9ca3af' }}>:</span>
+
+            {/* Input Score B */}
+            <input
+              type="number"
+              className="form-input"
+              style={{
+                width: '120px',
+                textAlign: 'center',
+                fontSize: '3rem',
+                padding: '0.75rem',
+                borderColor:
+                  (parseInt(editScoreB, 10) || 0) > (isUnlimitedScore ? 999 : maxScore)
+                    ? '#ef4444'
+                    : undefined,
+                borderWidth:
+                  (parseInt(editScoreB, 10) || 0) > (isUnlimitedScore ? 999 : maxScore)
+                    ? '2px'
+                    : undefined,
+              }}
+              value={editScoreB}
+              onChange={e => setEditScoreB(e.target.value)}
+              min="0"
+              max={isUnlimitedScore ? undefined : maxScore}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  onSubmit();
+                } else if (e.key === 'Tab' && e.shiftKey) {
+                  e.preventDefault();
+                  const modalBody = e.currentTarget.closest('.modal-body');
+                  if (modalBody) {
+                    const inputs = modalBody.querySelectorAll('input[type="number"]');
+                    if (inputs.length > 0) {
+                      const prevInput = inputs[0] as HTMLInputElement;
+                      prevInput.focus();
+                      prevInput.select();
+                    }
+                  }
+                }
+              }}
+            />
+
+            {/* Tireur B */}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+                flex: 1,
+                minWidth: '200px',
+              }}
+            >
+              <div style={{ fontSize: '1.5rem', fontWeight: 600, textAlign: 'left' }}>
+                {match.fencerB?.lastName}
+              </div>
+              <div style={{ fontSize: '1rem', color: '#6b7280', textAlign: 'left' }}>
+                {match.fencerB?.firstName} {match.fencerB?.club && `(${match.fencerB.club})`}
+              </div>
+            </div>
+          </div>
+
+          {/* Info score max */}
+          {!isUnlimitedScore && maxScore > 0 && (
+            <p
+              className="text-sm text-muted"
+              style={{ textAlign: 'center', marginBottom: '1rem', fontSize: '1rem' }}
+            >
+              💡 Score maximum : {maxScore} touches
+            </p>
+          )}
+
+          {/* Boutons spéciaux sur une ligne */}
+          <div
+            style={{
+              display: 'flex',
+              gap: '0.5rem',
+              justifyContent: 'center',
+              borderTop: '1px solid #e5e7eb',
+              paddingTop: '1rem',
+              marginTop: '1rem',
+            }}
+          >
+            <button
+              className="btn btn-warning"
+              onClick={() => onSpecialStatus('abandon')}
+              style={{ fontSize: '0.8rem', padding: '0.4rem 0.75rem' }}
+            >
+              🚴 Abandon
+            </button>
+            <button
+              className="btn btn-warning"
+              onClick={() => onSpecialStatus('forfait')}
+              style={{ fontSize: '0.8rem', padding: '0.4rem 0.75rem' }}
+            >
+              📋 Forfait
+            </button>
+            <button
+              className="btn btn-danger"
+              onClick={() => onSpecialStatus('exclusion')}
+              style={{ fontSize: '0.8rem', padding: '0.4rem 0.75rem' }}
+            >
+              🚫 Exclusion
+            </button>
+          </div>
+        </div>
+        <div
+          className="modal-footer"
+          style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}
+        >
+          <button className="btn btn-secondary" onClick={onClose}>
+            Annuler
+          </button>
+          <button className="btn btn-primary" onClick={onSubmit}>
+            Valider
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TableauScoreModal = React.memo(TableauScoreModalComponent);
+export default TableauScoreModal;

--- a/src/renderer/components/tableau/TableauToolbar.tsx
+++ b/src/renderer/components/tableau/TableauToolbar.tsx
@@ -1,0 +1,201 @@
+/**
+ * BellePoule Modern - TableauToolbar
+ * Barre d'outils du tableau à élimination directe
+ * Licensed under GPL-3.0
+ */
+
+import React from 'react';
+import { Fencer } from '../../../shared/types';
+
+interface TableauToolbarProps {
+  tableauSize: number;
+  rankingCount: number;
+  arenaCount: number;
+  autoAssignArenas: boolean;
+  onAutoAssignToggle: (enabled: boolean) => void;
+  onAutoFillScores: () => void;
+  viewMode: 'full' | 'pending';
+  onViewModeToggle: () => void;
+  pyramidViewMode: boolean;
+  onPyramidViewModeToggle: () => void;
+  onPrintClick: () => void;
+  onExportPdfClick: () => void;
+  champion: Fencer | null | undefined;
+}
+
+const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
+  tableauSize,
+  rankingCount,
+  arenaCount,
+  autoAssignArenas,
+  onAutoAssignToggle,
+  onAutoFillScores,
+  viewMode,
+  onViewModeToggle,
+  pyramidViewMode,
+  onPyramidViewModeToggle,
+  onPrintClick,
+  onExportPdfClick,
+  champion,
+}) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: '1rem',
+      }}
+    >
+      <h2 style={{ fontSize: '1.25rem', fontWeight: '600' }}>
+        Tableau de {tableauSize} - {rankingCount} qualifiés
+      </h2>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        {arenaCount > 0 && (
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.4rem',
+              fontSize: '0.875rem',
+              color: '#374151',
+              cursor: 'pointer',
+              padding: '0.5rem 0.75rem',
+              background: autoAssignArenas ? '#eff6ff' : '#f3f4f6',
+              border: `1px solid ${autoAssignArenas ? '#3b82f6' : '#d1d5db'}`,
+              borderRadius: '6px',
+              userSelect: 'none',
+            }}
+            title="Assigne automatiquement les matchs aux arènes disponibles en round-robin"
+          >
+            <input
+              type="checkbox"
+              checked={autoAssignArenas}
+              onChange={e => onAutoAssignToggle(e.target.checked)}
+              style={{ cursor: 'pointer' }}
+            />
+            <span>🏟️ Assignation auto</span>
+          </label>
+        )}
+        <button
+          onClick={onAutoFillScores}
+          style={{
+            background: '#f59e0b',
+            color: 'white',
+            border: 'none',
+            padding: '0.5rem 1rem',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            fontWeight: '500',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+          }}
+        >
+          🎲 Remplir auto
+        </button>
+        <button
+          onClick={onViewModeToggle}
+          style={{
+            background: viewMode === 'pending' ? '#3b82f6' : '#e5e7eb',
+            color: viewMode === 'pending' ? 'white' : '#374151',
+            border: 'none',
+            padding: '0.5rem 0.75rem',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            fontWeight: '500',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+          }}
+          title={
+            viewMode === 'full'
+              ? 'Afficher les matches en attente'
+              : 'Afficher le tableau complet'
+          }
+        >
+          {viewMode === 'full' ? '📋 Matchs en attente' : '📊 Tableau complet'}
+        </button>
+        <button
+          onClick={onPyramidViewModeToggle}
+          style={{
+            background: pyramidViewMode ? '#8b5cf6' : '#e5e7eb',
+            color: pyramidViewMode ? 'white' : '#374151',
+            border: 'none',
+            padding: '0.5rem 0.75rem',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            fontWeight: '500',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+          }}
+          title={pyramidViewMode ? 'Vue tableau' : 'Vue pyramidale'}
+        >
+          {pyramidViewMode ? '🔲 Tableau' : '🔺 Pyramide'}
+        </button>
+        <button
+          onClick={onPrintClick}
+          style={{
+            background: '#6366f1',
+            color: 'white',
+            border: 'none',
+            padding: '0.5rem 0.75rem',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            fontWeight: '500',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+          }}
+          title="Imprimer les feuilles de match"
+        >
+          🖨️ Imprimer
+        </button>
+        <button
+          onClick={onExportPdfClick}
+          style={{
+            background: '#10b981',
+            color: 'white',
+            border: 'none',
+            padding: '0.5rem 0.75rem',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            fontWeight: '500',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+          }}
+          title="Exporter les feuilles de match en PDF"
+        >
+          📄 Export PDF
+        </button>
+        {champion && (
+          <div
+            style={{
+              background: '#fef3c7',
+              padding: '0.5rem 1rem',
+              borderRadius: '8px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}
+          >
+            <span style={{ fontSize: '1.5rem' }}>🏆</span>
+            <span style={{ fontWeight: '600' }}>
+              {champion.lastName} {champion.firstName}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const TableauToolbar = React.memo(TableauToolbarComponent);
+export default TableauToolbar;


### PR DESCRIPTION
## Résumé

### TableauView 2154 → 1830 lignes (-324)

3 nouveaux sous-composants extraits :
- `tableau/TableauScoreModal.tsx` — modale saisie score
- `tableau/TableauPendingSection.tsx` — section round repliable
- `tableau/TableauToolbar.tsx` — barre d'outils (titre, arènes, PDF, vue)

### React.memo complété

- `DashboardComponents.tsx` — ModernStatCard, ActivityTimeline, Sparkline
- `Skeleton.tsx` — 6 composants skeleton
- `ModernVisualComponents.tsx`
- `EnhancedToast.tsx`
- `OfflineStatus.tsx`
- `CardModal.tsx`, `LiveDashboard.tsx`

## Test plan

- [ ] Saisie score dans tableau → modale s'ouvre et valide
- [ ] Sections rounds repliables → toggle fonctionne
- [ ] Export PDF tableau → fonctionne
- [ ] `npm run type-check` → 0 erreur

https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU)_