### PR TITLE
fix: dropdowns coupés par overflow hidden

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -58,8 +58,10 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const [editingFencer, setEditingFencer] = useState<Fencer | null>(null);
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
+  const [exportMenuPos, setExportMenuPos] = useState({ top: 0, right: 0 });
   const [importMenuOpen, setImportMenuOpen] = useState(false);
   const importMenuRef = useRef<HTMLDivElement>(null);
+  const [importMenuPos, setImportMenuPos] = useState({ top: 0, left: 0 });
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -302,16 +304,20 @@ const FencerListComponent: React.FC<FencerListProps> = ({
             <div ref={importMenuRef} style={{ position: 'relative', display: 'inline-block' }}>
               <button
                 className="btn btn-secondary"
-                onClick={() => setImportMenuOpen(o => !o)}
+                onClick={() => {
+                  const rect = importMenuRef.current?.getBoundingClientRect();
+                  if (rect) setImportMenuPos({ top: rect.bottom + 4, left: rect.left });
+                  setImportMenuOpen(o => !o);
+                }}
                 title="Importer"
               >
                 📥 Importer ▾
               </button>
               {importMenuOpen && (
                 <div style={{
-                  position: 'absolute',
-                  top: '100%',
-                  left: 0,
+                  position: 'fixed',
+                  top: importMenuPos.top,
+                  left: importMenuPos.left,
                   zIndex: 9999,
                   background: 'var(--bg-secondary, #2a2a3e)',
                   border: '1px solid var(--border-color, #444)',
@@ -366,16 +372,20 @@ const FencerListComponent: React.FC<FencerListProps> = ({
           <div ref={exportMenuRef} style={{ position: 'relative', display: 'inline-block' }}>
             <button
               className="btn btn-secondary"
-              onClick={() => setExportMenuOpen(o => !o)}
+              onClick={() => {
+                const rect = exportMenuRef.current?.getBoundingClientRect();
+                if (rect) setExportMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+                setExportMenuOpen(o => !o);
+              }}
               title="Exporter"
             >
               📤 Exporter ▾
             </button>
             {exportMenuOpen && (
               <div style={{
-                position: 'absolute',
-                top: '100%',
-                right: 0,
+                position: 'fixed',
+                top: exportMenuPos.top,
+                right: exportMenuPos.right,
                 zIndex: 9999,
                 background: 'var(--bg-secondary, #2a2a3e)',
                 border: '1px solid var(--border-color, #444)',

--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -924,7 +924,7 @@ select:focus {
 
 .comp-header {
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Problème
Deux dropdowns étaient coupés visuellement :
- Menu `⋯` dans l'en-tête de compétition (stats TIREURS/POINTÉS)
- Menus Importer/Exporter dans FencerList

## Cause
- `.comp-header { overflow: hidden }` clippait le dropdown absolu du bouton `⋯`
- `root { overflow: hidden }` + `phaseContent { overflow: auto }` clippaient les dropdowns absolus de FencerList

## Fix
- `design.css` : `.comp-header` passe de `overflow: hidden` à `overflow: visible`
- `FencerList.tsx` : les dropdowns import/export passent de `position: absolute` à `position: fixed` avec position calculée via `getBoundingClientRect()`, ce qui les fait échapper à tout container `overflow`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tu8sbnXCizmucFgXu9HHyY)_