### PR TITLE
fix(#429): arbitre assigné non persisté et non propagé au serveur distant

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -985,6 +985,13 @@ ipcMain.handle('db:updateMatch', async (_, id, updates) => {
   } else {
     db.updateMatch(id, updates);
   }
+
+  // Propager l'assignation d'arbitre au serveur distant
+  if (updates.refereeId) {
+    for (const { server } of remoteServers.values()) {
+      try { server.assignRefereeToMatch(id, updates.refereeId); } catch { /* non bloquant */ }
+    }
+  }
 });
 
 ipcMain.handle('db:upsertTableauMatch', async (_, params) => {

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3908,4 +3908,33 @@ export class RemoteScoreServer {
       `[RemoteScoreServer] Mot de passe ${password ? 'défini' : 'supprimé'} pour ${fullId}`
     );
   }
+
+  public assignRefereeToMatch(matchId: string, refereeId: string): void {
+    if (!this.session) return;
+
+    // Mettre à jour sessionMatches
+    const idx = this.sessionMatches.findIndex((m: any) => m.id === matchId);
+    if (idx >= 0) {
+      this.sessionMatches[idx] = { ...this.sessionMatches[idx], refereeId };
+    }
+
+    const resolvedRef = this.resolveReferee(refereeId);
+
+    // Mettre à jour les arènes ayant ce match en cours
+    for (const [aId, arena] of this.arenas) {
+      if (arena.currentMatch?.id === matchId) {
+        arena.currentMatch = {
+          ...arena.currentMatch,
+          ...(resolvedRef ? { referee: resolvedRef } : {}),
+        };
+        this.broadcastArenaUpdate(aId, {
+          arenaId: aId,
+          match: arena.currentMatch,
+          scoreA: arena.currentMatch.scoreA,
+          scoreB: arena.currentMatch.scoreB,
+          status: arena.status,
+        });
+      }
+    }
+  }
 }

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1183,7 +1183,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             pools={pools}
             matches={pools.flatMap(p => p.matches ?? [])}
             onRefereesChange={setReferees}
-            onAssignmentsChange={() => {}}
+            onAssignmentsChange={(assignments) => {
+              setPools(prev => prev.map(pool => ({
+                ...pool,
+                matches: (pool.matches ?? []).map(m => {
+                  const ref = assignments.get(m.id);
+                  return ref !== undefined ? { ...m, referee: ref } : m;
+                }),
+              })));
+            }}
           />
         )}
       </div>


### PR DESCRIPTION
Fixes #429

## Causes
1. `onAssignmentsChange` dans `CompetitionView` était un no-op `() => {}` → le state `pools` n'était jamais mis à jour → au retour sur l'onglet arbitres, les assignments disparaissaient
2. Le serveur distant (Socket.IO) n'était pas notifié quand un arbitre était assigné depuis l'appli principale via IPC

## Corrections
- **CompetitionView.tsx** : `onAssignmentsChange` met à jour le state `pools` en patchant chaque match avec son arbitre → survit aux changements d'onglet
- **remoteScoreServer.ts** : nouvelle méthode publique `assignRefereeToMatch()` qui met à jour `sessionMatches` et broadcast l'arène concernée via Socket.IO
- **main.ts** : le handler `db:updateMatch` notifie tous les serveurs distants actifs quand `refereeId` est présent dans les updates

---
_Generated by [Claude Code](https://claude.ai/code/session_016HyrYFt8dMxnCs9Qm2G5vE)_