### PR TITLE
perf: extraire les inline styles en constantes statiques

### DIFF
--- a/src/renderer/components/KioskDisplay.tsx
+++ b/src/renderer/components/KioskDisplay.tsx
@@ -18,6 +18,307 @@ import {
 
 type KioskView = 'pools' | 'ranking' | 'tableau';
 
+// ─── Static style constants (extracted to avoid new object on every render) ───
+
+const KIOSK_STYLES = {
+  root: {
+    position: 'fixed' as const,
+    inset: 0,
+    backgroundColor: '#0f172a',
+    color: 'white',
+    zIndex: 9999,
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    overflow: 'hidden',
+  },
+  menu: {
+    position: 'absolute' as const,
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10000,
+    padding: '1rem 2rem',
+    background: 'rgba(0,0,0,0.85)',
+    backdropFilter: 'blur(8px)',
+    display: 'flex',
+    alignItems: 'center' as const,
+    gap: '0.75rem',
+  },
+  menuLabel: { fontSize: '1rem', color: '#94a3b8', marginRight: '0.5rem', fontWeight: 600 },
+  menuFlex: { flex: 1 },
+  menuEscHint: { fontSize: '0.8rem', color: '#64748b' },
+  menuCloseBtn: {
+    padding: '0.5rem 1rem',
+    borderRadius: '8px',
+    border: '1px solid #475569',
+    background: 'transparent',
+    color: '#94a3b8',
+    cursor: 'pointer',
+    fontSize: '0.9rem',
+  },
+  poolsWrapper: { flex: 1, display: 'flex', flexDirection: 'column' as const, padding: '70px 40px 40px' },
+  poolsHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center' as const,
+    marginBottom: '24px',
+    borderBottom: '2px solid #334155',
+    paddingBottom: '20px',
+  },
+  poolsTitle: { margin: 0, fontSize: '2.2rem', fontWeight: 'bold' as const },
+  poolsSubtitle: { margin: '8px 0 0', fontSize: '1.1rem', color: '#94a3b8' },
+  poolsNavHint: { marginLeft: '1rem', fontSize: '0.9rem' },
+  poolsScoreBox: { textAlign: 'right' as const },
+  poolsScoreNum: { fontSize: '2.5rem', fontWeight: 'bold' as const, color: '#3b82f6' },
+  poolsScoreLabel: { fontSize: '0.9rem', color: '#64748b' },
+  poolsProgressTrack: {
+    width: '100%',
+    height: '6px',
+    backgroundColor: '#1e293b',
+    borderRadius: '3px',
+    marginBottom: '32px',
+    overflow: 'hidden',
+  },
+  poolsProgressFill: { height: '100%', backgroundColor: '#3b82f6', transition: 'width 0.5s ease' },
+  poolsContent: { flex: 1, display: 'flex', gap: '24px', minHeight: 0 },
+  poolsRankingCol: { flex: 1 },
+  poolsRankingTitle: { marginBottom: '16px', fontSize: '1.3rem', color: '#94a3b8' },
+  poolsRankingList: { display: 'flex', flexDirection: 'column' as const, gap: '10px' },
+  poolsMatchesCol: { width: '360px', flexShrink: 0 },
+  poolsMatchesTitle: { marginBottom: '16px', fontSize: '1.3rem', color: '#94a3b8' },
+  poolsMatchesList: { display: 'flex', flexDirection: 'column' as const, gap: '12px' },
+  poolsMatchCard: { padding: '16px', backgroundColor: '#dc2626', borderRadius: '10px' },
+  poolsMatchCardRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center' as const,
+    fontSize: '1.2rem',
+    fontWeight: 'bold' as const,
+  },
+  poolsMatchVs: { color: '#fca5a5', fontSize: '0.9rem' },
+  poolsMatchStrip: { textAlign: 'center' as const, marginTop: '8px', fontSize: '1rem', color: '#fca5a5' },
+  poolsMatchEmpty: { padding: '32px', textAlign: 'center' as const, color: '#64748b', fontSize: '1.1rem' },
+  poolsRankRow: {
+    display: 'flex',
+    alignItems: 'center' as const,
+    padding: '16px',
+    borderRadius: '10px',
+  },
+  poolsRankAvatar: {
+    width: '44px',
+    height: '44px',
+    borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center' as const,
+    justifyContent: 'center',
+    fontSize: '1.3rem',
+    fontWeight: 'bold' as const,
+    marginRight: '16px',
+    flexShrink: 0,
+  },
+  poolsRankInfo: { flex: 1 },
+  poolsRankName: { fontSize: '1.3rem', fontWeight: 'bold' as const },
+  poolsRankClub: { fontSize: '0.9rem', color: '#64748b' },
+  poolsRankStats: { textAlign: 'right' as const, flexShrink: 0 },
+  poolsRankScore: { fontSize: '1.5rem', fontWeight: 'bold' as const, color: '#3b82f6' },
+  poolsRankMatches: { fontSize: '0.85rem', color: '#94a3b8' },
+  poolsRankTouches: { fontSize: '0.85rem', color: '#64748b' },
+  poolsDotsRow: { display: 'flex', justifyContent: 'center', gap: '8px', marginTop: '20px' },
+  rankingWrapper: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    padding: '70px 40px 0',
+    minHeight: 0,
+  },
+  rankingHeader: {
+    marginBottom: '24px',
+    borderBottom: '2px solid #334155',
+    paddingBottom: '16px',
+    flexShrink: 0,
+  },
+  rankingTitle: { margin: 0, fontSize: '2rem', fontWeight: 'bold' as const },
+  rankingSubtitle: { margin: '6px 0 0', fontSize: '1.1rem', color: '#94a3b8' },
+  rankingScrollArea: { flex: 1, overflowY: 'auto' as const, paddingBottom: '40px' },
+  rankingTable: { width: '100%', borderCollapse: 'collapse' as const, fontSize: '1.05rem' },
+  rankingThead: { color: '#64748b', textAlign: 'left' as const, borderBottom: '1px solid #334155' },
+  rankingThRg: { padding: '10px 12px', width: '60px' },
+  rankingThName: { padding: '10px 12px' },
+  rankingThVm: { padding: '10px 12px', textAlign: 'center' as const, width: '70px' },
+  rankingThTd: { padding: '10px 12px', textAlign: 'center' as const, width: '60px' },
+  rankingThTr: { padding: '10px 12px', textAlign: 'center' as const, width: '60px' },
+  rankingThQuest: { padding: '10px 12px', textAlign: 'center' as const, width: '80px', color: '#a78bfa' },
+  rankingThIndice: { padding: '10px 12px', textAlign: 'center' as const, width: '70px' },
+  rankingTdRank: { padding: '12px', fontWeight: 'bold' as const, fontSize: '1.2rem' },
+  rankingTdLast: { padding: '12px', fontWeight: 600, fontSize: '1.1rem' },
+  rankingTdFirst: { padding: '12px', fontSize: '1.05rem' },
+  rankingTdClub: { padding: '12px', color: '#94a3b8', fontSize: '0.95rem' },
+  rankingTdRatio: { padding: '12px', textAlign: 'center' as const },
+  rankingTdTouches: { padding: '12px', textAlign: 'center' as const },
+  rankingTdQuest: { padding: '12px', textAlign: 'center' as const, color: '#a78bfa', fontWeight: 600 },
+  rankingTdIndice: { padding: '12px', textAlign: 'center' as const, fontWeight: 600 },
+  tableauWrapper: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    padding: '70px 40px 0',
+    minHeight: 0,
+  },
+  tableauHeader: {
+    marginBottom: '24px',
+    borderBottom: '2px solid #334155',
+    paddingBottom: '16px',
+    flexShrink: 0,
+  },
+  tableauTitle: { margin: 0, fontSize: '2rem', fontWeight: 'bold' as const },
+  tableauRoundLabel: { margin: '6px 0 0', fontSize: '1.3rem', color: '#3b82f6', fontWeight: 600 },
+  tableauScrollArea: { flex: 1, overflowY: 'auto' as const, paddingBottom: '40px' },
+  tableauGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(400px, 1fr))',
+    gap: '16px',
+  },
+  matchCardBye: {
+    padding: '20px 24px',
+    backgroundColor: '#1e293b',
+    borderRadius: '12px',
+    border: '1px solid #334155',
+    opacity: 0.5,
+  },
+  matchCardByeLabel: { textAlign: 'center' as const, color: '#64748b', fontSize: '1rem' },
+  matchCardByeName: { textAlign: 'center' as const, fontWeight: 'bold' as const, fontSize: '1.2rem', marginTop: '4px' },
+  matchCardVs: { textAlign: 'center' as const, fontSize: '0.75rem', color: '#475569', margin: '2px 0' },
+  finishedWrapper: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    minHeight: 0,
+    gap: '24px',
+  },
+  finishedTitle: {
+    textAlign: 'center' as const,
+    fontSize: '1.4rem',
+    fontWeight: 700,
+    color: '#fbbf24',
+    letterSpacing: '0.05em',
+    flexShrink: 0,
+  },
+  podiumRow: {
+    display: 'flex',
+    alignItems: 'flex-end' as const,
+    justifyContent: 'center',
+    gap: '16px',
+    flexShrink: 0,
+  },
+  podiumCol: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center' as const,
+    gap: '8px',
+  },
+  podiumMedal2: { fontSize: '2.2rem' },
+  podiumName2: { fontWeight: 700, fontSize: '1.2rem', textAlign: 'center' as const, maxWidth: '200px' },
+  podiumClub2: { fontSize: '0.85rem', color: '#94a3b8', textAlign: 'center' as const },
+  podiumBlock2: {
+    width: '180px',
+    height: '80px',
+    backgroundColor: '#475569',
+    borderRadius: '6px 6px 0 0',
+    display: 'flex',
+    alignItems: 'center' as const,
+    justifyContent: 'center',
+    fontSize: '1.4rem',
+    fontWeight: 800,
+    color: '#94a3b8',
+  },
+  podiumMedal1: { fontSize: '3rem' },
+  podiumName1: { fontWeight: 800, fontSize: '1.5rem', textAlign: 'center' as const, maxWidth: '220px', color: '#fbbf24' },
+  podiumClub1: { fontSize: '0.9rem', color: '#fbbf24', opacity: 0.8, textAlign: 'center' as const },
+  podiumBlock1: {
+    width: '200px',
+    height: '120px',
+    backgroundColor: '#b45309',
+    borderRadius: '6px 6px 0 0',
+    display: 'flex',
+    alignItems: 'center' as const,
+    justifyContent: 'center',
+    fontSize: '2rem',
+    fontWeight: 800,
+    color: '#fbbf24',
+  },
+  podiumMedal3: { fontSize: '2.2rem' },
+  podiumName3: { fontWeight: 700, fontSize: '1.2rem', textAlign: 'center' as const, maxWidth: '200px' },
+  podiumClub3: { fontSize: '0.85rem', color: '#94a3b8', textAlign: 'center' as const },
+  podiumBlock3: {
+    width: '180px',
+    height: '60px',
+    backgroundColor: '#713f12',
+    borderRadius: '6px 6px 0 0',
+    display: 'flex',
+    alignItems: 'center' as const,
+    justifyContent: 'center',
+    fontSize: '1.4rem',
+    fontWeight: 800,
+    color: '#d97706',
+  },
+  podiumEmpty: { textAlign: 'center' as const, color: '#94a3b8', fontSize: '1.3rem' },
+  elimRankingWrapper: {
+    flex: 1,
+    overflowY: 'hidden' as const,
+    borderTop: '1px solid #334155',
+    paddingTop: '16px',
+  },
+  elimRankingLabel: {
+    color: '#64748b',
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.08em',
+    marginBottom: '10px',
+    paddingLeft: '4px',
+  },
+  elimTable: { width: '100%', borderCollapse: 'collapse' as const, fontSize: '1rem' },
+  elimThead: { color: '#64748b', textAlign: 'left' as const, borderBottom: '1px solid #334155' },
+  elimThRg: { padding: '6px 10px', width: '50px' },
+  elimThName: { padding: '6px 10px' },
+  elimThElimAt: { padding: '6px 10px', color: '#475569', fontStyle: 'italic' as const },
+  elimTdRank: { padding: '8px 10px', fontWeight: 'bold' as const, fontSize: '1.1rem' },
+  elimTdRankSmall: { color: '#64748b' },
+  elimTdLast: { padding: '8px 10px', fontWeight: 600 },
+  elimTdFirst: { padding: '8px 10px' },
+  elimTdClub: { padding: '8px 10px', color: '#94a3b8', fontSize: '0.9rem' },
+  elimTdElimAt: { padding: '8px 10px', color: '#475569', fontSize: '0.85rem', fontStyle: 'italic' as const },
+  orgNoteOverlay: {
+    position: 'absolute' as const,
+    inset: 0,
+    zIndex: 10500,
+    background: 'rgba(2, 6, 23, 0.88)',
+    backdropFilter: 'blur(6px)',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center' as const,
+    justifyContent: 'space-evenly' as const,
+    textAlign: 'center' as const,
+    padding: '3rem',
+  },
+  orgNotePauseLabel: {
+    fontSize: 'clamp(2rem, 5vw, 4rem)' as const,
+    color: '#64748b',
+    fontWeight: 600,
+    letterSpacing: '0.2em',
+    textTransform: 'uppercase' as const,
+  },
+  orgNoteResumeTime: { fontSize: 'clamp(4rem, 14vw, 12rem)' as const, fontWeight: 700, color: '#f1f5f9' },
+  orgNoteCountdown: {
+    fontSize: 'clamp(3rem, 10vw, 8rem)' as const,
+    fontWeight: 800,
+    color: '#3b82f6',
+    fontVariantNumeric: 'tabular-nums' as const,
+  },
+  orgNoteMessage: { fontSize: 'clamp(2rem, 7vw, 6rem)' as const, color: '#94a3b8', fontStyle: 'italic' as const },
+} satisfies Record<string, React.CSSProperties>;
+
 const roundNames: Record<number, string> = {
   2: 'Finale',
   3: 'Petite finale',
@@ -322,40 +623,18 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
   return (
     <div
       onMouseMove={showMenu}
-      style={{
-        position: 'fixed',
-        inset: 0,
-        backgroundColor: '#0f172a',
-        color: 'white',
-        zIndex: 9999,
-        fontFamily: 'system-ui, -apple-system, sans-serif',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-      }}
+      style={KIOSK_STYLES.root}
     >
       {/* Menu auto-masquant */}
       <div
         style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          zIndex: 10000,
-          padding: '1rem 2rem',
-          background: 'rgba(0,0,0,0.85)',
-          backdropFilter: 'blur(8px)',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '0.75rem',
+          ...KIOSK_STYLES.menu,
           opacity: menuVisible ? 1 : 0,
           pointerEvents: menuVisible ? 'auto' : 'none',
           transition: 'opacity 0.4s ease',
         }}
       >
