### PR TITLE
feat: overlay de score pour streaming OBS/vMix

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -142,6 +142,7 @@ export class RemoteScoreServer {
       'kiosk.html',
       'login.html',
       'public.html',
+      'overlay.html',
     ];
 
     // Essayer plusieurs chemins pour trouver les fichiers
@@ -660,6 +661,16 @@ export class RemoteScoreServer {
         );
       }
       this.sendHtmlFromMemory('referee.html', res);
+    });
+
+    // Overlay de score pour streaming (OBS, vMix…) — lecture seule, aucune auth requise
+    this.app.get('/arene:arenaId/overlay', (req, res) => {
+      console.log(`[RemoteScoreServer] Accès overlay /arene${req.params.arenaId}/overlay`);
+      this.sendHtmlFromMemory('overlay.html', res);
+    });
+    this.app.get('/arena:arenaId/overlay', (req, res) => {
+      console.log(`[RemoteScoreServer] Accès overlay /arena${req.params.arenaId}/overlay`);
+      this.sendHtmlFromMemory('overlay.html', res);
     });
 
     // Vue publique par arène (lecture seule, pas d'authentification requise)

--- a/src/remote/overlay.html
+++ b/src/remote/overlay.html
@@ -1,0 +1,491 @@
+<!doctype html>
+<!--
+  BellePoule Modern — Overlay de score pour streaming (OBS, vMix, StreamElements…)
+
+  UTILISATION
+  ───────────
+  URL : http://<ip>:8066/arene<N>/overlay
+  Exemple : http://192.168.1.10:8066/arene1/overlay
+
+  Dans OBS :
+    Sources > + > Navigateur
+    URL     : http://192.168.1.10:8066/arene1/overlay
+    Largeur : 1280  Hauteur : 160
+    ✔ Actualiser le navigateur quand la scène devient active
+
+  PARAMÈTRES DE REQUÊTE (query params)
+  ──────────────────────────────────────
+  ?theme=transparent   Fond transparent (défaut) — recommandé dans OBS
+  ?theme=dark          Fond dégradé bleu foncé
+  ?theme=neon          Fond noir, couleurs néon
+  ?theme=light         Fond clair
+
+  ?w=1280&h=160        Dimensions de la vue (px). La page s'adapte à ces dimensions.
+
+  ?hide=timer          Masquer le chronomètre
+  ?hide=cards          Masquer les cartons
+  ?hide=club           Masquer le nom du club
+  ?hide=phase          Masquer le numéro de piste / phase
+  Combinaison : ?hide=club,phase
+
+  EXEMPLES
+  ────────
+  Bandeau transparent 1920×80  : /arene1/overlay?w=1920&h=80
+  Bloc coin néon 400×200       : /arene1/overlay?theme=neon&w=400&h=200
+  Sans clubs ni phase          : /arene1/overlay?hide=club,phase
+-->
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Overlay BellePoule</title>
+    <script src="/socket.io/socket.io.js"></script>
+    <style>
+      /* ── Police 7 segments (embarquée, identique à arena.html) ── */
+      @font-face {
+        font-family: 'DSEG7Classic';
+        src: url('data:font/woff2;base64,d09GMgABAAAAABQMAA4AAAAAWgAAABOxAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGhwGYACCcggEEQgKuRilZguBEgABNgIkA4E2BCAF72YHgTIbw04jA8HGAQh5fv0iKknrCv5bAodjyObBNMtgGNKl1aJERCtDEAN6YJfqaNsT9d3q/ezF8seFeWpDMBEOphkj8Vx4ILvPN9jdgzn3T3TsTlVcJlVyVUq1cmlUUmceoGNfb+aHbkfQUiT4imzjgZ4dRtEBVtAB/4u1tYhIgubaqO6JkBmaWRSNGrWSyJ547Z+ufeb/zn2856WLLGzUibfAjA94uTAoXABTbnBklWIQ0AqZrNP9DzA+sPL+t6mWWcuk8/SF5FvZZBCxLkSYljJ+L5tN/+Osy0nbw4zhtXJqPXkp9z/GiOCNbbGSSZZI8f9/7fvU1W9C8IIWSwVtVuSQUTEirt+pc/bt/8+cX/MBa1UqwG+IO3Ch7qPq7gECGUlEamyMSRShzfIRDtjFZhVbpcJsu3dXJKpOCCGY4DUeYzK+yIp636sRm4opotWDMdHkFSnbjxAgAA/+L7wCcLv5Q4Gntz9XAABegmgggQAC6EQ0+pwUt7g3nmD/+pOI73qCBMktAfNTFT4+PeeNiziu2qnEH4zNgmY9VE2jOFNLjRrGsErF9L3UeoAfPwrEM8qMmbbDqcwQJ5tLrWmz00/efXh5uroYC446keY0kbhC5JlnQiXZn4GVxrHMJ/qx4AIBeZhQ5qb+pBclWVE13TAtG4As2Z1+EEZxkmZ5UVZ103b94Kyrb2hs4uh/uNnRm8bH7QAig4VRy4c/jCgBnGPA/UYXDZgRLL25YJMs1u8razQnUtim4rQsBO9GamyRI005nDrz7A19dLrtR3DsafK2YU+Fg6Cs3bkcOhTCj/AXWQuIOQDVkUQky4G568ubJPDkVu5+/ppuO9n/ufS0vPUQxfLYGuzx6gs/Kj8Plt31aFaZjze91TCfT1aZUfSEAuMZHETvUNLSI9TFAopMi2Gm5WiPkBBmu4yaEadtjDFkePHSfBanDY6B+sMpAxiWZ38IzwmBBkavASSJ84Ve8l56AOXfc09i9St+9wnGi3GPNxz+jM7kTpLpA0s5kYSB2VPbWkorvIustG1Nc98XtzxHOz6MDwec45POVHGKl0Qs9ykbnFdpVtnI855xQ3xreFSppzpT3HmnJ7GH19racPXr2tU/Jak88RmAtG8qfkaa/dMnf9JM65E7/PJrYkU4fhOW3k/rz9aLaHK8SI5iMmykoyaO5M/+/xMXGlpoGh1PwlONnDfEwd9fzI2u6Dp5tSu65INAxtU6eiyG4eBaJ9Krsk0Vd4lX5GtfHSe8jDzSuBQMJcCTOGbLZYpC1qUdC69F/DHcrq1HBjVRbdkuruoTpx9xtP/wRWfWKPvt8RE4tNEP/speTxxXSJPKvM9bJNK4XZL1POdrwmH2dH4rw852Og5JAi0e38xex36POnFGNgPp1zZfpWlUcYB8NOFDCR5+ujaxm7088780npG+OkjlWeOBY5Xv/LPsq9vrkxIZS44+0ukAOeMfAcvn3pd43PP3HoFBr59eS6zh1s86ghd/QoqK/zwKwOa34t3Ch3xWxT+i3m2Fni1zjvw8nBm4kVuCvIG54Upan9aH+Mbi5xMYVkE8QGwA3EJ1L1/wJP9fAPMH0L3rR8Lh5PBKtzQO4fzixV6Y3/nD2R9+ngAtDAebvjR++BoGAISFFNJtrT2hUvD2tpS0X6ViwmSpBYQzpcUrvCpt/tGvdJcQl5VeQuPZ0jtHooqlj4jB/ZMH8ho8QoJIugO7CJVChBul5OZbqUz4X2pJYX9pCQvXS1tC+FS6a4gJpRcT95XetR70vdJHweD4YAcKGzxgjjMVxMpICzUm6BNRPW/HSsCBl/XQC5bk9Tcvtgg6VTuGZnpZNrh15EiX87Dup1FTnVpCshIofn3rJT9Je7+zCX7u8JO9cMovLFvC0/oYZz8fu9FFH5m7H2atXZ0ol1AUztqzV1fQo8BSynMK9/n16k8/e19F0WNBq/h92lsvvqmbegtvUFfXrDI+jhMXKmcqp46XKwoal7/Fe9pd3cnk5BtOLqqz6mcAt1/cdKC42jdTFCtEKI8l6Fjt3KXiF3Hc9rg+vyyTM4ZvcU20M5tJ8+3PvHVnl/qlJizyfrl2bSBYqfiAbfb3eBy7vdtF5P+n9Tb9ur4ehMviGdLD4oZqu/vAzorngn42znZFaPh4RWGxwUR4W/DNaMYpoTxv7YlrBhag5FliuX7JvCK6Sj+diP1rBZ09O5qzYv37B7L5dzUANiWWNe+Tr7FOdmAJgom7wn7skGmp6ShpD4p4lEA2v/uCFoacoMDyF1BhojoqTmgJhInyQKWO89p/ipybBOwArhYfMn67VqAYsvYsL7AaAUEu1WJu7i13D5TdAnEa5ST+ZINM1ZQX1JW8+cjCiy+w+O+rFosgwzN/PJs/c2Fu07x7jN60tee5QZVu9RLig5OGGFli0vP/67Erop8c/Fh5du/bgy/Pw/kJ2mLZFWfoM1uXLZoJ2ZWwBsYZb1aZF40asjyS/E3QamnaIrCyvSabQSxhGRNr14IKCUItOOV1qEPHn2HTfxGnt0WDZjoaDBCWKUaG2v3oytJOAenSCvHYmVqORa2RC6kdqbrzJ1sjT97coJGHceLv4xGdBSko2J4Xri3tsNWU0wKWhFPYpJjVZgdxEMvaY6h7mkzj9MiaKv90pHrBFltMNGAuCNA65LRZ0j8VWh7sVHnNSZ5RtgQVQqMFw6lViKRFOuzgSGYbE82o68xRy0eaiEfrDo47pirSbBZeY5T3HtMaGDJrnspySlgQL04KL5LmCa6ia0wZGvFqYJI4MRwXgaAZhlsn0EFhTYDcIkjpvuIhuMCoywJL1rSWOjBDiIqma7WxDFaYOT0qFpB0Yjucq7ThRXVsLStEwsteJS23BUnLA8oyZMeQxY3P+OOQI5eGqRhtQK9OtqEF4VgQMdNMogiDtpmDql8Pb4qyyYAsJKp5h1vEmf5n5APOBMWGUrUh6WbrNPQV/XxA22LOQVCtOVIVGMB7SjydOSOm0CgdC7XqdyjzXzMqJXppIWAaf0Q9efbi3dy7jXcLc2vgd59lv/OhHbzjyKG6rqJWMu74GyUqaVjJQ+hLW/BWF+86RMyokn8o0VxpE9vRGKp3VWjasMjCRSWX5YclsA4h+pLZSDhkxhjMV3Low4AsJbZrgyLOdn/3yf3kgKbCah+rwZxhJxlokBU7cMk3BlynYIrcVY7IAwq2yCL2Chv1bzk6gvsg3OAHquqrTrT+8YAXyY5uVIEF5+vw+BB0V363wPwhq+lY9DvASEGvYZUZM8SU5YSxASayWuOIumxMVHSlUYcB23BepiJtlAXMUY+aZjxM3R6ooTZESYVqZ0EsNkyMOGtzWXCVoRXmKAT8KwzNAaJ/+p4nddIzBNZ7/rQvmC1mod1Wamc1kTKKoWHb1kfWMb45I04vzR/OCsCB8DXJLASNzgZMCyyeiDOQtC648/gSFqgbe9OVb+/W1o2hQX9XCYVWPTUM/cF0ZuSpxNLRCm4jAZkDS/iWjeMmRFBEITdADONx8qezRm7IrIkO2H4b2s2lj4LwQKHjvc7EQIvzNULqXF/CFVNOX/f3MGPoXrcYPLW0vUSSt7GwNSV9PACrQOcWV0rRSe8gDENjhAPG/NNQtwA4UUJzxCs1vzqLtFqsxnztmy/LHtdGK0kakJlGPYDWI4VyDJugUh2b320wPpHMuoq51U6VpWekVGDs1X38ZfYZ2zFTS6yHQKUYKAYV6veevJkgzS7hL8Qli5cDeufz+vp5Cob9WejcgD7UqfNAlsu1FduJGlnzDf8ve7yi17i3yp0vtht01kc6Is2LEQVc2MAsrdTzyTLzgVtHsgjNlmO0ZoxKktY6MZAj4tBoM2FrzJHr34UbMxyWC/k29PTmHbbuM4YOHgsWa1JDo7ObOccVM+sRRV1uX1/9MPC7DGGJJuLTBg2qLy5NmibxVD0boWt9aW6e7jBpiVobHN/2wJOGHQtDiQVE3LMlidB73ohH3ltUuRCVAq7RTcBRU4ZwOpichi+46TQ6t03SUmIdEs/Qice63WX0bS4xvy26rTlpxf4WBAjFNw27iJv5iBomE/A1Vqs39qteV3rzJqB6M9q7r0OGJj21nB1OO9j/wlbpSRcosEledgD4hhnnHZalqbgtiNwqOl4Q/Rx3kenjEh4K6NLzzphuaGqAqAanjV7NVuqi82R7M3uzYtFMKBiqMdnDZm+H9W2bO4vbXyc7vPBJiccDuT3Nwzbd3H330u/n7Jh58ZogYKNBQKzpHvMBUlboYtOeJ+2hsf36OMBtHptzP3tVRWEFRCyxDFQD/nmyXSVQ+OkayQfK/+LRKItWhMMc1CElTTv16bqfKwZtkAzVZFTiiVuoGKZRF2yqq42WbX5ui3rFAotMiKejQEqriYyVbRoXOn0O9WU7FX+uj4SyirirYvEoOipgBaEBP601JE1JT2CJxthACtWK1/w0JkgFCHpqNSFI0aKdfxQVjMccalUqrZcpKSMhBArIuFNuRtvE888NKlPQagaFtdJSB0PFuwXDpUWxKeSB2YxTxnNhxFZYC8TD6UGAEEOwVxS8DVyJtscSGP3cpGPJ7ZwOK5yNQ7iJ/mAZABpKMQxaQCGCVAUpSA2pC4+YJRFWXyNyfKHqi1UuCqgDl9iuIBnbpCUy7AogI/VANLAD30ar2poHq0+KiJTApRXBUGVH15U3YpKcgsyGgqIssizVKKVQ8dbUWEeEIc+CwKXnGgUggWEZhBw7bAGpldLZ8NeZmYC2P9C+u103HfC1k6uCO99FObBrvsgEhhmx3SoLWuibNtZ16sqBl7/b4X05fufuAWCPFQm2UPODhIMg1lmeejRb8JNK3645Vzj13gWD9ubznlXpHCr5IDfoKeHN/zWkSfz/a/5e3n+3/rLoAxydTFOFbBwbWYe3QoafJ9g6E6d4fM62JUrC/EL+ODBmpmUfGOrzA+oNoCKNF+c5cSf6UEyJE+HDZkbNPo7BZuLcroJftyeU3u3eW+wBLbgRfrDcCzaAiUEA0LDj0TN8hbm045liTD+Kp1v3AWfG6divKB0U7WUU7aJjk3xgcoBPIuBZlX+0L5iBVy1evlCxEGZKjoASJQY7C8QACj4pgZcVYn9QJ5550JUAl0IOiPlgnldueoJQo1zU29o0ofLDykeIqAqB9fFYakOMzkGxoba9JjjiGL7iiAX9naFggRqBVdN0F1geVhFLEG+B8EQTxLEfIYXp369TAygMB1wAJlnmdQfiEbDVcYFzxbckExOEUZOQC08GHKK5sudsX+aowHYWtKJDbEjQ+1nAWH5KrlsDuMV8efhdtpZ/p7oIa6VizsAbNNp0crof3tqn6Uq1zALlpIC7nBG/Mr44XxXtBDMIe4tUhVypqRX7pUINVDcC8Lssu6xIYXHZO9wHYrGAejhrQFa4Hmzap2UkwItA4vyjiHFVYZ56dKzOKszEqWI8DiVqADZfRHT+EWoVw0ePZjZJRwPld+9jgAU7B+JgVWF297HsVIARupkCF1H1Yi+3rIS82GVuDKK5ILP3sdxMy0vMiGGuVFm4LSQ6IMAp1VBEFEkrFLdDgTu4M3SdM55ODJccQIsmmEhCaUzxeMKkXacG6MbUhb/7JWYB+Kb7vFLOJwexBJs0mbC91hJ7iQOzae7r0xYsADDcpgeTCKlxroTUvPudyyTLP1ker0fDZeCaIUJ+KNYdjulqx8xC+A8DjxoXgbt4nTLyaoATEneiTF+aWGacy/isgMKbis404BPu3SALTt0H1VRurupglzHvBsBpAOmcRaCoQmZWb6ww24SwI7v7AvZRhcTzJIPt44LsOak/qFSn7QFIFw+MWwUQ0ooFRFh8iF4F4JlWQrZ9VsdUI5rHrgs+Oc8q+ne9h1WKjomtxaA/AWBRSPRUxxqfGmRVmJFqvGWlx0rSmeHM3RfvGS75tksNcIZzLp2eW4KqDOV6DbjaICSZZ4O0wIW9FkaQBRAJCnWURsVUKpeYRktiDopTTz4ejyrMCrbWWQVDaJB6qjn3nzcMLMVfMh2NQ3WXkbC84THRxVFxiC3EXSqxPf2clFoWpSAdNYlm3JWQ/wcMOnR02Dq4ekqHg5ecIUi6TMvBoQAApRERLaeHAVXFelFEMZnzROqyLFuDpio6aABL6c+7gF0mnluo2aYHS156tWyiKRYunlvCJthJAicER5CubdY23GtY4as7YaOT4lNCDR72XcXsxMeJdNWEXYN9kSpSz0/4VwG6Dvy6DC63+0Nlc7SjEj7UmQEFmiSeminr4Vt8A5JucUVlMBgRbAdj/pMnOw/wZeSSe57S01PgKY8Kl2kPeEEv/7VS6aevyrP8wGF5WbnJ3wepQ40q6r2tr5zF34DZrUgI6xdT389XzsjTMMNPdpWn8tWIApmKosbBB6oGsGaSVENQNGxBk6w39IxBXJWneFWZqIrxFDMu6usSPN1dMlJDQVQPlD9KqfTAFhUUDwJXVWRvEMdab90Xc9Pi5YVTOzFJNwjLzFivp6QfIB0R9TQ5MNTzt6sx15G2IENotht6Wd7rlt1jrfBx4At/dVt8yqB7UyAKgVMPGT1NdF4w8ZhbfJUBfqqxRd578H609HGNYnFy5SmTr8BPlX5BjVUIoypOAAmA/+l1Zk8LOvJBovnxFyhIsBChwoSLEClKtCTJUqRKky5DpizZjByuGNDOF1OoSLESpcqUq1Cp7uum42Ytm9u069Cp683Kr6VXn34DBg0ZNmLUmHETJu0GAAA=') format('woff2');
+        font-weight: bold;
+        font-style: normal;
+        font-display: block;
+      }
+
+      /* ── Variables par thème ── */
+      :root {
+        --bg: transparent;
+        --overlay-border: rgba(255,255,255,0.15);
+        --name-color: #ffffff;
+        --club-color: rgba(255,255,255,0.75);
+        --score-a-color: #00e640;
+        --score-b-color: #ff2200;
+        --score-bg: rgba(0,0,0,0.65);
+        --score-glow-a: rgba(0,230,64,0.7);
+        --score-glow-b: rgba(255,34,0,0.7);
+        --timer-color: #ffaa00;
+        --timer-bg: rgba(0,0,0,0.6);
+        --timer-glow: rgba(255,170,0,0.8);
+        --card-white-bg: #f5f5f5; --card-white-fg: #333;
+        --card-yellow-bg: #ffc107; --card-yellow-fg: #333;
+        --card-red-bg:  #e53e3e; --card-red-fg: #fff;
+        --sd-color: #ff6b35;
+        --phase-color: rgba(255,255,255,0.55);
+        --name-shadow: 0 2px 6px rgba(0,0,0,0.8);
+        --panel-bg: rgba(0,0,0,0.55);
+        --panel-border-radius: 12px;
+      }
+      [data-theme="dark"] {
+        --bg: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+      }
+      [data-theme="neon"] {
+        --bg: #0a0a0a;
+        --score-a-color: #00ff88;
+        --score-b-color: #ff4444;
+        --score-glow-a: rgba(0,255,136,0.8);
+        --score-glow-b: rgba(255,68,68,0.8);
+        --timer-color: #00ccff;
+        --timer-glow: rgba(0,204,255,0.9);
+        --panel-bg: rgba(0,0,0,0.85);
+        --overlay-border: rgba(0,204,255,0.3);
+      }
+      [data-theme="light"] {
+        --bg: linear-gradient(135deg, #e8edf5 0%, #c8d8f0 100%);
+        --name-color: #111827;
+        --club-color: #374151;
+        --score-a-color: #059669;
+        --score-b-color: #dc2626;
+        --score-glow-a: rgba(5,150,105,0.5);
+        --score-glow-b: rgba(220,38,38,0.5);
+        --timer-color: #d97706;
+        --timer-glow: rgba(217,119,6,0.7);
+        --score-bg: rgba(255,255,255,0.85);
+        --timer-bg: rgba(255,255,255,0.85);
+        --panel-bg: rgba(255,255,255,0.75);
+        --overlay-border: rgba(0,0,0,0.1);
+        --name-shadow: 0 1px 4px rgba(0,0,0,0.2);
+        --phase-color: rgba(0,0,0,0.45);
+      }
+
+      /* ── Reset & base ── */
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      html, body {
+        width: var(--ov-w, 1280px);
+        height: var(--ov-h, 160px);
+        overflow: hidden;
+        background: var(--bg);
+        font-family: system-ui, sans-serif;
+        color: var(--name-color);
+      }
+
+      /* ── Layout principal ── */
+      .overlay-root {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+        gap: 6px;
+        padding: 8px 12px;
+      }
+
+      /* ── Panneaux tireur ── */
+      .fencer-panel {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 4px;
+        background: var(--panel-bg);
+        border-radius: var(--panel-border-radius);
+        border: 1px solid var(--overlay-border);
+        padding: 8px 12px;
+        height: 100%;
+        overflow: hidden;
+      }
+      .fencer-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .fencer-panel.side-b .fencer-row { flex-direction: row-reverse; }
+
+      .score-box {
+        flex-shrink: 0;
+        font-family: 'DSEG7Classic', monospace;
+        font-weight: bold;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--score-bg);
+        border-radius: 8px;
+        padding: 2px 8px;
+        min-width: 2.2em;
+        font-size: clamp(1.8rem, 5vw, 3.2rem);
+        line-height: 1;
+        letter-spacing: 0.02em;
+      }
+      .side-a .score-box {
+        color: var(--score-a-color);
+        text-shadow: 0 0 12px var(--score-glow-a), 0 0 28px var(--score-glow-a);
+      }
+      .side-b .score-box {
+        color: var(--score-b-color);
+        text-shadow: 0 0 12px var(--score-glow-b), 0 0 28px var(--score-glow-b);
+      }
+
+      .fencer-info {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+      }
+      .fencer-name {
+        font-weight: 700;
+        font-size: clamp(0.85rem, 2vw, 1.3rem);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        text-shadow: var(--name-shadow);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .fencer-club {
+        font-size: clamp(0.65rem, 1.2vw, 0.9rem);
+        color: var(--club-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      /* Cartons */
+      .cards-row {
+        display: flex;
+        gap: 4px;
+        flex-wrap: wrap;
+      }
+      .fencer-panel.side-b .cards-row { flex-direction: row-reverse; }
+
+      .card-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: clamp(14px, 1.5vw, 20px);
+        height: clamp(18px, 2vw, 26px);
+        border-radius: 3px;
+        font-weight: 700;
+        font-size: clamp(0.5rem, 0.8vw, 0.7rem);
+        line-height: 1;
+      }
+      .card-badge.white  { background: var(--card-white-bg);  color: var(--card-white-fg);  }
+      .card-badge.yellow { background: var(--card-yellow-bg); color: var(--card-yellow-fg); }
+      .card-badge.red    { background: var(--card-red-bg);    color: var(--card-red-fg);    }
+
+      /* ── Panneau central ── */
+      .center-panel {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        background: var(--timer-bg);
+        border-radius: var(--panel-border-radius);
+        border: 1px solid var(--overlay-border);
+        padding: 6px 14px;
+        height: 100%;
+        min-width: clamp(80px, 10vw, 160px);
+      }
+
+      .timer-display {
+        font-family: 'DSEG7Classic', monospace;
+        font-weight: bold;
+        font-size: clamp(1.4rem, 3.5vw, 2.8rem);
+        color: var(--timer-color);
+        text-shadow: 0 0 10px var(--timer-glow), 0 0 22px var(--timer-glow);
+        letter-spacing: 0.04em;
+        line-height: 1;
+        transition: color 0.3s;
+      }
+      .timer-display.warning { color: #ff9500; text-shadow: 0 0 10px rgba(255,149,0,0.9); }
+      .timer-display.danger  { color: #ff3b30; text-shadow: 0 0 10px rgba(255,59,48,0.9); animation: blink 0.8s step-end infinite; }
+      .timer-display.running { /* default color is already set */ }
+
+      @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0.25} }
+
+      .phase-label {
+        font-size: clamp(0.55rem, 0.9vw, 0.75rem);
+        color: var(--phase-color);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        white-space: nowrap;
+      }
+
+      .sd-badge {
+        display: none;
+        background: var(--sd-color);
+        color: #fff;
+        font-weight: 700;
+        font-size: clamp(0.5rem, 0.8vw, 0.65rem);
+        border-radius: 4px;
+        padding: 2px 6px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        animation: blink 0.8s step-end infinite;
+      }
+      .sd-badge.visible { display: inline-block; }
+
+      /* ── Écran d'attente ── */
+      .idle-screen {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        background: var(--panel-bg);
+        border-radius: var(--panel-border-radius);
+        color: var(--phase-color);
+        font-size: clamp(0.75rem, 1.5vw, 1rem);
+        letter-spacing: 0.06em;
+      }
+      .idle-screen.hidden { display: none; }
+      .overlay-root.hidden { display: none; }
+
+      /* ── Utilitaires hide ── */
+      .hide-timer   .timer-display,
+      .hide-timer   .sd-badge       { display: none !important; }
+      .hide-cards   .cards-row      { display: none !important; }
+      .hide-club    .fencer-club    { display: none !important; }
+      .hide-phase   .phase-label    { display: none !important; }
+    </style>
+  </head>
+  <body>
+    <!-- Écran principal -->
+    <div class="overlay-root hidden" id="overlay-root">
+      <!-- Tireur A (gauche / vert) -->
+      <div class="fencer-panel side-a" id="panel-a">
+        <div class="fencer-row">
+          <div class="score-box" id="score-a">0</div>
+          <div class="fencer-info">
+            <div class="fencer-name" id="name-a">—</div>
+            <div class="fencer-club" id="club-a"></div>
+          </div>
+        </div>
+        <div class="cards-row" id="cards-a"></div>
+      </div>
+
+      <!-- Panneau central (timer + phase) -->
+      <div class="center-panel">
+        <div class="timer-display" id="timer">03:00</div>
+        <div class="phase-label" id="phase-label">Piste 1</div>
+        <div class="sd-badge" id="sd-badge">⚡ Mort subite</div>
+      </div>
+
+      <!-- Tireur B (droite / rouge) -->
+      <div class="fencer-panel side-b" id="panel-b">
+        <div class="fencer-row">
+          <div class="score-box" id="score-b">0</div>
+          <div class="fencer-info">
+            <div class="fencer-name" id="name-b">—</div>
+            <div class="fencer-club" id="club-b"></div>
+          </div>
+        </div>
+        <div class="cards-row" id="cards-b"></div>
+      </div>
+    </div>
+
+    <!-- Écran d'attente affiché quand aucun match n'est en cours -->
+    <div class="idle-screen" id="idle-screen">
+      En attente d'un match…
+    </div>
+
+    <script>
+      (() => {
+        /* ── Lecture des paramètres ── */
+        const params  = new URLSearchParams(window.location.search);
+        const theme   = params.get('theme') || 'transparent';
+        const hidden  = (params.get('hide') || '').split(',').map(s => s.trim()).filter(Boolean);
+        const ow      = params.get('w');
+        const oh      = params.get('h');
+
+        /* Dimensions personnalisées */
+        if (ow) document.documentElement.style.setProperty('--ov-w', ow + 'px');
+        if (oh) document.documentElement.style.setProperty('--ov-h', oh + 'px');
+
+        /* Thème */
+        if (theme !== 'transparent') {
+          document.documentElement.setAttribute('data-theme', theme);
+        }
+
+        /* Masques de contenu */
+        const root = document.getElementById('overlay-root');
+        hidden.forEach(key => root.classList.add('hide-' + key));
+
+        /* ── Extraction de l'arenaId depuis l'URL ou le query param ── */
+        function getArenaId() {
+          const p = params.get('arena');
+          if (p) return p.startsWith('arena') ? p : 'arena' + p;
+          const m = window.location.pathname.match(/arene(\d+)/i) || window.location.pathname.match(/arena(\d+)/i);
+          return m ? 'arena' + m[1] : 'arena1';
+        }
+
+        const arenaId     = getArenaId();
+        const arenaNumber = arenaId.replace('arena', '');
+
+        document.getElementById('phase-label').textContent = 'Piste ' + arenaNumber;
+
+        /* ── État ── */
+        let scoreA    = 0, scoreB    = 0;
+        let cardsA    = [], cardsB   = [];
+        let timerSec  = 180;
+        let timerStat = 'paused';
+        let isSuddenDeath = false;
+        let matchStatus   = 'idle';
+        let phaseLabel    = 'Piste ' + arenaNumber;
+
+        /* ── DOM ── */
+        const elScoreA  = document.getElementById('score-a');
+        const elScoreB  = document.getElementById('score-b');
+        const elNameA   = document.getElementById('name-a');
+        const elClubA   = document.getElementById('club-a');
+        const elNameB   = document.getElementById('name-b');
+        const elClubB   = document.getElementById('club-b');
+        const elCardsA  = document.getElementById('cards-a');
+        const elCardsB  = document.getElementById('cards-b');
+        const elTimer   = document.getElementById('timer');
+        const elPhase   = document.getElementById('phase-label');
+        const elSDBadge = document.getElementById('sd-badge');
+        const elOverlay = document.getElementById('overlay-root');
+        const elIdle    = document.getElementById('idle-screen');
+
+        /* ── Rendu ── */
+        function fmtTime(sec) {
+          const m = Math.floor(sec / 60), s = sec % 60;
+          return String(m).padStart(2,'0') + ':' + String(s).padStart(2,'0');
+        }
+
+        function renderCards(cards) {
+          return cards.map(c => {
+            const label = c === 'white' ? 'B' : c === 'yellow' ? 'J' : 'R';
+            return `<span class="card-badge ${c}">${label}</span>`;
+          }).join('');
+        }
+
+        function renderTimer() {
+          elTimer.textContent = fmtTime(timerSec);
+          elTimer.className = 'timer-display';
+          if (timerStat === 'running') elTimer.classList.add('running');
+          if (timerSec <= 10)      elTimer.classList.add('danger');
+          else if (timerSec <= 30) elTimer.classList.add('warning');
+        }
+
+        function renderVisibility() {
+          const active = matchStatus === 'in_progress' || matchStatus === 'finished' || matchStatus === 'ready';
+          elOverlay.classList.toggle('hidden', !active);
+          elIdle.classList.toggle('hidden', active);
+        }
+
+        function applyUpdate(data) {
+          if (data.status)          { matchStatus = data.status; renderVisibility(); }
+          if (data.match) {
+            const fA = data.match.fencerA || {};
+            const fB = data.match.fencerB || {};
+            elNameA.textContent = (`${fA.lastName||''} ${fA.firstName||''}`).trim() || '—';
+            elClubA.textContent = fA.club || '';
+            elNameB.textContent = (`${fB.lastName||''} ${fB.firstName||''}`).trim() || '—';
+            elClubB.textContent = fB.club || '';
+
+            // Phase label depuis les métadonnées du match si disponibles
+            if (data.match.phaseName) {
+              phaseLabel = data.match.phaseName;
+            } else if (data.match.poolName) {
+              phaseLabel = data.match.poolName;
+            }
+            elPhase.textContent = phaseLabel;
+          }
+          if (data.scoreA !== undefined) { scoreA = data.scoreA; elScoreA.textContent = scoreA; }
+          if (data.scoreB !== undefined) { scoreB = data.scoreB; elScoreB.textContent = scoreB; }
+          if (data.cardsA)               { cardsA = data.cardsA; elCardsA.innerHTML  = renderCards(cardsA); }
+          if (data.cardsB)               { cardsB = data.cardsB; elCardsB.innerHTML  = renderCards(cardsB); }
+          if (data.time !== undefined)   { timerSec  = data.time; timerStat = data.timerStatus || timerStat; renderTimer(); }
+          if (data.suddenDeath !== undefined || data.overtimeType !== undefined) {
+            isSuddenDeath = !!(data.suddenDeath || data.overtimeType);
+            elSDBadge.classList.toggle('visible', isSuddenDeath);
+          }
+        }
+
+        /* ── Initialisation depuis l'API REST ── */
+        fetch('/api/arenas/' + arenaId)
+          .then(r => r.json())
+          .then(arena => {
+            if (arena && arena.currentMatch) {
+              applyUpdate({
+                status:  arena.status,
+                match:   arena.currentMatch,
+                scoreA:  arena.scoreA,
+                scoreB:  arena.scoreB,
+                cardsA:  arena.cardsA || [],
+                cardsB:  arena.cardsB || [],
+              });
+            }
+          })
+          .catch(() => {});
+
+        /* ── Socket.IO ── */
+        const socket = io({ transports: ['websocket', 'polling'] });
+
+        socket.on('connect', () => {
+          socket.emit('join_arena', { arenaId, role: 'overlay' });
+        });
+
+        socket.on('arena:' + arenaId + ':update', data => {
+          applyUpdate(data);
+        });
+
+        /* Replay d'événements au rechargement */
+        socket.on('arena:' + arenaId + ':replay', events => {
+          if (Array.isArray(events)) events.forEach(e => applyUpdate(e));
+        });
+
+        /* Rendu initial */
+        renderTimer();
+        renderVisibility();
+      })();
+    </script>
+  </body>
+</html>

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -444,6 +444,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     displayUrl: `${serverUrl}/arene${i + 1}`,
     poolUrl: `${serverUrl}/arene${i + 1}/poule`,
     publicUrl: `${serverUrl}/arene${i + 1}/public`,
+    overlayUrl: `${serverUrl}/arene${i + 1}/overlay`,
   }));
 
   // Contrôles +/− communs aux deux vues (pending uniquement, sans appel IPC direct)
