### PR TITLE
fix(#430): attribution matchs tableau sur arènes

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1244,14 +1244,18 @@ export class RemoteScoreServer {
             status: MatchStatus.FINISHED,
           });
           // Mettre à jour le score en mémoire de l'arène pour que le broadcast
-          // finishArenaMatch envoie le vrai score (pas 0-0) à l'affichage
-          for (const [, arena] of this.arenas) {
+          // finishArenaMatch envoie le vrai score (pas 0-0) à l'affichage, puis
+          // libérer l'arène exactement comme le fait la console arbitre.
+          let arenaToFinish: string | null = null;
+          for (const [arenaId, arena] of this.arenas) {
             if (arena.currentMatch && arena.currentMatch.id === matchId) {
               arena.currentMatch.scoreA = scoreA;
               arena.currentMatch.scoreB = scoreB;
+              arenaToFinish = arenaId;
               break;
             }
           }
+          if (arenaToFinish) this.finishArenaMatch(arenaToFinish);
         } else {
           // Match en mémoire uniquement (poule non persistée)
           // Synchroniser les scores dans l'arène et déclencher l'IPC vers le renderer
@@ -2460,10 +2464,13 @@ export class RemoteScoreServer {
     if (!matchToMove) {
       const sm = this.sessionMatches.find((m: any) => m.id === matchId);
       if (sm) {
+        // Mettre à jour les données de tireurs si le renderer fournit des données plus récentes
+        if (fencerA) sm.fencerA = fencerA;
+        if (fencerB) sm.fencerB = fencerB;
         matchToMove = {
           id: sm.id,
-          fencerA: sm.fencerA,
-          fencerB: sm.fencerB,
+          fencerA: fencerA ?? sm.fencerA,
+          fencerB: fencerB ?? sm.fencerB,
           scoreA: 0,
           scoreB: 0,
           status: 'not_started',
@@ -3810,7 +3817,14 @@ export class RemoteScoreServer {
     for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
 
     for (const match of pending) {
-      const preferred = match.arena ? `arena${match.arena}` : `arena${(rrIndex % strips) + 1}`;
+      // Ne distribuer automatiquement que les matchs explicitement assignés à une piste.
+      // Les matchs sans piste restent dans sessionMatches mais ne sont pas auto-assignés
+      // (le DT les assignera manuellement depuis l'interface tableau).
+      if (!match.arena) {
+        rrIndex++;
+        continue;
+      }
+      const preferred = `arena${match.arena}`;
       const targetId = this.arenas.has(preferred) ? preferred : `arena${(rrIndex % strips) + 1}`;
       queuesByArena.get(targetId)!.push({
         id: match.id,

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -259,6 +259,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     return () => { cancelled = true; };
   }, [isLoaded, pools.length, competition.id]);
 
+  // Rétablir isRemoteActive si une session est déjà en cours (ex: rechargement après phase poules)
+  useEffect(() => {
+    window.electronAPI.remote.getSession(competition.id)
+      .then((result: any) => {
+        if (result?.success && result?.session) setIsRemoteActive(true);
+      })
+      .catch(() => {});
+  }, [competition.id]);
+
   // Charger les tireurs au montage
   useEffect(() => {
     loadFencers();
@@ -1135,7 +1144,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               setFinalResults(results);
               setCurrentPhase('results');
             }}
-            onMatchArenaChange={(matchId, oldArena, newArena) => {
+            onMatchArenaChange={(matchId, oldArena, newArena, fencerAParam, fencerBParam) => {
               if (isRemoteActive) {
                 const match = tableauMatches.find(m => m.id === matchId);
                 window.electronAPI.remote.updateMatchArena(
@@ -1143,8 +1152,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                   matchId,
                   oldArena,
                   newArena,
-                  match?.fencerA ?? null,
-                  match?.fencerB ?? null
+                  fencerAParam ?? match?.fencerA ?? null,
+                  fencerBParam ?? match?.fencerB ?? null
                 );
               }
             }}
@@ -1164,6 +1173,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             competition={competition}
             pools={pools}
             tableauMatches={tableauMatches}
+            consolationBrackets={consolationBrackets}
             initialStripCount={remoteArenaCount}
             onArenaCountChange={setRemoteArenaCount}
             onStartRemote={() => setIsRemoteActive(true)}

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import QRCode from 'qrcode';
 import { Competition, Pool } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
-import { TableauMatch } from './TableauView';
+import { TableauMatch, ConsolationBracket } from './TableauView';
 import { useToast } from './Toast';
 import ThemeEditor from './ThemeEditor';
 import { CustomTheme, DisplayTheme } from '../../shared/types/remote';
@@ -17,6 +17,7 @@ interface RemoteScoreManagerProps {
   competition: Competition;
   pools: Pool[];
   tableauMatches?: TableauMatch[];
+  consolationBrackets?: ConsolationBracket[];
   onArenaCountChange?: (count: number) => void;
   onStartRemote: () => void;
   onStopRemote: () => void;
@@ -92,6 +93,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   competition,
   pools,
   tableauMatches,
+  consolationBrackets,
   onArenaCountChange,
   onStartRemote,
   onStopRemote,
@@ -225,11 +227,13 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   // sans avoir à arrêter/relancer la saisie distante (transition poules → tableau).
   const prevDeMatchesKeyRef = useRef<string>('');
   const pendingDeMatches = useMemo(
-    () =>
-      (tableauMatches || [])
-        .filter(m => m.winner === null && m.fencerA && m.fencerB)
-        .map(m => ({ ...m, isTableau: true })),
-    [tableauMatches]
+    () => [
+      ...(tableauMatches || []),
+      ...(consolationBrackets || []).flatMap(b => b.matches || []),
+    ]
+      .filter(m => m.winner === null && m.fencerA && m.fencerB)
+      .map(m => ({ ...m, isTableau: true })),
+    [tableauMatches, consolationBrackets]
   );
   useEffect(() => {
     const key = pendingDeMatches.map(m => m.id).join(',');
@@ -299,7 +303,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         },
         ...(pool.matches || []),
       ]);
-      const deMatches = (tableauMatches || [])
+      const deMatches = [
+        ...(tableauMatches || []),
+        ...(consolationBrackets || []).flatMap(b => b.matches || []),
+      ]
         .filter(m => m.winner === null && m.fencerA && m.fencerB)
         .map(m => ({ ...m, isTableau: true }));
       const allMatches = [...poolMatches, ...deMatches];

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -71,7 +71,7 @@ interface TableauViewProps {
   thirdPlaceMatch?: boolean;
   playAllPositions?: boolean;
   arenaCount?: number;
-  onMatchArenaChange?: (matchId: string, oldArena: number | null, newArena: number | null) => void;
+  onMatchArenaChange?: (matchId: string, oldArena: number | null, newArena: number | null, fencerA?: any, fencerB?: any) => void;
   consolationBrackets?: ConsolationBracket[];
   onConsolationBracketsChange?: (brackets: ConsolationBracket[]) => void;
 }
@@ -233,6 +233,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const [expandedRounds, setExpandedRounds] = useState<Set<number>>(new Set());
   const [showArenaModal, setShowArenaModal] = useState(false);
   const [selectedMatchForArena, setSelectedMatchForArena] = useState<string | null>(null);
+  const [selectedMatchConsolationBracketId, setSelectedMatchConsolationBracketId] = useState<string | null>(null);
   const [pyramidViewMode, setPyramidViewMode] = useState<boolean>(false);
   const [showPdfModal, setShowPdfModal] = useState(false);
   const [pdfMode, setPdfMode] = useState<'print' | 'pdf'>('pdf');
@@ -1628,7 +1629,11 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                                 viewMode="full"
                                 baseMatchHeight={BASE_MATCH_HEIGHT}
                                 onMatchClick={m => openScoreModal(m, bracket.id)}
-                                onArenaClick={() => {}}
+                                onArenaClick={arenaCount > 0 && match.winner === null ? m => {
+                                  setSelectedMatchForArena(m.id);
+                                  setSelectedMatchConsolationBracketId(bracket.id);
+                                  setShowArenaModal(true);
+                                } : undefined}
                               />
                             ))}
                           </div>
@@ -1730,70 +1735,90 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         </div>
       )}
 
-      {showArenaModal && selectedMatchForArena && (
-        <div className="modal-overlay" onClick={() => setShowArenaModal(false)}>
-          <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '400px' }}>
-            <div className="modal-header">
-              <h3 className="modal-title">Assigner à une piste</h3>
-              <button className="btn-close" onClick={() => setShowArenaModal(false)}>
-                &times;
-              </button>
-            </div>
-            <div className="modal-body" style={TV_STYLES.arenaModalBody}>
-              <p style={TV_STYLES.arenaModalHint}>Sélectionnez la piste pour ce match :</p>
-              <div style={TV_STYLES.arenaModalGrid}>
-                <button
-                  className={`btn ${!matches.find(m => m.id === selectedMatchForArena)?.arena ? 'btn-primary' : 'btn-secondary'}`}
-                  onClick={() => {
-                    const oldArena =
-                      matches.find(m => m.id === selectedMatchForArena)?.arena ?? null;
-                    const updatedMatches = matches.map(m =>
-                      m.id === selectedMatchForArena ? { ...m, arena: null } : m
-                    );
-                    onMatchesChange(updatedMatches);
-                    onMatchArenaChange?.(selectedMatchForArena!, oldArena, null);
-                    setShowArenaModal(false);
-                    setSelectedMatchForArena(null);
-                  }}
-                  style={TV_STYLES.arenaModalNoArenaBtn}
-                >
-                  -
+      {showArenaModal && selectedMatchForArena && (() => {
+        const isConsolation = !!selectedMatchConsolationBracketId;
+        const consolationBracket = isConsolation
+          ? consolationBrackets.find(b => b.id === selectedMatchConsolationBracketId)
+          : null;
+        const currentArena = isConsolation
+          ? (consolationBracket?.matches.find(m => m.id === selectedMatchForArena)?.arena ?? null)
+          : (matches.find(m => m.id === selectedMatchForArena)?.arena ?? null);
+
+        const closeModal = () => {
+          setShowArenaModal(false);
+          setSelectedMatchForArena(null);
+          setSelectedMatchConsolationBracketId(null);
+        };
+
+        const assignArena = (arenaNum: number | null) => {
+          const oldArena = currentArena;
+          if (isConsolation && consolationBracket) {
+            const updatedBracket = {
+              ...consolationBracket,
+              matches: consolationBracket.matches.map(m =>
+                m.id === selectedMatchForArena ? { ...m, arena: arenaNum } : m
+              ),
+            };
+            setConsolationBrackets(prev =>
+              prev.map(b => b.id === consolationBracket.id ? updatedBracket : b)
+            );
+            const consolMatch = consolationBracket.matches.find(m => m.id === selectedMatchForArena);
+            onMatchArenaChange?.(selectedMatchForArena!, oldArena, arenaNum, consolMatch?.fencerA ?? null, consolMatch?.fencerB ?? null);
+          } else {
+            const updatedMatches = matches.map(m =>
+              m.id === selectedMatchForArena ? { ...m, arena: arenaNum } : m
+            );
+            onMatchesChange(updatedMatches);
+            onMatchArenaChange?.(selectedMatchForArena!, oldArena, arenaNum);
+          }
+          closeModal();
+        };
+
+        return (
+          <div className="modal-overlay" onClick={closeModal}>
+            <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '400px' }}>
+              <div className="modal-header">
+                <h3 className="modal-title">Assigner à une piste</h3>
+                <button className="btn-close" onClick={closeModal}>
+                  &times;
                 </button>
-                {Array.from({ length: arenaCount }, (_, i) => i + 1).map(arenaNum => {
-                  const queueCount = matches.filter(
-                    m => m.arena === arenaNum && m.id !== selectedMatchForArena && m.winner === null
-                  ).length;
-                  return (
-                    <button
-                      key={arenaNum}
-                      className={`btn ${matches.find(m => m.id === selectedMatchForArena)?.arena === arenaNum ? 'btn-primary' : 'btn-secondary'}`}
-                      onClick={() => {
-                        const oldArena =
-                          matches.find(m => m.id === selectedMatchForArena)?.arena ?? null;
-                        const updatedMatches = matches.map(m =>
-                          m.id === selectedMatchForArena ? { ...m, arena: arenaNum } : m
-                        );
-                        onMatchesChange(updatedMatches);
-                        onMatchArenaChange?.(selectedMatchForArena!, oldArena, arenaNum);
-                        setShowArenaModal(false);
-                        setSelectedMatchForArena(null);
-                      }}
-                      style={{ padding: '0.75rem', position: 'relative' }}
-                    >
-                      Piste {arenaNum}
-                      {queueCount > 0 && (
-                        <span style={TV_STYLES.arenaQueueHint}>
-                          (+{queueCount})
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
+              </div>
+              <div className="modal-body" style={TV_STYLES.arenaModalBody}>
+                <p style={TV_STYLES.arenaModalHint}>Sélectionnez la piste pour ce match :</p>
+                <div style={TV_STYLES.arenaModalGrid}>
+                  <button
+                    className={`btn ${!currentArena ? 'btn-primary' : 'btn-secondary'}`}
+                    onClick={() => assignArena(null)}
+                    style={TV_STYLES.arenaModalNoArenaBtn}
+                  >
+                    -
+                  </button>
+                  {Array.from({ length: arenaCount }, (_, i) => i + 1).map(arenaNum => {
+                    const queueCount = matches.filter(
+                      m => m.arena === arenaNum && m.id !== selectedMatchForArena && m.winner === null
+                    ).length;
+                    return (
+                      <button
+                        key={arenaNum}
+                        className={`btn ${currentArena === arenaNum ? 'btn-primary' : 'btn-secondary'}`}
+                        onClick={() => assignArena(arenaNum)}
+                        style={{ padding: '0.75rem', position: 'relative' }}
+                      >
+                        Piste {arenaNum}
+                        {queueCount > 0 && (
+                          <span style={TV_STYLES.arenaQueueHint}>
+                            (+{queueCount})
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
     </div>
   );
 };


### PR DESCRIPTION
$(cat <<'EOF'
Fixes #430

## Corrections

- **Score DT libère l'arène** : `finishArenaMatch()` est maintenant appelé pour les matchs persistés en DB (pas seulement en mémoire) → l'arène passe en `finished` et charge automatiquement le match suivant. Avant ça, le score pouvait être « rejoué » depuis la console arbitre car la piste restait bloquée.

- **Noms de participants corrects** : `updateMatchArena()` préfère les données `fencerA/fencerB` transmises par le renderer plutôt que les données périmées dans `sessionMatches`. Les noms dans le kiosk/arène sont maintenant à jour.

- **Plus d'auto-assignation** : `refreshDeMatches()` ne distribue plus les matchs en round-robin automatique. Seuls les matchs avec une piste **explicitement choisie** par le DT sont mis en file. Les nouveaux matchs n'apparaissent plus sur une piste sans action du DT.

- **`isRemoteActive` restauré au démarrage** : `CompetitionView` vérifie au montage si une session est déjà active côté serveur. Résultat : `onMatchArenaChange` fonctionne dès l'onglet tableau sans avoir à repasser par l'onglet remote au préalable (corrige la dépendance au « premier score »).

- **Sous-tableaux (consolation)** : les brackets de consolation sont inclus dans `pendingDeMatches` / `startSession` et disposent d'un bouton d'assignation de piste dans `TableauView`.

## Fichiers modifiés

| Fichier | Changement |
|---|---|
| `src/main/remoteScoreServer.ts` | finishArenaMatch pour DB, fencerA/B frais, pas de round-robin |
| `src/renderer/components/CompetitionView.tsx` | init isRemoteActive, consolationBrackets → RemoteScoreManager, fencerA/B depuis callback |
| `src/renderer/components/RemoteScoreManager.tsx` | prop consolationBrackets, inclus dans deMatches |
| `src/renderer/components/TableauView.tsx` | signature étendue onMatchArenaChange, bouton piste sur matchs consolation |
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYmCLw2ET882vEkh1smTJK)_