-        <span
-          style={{ fontSize: '1rem', color: '#94a3b8', marginRight: '0.5rem', fontWeight: 600 }}
-        >
+        <span style={KIOSK_STYLES.menuLabel}>
           Mode Kiosk
         </span>
         <button
@@ -385,19 +664,11 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
         >
           🥇 Tableau
         </button>
-        <div style={{ flex: 1 }} />
-        <span style={{ fontSize: '0.8rem', color: '#64748b' }}>Echap pour quitter</span>
+        <div style={KIOSK_STYLES.menuFlex} />
+        <span style={KIOSK_STYLES.menuEscHint}>Echap pour quitter</span>
         <button
           onClick={onClose}
-          style={{
-            padding: '0.5rem 1rem',
-            borderRadius: '8px',
-            border: '1px solid #475569',
-            background: 'transparent',
-            color: '#94a3b8',
-            cursor: 'pointer',
-            fontSize: '0.9rem',
-          }}
+          style={KIOSK_STYLES.menuCloseBtn}
         >
           ✕ Fermer
         </button>
@@ -405,113 +676,79 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
 
       {/* ===== VUE POULES ===== */}
       {currentView === 'pools' && currentPool && (
-        <div
-          style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: '70px 40px 40px' }}
-        >
+        <div style={KIOSK_STYLES.poolsWrapper}>
           {/* Header poule */}
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: '24px',
-              borderBottom: '2px solid #334155',
-              paddingBottom: '20px',
-            }}
-          >
+          <div style={KIOSK_STYLES.poolsHeader}>
             <div>
-              <h1 style={{ margin: 0, fontSize: '2.2rem', fontWeight: 'bold' }}>
+              <h1 style={KIOSK_STYLES.poolsTitle}>
                 {competition.title}
               </h1>
