### PR TITLE
fix: dropdowns import/export invisibles + barre progression couvre menu ⋯

### DIFF
--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -1121,7 +1121,7 @@ select:focus {
   position: relative;
   height: 4px;
   background: rgba(255, 255, 255, 0.15);
-  z-index: 1;
+  z-index: 0;
 }
 
 .comp-header-progress-fill {
@@ -1152,7 +1152,7 @@ select:focus {
 
 @keyframes phase-slide-in {
   from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
+  to   { opacity: 1; transform: none; }
 }
 
 .phase-content {


### PR DESCRIPTION
## Problèmes corrigés

- **Dropdowns Importer/Exporter invisibles** : l'animation `phase-slide-in` utilisait `transform: translateY(0)` dans le keyframe `to`. Avec `animation-fill-mode: both`, ce transform persiste après la fin de l'animation et crée un nouveau stacking context + containing block pour `position: fixed` — les dropdowns étaient positionnés relativement à `.phase-content` et disparaissaient. Fix : `transform: none` dans `to`.

- **Barre de progression couvre le dropdown "⋯"** : `.comp-header-progress` avait `z-index: 1`, même valeur que `.comp-header-content` (parent du dropdown). L'ordre DOM faisait peindre la barre au-dessus du menu. Fix : `z-index: 0` sur la progress bar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMtrRjTHuUHyc5hMr5fdir)_