### PR TITLE
fix: résultats finaux non affichés en mode playAllPositions (tableauSize <= 4)

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -360,7 +360,12 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const mainThirdEntry = matches.find(m => m.round === 3);
     const mainThirdDone = !mainThirdEntry || !!mainThirdEntry.winner;
     if (!mainFinalDone || !mainThirdDone) return;
-    if (consolationBrackets.length === 0) return; // les brackets ne sont pas encore créés
+    // Des brackets de consolation sont attendus quand tableauSize >= 8 (rounds > 4)
+    // ou quand il y a des barrages. Pour tableauSize <= 4, aucun bracket de consolation
+    // n'est créé (les demi-finalistes perdants vont directement à la petite finale).
+    const hasBarrages = matches.some(m => m.round === tableauSize * 2);
+    const needsConsolation = tableauSize >= 8 || hasBarrages;
+    if (needsConsolation && consolationBrackets.length === 0) return; // pas encore créés
     if (consolationBrackets.some(b => !b.isComplete)) return;
     onComplete(buildCombinedResults(matches, consolationBrackets));
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes #480

## Cause

En mode `playAllPositions=true` avec `tableauSize <= 4`, aucun bracket de consolation n'est créé car le code exclut les rounds `<= 4` du calcul des consolations (les demi-finalistes perdants vont directement à la petite finale).

Or le guard `consolationBrackets.length === 0` dans l'effet de complétion interprétait cette absence comme « brackets pas encore créés » et bloquait indéfiniment l'appel à `onComplete` → la phase ne passait jamais à `'results'`.

## Fix

Distinguer « brackets attendus mais pas encore créés » de « aucun bracket nécessaire » :

- `tableauSize >= 8` ou présence de barrages → brackets attendus → on attend
- `tableauSize <= 4` sans barrages → pas de consolation → on peut compléter directement

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3DfjN6ZP6gtFckgS6onWA)_