-              <p style={{ margin: '8px 0 0', fontSize: '1.1rem', color: '#94a3b8' }}>
+              <p style={KIOSK_STYLES.poolsSubtitle}>
                 Poule {currentPool.number} / {pools.length}
-                <span style={{ marginLeft: '1rem', fontSize: '0.9rem' }}>
+                <span style={KIOSK_STYLES.poolsNavHint}>
                   {pools.length > 1 && '← → naviguer'}
                 </span>
               </p>
             </div>
-            <div style={{ textAlign: 'right' }}>
-              <div style={{ fontSize: '2.5rem', fontWeight: 'bold', color: '#3b82f6' }}>
+            <div style={KIOSK_STYLES.poolsScoreBox}>
+              <div style={KIOSK_STYLES.poolsScoreNum}>
                 {poolCompleted}/{poolTotal}
               </div>
-              <div style={{ fontSize: '0.9rem', color: '#64748b' }}>matchs terminés</div>
+              <div style={KIOSK_STYLES.poolsScoreLabel}>matchs terminés</div>
             </div>
           </div>
 
           {/* Barre de progression */}
-          <div
-            style={{
-              width: '100%',
-              height: '6px',
-              backgroundColor: '#1e293b',
-              borderRadius: '3px',
-              marginBottom: '32px',
-              overflow: 'hidden',
-            }}
-          >
+          <div style={KIOSK_STYLES.poolsProgressTrack}>
             <div
               style={{
+                ...KIOSK_STYLES.poolsProgressFill,
                 width: `${poolProgress}%`,
-                height: '100%',
-                backgroundColor: '#3b82f6',
-                transition: 'width 0.5s ease',
               }}
             />
           </div>
 
           {/* Contenu */}
-          <div style={{ flex: 1, display: 'flex', gap: '24px', minHeight: 0 }}>
+          <div style={KIOSK_STYLES.poolsContent}>
             {/* Classement poule */}
-            <div style={{ flex: 1 }}>
-              <h2 style={{ marginBottom: '16px', fontSize: '1.3rem', color: '#94a3b8' }}>
+            <div style={KIOSK_STYLES.poolsRankingCol}>
+              <h2 style={KIOSK_STYLES.poolsRankingTitle}>
                 Classement
               </h2>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+              <div style={KIOSK_STYLES.poolsRankingList}>
                 {currentPool.ranking?.slice(0, 8).map((rank, i) => (
                   <div
                     key={rank.fencer.id}
                     style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      padding: '16px',
+                      ...KIOSK_STYLES.poolsRankRow,
                       backgroundColor: i < 3 ? '#1e3a5f' : '#1e293b',
-                      borderRadius: '10px',
                       border: i < 3 ? '2px solid #3b82f6' : '2px solid transparent',
                     }}
                   >
                     <div
                       style={{
-                        width: '44px',
-                        height: '44px',
-                        borderRadius: '50%',
+                        ...KIOSK_STYLES.poolsRankAvatar,
                         backgroundColor: i < 3 ? '#3b82f6' : '#475569',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '1.3rem',
-                        fontWeight: 'bold',
-                        marginRight: '16px',
-                        flexShrink: 0,
                       }}
                     >
                       {i + 1}
                     </div>
-                    <div style={{ flex: 1 }}>
-                      <div style={{ fontSize: '1.3rem', fontWeight: 'bold' }}>
+                    <div style={KIOSK_STYLES.poolsRankInfo}>
+                      <div style={KIOSK_STYLES.poolsRankName}>
                         {rank.fencer.lastName} {rank.fencer.firstName}
                       </div>
-                      <div style={{ fontSize: '0.9rem', color: '#64748b' }}>
+                      <div style={KIOSK_STYLES.poolsRankClub}>
                         {rank.fencer.club || 'Sans club'}
                       </div>
                     </div>
-                    <div style={{ textAlign: 'right', flexShrink: 0 }}>
-                      <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#3b82f6' }}>
+                    <div style={KIOSK_STYLES.poolsRankStats}>
+                      <div style={KIOSK_STYLES.poolsRankScore}>
                         {rank.victories}V – {rank.defeats}D
                       </div>
-                      <div style={{ fontSize: '0.85rem', color: '#94a3b8' }}>
+                      <div style={KIOSK_STYLES.poolsRankMatches}>
                         {rank.matchesPlayed} match{rank.matchesPlayed !== 1 ? 's' : ''}
                       </div>
-                      <div style={{ fontSize: '0.85rem', color: '#64748b' }}>
+                      <div style={KIOSK_STYLES.poolsRankTouches}>
                         TD {rank.touchesScored} / TR {rank.touchesReceived}
                       </div>
                     </div>
@@ -521,54 +758,32 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             </div>
 
             {/* Matchs en cours */}
-            <div style={{ width: '360px', flexShrink: 0 }}>
-              <h2 style={{ marginBottom: '16px', fontSize: '1.3rem', color: '#94a3b8' }}>
+            <div style={KIOSK_STYLES.poolsMatchesCol}>
+              <h2 style={KIOSK_STYLES.poolsMatchesTitle}>
                 Matchs en cours
               </h2>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div style={KIOSK_STYLES.poolsMatchesList}>
                 {currentPool.matches
                   .filter(m => m.status === MatchStatus.IN_PROGRESS)
                   .slice(0, 4)
                   .map((match, idx) => (
                     <div
                       key={match.id}
-                      style={{ padding: '16px', backgroundColor: '#dc2626', borderRadius: '10px' }}
+                      style={KIOSK_STYLES.poolsMatchCard}
                     >
-                      <div
-                        style={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          alignItems: 'center',
-                          fontSize: '1.2rem',
-                          fontWeight: 'bold',
-                        }}
-                      >
+                      <div style={KIOSK_STYLES.poolsMatchCardRow}>
                         <span>{match.fencerA?.lastName || 'TBD'}</span>
-                        <span style={{ color: '#fca5a5', fontSize: '0.9rem' }}>VS</span>
+                        <span style={KIOSK_STYLES.poolsMatchVs}>VS</span>
                         <span>{match.fencerB?.lastName || 'TBD'}</span>
                       </div>
-                      <div
-                        style={{
-                          textAlign: 'center',
-                          marginTop: '8px',
-                          fontSize: '1rem',
-                          color: '#fca5a5',
-                        }}
-                      >
+                      <div style={KIOSK_STYLES.poolsMatchStrip}>
                         Piste {match.strip || idx + 1}
                       </div>
                     </div>
                   ))}
                 {currentPool.matches.filter(m => m.status === MatchStatus.IN_PROGRESS).length ===
                   0 && (
-                  <div
-                    style={{
-                      padding: '32px',
-                      textAlign: 'center',
-                      color: '#64748b',
-                      fontSize: '1.1rem',
-                    }}
-                  >
+                  <div style={KIOSK_STYLES.poolsMatchEmpty}>
                     Aucun match en cours
                   </div>
                 )}
