### PR TITLE
fix(#478): transaction SQLite atomique – ajout tireur mid-competition

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1407,22 +1407,36 @@ export class DatabaseManager {
     if (existingFencers.some(f => f.id === fencerId)) {
       throw new Error('Fencer already in this pool');
     }
-    const nextPosition = existingFencers.length;
-    this.addFencerToPool(poolId, fencerId, nextPosition);
 
-    const maxNumRow = this.db.exec(
-      `SELECT COALESCE(MAX(number), 0) AS max_num FROM matches WHERE pool_id = '${poolId}'`
-    );
-    let nextMatchNumber: number =
-      (maxNumRow[0]?.values[0]?.[0] as number | null) ?? 0;
-
-    for (const existing of existingFencers) {
-      nextMatchNumber += 1;
-      this.createMatch(
-        { number: nextMatchNumber, fencerA: { id: fencerId } as any, fencerB: { id: existing.id } as any, maxScore },
-        poolId
+    this.db.run('BEGIN');
+    try {
+      const nextPosition = existingFencers.length;
+      this.run(
+        `INSERT OR REPLACE INTO pool_fencers (pool_id, fencer_id, position) VALUES (?, ?, ?)`,
+        [poolId, fencerId, nextPosition]
       );
+
+      const maxNumRow = this.db.exec(
+        `SELECT COALESCE(MAX(number), 0) AS max_num FROM matches WHERE pool_id = '${poolId}'`
+      );
+      let nextMatchNumber: number =
+        (maxNumRow[0]?.values[0]?.[0] as number | null) ?? 0;
+
+      const now = new Date().toISOString();
+      for (const existing of existingFencers) {
+        nextMatchNumber += 1;
+        const matchId = uuidv4();
+        this.run(
+          `INSERT INTO matches (id, number, pool_id, fencer_a_id, fencer_b_id, max_score, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [matchId, nextMatchNumber, poolId, fencerId, existing.id, maxScore, 'not_started', now, now]
+        );
+      }
+      this.db.run('COMMIT');
+    } catch (err) {
+      this.db.run('ROLLBACK');
+      throw err;
     }
+
     this.save();
     const phaseId = this.db.exec(`SELECT phase_id FROM pools WHERE id = '${poolId}'`)[0]?.values[0]?.[0] as string | undefined;
     if (!phaseId) throw new Error(`Pool ${poolId} introuvable après ajout`);


### PR DESCRIPTION
Fixes #478 (suite du commentaire "la compétition se met en erreur complètement")

## Cause racine
Sans transaction, si l'insertion d'un match échouait en cours de boucle, la DB se retrouvait en état partiel : le tireur était dans `pool_fencers` mais seulement N-K matchs créés sur N attendus. Au prochain chargement, la poule affichait un tireur sans tous ses matchs → erreur d'affichage ou crash de rendu.

## Corrections
- **`addFencerToPoolMidCompetition`** : toute l'opération (INSERT pool_fencers + INSERT matches) est enveloppée dans `BEGIN / COMMIT / ROLLBACK`
- Les INSERT de matchs sont maintenant inline (supprime les `save()` intermédiaires inutiles dans la boucle)
- En cas d'erreur, le ROLLBACK garantit un état DB cohérent et le toast affiché (commit précédent) informe l'utilisateur

---
_Generated by [Claude Code](https://claude.ai/code/session_0157Ue9cxhYr8hD9sqd7CaSk)_