### PR TITLE
fix: dropdown import/export limité hauteur viewport

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -325,6 +325,8 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                   boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
                   minWidth: '230px',
                   padding: '4px 0',
+                  maxHeight: `calc(100vh - ${importMenuPos.top}px - 8px)`,
+                  overflowY: 'auto',
                 }}>
                   <button
                     className="btn btn-ghost"
@@ -393,6 +395,8 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                 boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
                 minWidth: '160px',
                 padding: '4px 0',
+                maxHeight: `calc(100vh - ${exportMenuPos.top}px - 8px)`,
+                overflowY: 'auto',
               }}>
                 <button
                   className="btn btn-ghost"


### PR DESCRIPTION
Ajout de `maxHeight: calc(100vh - top - 8px)` + `overflowY: auto` sur les deux dropdowns (import/export) pour qu'ils ne débordent jamais en bas de l'écran.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tu8sbnXCizmucFgXu9HHyY)_