### PR TITLE
perf: inline styles → constantes dans ResultsView + TableauView

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -50,6 +50,35 @@ interface CompetitionViewProps {
   onPhaseApplied?: () => void;
 }
 
+// ─── Static style constants ───────────────────────────────────────────────────
+
+const CV_STYLES = {
+  root: { display: 'flex', flex: 1, flexDirection: 'column' as const, overflow: 'hidden' } satisfies React.CSSProperties,
+  thirdPlaceOverlay: { position: 'fixed' as const, top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0, 0, 0, 0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 } satisfies React.CSSProperties,
+  thirdPlaceModal: { backgroundColor: 'white', padding: '2rem', borderRadius: '8px', boxShadow: '0 10px 25px rgba(0, 0, 0, 0.25)', maxWidth: '500px', width: '90%' } satisfies React.CSSProperties,
+  thirdPlaceTitle: { margin: '0 0 1rem 0', color: '#1f2937' } satisfies React.CSSProperties,
+  thirdPlaceBtnRow: { display: 'flex', gap: '1rem', justifyContent: 'flex-end' as const, marginTop: '1.5rem' } satisfies React.CSSProperties,
+  kioskOverlay: { position: 'fixed' as const, top: 0, left: 0, right: 0, bottom: 0, zIndex: 9999, background: '#f3f4f6', overflow: 'auto' as const } satisfies React.CSSProperties,
+  kioskCloseWrapper: { position: 'sticky' as const, top: '1rem', right: '1rem', float: 'right' as const, zIndex: 10000, margin: '1rem' } satisfies React.CSSProperties,
+  kioskCloseBtn: { background: '#ef4444', color: 'white', border: 'none', padding: '0.75rem 1.5rem', borderRadius: '8px', cursor: 'pointer', fontSize: '1rem', fontWeight: 'bold' as const } satisfies React.CSSProperties,
+  kioskContent: { padding: '2rem' } satisfies React.CSSProperties,
+  kioskHeading: { marginBottom: '2rem', color: '#1f2937' } satisfies React.CSSProperties,
+  kioskPoolCard: { marginBottom: '3rem', background: 'white', borderRadius: '12px', padding: '1.5rem', boxShadow: '0 4px 6px rgba(0,0,0,0.1)' } satisfies React.CSSProperties,
+  kioskPoolTitle: { marginBottom: '1rem', color: '#374151', borderBottom: '2px solid #e5e7eb', paddingBottom: '0.5rem' } satisfies React.CSSProperties,
+  kioskMatchGrid: { display: 'grid', gap: '1rem' } satisfies React.CSSProperties,
+  kioskMatchFencerA: { display: 'flex', alignItems: 'center', gap: '1rem', flex: 1 } satisfies React.CSSProperties,
+  kioskMatchScores: { display: 'flex', alignItems: 'center', gap: '1rem' } satisfies React.CSSProperties,
+  kioskMatchScoreInput: { width: '60px', padding: '0.5rem', fontSize: '1.25rem', textAlign: 'center' as const, border: '2px solid #d1d5db', borderRadius: '6px' } satisfies React.CSSProperties,
+  kioskMatchSep: { fontSize: '1.5rem', fontWeight: 'bold' as const, color: '#6b7280' } satisfies React.CSSProperties,
+  kioskMatchFencerB: { display: 'flex', alignItems: 'center', gap: '1rem', flex: 1, justifyContent: 'flex-end' as const } satisfies React.CSSProperties,
+  kioskMatchName: { fontWeight: 'bold' as const } satisfies React.CSSProperties,
+  kioskFinishRow: { textAlign: 'center' as const, marginTop: '2rem' } satisfies React.CSSProperties,
+  kioskFinishBtn: { background: '#10b981', color: 'white', border: 'none', padding: '1rem 2rem', borderRadius: '8px', cursor: 'pointer', fontSize: '1.25rem', fontWeight: 'bold' as const } satisfies React.CSSProperties,
+  poolsExportRow: { textAlign: 'center' as const, marginBottom: '2rem' } satisfies React.CSSProperties,
+  questWrapper: { display: 'none' } satisfies React.CSSProperties,
+  phaseContent: { flex: 1, overflow: 'auto' as const } satisfies React.CSSProperties,
+} satisfies Record<string, React.CSSProperties>;
+
 const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate, requestPhase, onPhaseApplied }) => {
   const { showToast } = useToast();
   const { t, language } = useTranslation();
@@ -856,7 +885,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   }, [pools, tableauMatches]);
 
   return (
-    <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' }}>
+    <div style={CV_STYLES.root}>
       <CompetitionHeader
         competition={competition}
         language={language}
@@ -898,7 +927,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       />
 
       {/* Content — keyed pour animation de transition */}
-      <div key={currentPhase} className="phase-content" style={{ flex: 1, overflow: 'auto' }}>
+      <div key={currentPhase} className="phase-content" style={CV_STYLES.phaseContent}>
         {currentPhase === 'checkin' && (
           <FencerList
             fencers={fencers}
@@ -972,7 +1001,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             ) : (
               <>
                 {pools.length > 1 && (
-                  <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+                  <div style={CV_STYLES.poolsExportRow}>
                     <button className="btn btn-success" onClick={handleExportAllPoolsPDF}>
                       📄 Exporter toutes les poules en PDF
                     </button>
@@ -1057,7 +1086,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         )}
 
         {questEnabled && questConfig && (
-          <div style={{ display: currentPhase === 'quest' ? undefined : 'none' }}>
+          <div style={currentPhase === 'quest' ? undefined : CV_STYLES.questWrapper}>
             <QuestPhaseView
               fencers={(() => {
                 const checked = getCheckedInFencers();
@@ -1195,42 +1224,12 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       )}
 
       {showThirdPlaceDialog && (
-        <div
-          className="modal-overlay"
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-        >
-          <div
-            style={{
-              backgroundColor: 'white',
-              padding: '2rem',
-              borderRadius: '8px',
-              boxShadow: '0 10px 25px rgba(0, 0, 0, 0.25)',
-              maxWidth: '500px',
-              width: '90%',
-            }}
-          >
-            <h3 style={{ margin: '0 0 1rem 0', color: '#1f2937' }}>
+        <div className="modal-overlay" style={CV_STYLES.thirdPlaceOverlay}>
+          <div style={CV_STYLES.thirdPlaceModal}>
+            <h3 style={CV_STYLES.thirdPlaceTitle}>
               {t('competition.third_place_match_dialog')}
             </h3>
-            <div
-              style={{
-                display: 'flex',
-                gap: '1rem',
-                justifyContent: 'flex-end',
-                marginTop: '1.5rem',
-              }}
-            >
+            <div style={CV_STYLES.thirdPlaceBtnRow}>
               <button className="btn btn-secondary" onClick={() => handleThirdPlaceDecision(false)}>
                 Non
               </button>
@@ -1286,70 +1285,18 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
       {/* Mode Kiosk - Interface tablette arbitre */}
       {showKiosk && pools.length > 0 && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            zIndex: 9999,
-            background: '#f3f4f6',
-            overflow: 'auto',
-          }}
-        >
-          <div
-            style={{
-              position: 'sticky',
-              top: '1rem',
-              right: '1rem',
-              float: 'right',
-              zIndex: 10000,
-              margin: '1rem',
-            }}
-          >
-            <button
-              onClick={() => setShowKiosk(false)}
-              style={{
-                background: '#ef4444',
-                color: 'white',
-                border: 'none',
-                padding: '0.75rem 1.5rem',
-                borderRadius: '8px',
-                cursor: 'pointer',
-                fontSize: '1rem',
-                fontWeight: 'bold',
-              }}
-            >
+        <div style={CV_STYLES.kioskOverlay}>
+          <div style={CV_STYLES.kioskCloseWrapper}>
+            <button onClick={() => setShowKiosk(false)} style={CV_STYLES.kioskCloseBtn}>
               ✕ Quitter Mode Kiosk
             </button>
           </div>
-          <div style={{ padding: '2rem' }}>
-            <h2 style={{ marginBottom: '2rem', color: '#1f2937' }}>
-              Mode Kiosk - Saisie des scores
-            </h2>
+          <div style={CV_STYLES.kioskContent}>
+            <h2 style={CV_STYLES.kioskHeading}>Mode Kiosk - Saisie des scores</h2>
             {pools.map((pool, poolIndex) => (
-              <div
-                key={pool.id}
-                style={{
-                  marginBottom: '3rem',
-                  background: 'white',
-                  borderRadius: '12px',
-                  padding: '1.5rem',
-                  boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
-                }}
-              >
-                <h3
-                  style={{
-                    marginBottom: '1rem',
-                    color: '#374151',
-                    borderBottom: '2px solid #e5e7eb',
-                    paddingBottom: '0.5rem',
-                  }}
-                >
-                  Poule {pool.number}
-                </h3>
-                <div style={{ display: 'grid', gap: '1rem' }}>
+              <div key={pool.id} style={CV_STYLES.kioskPoolCard}>
+                <h3 style={CV_STYLES.kioskPoolTitle}>Poule {pool.number}</h3>
+                <div style={CV_STYLES.kioskMatchGrid}>
                   {pool.matches.map(
                     (match, matchIndex) =>
                       match.status !== 'finished' && (
@@ -1368,9 +1315,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                                 : '1px solid #e5e7eb',
                           }}
                         >
-                          <div
-                            style={{ display: 'flex', alignItems: 'center', gap: '1rem', flex: 1 }}
-                          >
+                          <div style={CV_STYLES.kioskMatchFencerA}>
                             <FencerPhoto
                               photo={match.fencerA?.photo}
                               firstName={match.fencerA?.firstName || ''}
@@ -1378,24 +1323,17 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                               size="medium"
                               editable={false}
                             />
-                            <span style={{ fontWeight: 'bold' }}>
+                            <span style={CV_STYLES.kioskMatchName}>
                               {match.fencerA?.firstName} {match.fencerA?.lastName}
                             </span>
                           </div>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                          <div style={CV_STYLES.kioskMatchScores}>
                             <input
                               type="number"
                               min="0"
                               max={poolMaxScore}
                               defaultValue={match.scoreA?.value || 0}
-                              style={{
-                                width: '60px',
-                                padding: '0.5rem',
-                                fontSize: '1.25rem',
-                                textAlign: 'center',
-                                border: '2px solid #d1d5db',
-                                borderRadius: '6px',
-                              }}
+                              style={CV_STYLES.kioskMatchScoreInput}
                               onChange={e => {
                                 const scoreA = parseInt(e.target.value) || 0;
                                 const scoreB = match.scoreB?.value || 0;
@@ -1404,24 +1342,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                                 }
                               }}
                             />
-                            <span
-                              style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#6b7280' }}
-                            >
-                              -
-                            </span>
+                            <span style={CV_STYLES.kioskMatchSep}>-</span>
                             <input
                               type="number"
                               min="0"
                               max={poolMaxScore}
                               defaultValue={match.scoreB?.value || 0}
-                              style={{
-                                width: '60px',
-                                padding: '0.5rem',
-                                fontSize: '1.25rem',
-                                textAlign: 'center',
-                                border: '2px solid #d1d5db',
-                                borderRadius: '6px',
-                              }}
+                              style={CV_STYLES.kioskMatchScoreInput}
                               onChange={e => {
                                 const scoreB = parseInt(e.target.value) || 0;
                                 const scoreA = match.scoreA?.value || 0;
@@ -1431,16 +1358,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                               }}
                             />
                           </div>
-                          <div
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '1rem',
-                              flex: 1,
-                              justifyContent: 'flex-end',
-                            }}
-                          >
-                            <span style={{ fontWeight: 'bold' }}>
+                          <div style={CV_STYLES.kioskMatchFencerB}>
+                            <span style={CV_STYLES.kioskMatchName}>
                               {match.fencerB?.firstName} {match.fencerB?.lastName}
                             </span>
                             <FencerPhoto
@@ -1458,22 +1377,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               </div>
             ))}
             {areAllPoolsComplete() && (
-              <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+              <div style={CV_STYLES.kioskFinishRow}>
                 <button
                   onClick={() => {
                     setShowKiosk(false);
                     handleGoToRanking();
                   }}
-                  style={{
-                    background: '#10b981',
-                    color: 'white',
-                    border: 'none',
-                    padding: '1rem 2rem',
-                    borderRadius: '8px',
-                    cursor: 'pointer',
-                    fontSize: '1.25rem',
-                    fontWeight: 'bold',
-                  }}
+                  style={CV_STYLES.kioskFinishBtn}
                 >
                   ✓ Tous les matchs sont terminés - Voir le classement
                 </button>

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -1047,7 +1047,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           })}
         </div>
 
-        <div className="arena-url-card" style={{ marginTop: '1rem' }}>
+        <div className="arena-url-card" style={RSM_STYLES.kioskCard}>
           <div className="arena-url-header">
             <strong>🖥️ Kiosk (affichage public)</strong>
           </div>
@@ -1104,19 +1104,9 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
             {qrDataUrl ? (
               <img src={qrDataUrl} alt="QR code" width={220} height={220} />
             ) : (
-              <div
-                style={{
-                  width: 220,
-                  height: 220,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                Génération…
-              </div>
+              <div style={RSM_STYLES.qrSpinner}>Génération…</div>
             )}
-            <code style={{ fontSize: '0.75rem', wordBreak: 'break-all', textAlign: 'center' }}>
+            <code style={RSM_STYLES.qrCode}>
               {activeQR.url}
             </code>
             <button className="btn btn-secondary" onClick={() => setActiveQR(null)}>

--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -23,6 +23,48 @@ interface ResultsViewProps {
   finalResults: FinalResult[];
 }
 
+// ─── Static style constants ───────────────────────────────────────────────────
+
+const RV_STYLES = {
+  wrapper: { padding: '2rem', maxWidth: '900px', margin: '0 auto' } satisfies React.CSSProperties,
+  champHeader: { textAlign: 'center' as const, padding: '2rem', background: 'linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%)', borderRadius: '12px', marginBottom: '2rem', color: 'white', boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' } satisfies React.CSSProperties,
+  champTrophy: { fontSize: '4rem', marginBottom: '0.5rem' } satisfies React.CSSProperties,
+  champTitle: { fontSize: '1.5rem', marginBottom: '0.5rem' } satisfies React.CSSProperties,
+  champName: { fontSize: '2rem', fontWeight: '700' } satisfies React.CSSProperties,
+  champClub: { opacity: 0.9, marginTop: '0.5rem' } satisfies React.CSSProperties,
+  podiumRow: { display: 'flex', justifyContent: 'center', alignItems: 'flex-end', gap: '1rem', marginBottom: '2rem', padding: '1rem' } satisfies React.CSSProperties,
+  podium2: { textAlign: 'center' as const, background: '#e5e7eb', padding: '1rem', borderRadius: '8px 8px 0 0', minWidth: '150px', height: '120px', display: 'flex', flexDirection: 'column' as const, justifyContent: 'flex-end' as const } satisfies React.CSSProperties,
+  podium2Medal: { fontSize: '2rem' } satisfies React.CSSProperties,
+  podium2Name: { fontWeight: '600', fontSize: '0.875rem' } satisfies React.CSSProperties,
+  podium2Place: { fontSize: '0.75rem', color: '#6b7280' } satisfies React.CSSProperties,
+  podium1: { textAlign: 'center' as const, background: '#fef3c7', padding: '1rem', borderRadius: '8px 8px 0 0', minWidth: '150px', height: '160px', display: 'flex', flexDirection: 'column' as const, justifyContent: 'flex-end' as const, border: '2px solid #f59e0b' } satisfies React.CSSProperties,
+  podium1Medal: { fontSize: '2.5rem' } satisfies React.CSSProperties,
+  podium1Name: { fontWeight: '700', fontSize: '1rem' } satisfies React.CSSProperties,
+  podium1Place: { fontSize: '0.875rem', color: '#92400e' } satisfies React.CSSProperties,
+  podium3: { textAlign: 'center' as const, background: '#fed7aa', padding: '1rem', borderRadius: '8px 8px 0 0', minWidth: '150px', height: '100px', display: 'flex', flexDirection: 'column' as const, justifyContent: 'flex-end' as const } satisfies React.CSSProperties,
+  podium3Medal: { fontSize: '1.5rem' } satisfies React.CSSProperties,
+  podium3Name: { fontWeight: '600', fontSize: '0.875rem' } satisfies React.CSSProperties,
+  podium3Place: { fontSize: '0.75rem', color: '#6b7280' } satisfies React.CSSProperties,
+  tableWrapper: { background: 'white', borderRadius: '8px', boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)', overflow: 'hidden' } satisfies React.CSSProperties,
+  tableHeader: { padding: '1rem', background: '#f9fafb', borderBottom: '1px solid #e5e7eb', fontWeight: '600' } satisfies React.CSSProperties,
+  table: { width: '100%', borderCollapse: 'collapse' as const } satisfies React.CSSProperties,
+  thead: { background: '#f9fafb', borderBottom: '2px solid #e5e7eb' } satisfies React.CSSProperties,
+  thRank: { padding: '0.75rem', textAlign: 'left' as const, width: '60px' } satisfies React.CSSProperties,
+  thLeft: { padding: '0.75rem', textAlign: 'left' as const } satisfies React.CSSProperties,
+  thCenter: { padding: '0.75rem', textAlign: 'center' as const } satisfies React.CSSProperties,
+  tdPad: { padding: '0.75rem' } satisfies React.CSSProperties,
+  tdMedalSpan: { marginRight: '0.5rem' } satisfies React.CSSProperties,
+  tdClub: { padding: '0.75rem', color: '#6b7280' } satisfies React.CSSProperties,
+  tdElim: { padding: '0.75rem', textAlign: 'center' as const, color: '#6b7280' } satisfies React.CSSProperties,
+  exportRow: { display: 'flex', gap: '1rem', justifyContent: 'center', marginTop: '2rem', flexWrap: 'wrap' as const } satisfies React.CSSProperties,
+  btnPrint: { padding: '0.75rem 1.5rem', background: '#3b82f6', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
+  btnCopy: { padding: '0.75rem 1.5rem', background: '#10b981', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
+  btnCsv: { padding: '0.75rem 1.5rem', background: '#f59e0b', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
+  btnXml: { padding: '0.75rem 1.5rem', background: '#8b5cf6', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
+  btnPdf: { padding: '0.75rem 1.5rem', background: '#ef4444', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
+  legend: { textAlign: 'center' as const, marginTop: '1.5rem', fontSize: '0.875rem', color: '#6b7280' } satisfies React.CSSProperties,
+} satisfies Record<string, React.CSSProperties>;
+
 const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, finalResults }) => {
   const { showToast } = useToast();
   const rankingTemplate = usePdfTemplateStore(s => s.templates.ranking);
@@ -135,140 +177,64 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
   const champion = resultsToDisplay.find(r => r.rank === 1);
 
   return (
-    <div style={{ padding: '2rem', maxWidth: '900px', margin: '0 auto' }}>
+    <div style={RV_STYLES.wrapper}>
       {/* En-tête avec le champion */}
       {champion && (
-        <div
-          style={{
-            textAlign: 'center',
-            padding: '2rem',
-            background: 'linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%)',
-            borderRadius: '12px',
-            marginBottom: '2rem',
-            color: 'white',
-            boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-          }}
-        >
-          <div style={{ fontSize: '4rem', marginBottom: '0.5rem' }}>🏆</div>
-          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>Champion</h1>
-          <div style={{ fontSize: '2rem', fontWeight: '700' }}>
+        <div style={RV_STYLES.champHeader}>
+          <div style={RV_STYLES.champTrophy}>🏆</div>
+          <h1 style={RV_STYLES.champTitle}>Champion</h1>
+          <div style={RV_STYLES.champName}>
             {champion.fencer.firstName} {champion.fencer.lastName}
           </div>
           {champion.fencer.club && (
-            <div style={{ opacity: 0.9, marginTop: '0.5rem' }}>{champion.fencer.club}</div>
+            <div style={RV_STYLES.champClub}>{champion.fencer.club}</div>
           )}
         </div>
       )}
 
       {/* Podium visuel */}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'flex-end',
-          gap: '1rem',
-          marginBottom: '2rem',
-          padding: '1rem',
-        }}
-      >
+      <div style={RV_STYLES.podiumRow}>
         {/* 2ème place */}
         {resultsToDisplay[1] && (
-          <div
-            style={{
-              textAlign: 'center',
-              background: '#e5e7eb',
-              padding: '1rem',
-              borderRadius: '8px 8px 0 0',
-              minWidth: '150px',
-              height: '120px',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'flex-end',
-            }}
-          >
-            <div style={{ fontSize: '2rem' }}>🥈</div>
-            <div style={{ fontWeight: '600', fontSize: '0.875rem' }}>
-              {resultsToDisplay[1].fencer.lastName}
-            </div>
-            <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>2ème</div>
+          <div style={RV_STYLES.podium2}>
+            <div style={RV_STYLES.podium2Medal}>🥈</div>
+            <div style={RV_STYLES.podium2Name}>{resultsToDisplay[1].fencer.lastName}</div>
+            <div style={RV_STYLES.podium2Place}>2ème</div>
           </div>
         )}
 
         {/* 1ère place */}
         {resultsToDisplay[0] && (
-          <div
-            style={{
-              textAlign: 'center',
-              background: '#fef3c7',
-              padding: '1rem',
-              borderRadius: '8px 8px 0 0',
-              minWidth: '150px',
-              height: '160px',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'flex-end',
-              border: '2px solid #f59e0b',
-            }}
-          >
-            <div style={{ fontSize: '2.5rem' }}>🥇</div>
-            <div style={{ fontWeight: '700', fontSize: '1rem' }}>
-              {resultsToDisplay[0].fencer.lastName}
-            </div>
-            <div style={{ fontSize: '0.875rem', color: '#92400e' }}>1er</div>
+          <div style={RV_STYLES.podium1}>
+            <div style={RV_STYLES.podium1Medal}>🥇</div>
+            <div style={RV_STYLES.podium1Name}>{resultsToDisplay[0].fencer.lastName}</div>
+            <div style={RV_STYLES.podium1Place}>1er</div>
           </div>
         )}
 
         {/* 3ème place */}
         {resultsToDisplay[2] && (
-          <div
-            style={{
-              textAlign: 'center',
-              background: '#fed7aa',
-              padding: '1rem',
-              borderRadius: '8px 8px 0 0',
-              minWidth: '150px',
-              height: '100px',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'flex-end',
-            }}
-          >
-            <div style={{ fontSize: '1.5rem' }}>🥉</div>
-            <div style={{ fontWeight: '600', fontSize: '0.875rem' }}>
-              {resultsToDisplay[2].fencer.lastName}
-            </div>
-            <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>3ème</div>
+          <div style={RV_STYLES.podium3}>
+            <div style={RV_STYLES.podium3Medal}>🥉</div>
+            <div style={RV_STYLES.podium3Name}>{resultsToDisplay[2].fencer.lastName}</div>
+            <div style={RV_STYLES.podium3Place}>3ème</div>
           </div>
         )}
       </div>
 
       {/* Tableau complet des résultats */}
-      <div
-        style={{
-          background: 'white',
-          borderRadius: '8px',
-          boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
-          overflow: 'hidden',
-        }}
-      >
-        <div
-          style={{
-            padding: '1rem',
-            background: '#f9fafb',
-            borderBottom: '1px solid #e5e7eb',
-            fontWeight: '600',
-          }}
-        >
+      <div style={RV_STYLES.tableWrapper}>
+        <div style={RV_STYLES.tableHeader}>
           📊 Classement final - {resultsToDisplay.length} tireurs
         </div>
 
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table style={RV_STYLES.table}>
           <thead>
-            <tr style={{ background: '#f9fafb', borderBottom: '2px solid #e5e7eb' }}>
-              <th style={{ padding: '0.75rem', textAlign: 'left', width: '60px' }}>Rang</th>
-              <th style={{ padding: '0.75rem', textAlign: 'left' }}>Tireur</th>
-              <th style={{ padding: '0.75rem', textAlign: 'left' }}>Club</th>
-              <th style={{ padding: '0.75rem', textAlign: 'center' }}>Éliminé en</th>
+            <tr style={RV_STYLES.thead}>
+              <th style={RV_STYLES.thRank}>Rang</th>
+              <th style={RV_STYLES.thLeft}>Tireur</th>
+              <th style={RV_STYLES.thLeft}>Club</th>
+              <th style={RV_STYLES.thCenter}>Éliminé en</th>
             </tr>
           </thead>
           <tbody>
@@ -280,22 +246,18 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
                   borderBottom: '1px solid #e5e7eb',
                 }}
               >
-                <td style={{ padding: '0.75rem' }}>
-                  <span style={{ marginRight: '0.5rem' }}>{getMedalEmoji(result.rank)}</span>
+                <td style={RV_STYLES.tdPad}>
+                  <span style={RV_STYLES.tdMedalSpan}>{getMedalEmoji(result.rank)}</span>
                   {result.rank}
                 </td>
-                <td style={{ padding: '0.75rem' }}>
+                <td style={RV_STYLES.tdPad}>
                   {result.fencer.firstName} {result.fencer.lastName}
                   {result.fencer.status === FencerStatus.ABANDONED && ' (A)'}
                   {result.fencer.status === FencerStatus.FORFAIT && ' (F)'}
                   {result.fencer.status === FencerStatus.EXCLUDED && ' (X)'}
                 </td>
-                <td style={{ padding: '0.75rem', color: '#6b7280' }}>
-                  {result.fencer.club || '-'}
-                </td>
-                <td style={{ padding: '0.75rem', textAlign: 'center', color: '#6b7280' }}>
-                  {result.eliminatedAt || '-'}
-                </td>
+                <td style={RV_STYLES.tdClub}>{result.fencer.club || '-'}</td>
+                <td style={RV_STYLES.tdElim}>{result.eliminatedAt || '-'}</td>
               </tr>
             ))}
           </tbody>
@@ -303,30 +265,8 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
       </div>
 
       {/* Boutons d'export */}
-      <div
-        style={{
-          display: 'flex',
-          gap: '1rem',
-          justifyContent: 'center',
-          marginTop: '2rem',
-          flexWrap: 'wrap',
-        }}
-      >
-        <button
-          onClick={() => window.electronAPI.print()}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: '#3b82f6',
-            color: 'white',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-          }}
-        >
+      <div style={RV_STYLES.exportRow}>
+        <button onClick={() => window.electronAPI.print()} style={RV_STYLES.btnPrint}>
           🖨️ Imprimer
         </button>
         <button
@@ -340,85 +280,23 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
             navigator.clipboard.writeText(text);
             showToast('Résultats copiés dans le presse-papier !', 'success');
           }}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: '#10b981',
-            color: 'white',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-          }}
+          style={RV_STYLES.btnCopy}
         >
           📋 Copier
         </button>
