### PR TITLE
fix(overlay): 5 correctifs suite retours terrain

### DIFF
--- a/src/remote/overlay-config.html
+++ b/src/remote/overlay-config.html
@@ -187,8 +187,7 @@
         linear-gradient(-45deg, transparent 75%, #555 75%);
       background-size: 16px 16px;
       background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
-      width: 100%;
-      max-width: 900px;
+      /* La taille est gérée en JS via style.width/height — pas de max-width CSS */
     }
     .checkerboard.opaque-bg {
       background-image: none;
@@ -323,10 +322,10 @@
       <div class="section-body">
         <div class="chips">
           <label class="chip active" id="chip-scores-inner" onclick="setScorePos('inner')">
-            <span>◀ Score ▶ côté centre</span>
+            <span>[Nom·Score] ⬛ [Score·Nom] — côté extérieur</span>
           </label>
           <label class="chip" id="chip-scores-outer" onclick="setScorePos('outer')">
-            <span>◀ Score ▶ côté extérieur</span>
+            <span>[Score·Nom] ⬛ [Nom·Score] — côté centre</span>
           </label>
         </div>
       </div>
@@ -481,8 +480,8 @@
     const url    = buildUrl();
     document.getElementById('generated-url').textContent = url;
 
-    const wrapper  = document.querySelector('.preview-wrapper');
-    const maxW     = wrapper.clientWidth - 4;
+    const area     = document.querySelector('.preview-area');
+    const maxW     = (area ? area.clientWidth : wrapper.clientWidth) - 48;
     const scale    = Math.min(1, maxW / state.width);
     const iframe   = document.getElementById('preview');
     const checker  = document.getElementById('checker');

--- a/src/remote/overlay.html
+++ b/src/remote/overlay.html
@@ -70,7 +70,7 @@
         --sd-color: #ff6b35;
         --phase-color: rgba(255,255,255,0.55);
         --name-shadow: 0 2px 6px rgba(0,0,0,0.8);
-        --panel-bg: rgba(0,0,0,0.55);
+        --panel-bg: rgba(0,0,0,0.60);
         --panel-border-radius: 12px;
       }
       [data-theme="dark"] {
@@ -225,11 +225,11 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: clamp(14px, 1.5vw, 20px);
-        height: clamp(18px, 2vw, 26px);
+        width: clamp(10px, min(1.5vw, 3vh), 18px);
+        height: clamp(13px, min(2vw, 4vh), 22px);
         border-radius: 3px;
         font-weight: 700;
-        font-size: clamp(0.5rem, 0.8vw, 0.7rem);
+        font-size: clamp(0.4rem, min(0.8vw, 1.5vh), 0.65rem);
         line-height: 1;
       }
       .card-badge.white  { background: var(--card-white-bg);  color: var(--card-white-fg);  }
@@ -420,6 +420,10 @@
         let matchStatus   = 'idle';
         let phaseLabel    = 'Piste ' + arenaNumber;
 
+        const holdResultSec = parseInt(params.get('holdresult') || '5', 10);
+        let pendingMatchData = null;
+        let pendingMatchTimer = null;
+
         /* ── DOM ── */
         const elScoreA  = document.getElementById('score-a');
         const elScoreB  = document.getElementById('score-b');
@@ -462,7 +466,7 @@
           elIdle.classList.toggle('hidden', active);
         }
 
-        function applyUpdate(data) {
+        function applyMatchData(data) {
           if (data.status)          { matchStatus = data.status; renderVisibility(); }
           if (data.match) {
             const fA = data.match.fencerA || {};
@@ -489,6 +493,21 @@
             isSuddenDeath = !!(data.suddenDeath || data.overtimeType);
             elSDBadge.classList.toggle('visible', isSuddenDeath);
           }
+        }
+
+        function applyUpdate(data) {
+          /* Gel du résultat : si on reçoit un nouveau match alors que le précédent vient de se
+             terminer, on attend holdResultSec avant d'afficher les nouvelles infos. */
+          const isNewMatch = data.match && matchStatus === 'finished';
+          if (isNewMatch && holdResultSec > 0) {
+            clearTimeout(pendingMatchTimer);
+            pendingMatchData = data;
+            pendingMatchTimer = setTimeout(() => {
+              if (pendingMatchData) { applyMatchData(pendingMatchData); pendingMatchData = null; }
+            }, holdResultSec * 1000);
+            return;
+          }
+          applyMatchData(data);
         }
 
         /* ── Initialisation depuis l'API REST ── */


### PR DESCRIPTION
## Correctifs overlay streaming

- **Opacité fond transparent** : 0.55 → 0.60 pour meilleure lisibilité
- **Cartons à 80px** : taille via `clamp(vw, vh)` — proportionnels à la hauteur, OK à 1920×80 et 1920×160
- **Gel du résultat** : après validation match, l'overlay garde l'affichage N secondes avant de basculer sur le suivant (`?holdresult=N`, défaut 5s)
- **Prévisualisation 1920px** : calcul de `maxW` depuis `.preview-area` + suppression du `max-width: 900px` CSS qui bloquait le scaling
- **Labels chips score** : schéma ASCII `[Nom·Score] ⬛ [Score·Nom]` pour lever l'ambiguïté centre/extérieur

https://claude.ai/code/session_01EQL8ps1dKUDaR2igZefXVn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQL8ps1dKUDaR2igZefXVn)_