### PR TITLE
fix: dropdown position + CSP fonts + boucle infinie useEffect

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -58,10 +58,8 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const [editingFencer, setEditingFencer] = useState<Fencer | null>(null);
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
-  const [exportMenuPos, setExportMenuPos] = useState({ top: 0, right: 0 });
   const [importMenuOpen, setImportMenuOpen] = useState(false);
   const importMenuRef = useRef<HTMLDivElement>(null);
-  const [importMenuPos, setImportMenuPos] = useState({ top: 0, left: 0 });
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -304,20 +302,17 @@ const FencerListComponent: React.FC<FencerListProps> = ({
             <div ref={importMenuRef} style={{ position: 'relative', display: 'inline-block' }}>
               <button
                 className="btn btn-secondary"
-                onClick={() => {
-                  const rect = importMenuRef.current?.getBoundingClientRect();
-                  if (rect) setImportMenuPos({ top: rect.bottom + 4, left: rect.left });
-                  setImportMenuOpen(o => !o);
-                }}
+                onClick={() => setImportMenuOpen(o => !o)}
                 title="Importer"
               >
                 📥 Importer ▾
               </button>
               {importMenuOpen && (
                 <div style={{
-                  position: 'fixed',
-                  top: importMenuPos.top,
-                  left: importMenuPos.left,
+                  position: 'absolute',
+                  top: '100%',
+                  left: 0,
+                  marginTop: '4px',
                   zIndex: 9999,
                   background: 'var(--bg-secondary, #2a2a3e)',
                   border: '1px solid var(--border-color, #444)',
@@ -325,7 +320,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                   boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
                   minWidth: '230px',
                   padding: '4px 0',
-                  maxHeight: `calc(100vh - ${importMenuPos.top}px - 8px)`,
+                  maxHeight: '60vh',
                   overflowY: 'auto',
                 }}>
                   <button
@@ -374,20 +369,17 @@ const FencerListComponent: React.FC<FencerListProps> = ({
           <div ref={exportMenuRef} style={{ position: 'relative', display: 'inline-block' }}>
             <button
               className="btn btn-secondary"
-              onClick={() => {
-                const rect = exportMenuRef.current?.getBoundingClientRect();
-                if (rect) setExportMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
-                setExportMenuOpen(o => !o);
-              }}
+              onClick={() => setExportMenuOpen(o => !o)}
               title="Exporter"
             >
               📤 Exporter ▾
             </button>
             {exportMenuOpen && (
               <div style={{
-                position: 'fixed',
-                top: exportMenuPos.top,
-                right: exportMenuPos.right,
+                position: 'absolute',
+                top: '100%',
+                right: 0,
+                marginTop: '4px',
                 zIndex: 9999,
                 background: 'var(--bg-secondary, #2a2a3e)',
                 border: '1px solid var(--border-color, #444)',
@@ -395,7 +387,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                 boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
                 minWidth: '160px',
                 padding: '4px 0',
-                maxHeight: `calc(100vh - ${exportMenuPos.top}px - 8px)`,
+                maxHeight: '60vh',
                 overflowY: 'auto',
               }}>
                 <button

--- a/src/renderer/hooks/useFencerManagement.ts
+++ b/src/renderer/hooks/useFencerManagement.ts
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Competition, Fencer, FencerStatus } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { useToast } from '../components/Toast';
@@ -18,6 +18,10 @@ interface UseFencerManagementProps {
 export const useFencerManagement = ({ competition, onUpdate }: UseFencerManagementProps) => {
   const { showToast } = useToast();
   const [fencers, setFencers] = useState<Fencer[]>(competition.fencers || []);
+  const competitionRef = useRef(competition);
+  const onUpdateRef = useRef(onUpdate);
+  competitionRef.current = competition;
+  onUpdateRef.current = onUpdate;
 
   // Synchroniser avec la compétition parente
   useEffect(() => {
@@ -29,14 +33,15 @@ export const useFencerManagement = ({ competition, onUpdate }: UseFencerManageme
     if (!window.electronAPI?.db?.getFencersByCompetition) return;
 
     try {
-      const data = await window.electronAPI.db.getFencersByCompetition(competition.id);
+      const comp = competitionRef.current;
+      const data = await window.electronAPI.db.getFencersByCompetition(comp.id);
       setFencers(data);
-      onUpdate({ ...competition, fencers: data });
+      onUpdateRef.current({ ...comp, fencers: data });
     } catch (error) {
       logger.error(LogCategory.UI, 'Failed to load fencers', error as Error);
       showToast('Erreur lors du chargement des tireurs', 'error');
     }
-  }, [competition, onUpdate, showToast]);
+  }, [showToast]);
 
   // Ajouter un tireur
   const addFencer = useCallback(

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>BellePoule Modern</title>
 </head>
 <body>


### PR DESCRIPTION
## Corrections

- **Dropdown import/export** : `position: fixed` → `position: absolute` dans le container `relative`. Plus de calcul `getBoundingClientRect`, menu s'ouvre juste sous le bouton.
- **CSP fonts** : `https://fonts.googleapis.com` + `https://fonts.gstatic.com` ajoutés au meta CSP de `index.html`.
- **Boucle infinie** : `loadFencers` avait `competition` (objet entier) dans ses deps de `useCallback`. À chaque appel `onUpdate({ ...competition, fencers: data })`, un nouvel objet était créé → `competition` changeait → `loadFencers` changeait → useEffect se redéclenchait. Fix : refs stables pour `competition` et `onUpdate`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hvs8b5FbQVc4QbAJAe9w3A)_