-        <button
-          onClick={exportCSV}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: '#f59e0b',
-            color: 'white',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-          }}
-        >
+        <button onClick={exportCSV} style={RV_STYLES.btnCsv}>
           📊 CSV
         </button>
-        <button
-          onClick={exportXML}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: '#8b5cf6',
-            color: 'white',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-          }}
-        >
+        <button onClick={exportXML} style={RV_STYLES.btnXml}>
           📝 XML
         </button>
-        <button
-          onClick={exportPDF}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: '#ef4444',
-            color: 'white',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-          }}
-        >
+        <button onClick={exportPDF} style={RV_STYLES.btnPdf}>
           📄 PDF
         </button>
       </div>
 
       {/* Légende */}
-      <div
-        style={{
-          textAlign: 'center',
-          marginTop: '1.5rem',
-          fontSize: '0.875rem',
-          color: '#6b7280',
-        }}
-      >
-        (A) = Abandon • (F) = Forfait • (X) = Exclu
-      </div>
+      <div style={RV_STYLES.legend}>(A) = Abandon • (F) = Forfait • (X) = Exclu</div>
     </div>
   );
 };

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -76,6 +76,49 @@ interface TableauViewProps {
   onConsolationBracketsChange?: (brackets: ConsolationBracket[]) => void;
 }
 