@@ -578,9 +793,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
 
           {/* Navigation dots */}
           {pools.length > 1 && (
-            <div
-              style={{ display: 'flex', justifyContent: 'center', gap: '8px', marginTop: '20px' }}
-            >
+            <div style={KIOSK_STYLES.poolsDotsRow}>
               {pools.map((_, i) => (
                 <div
                   key={i}
@@ -602,26 +815,11 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
 
       {/* ===== VUE CLASSEMENT ===== */}
       {currentView === 'ranking' && (
-        <div
-          style={{
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            padding: '70px 40px 0',
-            minHeight: 0,
-          }}
-        >
+        <div style={KIOSK_STYLES.rankingWrapper}>
           {/* Header */}
-          <div
-            style={{
-              marginBottom: '24px',
-              borderBottom: '2px solid #334155',
-              paddingBottom: '16px',
-              flexShrink: 0,
-            }}
-          >
-            <h1 style={{ margin: 0, fontSize: '2rem', fontWeight: 'bold' }}>{competition.title}</h1>
-            <p style={{ margin: '6px 0 0', fontSize: '1.1rem', color: '#94a3b8' }}>
+          <div style={KIOSK_STYLES.rankingHeader}>
+            <h1 style={KIOSK_STYLES.rankingTitle}>{competition.title}</h1>
+            <p style={KIOSK_STYLES.rankingSubtitle}>
               Classement Provisoire · {overallRanking.length} tireur
               {overallRanking.length > 1 ? 's' : ''}
             </p>
@@ -631,33 +829,24 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
           <div
             ref={rankingScrollRef}
             data-kiosk-scroll=""
-            style={{ flex: 1, overflowY: 'auto', paddingBottom: '40px' }}
+            style={KIOSK_STYLES.rankingScrollArea}
           >
-            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '1.05rem' }}>
+            <table style={KIOSK_STYLES.rankingTable}>
               <thead>
-                <tr
-                  style={{ color: '#64748b', textAlign: 'left', borderBottom: '1px solid #334155' }}
-                >
-                  <th style={{ padding: '10px 12px', width: '60px' }}>Rg</th>
-                  <th style={{ padding: '10px 12px' }}>Nom</th>
-                  <th style={{ padding: '10px 12px' }}>Prénom</th>
-                  <th style={{ padding: '10px 12px' }}>Club</th>
-                  <th style={{ padding: '10px 12px', textAlign: 'center', width: '70px' }}>V/M</th>
-                  <th style={{ padding: '10px 12px', textAlign: 'center', width: '60px' }}>TD</th>
-                  <th style={{ padding: '10px 12px', textAlign: 'center', width: '60px' }}>TR</th>
+                <tr style={KIOSK_STYLES.rankingThead}>
+                  <th style={KIOSK_STYLES.rankingThRg}>Rg</th>
+                  <th style={KIOSK_STYLES.rankingThName}>Nom</th>
+                  <th style={KIOSK_STYLES.rankingThName}>Prénom</th>
+                  <th style={KIOSK_STYLES.rankingThName}>Club</th>
+                  <th style={KIOSK_STYLES.rankingThVm}>V/M</th>
+                  <th style={KIOSK_STYLES.rankingThTd}>TD</th>
+                  <th style={KIOSK_STYLES.rankingThTr}>TR</th>
                   {isLaserSabre && (
-                    <th
-                      style={{
-                        padding: '10px 12px',
-                        textAlign: 'center',
-                        width: '80px',
-                        color: '#a78bfa',
-                      }}
-                    >
+                    <th style={KIOSK_STYLES.rankingThQuest}>
                       Quest
                     </th>
                   )}
-                  <th style={{ padding: '10px 12px', textAlign: 'center', width: '70px' }}>
+                  <th style={KIOSK_STYLES.rankingThIndice}>
                     Indice
                   </th>
                 </tr>
@@ -673,41 +862,30 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                   >
                     <td
                       style={{
-                        padding: '12px',
-                        fontWeight: 'bold',
-                        fontSize: '1.2rem',
+                        ...KIOSK_STYLES.rankingTdRank,
                         color: i < 3 ? '#3b82f6' : 'white',
                       }}
                     >
                       {r.rank}
                     </td>
-                    <td style={{ padding: '12px', fontWeight: 600, fontSize: '1.1rem' }}>
+                    <td style={KIOSK_STYLES.rankingTdLast}>
                       {r.fencer.lastName}
                     </td>
-                    <td style={{ padding: '12px', fontSize: '1.05rem' }}>{r.fencer.firstName}</td>
-                    <td style={{ padding: '12px', color: '#94a3b8', fontSize: '0.95rem' }}>
+                    <td style={KIOSK_STYLES.rankingTdFirst}>{r.fencer.firstName}</td>
+                    <td style={KIOSK_STYLES.rankingTdClub}>
                       {r.fencer.club || '–'}
                     </td>
-                    <td style={{ padding: '12px', textAlign: 'center' }}>{formatRatio(r.ratio)}</td>
-                    <td style={{ padding: '12px', textAlign: 'center' }}>{r.touchesScored}</td>
-                    <td style={{ padding: '12px', textAlign: 'center' }}>{r.touchesReceived}</td>
+                    <td style={KIOSK_STYLES.rankingTdRatio}>{formatRatio(r.ratio)}</td>
+                    <td style={KIOSK_STYLES.rankingTdTouches}>{r.touchesScored}</td>
+                    <td style={KIOSK_STYLES.rankingTdTouches}>{r.touchesReceived}</td>
                     {isLaserSabre && (
-                      <td
-                        style={{
-                          padding: '12px',
-                          textAlign: 'center',
-                          color: '#a78bfa',
-                          fontWeight: 600,
-                        }}
-                      >
+                      <td style={KIOSK_STYLES.rankingTdQuest}>
                         {r.questPoints || 0}
                       </td>
                     )}
                     <td
                       style={{
-                        padding: '12px',
-                        textAlign: 'center',
-                        fontWeight: 600,
+                        ...KIOSK_STYLES.rankingTdIndice,
                         color: r.index >= 0 ? '#10b981' : '#f87171',
                       }}
                     >
@@ -723,26 +901,11 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
 
       {/* ===== VUE TABLEAU ===== */}
       {currentView === 'tableau' && (
-        <div
-          style={{
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            padding: '70px 40px 0',
-            minHeight: 0,
-          }}
-        >
+        <div style={KIOSK_STYLES.tableauWrapper}>
           {/* Header */}
-          <div
-            style={{
-              marginBottom: '24px',
-              borderBottom: '2px solid #334155',
-              paddingBottom: '16px',
-              flexShrink: 0,
-            }}
-          >
-            <h1 style={{ margin: 0, fontSize: '2rem', fontWeight: 'bold' }}>{competition.title}</h1>
-            <p style={{ margin: '6px 0 0', fontSize: '1.3rem', color: '#3b82f6', fontWeight: 600 }}>
+          <div style={KIOSK_STYLES.tableauHeader}>
+            <h1 style={KIOSK_STYLES.tableauTitle}>{competition.title}</h1>
+            <p style={KIOSK_STYLES.tableauRoundLabel}>
               {activeRound !== null
                 ? roundNames[activeRound] || `Tour ${activeRound}`
                 : 'Tableau terminé'}
@@ -754,39 +917,20 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             <div
               ref={tableauScrollRef}
               data-kiosk-scroll=""
-              style={{ flex: 1, overflowY: 'auto', paddingBottom: '40px' }}
+              style={KIOSK_STYLES.tableauScrollArea}
             >
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'repeat(auto-fill, minmax(400px, 1fr))',
-                  gap: '16px',
-                }}
-              >
+              <div style={KIOSK_STYLES.tableauGrid}>
                 {activeRoundMatches.map(match => {
                   if (match.isBye) {
                     return (
                       <div
                         key={match.id}
-                        style={{
-                          padding: '20px 24px',
-                          backgroundColor: '#1e293b',
-                          borderRadius: '12px',
-                          border: '1px solid #334155',
-                          opacity: 0.5,
-                        }}
+                        style={KIOSK_STYLES.matchCardBye}
                       >
-                        <div style={{ textAlign: 'center', color: '#64748b', fontSize: '1rem' }}>
+                        <div style={KIOSK_STYLES.matchCardByeLabel}>
                           EXEMPT
                         </div>
-                        <div
-                          style={{
-                            textAlign: 'center',
-                            fontWeight: 'bold',
-                            fontSize: '1.2rem',
-                            marginTop: '4px',
-                          }}
-                        >
+                        <div style={KIOSK_STYLES.matchCardByeName}>
                           {match.fencerA?.lastName || match.fencerB?.lastName || '–'}
                         </div>
                       </div>

--- a/src/renderer/components/KioskDisplay.tsx
+++ b/src/renderer/components/KioskDisplay.tsx
@@ -1067,265 +1067,87 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             </div>
           ) : (
             /* Tableau terminé – podium + classement */
-            <div
-              style={{
-                flex: 1,
-                display: 'flex',
-                flexDirection: 'column',
-                minHeight: 0,
-                gap: '24px',
-              }}
-            >
+            <div style={KIOSK_STYLES.finishedWrapper}>
               {/* Titre */}
-              <div
-                style={{
-                  textAlign: 'center',
-                  fontSize: '1.4rem',
-                  fontWeight: 700,
-                  color: '#fbbf24',
-                  letterSpacing: '0.05em',
-                  flexShrink: 0,
-                }}
-              >
+              <div style={KIOSK_STYLES.finishedTitle}>
                 🏆 RÉSULTATS FINAUX
               </div>
 
               {/* Podium visuel */}
               {podium ? (
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'flex-end',
-                    justifyContent: 'center',
-                    gap: '16px',
-                    flexShrink: 0,
-                  }}
-                >
+                <div style={KIOSK_STYLES.podiumRow}>
                   {/* 2e place */}
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: '8px',
-                    }}
-                  >
-                    <div style={{ fontSize: '2.2rem' }}>🥈</div>
-                    <div
-                      style={{
-                        fontWeight: 700,
-                        fontSize: '1.2rem',
-                        textAlign: 'center',
-                        maxWidth: '200px',
-                      }}
-                    >
+                  <div style={KIOSK_STYLES.podiumCol}>
+                    <div style={KIOSK_STYLES.podiumMedal2}>🥈</div>
+                    <div style={KIOSK_STYLES.podiumName2}>
                       {podium.second ? `${podium.second.lastName} ${podium.second.firstName}` : '–'}
                     </div>
                     {podium.second?.club && (
-                      <div style={{ fontSize: '0.85rem', color: '#94a3b8', textAlign: 'center' }}>
-                        {podium.second.club}
-                      </div>
+                      <div style={KIOSK_STYLES.podiumClub2}>{podium.second.club}</div>
                     )}
-                    <div
-                      style={{
-                        width: '180px',
-                        height: '80px',
-                        backgroundColor: '#475569',
-                        borderRadius: '6px 6px 0 0',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '1.4rem',
-                        fontWeight: 800,
-                        color: '#94a3b8',
-                      }}
-                    >
-                      2
-                    </div>
+                    <div style={KIOSK_STYLES.podiumBlock2}>2</div>
                   </div>
                   {/* 1re place */}
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: '8px',
-                    }}
-                  >
-                    <div style={{ fontSize: '3rem' }}>🥇</div>
-                    <div
-                      style={{
-                        fontWeight: 800,
-                        fontSize: '1.5rem',
-                        textAlign: 'center',
-                        maxWidth: '220px',
-                        color: '#fbbf24',
-                      }}
-                    >
+                  <div style={KIOSK_STYLES.podiumCol}>
+                    <div style={KIOSK_STYLES.podiumMedal1}>🥇</div>
+                    <div style={KIOSK_STYLES.podiumName1}>
                       {podium.first.lastName} {podium.first.firstName}
                     </div>
                     {podium.first.club && (
-                      <div
-                        style={{
-                          fontSize: '0.9rem',
-                          color: '#fbbf24',
-                          opacity: 0.8,
-                          textAlign: 'center',
-                        }}
-                      >
-                        {podium.first.club}
-                      </div>
+                      <div style={KIOSK_STYLES.podiumClub1}>{podium.first.club}</div>
                     )}
-                    <div
-                      style={{
-                        width: '200px',
-                        height: '120px',
-                        backgroundColor: '#b45309',
-                        borderRadius: '6px 6px 0 0',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '2rem',
-                        fontWeight: 800,
-                        color: '#fbbf24',
-                      }}
-                    >
-                      1
-                    </div>
+                    <div style={KIOSK_STYLES.podiumBlock1}>1</div>
                   </div>
                   {/* 3e place */}
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: '8px',
-                    }}
-                  >
-                    <div style={{ fontSize: '2.2rem' }}>🥉</div>
-                    <div
-                      style={{
-                        fontWeight: 700,
-                        fontSize: '1.2rem',
-                        textAlign: 'center',
-                        maxWidth: '200px',
-                      }}
-                    >
+                  <div style={KIOSK_STYLES.podiumCol}>
+                    <div style={KIOSK_STYLES.podiumMedal3}>🥉</div>
+                    <div style={KIOSK_STYLES.podiumName3}>
                       {podium.third ? `${podium.third.lastName} ${podium.third.firstName}` : '–'}
                     </div>
                     {podium.third?.club && (
-                      <div style={{ fontSize: '0.85rem', color: '#94a3b8', textAlign: 'center' }}>
-                        {podium.third.club}
-                      </div>
+                      <div style={KIOSK_STYLES.podiumClub3}>{podium.third.club}</div>
                     )}
-                    <div
-                      style={{
-                        width: '180px',
-                        height: '60px',
-                        backgroundColor: '#713f12',
-                        borderRadius: '6px 6px 0 0',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '1.4rem',
-                        fontWeight: 800,
-                        color: '#d97706',
-                      }}
-                    >
-                      3
-                    </div>
+                    <div style={KIOSK_STYLES.podiumBlock3}>3</div>
                   </div>
                 </div>
               ) : (
-                <div style={{ textAlign: 'center', color: '#94a3b8', fontSize: '1.3rem' }}>
-                  Tableau terminé
-                </div>
+                <div style={KIOSK_STYLES.podiumEmpty}>Tableau terminé</div>
               )}
 
               {/* Classement général */}
               {elimRanking.length > 0 && (
-                <div
-                  ref={tableauScrollRef}
-                  style={{
-                    flex: 1,
-                    overflowY: 'hidden',
-                    borderTop: '1px solid #334155',
-                    paddingTop: '16px',
-                  }}
-                >
-                  <div
-                    style={{
-                      color: '#64748b',
-                      fontSize: '0.85rem',
-                      fontWeight: 600,
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.08em',
-                      marginBottom: '10px',
-                      paddingLeft: '4px',
-                    }}
-                  >
-                    Classement général
-                  </div>
-                  <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '1rem' }}>
+                <div ref={tableauScrollRef} style={KIOSK_STYLES.elimRankingWrapper}>
+                  <div style={KIOSK_STYLES.elimRankingLabel}>Classement général</div>
+                  <table style={KIOSK_STYLES.elimTable}>
                     <thead>
-                      <tr
-                        style={{
-                          color: '#64748b',
-                          textAlign: 'left',
-                          borderBottom: '1px solid #334155',
-                        }}
-                      >
-                        <th style={{ padding: '6px 10px', width: '50px' }}>Rg</th>
-                        <th style={{ padding: '6px 10px' }}>Nom</th>
-                        <th style={{ padding: '6px 10px' }}>Prénom</th>
-                        <th style={{ padding: '6px 10px' }}>Club</th>
-                        <th style={{ padding: '6px 10px', color: '#475569', fontStyle: 'italic' }}>
-                          Éliminé en
-                        </th>
+                      <tr style={KIOSK_STYLES.elimThead}>
+                        <th style={KIOSK_STYLES.elimThRg}>Rg</th>
+                        <th style={KIOSK_STYLES.elimThName}>Nom</th>
+                        <th style={KIOSK_STYLES.elimThName}>Prénom</th>
+                        <th style={KIOSK_STYLES.elimThName}>Club</th>
+                        <th style={KIOSK_STYLES.elimThElimAt}>Éliminé en</th>
                       </tr>
                     </thead>
                     <tbody>
                       {elimRanking.map(r => {
                         const medals: Record<number, string> = { 1: '🥇', 2: '🥈', 3: '🥉' };
-                        const isTop3 = r.place <= 3;
                         return (
                           <tr
                             key={r.fencer.id}
                             style={{
                               borderBottom: '1px solid #1e293b',
-                              backgroundColor: isTop3 ? 'rgba(251,191,36,0.06)' : 'transparent',
+                              backgroundColor: r.place <= 3 ? 'rgba(251,191,36,0.06)' : 'transparent',
                             }}
                           >
-                            <td
-                              style={{
-                                padding: '8px 10px',
-                                fontWeight: 'bold',
-                                fontSize: '1.1rem',
-                              }}
-                            >
+                            <td style={KIOSK_STYLES.elimTdRank}>
                               {medals[r.place] ?? (
-                                <span style={{ color: '#64748b' }}>{r.place}</span>
+                                <span style={KIOSK_STYLES.elimTdRankSmall}>{r.place}</span>
                               )}
                             </td>
-                            <td style={{ padding: '8px 10px', fontWeight: 600 }}>
-                              {r.fencer.lastName}
-                            </td>
-                            <td style={{ padding: '8px 10px' }}>{r.fencer.firstName}</td>
-                            <td
-                              style={{ padding: '8px 10px', color: '#94a3b8', fontSize: '0.9rem' }}
-                            >
-                              {r.fencer.club || '–'}
-                            </td>
-                            <td
-                              style={{
-                                padding: '8px 10px',
-                                color: '#475569',
-                                fontSize: '0.85rem',
-                                fontStyle: 'italic',
-                              }}
-                            >
-                              {r.eliminatedAt}
-                            </td>
+                            <td style={KIOSK_STYLES.elimTdLast}>{r.fencer.lastName}</td>
+                            <td style={KIOSK_STYLES.elimTdFirst}>{r.fencer.firstName}</td>
+                            <td style={KIOSK_STYLES.elimTdClub}>{r.fencer.club || '–'}</td>
+                            <td style={KIOSK_STYLES.elimTdElimAt}>{r.eliminatedAt}</td>
                           </tr>
                         );
                       })}
@@ -1340,38 +1162,18 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
 
       {/* ===== OVERLAY NOTE D'ORGANISATION ===== */}
       {orgNote && (
-        <div
-          style={{
-            position: 'absolute',
-            inset: 0,
-            zIndex: 10500,
-            background: 'rgba(2, 6, 23, 0.88)',
-            backdropFilter: 'blur(6px)',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'space-evenly',
-            textAlign: 'center',
-            padding: '3rem',
-          }}
-        >
-          <div style={{ fontSize: 'clamp(2rem, 5vw, 4rem)', color: '#64748b', fontWeight: 600, letterSpacing: '0.2em', textTransform: 'uppercase' }}>
-            ⏸ Pause
-          </div>
+        <div style={KIOSK_STYLES.orgNoteOverlay}>
+          <div style={KIOSK_STYLES.orgNotePauseLabel}>⏸ Pause</div>
           {orgNote.type === 'target_time' && orgNote.targetTime && (
             <>
-              <div style={{ fontSize: 'clamp(4rem, 14vw, 12rem)', fontWeight: 700, color: '#f1f5f9' }}>
+              <div style={KIOSK_STYLES.orgNoteResumeTime}>
                 Reprise à {orgNote.targetTime.replace(':', 'h')}
               </div>
-              <div style={{ fontSize: 'clamp(3rem, 10vw, 8rem)', fontWeight: 800, color: '#3b82f6', fontVariantNumeric: 'tabular-nums' }}>
-                dans {orgNoteCountdown}
-              </div>
+              <div style={KIOSK_STYLES.orgNoteCountdown}>dans {orgNoteCountdown}</div>
             </>
           )}
           {orgNote.message && (
-            <div style={{ fontSize: 'clamp(2rem, 7vw, 6rem)', color: '#94a3b8', fontStyle: 'italic' }}>
-              «&nbsp;{orgNote.message}&nbsp;»
-            </div>
+            <div style={KIOSK_STYLES.orgNoteMessage}>«&nbsp;{orgNote.message}&nbsp;»</div>
           )}
         </div>
       )}

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -36,6 +36,58 @@ interface RemoteSession {
   startTime?: Date;
 }
 
+// ─── Static style constants ───────────────────────────────────────────────────
+
+const RSM_STYLES = {
+  stripCountRow: { display: 'flex', alignItems: 'center', gap: '1rem', margin: '0.75rem 0' } satisfies React.CSSProperties,
+  stripCountControls: { display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
+  stripCountBtn: { padding: '0.2rem 0.5rem', fontSize: '1rem' } satisfies React.CSSProperties,
+  stripCountSave: { padding: '0.2rem 0.6rem' } satisfies React.CSSProperties,
+  stripCountPending: { color: 'var(--warning-color, orange)', fontSize: '0.85rem' } satisfies React.CSSProperties,
+  stripCountStrong: { minWidth: '1.5rem', textAlign: 'center' as const } satisfies React.CSSProperties,
+  checkboxLabel: { display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.5rem 0', cursor: 'pointer' } satisfies React.CSSProperties,
+  kioskViewsSection: { margin: '0.5rem 0' } satisfies React.CSSProperties,
+  kioskViewsTitle: { fontSize: '0.875rem', marginBottom: '0.25rem', color: 'inherit' } satisfies React.CSSProperties,
+  kioskViewLabel: { display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' } satisfies React.CSSProperties,
+  interfaceRow: { display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.75rem 0' } satisfies React.CSSProperties,
+  interfaceLabel: { whiteSpace: 'nowrap' as const } satisfies React.CSSProperties,
+  portRow: { display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.75rem 0' } satisfies React.CSSProperties,
+  portInput: { width: '80px' } satisfies React.CSSProperties,
+  portHint: { fontSize: '0.8rem', opacity: 0.6 } satisfies React.CSSProperties,
+  portActiveRow: { display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.25rem' } satisfies React.CSSProperties,
+  portActiveLabel: { whiteSpace: 'nowrap' as const, fontSize: '0.875rem' } satisfies React.CSSProperties,
+  portActiveInput: { width: '75px' } satisfies React.CSSProperties,
+  portActiveBtn: { fontSize: '0.8rem', padding: '0.2rem 0.5rem' } satisfies React.CSSProperties,
+  themeSection: { margin: '0.5rem 0' } satisfies React.CSSProperties,
+  themeTitle: { fontSize: '0.875rem', marginBottom: '0.4rem', color: 'inherit' } satisfies React.CSSProperties,
+  themeRow: { display: 'flex', gap: '0.5rem' } satisfies React.CSSProperties,
+  wallpaperSection: { margin: '0.5rem 0' } satisfies React.CSSProperties,
+  wallpaperTitle: { fontSize: '0.875rem', marginBottom: '0.4rem', color: 'inherit' } satisfies React.CSSProperties,
+  wallpaperRow: { display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' as const } satisfies React.CSSProperties,
+  wallpaperImg: { width: 80, height: 45, objectFit: 'cover' as const, borderRadius: '0.25rem', border: '1px solid #475569' } satisfies React.CSSProperties,
+  wallpaperImportLabel: { padding: '0.35rem 0.75rem', borderRadius: '0.375rem', border: '1px solid #475569', background: 'transparent', color: '#e2e8f0', cursor: 'pointer', fontSize: '0.8rem' } satisfies React.CSSProperties,
+  wallpaperHiddenInput: { display: 'none' } satisfies React.CSSProperties,
+  wallpaperDeleteBtn: { padding: '0.35rem 0.5rem', borderRadius: '0.375rem', border: '1px solid #475569', background: 'transparent', color: '#f87171', cursor: 'pointer', fontSize: '0.8rem' } satisfies React.CSSProperties,
+  orgNoteBox: { margin: '0.75rem 0', padding: '0.75rem', border: '1px solid #334155', borderRadius: '0.5rem', background: '#1e293b' } satisfies React.CSSProperties,
+  orgNoteTitle: { fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.5rem', color: '#94a3b8' } satisfies React.CSSProperties,
+  orgNoteTypeRow: { display: 'flex', gap: '1rem', marginBottom: '0.5rem' } satisfies React.CSSProperties,
+  orgNoteRadioLabel: { display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer', color: '#e2e8f0' } satisfies React.CSSProperties,
+  orgNoteTextarea: { width: '100%', padding: '0.4rem 0.6rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#0f172a', color: '#e2e8f0', boxSizing: 'border-box' as const, marginBottom: '0.4rem', resize: 'vertical' as const, fontFamily: 'inherit', fontSize: 'inherit' } satisfies React.CSSProperties,
+  orgNoteTimeRow: { display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.4rem' } satisfies React.CSSProperties,
+  orgNoteSelect: { padding: '0.4rem 0.6rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#0f172a', color: '#e2e8f0', cursor: 'pointer' } satisfies React.CSSProperties,
+  orgNoteTimeInput: { padding: '0.4rem 0.6rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#0f172a', color: '#e2e8f0' } satisfies React.CSSProperties,
+  orgNoteBtnRow: { display: 'flex', gap: '0.5rem', marginTop: '0.25rem' } satisfies React.CSSProperties,
+  orgNoteHideBtn: { padding: '0.4rem 0.75rem', borderRadius: '0.3rem', border: 'none', background: '#475569', color: '#fff', cursor: 'pointer' } satisfies React.CSSProperties,
+  orgNoteActive: { fontSize: '0.75rem', color: '#22c55e', marginTop: '0.4rem' } satisfies React.CSSProperties,
+  launchSection: { margin: '0.75rem 0' } satisfies React.CSSProperties,
+  launchBtn: { padding: '0.6rem 1.2rem', fontSize: '1rem', fontWeight: 'bold' as const } satisfies React.CSSProperties,
+  pisteresumeSummary: { marginTop: '1rem', padding: '0.75rem', background: '#f3f4f6', borderRadius: '8px' } satisfies React.CSSProperties,
+  pisteresumeFlex: { display: 'flex', flexWrap: 'wrap' as const, gap: '0.5rem' } satisfies React.CSSProperties,
+  qrSpinner: { width: 220, height: 220, display: 'flex', alignItems: 'center', justifyContent: 'center' } satisfies React.CSSProperties,
+  qrCode: { fontSize: '0.75rem', wordBreak: 'break-all' as const, textAlign: 'center' as const } satisfies React.CSSProperties,
+  kioskCard: { marginTop: '1rem' } satisfies React.CSSProperties,
+} satisfies Record<string, React.CSSProperties>;
+
 const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   competition,
   pools,
@@ -396,29 +448,26 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
 
   // Contrôles +/− communs aux deux vues (pending uniquement, sans appel IPC direct)
   const stripCountControls = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+    <div style={RSM_STYLES.stripCountControls}>
       <button
         className="btn btn-secondary"
         onClick={() => setPendingCount(Math.max(1, effectivePending - 1))}
         disabled={effectivePending <= 1 || isLoading}
-        style={{ padding: '0.2rem 0.5rem', fontSize: '1rem' }}
+        style={RSM_STYLES.stripCountBtn}
       >
         −
       </button>
-      <strong style={{ minWidth: '1.5rem', textAlign: 'center' }}>{effectivePending}</strong>
+      <strong style={RSM_STYLES.stripCountStrong}>{effectivePending}</strong>
       <button
         className="btn btn-secondary"
         onClick={() => setPendingCount(Math.min(20, effectivePending + 1))}
         disabled={effectivePending >= 20 || isLoading}
-        style={{ padding: '0.2rem 0.5rem', fontSize: '1rem' }}
+        style={RSM_STYLES.stripCountBtn}
       >
         +
       </button>
       {hasPendingChanges && (
-        <span
-          style={{ color: 'var(--warning-color, orange)', fontSize: '0.85rem' }}
-          title="Modifications non sauvegardées"
-        >
+        <span style={RSM_STYLES.stripCountPending} title="Modifications non sauvegardées">
           ●
         </span>
       )}
@@ -426,7 +475,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         className="btn btn-primary"
         onClick={handleSaveStripCount}
         disabled={!hasPendingChanges || isLoading}
-        style={{ padding: '0.2rem 0.6rem' }}
+        style={RSM_STYLES.stripCountSave}
       >
         Sauvegarder
       </button>
@@ -442,19 +491,11 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             La saisie distante permet aux arbitres de saisir les scores depuis une tablette. Les
             arbitres se connectent via un navigateur web sur le réseau local.
           </p>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', margin: '0.75rem 0' }}>
+          <div style={RSM_STYLES.stripCountRow}>
             <span>Pistes :</span>
             {stripCountControls}
           </div>
-          <label
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.5rem',
-              margin: '0.5rem 0',
-              cursor: 'pointer',
-            }}
-          >
+          <label style={RSM_STYLES.checkboxLabel}>
             <input
               type="checkbox"
               checked={showPhotos}
@@ -462,15 +503,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             />
             Afficher les photos des combattants avant le combat
           </label>
-          <label
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.5rem',
-              margin: '0.5rem 0',
-              cursor: 'pointer',
-            }}
-          >
+          <label style={RSM_STYLES.checkboxLabel}>
             <input
               type="checkbox"
               checked={cardAnnounce}
@@ -478,10 +511,8 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             />
             📣 Carton avancer (afficher bandeau + raison sur les écrans)
           </label>
-          <div style={{ margin: '0.5rem 0' }}>
-            <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem', color: 'inherit' }}>
-              Vues kiosk :
-            </div>
+          <div style={RSM_STYLES.kioskViewsSection}>
+            <div style={RSM_STYLES.kioskViewsTitle}>Vues kiosk :</div>
             {(
               [
                 { key: 'poules', label: 'Poules' },
@@ -490,10 +521,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                 { key: 'suivants', label: 'Matchs suivants' },
               ] as const
             ).map(({ key, label }) => (
-              <label
-                key={key}
-                style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}
-              >
+              <label key={key} style={RSM_STYLES.kioskViewLabel}>
                 <input
                   type="checkbox"
                   checked={kioskViews[key]}
@@ -503,10 +531,8 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               </label>
             ))}
           </div>
-          <div
-            style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.75rem 0' }}
-          >
-            <label htmlFor="remote-interface" style={{ whiteSpace: 'nowrap' }}>
+          <div style={RSM_STYLES.interfaceRow}>
+            <label htmlFor="remote-interface" style={RSM_STYLES.interfaceLabel}>
               Interface :
             </label>
             <select
@@ -525,10 +551,8 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               ))}
             </select>
           </div>
-          <div
-            style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.75rem 0' }}
-          >
-            <label htmlFor="remote-port" style={{ whiteSpace: 'nowrap' }}>
+          <div style={RSM_STYLES.portRow}>
+            <label htmlFor="remote-port" style={RSM_STYLES.interfaceLabel}>
               Port :
             </label>
             <input
@@ -538,10 +562,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               max={65535}
               value={remotePort}
               onChange={e => handlePortChange(parseInt(e.target.value, 10))}
-              style={{ width: '80px' }}
+              style={RSM_STYLES.portInput}
               disabled={isLoading}
             />
-            <span style={{ fontSize: '0.8rem', opacity: 0.6 }}>1–65535, défaut 8066</span>
+            <span style={RSM_STYLES.portHint}>1–65535, défaut 8066</span>
           </div>
           <button className="btn-primary" onClick={onStartRemote}>
             ⚡ Démarrer la saisie distante
@@ -559,8 +583,8 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           <p>
             Serveur: <strong>{serverUrl}</strong>
           </p>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.25rem' }}>
-            <label htmlFor={`remote-port-active-${competition.id}`} style={{ whiteSpace: 'nowrap', fontSize: '0.875rem' }}>
+          <div style={RSM_STYLES.portActiveRow}>
+            <label htmlFor={`remote-port-active-${competition.id}`} style={RSM_STYLES.portActiveLabel}>
               Port :
             </label>
             <input
@@ -570,7 +594,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               max={65535}
               value={remotePort}
               onChange={e => handlePortChange(parseInt(e.target.value, 10))}
-              style={{ width: '75px' }}
+              style={RSM_STYLES.portActiveInput}
               disabled={isLoading}
             />
             <button
@@ -578,7 +602,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               onClick={handleChangePort}
               disabled={isLoading}
               title="Redémarrer le serveur sur ce port"
-              style={{ fontSize: '0.8rem', padding: '0.2rem 0.5rem' }}
+              style={RSM_STYLES.portActiveBtn}
             >
               🔄 Recharger
             </button>
@@ -590,21 +614,11 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       </div>
 
       <div className="arena-urls-section">
-        <div
-          style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '0.75rem' }}
-        >
+        <div style={RSM_STYLES.stripCountRow}>
           <h4 style={{ margin: 0 }}>Pistes ({arenaCount})</h4>
           {stripCountControls}
         </div>
-        <label
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-            margin: '0.5rem 0',
-            cursor: 'pointer',
-          }}
-        >
+        <label style={RSM_STYLES.checkboxLabel}>
           <input
             type="checkbox"
             checked={showPhotos}
