### PR TITLE
fix: dropdown Importer/Exporter clipé par la card recherche

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -259,7 +259,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
 
   return (
     <div className="content">
-      <div className="flex justify-between items-center mb-4">
+      <div className="flex justify-between items-center mb-4" style={{ position: 'relative', zIndex: 2 }}>
         <div>
           <h2 style={{ fontSize: '1.25rem', fontWeight: '600' }}>{t('fencer.add')}</h2>
           <p className="text-sm text-muted">


### PR DESCRIPTION
## Fix\nAjout de `position: relative; zIndex: 2` sur le div header de `FencerList.tsx` pour créer un contexte d'empilement qui gagne sur la `.card` de la barre de recherche (sibling DOM suivant). Le dropdown avait déjà `zIndex: 9999` mais son ancêtre ne dominait pas la card adjacente.

---
_Generated by [Claude Code](https://claude.ai/code/session_0145Kxsjgx9iXhtHMqyeeArj)_