+// ─── Static style constants ───────────────────────────────────────────────────
+
+const TV_STYLES = {
+  root: { padding: '1rem' } satisfies React.CSSProperties,
+  scrollArea: { padding: '1rem', background: '#f9fafb', borderRadius: '8px', maxHeight: '70vh', overflowY: 'auto' as const } satisfies React.CSSProperties,
+  pendingOrderRow: { marginBottom: '0.75rem', display: 'flex', justifyContent: 'flex-end' as const } satisfies React.CSSProperties,
+  pendingOrderBtn: { background: '#e5e7eb', border: 'none', padding: '0.375rem 0.75rem', borderRadius: '4px', cursor: 'pointer', fontSize: '0.875rem', fontWeight: '500', color: '#374151', display: 'flex', alignItems: 'center', gap: '0.25rem' } satisfies React.CSSProperties,
+  summaryBox: { marginTop: '1rem', padding: '0.75rem', background: '#f3f4f6', borderRadius: '8px' } satisfies React.CSSProperties,
+  summaryTitle: { fontSize: '0.875rem', fontWeight: '600', marginBottom: '0.5rem' } satisfies React.CSSProperties,
+  summaryFlex: { display: 'flex', flexWrap: 'wrap' as const, gap: '0.5rem' } satisfies React.CSSProperties,
+  summaryItemBase: { padding: '0.5rem 0.75rem', borderRadius: '4px', fontSize: '0.75rem', border: '1px solid #e5e7eb' } satisfies React.CSSProperties,
+  pendingEmpty: { padding: '2rem', textAlign: 'center' as const, color: '#6b7280' } satisfies React.CSSProperties,
+  roundCol: { display: 'flex', flexDirection: 'column' as const, justifyContent: 'flex-start', minWidth: '200px' } satisfies React.CSSProperties,
+  roundHeader: { textAlign: 'center' as const, fontWeight: '600', marginBottom: '0.5rem', color: '#374151', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', userSelect: 'none' as const } satisfies React.CSSProperties,
+  roundHeaderChevron: { fontSize: '1rem', fontWeight: 'bold', marginRight: '0.25rem' } satisfies React.CSSProperties,
+  fullRoundsRow: { display: 'flex', gap: '1rem', overflowX: 'auto' as const } satisfies React.CSSProperties,
+  barragesBox: { marginBottom: '1rem', padding: '0.75rem', background: '#eff6ff', borderRadius: '8px', border: '1px solid #bfdbfe' } satisfies React.CSSProperties,
+  barragesTitle: { fontWeight: 600, marginBottom: '0.5rem', color: '#1e40af' } satisfies React.CSSProperties,
+  barragesFlex: { display: 'flex', gap: '0.5rem', flexWrap: 'wrap' as const } satisfies React.CSSProperties,
+  consolationSection: { marginTop: '1.5rem' } satisfies React.CSSProperties,
+  consolationCard: { background: '#f9fafb', borderRadius: '8px', padding: '1rem', marginBottom: '1rem', border: '1px solid #e5e7eb' } satisfies React.CSSProperties,
+  consolationHeader: { display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' } satisfies React.CSSProperties,
+  consolationTitle: { margin: 0, fontSize: '1rem', fontWeight: 600, color: '#374151' } satisfies React.CSSProperties,
+  consolationDoneBadge: { background: '#d1fae5', color: '#065f46', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 500 } satisfies React.CSSProperties,
+  consolationWinnerBadge: { background: '#fef3c7', padding: '0.25rem 0.75rem', borderRadius: '8px', fontSize: '0.875rem', fontWeight: 600 } satisfies React.CSSProperties,
+  consolationRoundsRow: { display: 'flex', gap: '1rem', overflowX: 'auto' as const } satisfies React.CSSProperties,
+  consolationRoundCol: { display: 'flex', flexDirection: 'column' as const, minWidth: '200px' } satisfies React.CSSProperties,
+  consolationRoundTitle: { textAlign: 'center' as const, fontWeight: 600, marginBottom: '0.5rem', color: '#374151', fontSize: '0.875rem' } satisfies React.CSSProperties,
+  consolationRoundMatches: { display: 'flex', flexDirection: 'column' as const, gap: '0.5rem' } satisfies React.CSSProperties,
+  pdfModalBody: { padding: '1.5rem' } satisfies React.CSSProperties,
+  pdfModalHint: { marginBottom: '1rem', color: '#6b7280', fontSize: '0.875rem' } satisfies React.CSSProperties,
+  pdfModalLabel: { display: 'block', fontWeight: '600', marginBottom: '0.5rem' } satisfies React.CSSProperties,
+  pdfModalMaxHint: { fontWeight: '400', color: '#6b7280' } satisfies React.CSSProperties,
+  pdfModalBtnRow: { display: 'flex', gap: '0.5rem', alignItems: 'center' } satisfies React.CSSProperties,
+  pdfModalCountHint: { marginTop: '0.75rem', fontSize: '0.8rem', color: '#9ca3af' } satisfies React.CSSProperties,
+  pdfModalFooter: { display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' as const } satisfies React.CSSProperties,
+  arenaModalBody: { padding: '1.5rem' } satisfies React.CSSProperties,
+  arenaModalHint: { marginBottom: '1rem', color: '#6b7280' } satisfies React.CSSProperties,
+  arenaModalGrid: { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '0.5rem' } satisfies React.CSSProperties,
+  arenaModalNoArenaBtn: { padding: '0.75rem' } satisfies React.CSSProperties,
+  arenaQueueHint: { fontSize: '0.7rem', marginLeft: '0.3rem', color: '#6b7280' } satisfies React.CSSProperties,
+} satisfies Record<string, React.CSSProperties>;
+
 const BASE_MATCH_HEIGHT = 100;
 const SLOT_HEIGHT = BASE_MATCH_HEIGHT + 50; // hauteur d'un créneau dans la première colonne
 
@@ -1283,31 +1326,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const isExpanded = expandedRounds.size === 0 || expandedRounds.has(round);
 
     return (
-      <div
-        key={round}
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'flex-start',
-          minWidth: '200px',
-        }}
-      >
-        <div
-          onClick={() => toggleRoundExpansion(round)}
-          style={{
-            textAlign: 'center',
-            fontWeight: '600',
-            marginBottom: '0.5rem',
-            color: '#374151',
-            cursor: 'pointer',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: '0.5rem',
-            userSelect: 'none',
-          }}
-        >
-          <span style={{ fontSize: '1rem', fontWeight: 'bold', marginRight: '0.25rem' }}>
+      <div key={round} style={TV_STYLES.roundCol}>
+        <div onClick={() => toggleRoundExpansion(round)} style={TV_STYLES.roundHeader}>
+          <span style={TV_STYLES.roundHeaderChevron}>
             {isExpanded ? '▼' : '▶'}
           </span>
           {getRoundName(round)}
@@ -1446,7 +1467,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   };
 
   return (
-    <div style={{ padding: '1rem' }}>
+    <div style={TV_STYLES.root}>
       <TableauToolbar
         tableauSize={tableauSize}
         rankingCount={ranking.length}
@@ -1463,34 +1484,14 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         champion={champion}
       />
 
-      <div
-        style={{
-          padding: '1rem',
-          background: '#f9fafb',
-          borderRadius: '8px',
-          maxHeight: '70vh',
-          overflowY: 'auto',
-        }}
-      >
+      <div style={TV_STYLES.scrollArea}>
         {viewMode === 'pending' ? (
           pendingViewRounds.length > 0 ? (
             <>
-              <div style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'flex-end' }}>
+              <div style={TV_STYLES.pendingOrderRow}>
                 <button
                   onClick={() => setPendingOrder(prev => (prev === 'asc' ? 'desc' : 'asc'))}
-                  style={{
-                    background: '#e5e7eb',
-                    border: 'none',
-                    padding: '0.375rem 0.75rem',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontSize: '0.875rem',
-                    fontWeight: '500',
-                    color: '#374151',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.25rem',
-                  }}
+                  style={TV_STYLES.pendingOrderBtn}
                   title={pendingOrder === 'asc' ? 'Affichage croissant' : 'Affichage décroissant'}
                 >
                   {pendingOrder === 'asc' ? '🔼 Croissant' : '🔽 Décroissant'}
@@ -1507,18 +1508,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 />
               ))}
 