@@ -615,15 +629,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           />
           Afficher les photos des combattants avant le combat
         </label>
-        <label
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-            margin: '0.5rem 0',
-            cursor: 'pointer',
-          }}
-        >
+        <label style={RSM_STYLES.checkboxLabel}>
           <input
             type="checkbox"
             checked={cardAnnounce}
@@ -635,10 +641,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           📣 Carton avancer (afficher bandeau + raison sur les écrans)
         </label>
         {!isLaunched && (
-          <div style={{ margin: '0.75rem 0' }}>
+          <div style={RSM_STYLES.launchSection}>
             <button
               className="btn-primary"
-              style={{ padding: '0.6rem 1.2rem', fontSize: '1rem', fontWeight: 'bold' }}
+              style={RSM_STYLES.launchBtn}
               onClick={async () => {
                 const result = await window.electronAPI.remote.launchCompetition(competition.id);
                 if (result.success) {
@@ -655,11 +661,9 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             </button>
           </div>
         )}
-        <div style={{ margin: '0.5rem 0' }}>
-          <div style={{ fontSize: '0.875rem', marginBottom: '0.4rem', color: 'inherit' }}>
-            Thème de l'affichage :
-          </div>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <div style={RSM_STYLES.themeSection}>
+          <div style={RSM_STYLES.themeTitle}>Thème de l'affichage :</div>
+          <div style={RSM_STYLES.themeRow}>
             {(
               [
                 { value: 'dark', label: 'Sombre', icon: '🌙' },
@@ -691,34 +695,22 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             ))}
           </div>
         </div>
-        <div style={{ margin: '0.5rem 0' }}>
-          <div style={{ fontSize: '0.875rem', marginBottom: '0.4rem', color: 'inherit' }}>
-            Fond d'écran arènes (écran d'attente) :
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <div style={RSM_STYLES.wallpaperSection}>
+          <div style={RSM_STYLES.wallpaperTitle}>Fond d'écran arènes (écran d'attente) :</div>
+          <div style={RSM_STYLES.wallpaperRow}>
             {arenaWallpaper && (
               <img
                 src={arenaWallpaper}
                 alt="Fond d'écran"
-                style={{ width: 80, height: 45, objectFit: 'cover', borderRadius: '0.25rem', border: '1px solid #475569' }}
+                style={RSM_STYLES.wallpaperImg}
               />
             )}
-            <label
-              style={{
-                padding: '0.35rem 0.75rem',
-                borderRadius: '0.375rem',
-                border: '1px solid #475569',
-                background: 'transparent',
-                color: '#e2e8f0',
-                cursor: 'pointer',
-                fontSize: '0.8rem',
-              }}
-            >
+            <label style={RSM_STYLES.wallpaperImportLabel}>
               {arenaWallpaper ? '🖼 Changer' : '🖼 Importer'}
               <input
                 type="file"
                 accept="image/*"
-                style={{ display: 'none' }}
+                style={RSM_STYLES.wallpaperHiddenInput}
                 onChange={async e => {
                   const file = e.target.files?.[0];
                   if (!file) return;
@@ -739,25 +731,15 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                   setArenaWallpaper(null);
                   await window.electronAPI.remote.setWallpaper(competition.id, null);
                 }}
-                style={{
-                  padding: '0.35rem 0.5rem',
-                  borderRadius: '0.375rem',
-                  border: '1px solid #475569',
-                  background: 'transparent',
-                  color: '#f87171',
-                  cursor: 'pointer',
-                  fontSize: '0.8rem',
-                }}
+                style={RSM_STYLES.wallpaperDeleteBtn}
               >
                 ✕ Supprimer
               </button>
             )}
           </div>
         </div>