@@ -976,6 +977,29 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                       setActiveQR({
                         url: arena.publicUrl,
                         label: `Piste ${arena.number} – Public`,
+                      })
+                    }
+                    title="QR code"
+                  >
+                    📱
+                  </button>
+                </div>
+                <div className="arena-url-row">
+                  <span className="arena-url-label" title="À coller dans OBS > Sources > Navigateur">🎥 Overlay</span>
+                  <code className="arena-url-value">{arena.overlayUrl}</code>
+                  <button
+                    className="btn-copy"
+                    onClick={() => copyToClipboard(arena.overlayUrl, arena.number * 10 + 4)}
+                    title="Copier l'URL overlay (OBS Browser Source)"
+                  >
+                    {copiedIndex === arena.number * 10 + 4 ? '✓' : '📋'}
+                  </button>
+                  <button
+                    className="btn-qr"
+                    onClick={() =>
+                      setActiveQR({
+                        url: arena.overlayUrl,
+                        label: `Piste ${arena.number} – Overlay stream`,
                       })
                     }
                     title="QR code"


### PR DESCRIPTION
## Résumé

- Nouvelle page `/arene<N>/overlay` — fond transparent par défaut, utilisable comme **Browser Source OBS** sans chroma key
- Layout 3 colonnes : `[Nom A | Score A]` · `[Timer]` · `[Score B | Nom B]` avec cartons et badge mort subite
- Bouton **🎥 Overlay** (copier URL + QR) ajouté dans le panneau Remote Score Manager pour chaque piste

## Utilisation OBS

1. Démarrer le serveur distant dans BellePoule
2. OBS > Sources > + > **Navigateur**
3. URL : `http://<ip>:8066/arene1/overlay` — Largeur : `1280` — Hauteur : `160`
4. ✔ _Actualiser le navigateur quand la scène devient active_

## Paramètres disponibles

| Paramètre | Valeurs | Défaut |
|-----------|---------|--------|
| `?theme=` | `transparent` · `dark` · `neon` · `light` | `transparent` |
| `?w=` / `?h=` | px | `1280` / `160` |
| `?hide=` | `timer,cards,club,phase` (combinables) | — |

## Fichiers modifiés

- `src/remote/overlay.html` — nouvelle page HTML autonome (Socket.IO read-only)
- `src/main/remoteScoreServer.ts` — routes `/arene<N>/overlay` + chargement en mémoire
- `src/renderer/components/RemoteScoreManager.tsx` — ligne URL overlay par piste

https://claude.ai/code/session_01AURf8HXY1WU4zM2xGK2oTT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AURf8HXY1WU4zM2xGK2oTT)_