### PR TITLE
fix: corriger type onArenaClick consolation (TS2322/TS2339)

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -1629,11 +1629,11 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                                 viewMode="full"
                                 baseMatchHeight={BASE_MATCH_HEIGHT}
                                 onMatchClick={m => openScoreModal(m, bracket.id)}
-                                onArenaClick={arenaCount > 0 && match.winner === null ? m => {
-                                  setSelectedMatchForArena(m.id);
+                                onArenaClick={arenaCount > 0 && match.winner === null ? () => {
+                                  setSelectedMatchForArena(match.id);
                                   setSelectedMatchConsolationBracketId(bracket.id);
                                   setShowArenaModal(true);
-                                } : undefined}
+                                } : () => {}}
                               />
                             ))}
                           </div>


### PR DESCRIPTION
Correction du build CI cassé après merge de #495.

`onArenaClick` dans `MatchCard` est typé `(matchId: string) => void` (non optionnel). Le code des brackets de consolation passait `undefined` (TS2322) et utilisait le `TableauMatch` comme paramètre au lieu de l'ignorer (TS2339).

Fix : remplace `undefined` par `() => {}` et ignore le paramètre dans le handler consolation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYmCLw2ET882vEkh1smTJK)_