-        <div style={{ margin: '0.5rem 0' }}>
-          <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem', color: 'inherit' }}>
-            Vues kiosk :
-          </div>
+        <div style={RSM_STYLES.kioskViewsSection}>
+          <div style={RSM_STYLES.kioskViewsTitle}>Vues kiosk :</div>
           {(
             [
               { key: 'poules', label: 'Poules' },
@@ -765,10 +747,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               { key: 'direct', label: 'Matchs en direct' },
             ] as const
           ).map(({ key, label }) => (
-            <label
-              key={key}
-              style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}
-            >
+            <label key={key} style={RSM_STYLES.kioskViewLabel}>
               <input
                 type="checkbox"
                 checked={kioskViews[key]}
@@ -784,35 +763,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         </div>
 
         {/* Note d'organisation */}
-        <div
-          style={{
-            margin: '0.75rem 0',
-            padding: '0.75rem',
-            border: '1px solid #334155',
-            borderRadius: '0.5rem',
-            background: '#1e293b',
-          }}
-        >
-          <div
-            style={{
-              fontSize: '0.875rem',
-              fontWeight: 600,
-              marginBottom: '0.5rem',
-              color: '#94a3b8',
-            }}
-          >
-            Note d'organisation (kiosk)
-          </div>
-          <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.5rem' }}>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.4rem',
-                cursor: 'pointer',
-                color: '#e2e8f0',
-              }}
-            >
+        <div style={RSM_STYLES.orgNoteBox}>
+          <div style={RSM_STYLES.orgNoteTitle}>Note d'organisation (kiosk)</div>
+          <div style={RSM_STYLES.orgNoteTypeRow}>
+            <label style={RSM_STYLES.orgNoteRadioLabel}>
               <input
                 type="radio"
                 name="orgNoteType"
