### PR TITLE
Fix menus import/export invisibles sur la phase appel

### DIFF
--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -862,11 +862,11 @@ select:focus {
 
 @keyframes phase-enter {
   from { opacity: 0; transform: translateX(8px); }
-  to   { opacity: 1; transform: translateX(0); }
+  to   { opacity: 1; transform: none; }
 }
 
 .content {
-  animation: phase-enter var(--duration-slow) var(--ease-out) both;
+  animation: phase-enter var(--duration-slow) var(--ease-out) backwards;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Problème

Les menus déroulants Import/Export sur la phase d'appel n'apparaissaient pas au clic.

## Cause

L'animation `phase-enter` sur `.content` utilisait `fill-mode: both`, ce qui maintenait `transform: translateX(0)` après la fin de l'animation. En CSS, tout élément avec un `transform` actif crée un nouveau *containing block* pour ses descendants `position: fixed`. Les dropdowns se positionnaient donc par rapport à `.content` (décalé) au lieu du viewport.

## Fix

`src/renderer/styles/design.css` :
- `fill-mode: both` → `fill-mode: backwards` (le state final n'est plus maintenu)
- `to { transform: translateX(0) }` → `to { transform: none }` (pas de transform résiduel)

https://claude.ai/code/session_01UpiNvsvkEfw9VGzqeiAFyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpiNvsvkEfw9VGzqeiAFyZ)_