### PR TITLE
fix: re-déclenchement onComplete au changement d'onglet (playAllPositions)

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -356,6 +356,8 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   // playAllPositions : déclencher onComplete quand le tableau principal ET tous les brackets de consolation sont terminés
   useEffect(() => {
     if (!playAllPositions || !onComplete || matches.length === 0) return;
+    // Ignorer au montage (données déjà complètes restaurées depuis DB)
+    if (matches === mountMatchesRef.current) return;
     const mainFinalDone = !!matches.find(m => m.round === 2)?.winner;
     const mainThirdEntry = matches.find(m => m.round === 3);
     const mainThirdDone = !mainThirdEntry || !!mainThirdEntry.winner;


### PR DESCRIPTION
Régression introduite par #483.

## Cause

L'effet `playAllPositions` n'avait pas le guard `mountMatchesRef` que le safety-net utilise. À chaque remontage de `TableauView` (changement d'onglet), si la finale était déjà scorée et `tableauSize <= 4`, `onComplete` était rappelé → redirection forcée vers les résultats, avec perte apparente des scores saisis.

## Fix

Ajout de `if (matches === mountMatchesRef.current) return;` en tête de l'effet `playAllPositions`, identique au guard du safety-net.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3DfjN6ZP6gtFckgS6onWA)_