### PR TITLE
fix(#478): ajout tireur manuel – modale reste ouverte sans feedback

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1424,9 +1424,11 @@ export class DatabaseManager {
       );
     }
     this.save();
-    return this.getPoolsByPhase(
-      (this.db.exec(`SELECT phase_id FROM pools WHERE id = '${poolId}'`)[0]?.values[0]?.[0] as string)
-    ).find(p => p.id === poolId)!;
+    const phaseId = this.db.exec(`SELECT phase_id FROM pools WHERE id = '${poolId}'`)[0]?.values[0]?.[0] as string | undefined;
+    if (!phaseId) throw new Error(`Pool ${poolId} introuvable après ajout`);
+    const updated = this.getPoolsByPhase(phaseId).find(p => p.id === poolId);
+    if (!updated) throw new Error(`Poule mise à jour introuvable`);
+    return updated;
   }
 
   public getPoolsByPhase(phaseId: string): Pool[] {

--- a/src/renderer/components/AddFencerToPoolModal.tsx
+++ b/src/renderer/components/AddFencerToPoolModal.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { Fencer, Pool } from '../../shared/types';
+import { useToast } from './Toast';
 
 interface AddFencerToPoolModalProps {
   pool: Pool;
@@ -22,6 +23,7 @@ const AddFencerToPoolModalComponent: React.FC<AddFencerToPoolModalProps> = ({
   onConfirm,
   onClose,
 }) => {
+  const { showToast } = useToast();
   const [allFencers, setAllFencers] = useState<Fencer[]>([]);
   const [allPoolFencerIds, setAllPoolFencerIds] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
@@ -70,6 +72,11 @@ const AddFencerToPoolModalComponent: React.FC<AddFencerToPoolModalProps> = ({
         maxScore
       );
       onConfirm(updatedPool);
+    } catch (err) {
+      showToast(
+        "Erreur lors de l'ajout : " + (err instanceof Error ? err.message : 'Erreur inconnue'),
+        'error'
+      );
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
Fixes #478

## Cause
`handleAdd` dans `AddFencerToPoolModal` n'avait pas de `catch`. Si l'appel IPC `addFencerToPoolMidCompetition` levait une exception, `onConfirm` n'était jamais appelé → modale restait ouverte, aucun feedback utilisateur.

## Corrections
- **`AddFencerToPoolModal`** : ajout d'un `catch` qui affiche un toast d'erreur avec le message
- **`database/index.ts`** : `addFencerToPoolMidCompetition` throw explicitement si `phase_id` ou la poule sont introuvables après l'insertion (au lieu de retourner `undefined` via `!`)

---
_Generated by [Claude Code](https://claude.ai/code/session_0157Ue9cxhYr8hD9sqd7CaSk)_