-              <div
-                style={{
-                  marginTop: '1rem',
-                  padding: '0.75rem',
-                  background: '#f3f4f6',
-                  borderRadius: '8px',
-                }}
-              >
-                <h4 style={{ fontSize: '0.875rem', fontWeight: '600', marginBottom: '0.5rem' }}>
-                  Résumé des pistes
-                </h4>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+              <div style={TV_STYLES.summaryBox}>
+                <h4 style={TV_STYLES.summaryTitle}>Résumé des pistes</h4>
+                <div style={TV_STYLES.summaryFlex}>
                   {Array.from({ length: arenaCount }, (_, i) => i + 1).map(arenaNum => {
                     const arenaMatches = pendingMatches.filter(m => m.arena === arenaNum);
                     return (
@@ -1554,18 +1546,16 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
               </div>
             </>
           ) : (
-            <div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>
-              ✓ Tous les matches sont terminés
-            </div>
+            <div style={TV_STYLES.pendingEmpty}>✓ Tous les matches sont terminés</div>
           )
         ) : pyramidViewMode ? (
           <Bracket matches={convertToBracketMatches()} tableSize={tableauSize} />
         ) : (
           <>
             {playAllPositions && matches.some(m => m.round === tableauSize * 2) && (
-              <div style={{ marginBottom: '1rem', padding: '0.75rem', background: '#eff6ff', borderRadius: '8px', border: '1px solid #bfdbfe' }}>
-                <div style={{ fontWeight: 600, marginBottom: '0.5rem', color: '#1e40af' }}>Barrages</div>
-                <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+              <div style={TV_STYLES.barragesBox}>
+                <div style={TV_STYLES.barragesTitle}>Barrages</div>
+                <div style={TV_STYLES.barragesFlex}>
                   {matches.filter(m => m.round === tableauSize * 2).sort((a, b) => a.position - b.position).map(match => (
                     <MatchCard
                       key={match.id}
@@ -1579,7 +1569,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 </div>
               </div>
             )}
-            <div style={{ display: 'flex', gap: '1rem', overflowX: 'auto' }}>
+            <div style={TV_STYLES.fullRoundsRow}>
               {rounds.map(round => renderRound(round))}
             </div>
           </>

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -1580,7 +1580,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
 
       {/* Brackets de consolation (mode Jouer toutes les places) */}
       {playAllPositions && consolationBrackets.length > 0 && (
-        <div style={{ marginTop: '1.5rem' }}>
+        <div style={TV_STYLES.consolationSection}>
           {consolationBrackets
             .sort((a, b) => a.firstPlace - b.firstPlace)
             .map(bracket => {
@@ -1593,41 +1593,26 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 if (fi !== -1) bracketRounds.splice(fi, 0, 3);
               }
               return (
-                <div
-                  key={bracket.id}
-                  style={{
-                    background: '#f9fafb',
-                    borderRadius: '8px',
-                    padding: '1rem',
-                    marginBottom: '1rem',
-                    border: '1px solid #e5e7eb',
-                  }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
-                    <h3 style={{ margin: 0, fontSize: '1rem', fontWeight: 600, color: '#374151' }}>
-                      🥋 {bracket.name}
-                    </h3>
+                <div key={bracket.id} style={TV_STYLES.consolationCard}>
+                  <div style={TV_STYLES.consolationHeader}>
+                    <h3 style={TV_STYLES.consolationTitle}>🥋 {bracket.name}</h3>
                     {bracket.isComplete && (
-                      <span style={{ background: '#d1fae5', color: '#065f46', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 500 }}>
-                        Terminé
-                      </span>
+                      <span style={TV_STYLES.consolationDoneBadge}>Terminé</span>
                     )}
                     {finalM?.winner && (
-                      <span style={{ background: '#fef3c7', padding: '0.25rem 0.75rem', borderRadius: '8px', fontSize: '0.875rem', fontWeight: 600 }}>
+                      <span style={TV_STYLES.consolationWinnerBadge}>
                         🏆 {finalM.winner.lastName} {finalM.winner.firstName}
                       </span>
                     )}
                   </div>
-                  <div style={{ display: 'flex', gap: '1rem', overflowX: 'auto' }}>
+                  <div style={TV_STYLES.consolationRoundsRow}>
                     {bracketRounds.map(round => {
                       const roundMatches = bracket.matches.filter(m => m.round === round).sort((a, b) => a.position - b.position);
                       const roundName = round === 3 ? 'Petite finale' : round === 2 ? 'Finale' : round === 4 ? 'Demi-finales' : round === 8 ? 'Quarts' : `Tableau de ${round}`;
                       return (
-                        <div key={round} style={{ display: 'flex', flexDirection: 'column', minWidth: '200px' }}>
-                          <div style={{ textAlign: 'center', fontWeight: 600, marginBottom: '0.5rem', color: '#374151', fontSize: '0.875rem' }}>
-                            {roundName}
-                          </div>
-                          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                        <div key={round} style={TV_STYLES.consolationRoundCol}>
+                          <div style={TV_STYLES.consolationRoundTitle}>{roundName}</div>
+                          <div style={TV_STYLES.consolationRoundMatches}>
                             {roundMatches.map(match => (
                               <MatchCard
                                 key={match.id}
@@ -1682,18 +1667,16 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 &times;
               </button>
             </div>
-            <div className="modal-body" style={{ padding: '1.5rem' }}>
-              <p style={{ marginBottom: '1rem', color: '#6b7280', fontSize: '0.875rem' }}>
+            <div className="modal-body" style={TV_STYLES.pdfModalBody}>
+              <p style={TV_STYLES.pdfModalHint}>
                 Chaque fiche contient le nom complet des combattants, une case score et une case
                 signature.
               </p>
-              <label style={{ display: 'block', fontWeight: '600', marginBottom: '0.5rem' }}>
+              <label style={TV_STYLES.pdfModalLabel}>
                 Matchs par feuille A4{' '}
-                <span style={{ fontWeight: '400', color: '#6b7280' }}>
-                  (max {MAX_MATCHES_PER_PAGE_TABLEAU})
-                </span>
+                <span style={TV_STYLES.pdfModalMaxHint}>(max {MAX_MATCHES_PER_PAGE_TABLEAU})</span>
               </label>
-              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <div style={TV_STYLES.pdfModalBtnRow}>
                 {Array.from({ length: MAX_MATCHES_PER_PAGE_TABLEAU }, (_, i) => i + 1).map(n => (
                   <button
                     key={n}
@@ -1714,7 +1697,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                   </button>
                 ))}
               </div>
-              <p style={{ marginTop: '0.75rem', fontSize: '0.8rem', color: '#9ca3af' }}>
+              <p style={TV_STYLES.pdfModalCountHint}>
                 {matches.filter(m => !m.isBye && m.fencerA && m.fencerB).length} matchs →{' '}
                 {Math.ceil(
                   matches.filter(m => !m.isBye && m.fencerA && m.fencerB).length / pdfMatchesPerPage
@@ -1727,10 +1710,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                   : ''}
               </p>
             </div>
-            <div
-              className="modal-footer"
-              style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}
-            >
+            <div className="modal-footer" style={TV_STYLES.pdfModalFooter}>
               <button className="btn btn-secondary" onClick={() => setShowPdfModal(false)}>
                 Annuler
               </button>
@@ -1751,13 +1731,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 &times;
               </button>
             </div>
-            <div className="modal-body" style={{ padding: '1.5rem' }}>
-              <p style={{ marginBottom: '1rem', color: '#6b7280' }}>
-                Sélectionnez la piste pour ce match :
-              </p>
-              <div
-                style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '0.5rem' }}
-              >
+            <div className="modal-body" style={TV_STYLES.arenaModalBody}>
+              <p style={TV_STYLES.arenaModalHint}>Sélectionnez la piste pour ce match :</p>
+              <div style={TV_STYLES.arenaModalGrid}>
                 <button
                   className={`btn ${!matches.find(m => m.id === selectedMatchForArena)?.arena ? 'btn-primary' : 'btn-secondary'}`}
                   onClick={() => {
@@ -1771,7 +1747,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                     setShowArenaModal(false);
                     setSelectedMatchForArena(null);
                   }}
-                  style={{ padding: '0.75rem' }}
+                  style={TV_STYLES.arenaModalNoArenaBtn}
                 >
                   -
                 </button>
@@ -1798,9 +1774,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                     >
                       Piste {arenaNum}
                       {queueCount > 0 && (
-                        <span
-                          style={{ fontSize: '0.7rem', marginLeft: '0.3rem', color: '#6b7280' }}
-                        >
+                        <span style={TV_STYLES.arenaQueueHint}>
                           (+{queueCount})
                         </span>
                       )}


### PR DESCRIPTION
## Résumé

Suite de #475 — extraction des `style={{}}` statiques restants.

### Fichiers
- `ResultsView.tsx` — ~40 inline styles extraits
- `TableauView.tsx` — ~51 inline styles extraits
- `RemoteScoreManager.tsx` — corrections supplémentaires

## Test plan

- [ ] `npm run build:ci` → succès
- [ ] Affichage résultats → identique
- [ ] Tableau élimination → identique

https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJxUU4pfpRMSbCmkdE4fjU)_