### PR TITLE
Fix: nettoyer la config remote scoring à la fermeture d'une compétition

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -227,6 +227,9 @@ const AppContent: React.FC = () => {
       }
     }
 
+    localStorage.removeItem(`bellepoule-remote-launched-${competitionId}`);
+    localStorage.removeItem(`bellepoule-remote-port-${competitionId}`);
+
     const newOpenCompetitions = openCompetitions.filter(
       open => open.competition.id !== competitionId
     );
@@ -249,6 +252,8 @@ const AppContent: React.FC = () => {
     try {
       if (window.electronAPI) {
         await window.electronAPI.db.deleteCompetition(id);
+        localStorage.removeItem(`bellepoule-remote-launched-${id}`);
+        localStorage.removeItem(`bellepoule-remote-port-${id}`);
         setCompetitions(prev => prev.filter(c => c.id !== id));
 
         // Supprimer l'onglet ouvert pour cette compétition (évite le tab fantôme)


### PR DESCRIPTION
## Problème\nÀ la fermeture d'une compétition, les clés `localStorage` de la configuration de saisie distante (`bellepoule-remote-launched-{id}` et `bellepoule-remote-port-{id}`) n'étaient pas supprimées. Lors d'une réouverture, le composant `RemoteScoreManager` restaurait l'état « serveur lancé » depuis le localStorage, même si la compétition avait été fermée.\n\n## Fix\n- `handleTabClose` : supprime les 2 clés localStorage à la fermeture d'un onglet\n- `handleDeleteCompetition` : idem à la suppression

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pea3NhrnqioBFuBoWzhFWN)_