@@ -821,15 +775,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               />
               Message libre
             </label>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.4rem',
-                cursor: 'pointer',
-                color: '#e2e8f0',
-              }}
-            >
+            <label style={RSM_STYLES.orgNoteRadioLabel}>
               <input
                 type="radio"
                 name="orgNoteType"
@@ -844,40 +790,14 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             value={orgNoteMessage}
             onChange={e => setOrgNoteMessage(e.target.value)}
             rows={3}
-            style={{
-              width: '100%',
-              padding: '0.4rem 0.6rem',
-              borderRadius: '0.3rem',
-              border: '1px solid #475569',
-              background: '#0f172a',
-              color: '#e2e8f0',
-              boxSizing: 'border-box',
-              marginBottom: '0.4rem',
-              resize: 'vertical',
-              fontFamily: 'inherit',
-              fontSize: 'inherit',
-            }}
+            style={RSM_STYLES.orgNoteTextarea}
           />
           {orgNoteType === 'target_time' && (
-            <div
-              style={{
-                display: 'flex',
-                gap: '0.5rem',
-                alignItems: 'center',
-                marginBottom: '0.4rem',
-              }}
-            >
+            <div style={RSM_STYLES.orgNoteTimeRow}>
               <select
                 value={orgNotePrefix}
                 onChange={e => setOrgNotePrefix(e.target.value)}
-                style={{
-                  padding: '0.4rem 0.6rem',
-                  borderRadius: '0.3rem',
-                  border: '1px solid #475569',
-                  background: '#0f172a',
-                  color: '#e2e8f0',
-                  cursor: 'pointer',
-                }}
+                style={RSM_STYLES.orgNoteSelect}
               >
                 {['Reprise', 'Début', 'Fin', 'Pause', 'Déjeuner', 'Cérémonie'].map(p => (
                   <option key={p} value={p}>
@@ -889,17 +809,11 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                 type="time"
                 value={orgNoteTime}
                 onChange={e => setOrgNoteTime(e.target.value)}
-                style={{
-                  padding: '0.4rem 0.6rem',
-                  borderRadius: '0.3rem',
-                  border: '1px solid #475569',
-                  background: '#0f172a',
-                  color: '#e2e8f0',
-                }}
+                style={RSM_STYLES.orgNoteTimeInput}
               />
             </div>
           )}
-          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.25rem' }}>
+          <div style={RSM_STYLES.orgNoteBtnRow}>
             <button
               disabled={!orgNoteMessage.trim() || (orgNoteType === 'target_time' && !orgNoteTime)}
               onClick={async () => {
@@ -933,23 +847,14 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                   await window.electronAPI.remote.clearOrgNote(competition.id);
                   setOrgNoteActive(false);
                 }}
-                style={{
-                  padding: '0.4rem 0.75rem',
-                  borderRadius: '0.3rem',
-                  border: 'none',
-                  background: '#475569',
-                  color: '#fff',
-                  cursor: 'pointer',
-                }}
+                style={RSM_STYLES.orgNoteHideBtn}
               >
                 ✕ Masquer
               </button>
             )}
           </div>
           {orgNoteActive && (
-            <div style={{ fontSize: '0.75rem', color: '#22c55e', marginTop: '0.4rem' }}>
-              ● Note visible sur le kiosk
-            </div>
+            <div style={RSM_STYLES.orgNoteActive}>● Note visible sur le kiosk</div>
           )}
         </div>
 


### PR DESCRIPTION
## Résumé

Extraction des `style={{...}}` statiques en constantes à niveau module dans les composants les plus lourds.

### Composants traités
- `KioskDisplay.tsx` — 124 → ~58 inline styles ✅
- `RemoteScoreManager.tsx` — en cours
- `ResultsView.tsx` — en cours
- `TableauView.tsx` — en cours
- `CompetitionView.tsx` — en cours

## Impact

Chaque `style={{}}` inline crée un nouvel objet à chaque render, ce qui invalide `React.memo` même si les valeurs n'ont pas changé. Les constantes statiques sont créées une seule fois au chargement du module.

## Test plan

- [ ] `npm run build:ci` → succès
- [ ] Affichage Kiosk → identique
- [ ] Pas de régression visuelle

https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU)_