### PR TITLE
fix: RefObject<HTMLDivElement|null> dans TableauScoreModal

### DIFF
--- a/src/renderer/components/tableau/TableauScoreModal.tsx
+++ b/src/renderer/components/tableau/TableauScoreModal.tsx
@@ -15,7 +15,7 @@ interface TableauScoreModalProps {
   setEditScoreB: (v: string) => void;
   maxScore: number;
   isUnlimitedScore: boolean;
-  modalRef: React.RefObject<HTMLDivElement>;
+  modalRef: React.RefObject<HTMLDivElement | null>;
   onClose: () => void;
   onSubmit: () => void;
   onSpecialStatus: (status: 'abandon' | 'forfait' | 'exclusion') => void;


### PR DESCRIPTION
## Résumé

Correction de la dernière erreur TS bloquant `npm run build:ci`.

`TableauScoreModal.tsx` déclarait `modalRef: React.RefObject<HTMLDivElement>` mais `useRef` retourne `RefObject<HTMLDivElement | null>` en React 19.

## Test plan

- [ ] `npm run build:ci` → succès

https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU)_