### PR TITLE
fix: corriger erreurs TS build — sous-composants extraits

### DIFF
--- a/src/renderer/components/competition/CompetitionHeader.tsx
+++ b/src/renderer/components/competition/CompetitionHeader.tsx
@@ -18,12 +18,12 @@ interface MatchProgress {
 interface CompetitionHeaderProps {
   competition: Competition;
   language: string;
-  t: (key: string, params?: Record<string, unknown>) => string;
+  t: (key: string, params?: { [key: string]: string | number }) => string;
   matchProgress: MatchProgress | null;
   showConfetti: boolean;
   showActionsMenu: boolean;
   setShowActionsMenu: React.Dispatch<React.SetStateAction<boolean>>;
-  actionsMenuRef: React.RefObject<HTMLDivElement>;
+  actionsMenuRef: React.RefObject<HTMLDivElement | null>;
   currentPhase: Phase;
   pools: Array<{ matches: Array<{ status: MatchStatus }> }>;
   tableauMatches: Array<unknown>;

--- a/src/renderer/components/competition/CompetitionNav.tsx
+++ b/src/renderer/components/competition/CompetitionNav.tsx
@@ -38,7 +38,7 @@ interface CompetitionNavProps {
   currentPhase: Phase;
   setCurrentPhase: (phase: Phase) => void;
   language: string;
-  t: (key: string, params?: Record<string, unknown>) => string;
+  t: (key: string, params?: { [key: string]: string | number }) => string;
   handleGoBack: () => void;
   handleGeneratePools: () => void;
   poolsNextAction: PoolsNextAction | null;

--- a/src/renderer/components/pool/PoolMatchList.tsx
+++ b/src/renderer/components/pool/PoolMatchList.tsx
@@ -4,10 +4,10 @@
  */
 
 import React from 'react';
-import { Score, FencerStatus, MatchStatus } from '../../../shared/types';
+import { Match, FencerStatus, MatchStatus } from '../../../shared/types';
 
 interface OrderedMatchEntry {
-  match: Score;
+  match: Match;
   index: number;
 }
 


### PR DESCRIPTION
## Résumé

Correction des erreurs TypeScript introduites par l'extraction des sous-composants (PRs #469 et #472).

### Fixes

- `pool/PoolMatchList.tsx` — type `Score` → `Match` (le type correct des matchs de poule)
- `competition/CompetitionHeader.tsx` — signature `t()` : `Record<string, unknown>` → `{ [key: string]: string | number }` + `RefObject<HTMLDivElement | null>`
- `competition/CompetitionNav.tsx` — même correction sur `t()`

### Contexte

`npm run build:ci` échouait avec 45+ erreurs TS. Build maintenant propre (0 erreur, 2 warnings tsconfig préexistants).

## Test plan

- [ ] `npm run build:ci` → succès
- [ ] `npm run type-check` → 0 erreur nouvelle

https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU)_