### PR TITLE
feat: auto-inscription tireur via tablette (saisie distante)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1862,6 +1862,17 @@ ipcMain.handle('remote:changePort', async (_, competitionId: string, newPort: nu
   }
 });
 
+ipcMain.handle('remote:setRegistrationEnabled', async (_, competitionId: string, enabled: boolean) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: false, error: 'Serveur non démarré' };
+    entry.server.setRegistrationEnabled(enabled);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle('app:getLogo', async () => {
   const logoPath = path.join(app.getPath('userData'), 'logo.dat');
   try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -493,6 +493,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:acknowledgeDTCall', competitionId, arenaId),
     resetPoolMatch: (competitionId: string, matchId: string) =>
       ipcRenderer.invoke('remote:resetPoolMatch', competitionId, matchId),
+    setRegistrationEnabled: (competitionId: string, enabled: boolean) =>
+      ipcRenderer.invoke('remote:setRegistrationEnabled', competitionId, enabled),
   },
 
   // Remote event listeners (for real-time updates)

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -65,6 +65,9 @@ export class RemoteScoreServer {
     suivants: true,
   };
 
+  // Inscription distante : actif pendant la phase CHECKIN, désactivé après génération des poules
+  private registrationEnabled: boolean = true;
+
   // Stocker le contenu des fichiers HTML en mémoire pour éviter les problèmes de chemin
   private htmlFiles: Map<string, string> = new Map();
 
@@ -144,6 +147,7 @@ export class RemoteScoreServer {
       'public.html',
       'overlay.html',
       'overlay-config.html',
+      'register.html',
     ];
 
     // Essayer plusieurs chemins pour trouver les fichiers
@@ -714,6 +718,84 @@ export class RemoteScoreServer {
     // Page de connexion pour les pages protégées par mot de passe
     this.app.get('/login', (_req, res) => {
       this.sendHtmlFromMemory('login.html', res);
+    });
+
+    // ── Auto-inscription tireur (phase CHECKIN) ────────────────────────────
+    this.app.get('/register', (_req, res) => {
+      this.sendHtmlFromMemory('register.html', res);
+    });
+
+    this.app.get('/inscription', (_req, res) => {
+      this.sendHtmlFromMemory('register.html', res);
+    });
+
+    this.app.get('/api/register/status', (_req, res) => {
+      res.json({ open: this.registrationEnabled });
+    });
+
+    this.app.post('/api/register', (req, res) => {
+      if (!this.registrationEnabled) {
+        return res.status(403).json({ registrationClosed: true, error: 'Inscription fermée' });
+      }
+
+      const ip =
+        (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
+        req.socket.remoteAddress ||
+        'unknown';
+
+      // Rate limit : 5 inscriptions par IP par minute
+      if (!this.checkRegistrationRateLimit(ip)) {
+        return res.status(429).json({ error: 'Trop de demandes. Réessayez dans 1 minute.' });
+      }
+
+      const { lastName, firstName, gender, club, license, nationality, birthDate, photo } =
+        req.body as Record<string, string | null | undefined>;
+
+      if (!lastName || typeof lastName !== 'string' || lastName.trim() === '') {
+        return res.status(400).json({ error: 'Nom obligatoire' });
+      }
+      if (!firstName || typeof firstName !== 'string' || firstName.trim() === '') {
+        return res.status(400).json({ error: 'Prénom obligatoire' });
+      }
+      if (!gender || !['M', 'F', 'X'].includes(gender)) {
+        return res.status(400).json({ error: 'Genre invalide' });
+      }
+
+      const competitionId = this.session?.competitionId;
+      if (!competitionId) {
+        return res.status(503).json({ error: 'Aucune compétition active' });
+      }
+
+      // Valider la taille de la photo (base64, max ~500 KB → ~667 KB en base64)
+      if (photo && typeof photo === 'string' && photo.length > 700_000) {
+        return res.status(400).json({ error: 'Photo trop volumineuse (max 500 KB)' });
+      }
+
+      try {
+        const strip = (s: string | null | undefined, max = 100) =>
+          s ? s.replace(/<[^>]*>/g, '').trim().substring(0, max) : undefined;
+
+        const fencerData = {
+          lastName: strip(lastName, 100)!.toUpperCase(),
+          firstName: strip(firstName, 100)!,
+          gender,
+          club: strip(club) || undefined,
+          license: strip(license, 50) || undefined,
+          nationality: strip(nationality, 3) || 'FRA',
+          birthDate: birthDate ? new Date(birthDate) : undefined,
+          photo: photo && typeof photo === 'string' && photo.startsWith('data:image/')
+            ? photo
+            : undefined,
+          status: 'N', // NOT_CHECKED_IN
+        };
+
+        const newFencer = this.db.addFencer(competitionId, fencerData as any);
+        console.log(`[RemoteScoreServer] Inscription tireur: ${fencerData.lastName} ${fencerData.firstName} (id=${newFencer.id})`);
+        res.json({ success: true, fencerRef: newFencer.ref, fencerId: newFencer.id });
+      } catch (err) {
+        console.error('[RemoteScoreServer] Erreur inscription tireur:', err);
+        res.status(500).json({ error: 'Erreur lors de l\'inscription' });
+      }
     });
 
     // API: authentification par mot de passe pour une arène
@@ -3139,6 +3221,25 @@ export class RemoteScoreServer {
     } catch (err) {
       console.error(`[RemoteScoreServer] Erreur persistance arène ${arenaId}:`, err);
     }
+  }
+
+  public setRegistrationEnabled(enabled: boolean): void {
+    this.registrationEnabled = enabled;
+    console.log(`[RemoteScoreServer] Inscription distante ${enabled ? 'activée' : 'désactivée'}`);
+  }
+
+  private registrationRateLimiter: Map<string, { count: number; resetAt: number }> = new Map();
+
+  private checkRegistrationRateLimit(ip: string): boolean {
+    const now = Date.now();
+    const entry = this.registrationRateLimiter.get(ip);
+    if (!entry || now > entry.resetAt) {
+      this.registrationRateLimiter.set(ip, { count: 1, resetAt: now + 60_000 });
+      return true;
+    }
+    if (entry.count >= 5) return false;
+    entry.count++;
+    return true;
   }
 
   private checkScoreRateLimit(ip: string): boolean {

--- a/src/remote/register.html
+++ b/src/remote/register.html
@@ -1,0 +1,535 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <title>Inscription tireur</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f172a;
+      --surface: #1e293b;
+      --border: #334155;
+      --accent: #3b82f6;
+      --accent-hover: #2563eb;
+      --text: #f1f5f9;
+      --text-muted: #94a3b8;
+      --danger: #ef4444;
+      --success: #22c55e;
+      --radius: 10px;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 1.5rem 1rem 3rem;
+    }
+
+    header {
+      width: 100%;
+      max-width: 480px;
+      text-align: center;
+      margin-bottom: 1.5rem;
+    }
+
+    header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+    }
+
+    header p {
+      color: var(--text-muted);
+      font-size: 0.875rem;
+      margin-top: 0.25rem;
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem;
+      width: 100%;
+      max-width: 480px;
+    }
+
+    .form-group {
+      margin-bottom: 1rem;
+    }
+
+    label {
+      display: block;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.4rem;
+    }
+
+    label .req { color: var(--accent); }
+
+    input, select {
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      color: var(--text);
+      font-size: 1rem;
+      outline: none;
+      transition: border-color 0.15s;
+      -webkit-appearance: none;
+    }
+
+    input:focus, select:focus {
+      border-color: var(--accent);
+    }
+
+    select option { background: var(--bg); }
+
+    .row-2 {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.75rem;
+    }
+
+    /* ── Camera section ── */
+    .photo-section {
+      margin-top: 1.25rem;
+      border-top: 1px solid var(--border);
+      padding-top: 1.25rem;
+    }
+
+    .photo-section h2 {
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+      color: var(--text);
+    }
+
+    #camera-area {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 4/3;
+      background: #000;
+      border-radius: 8px;
+      overflow: hidden;
+      display: none;
+    }
+
+    #camera-area video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    #preview-area {
+      width: 100%;
+      aspect-ratio: 4/3;
+      border-radius: 8px;
+      overflow: hidden;
+      display: none;
+      background: #000;
+    }
+
+    #preview-area img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    canvas { display: none; }
+
+    .camera-btns {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      padding: 0.7rem 1.25rem;
+      border-radius: 8px;
+      font-size: 0.95rem;
+      font-weight: 600;
+      border: none;
+      cursor: pointer;
+      transition: opacity 0.15s, background 0.15s;
+    }
+
+    .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+    .btn-primary { background: var(--accent); color: #fff; width: 100%; }
+    .btn-primary:not(:disabled):hover { background: var(--accent-hover); }
+
+    .btn-secondary { background: var(--border); color: var(--text); flex: 1; }
+    .btn-secondary:not(:disabled):hover { background: #475569; }
+
+    .btn-danger-outline {
+      background: transparent;
+      color: var(--danger);
+      border: 1px solid var(--danger);
+      flex: 1;
+    }
+
+    .btn-submit {
+      margin-top: 1.5rem;
+      font-size: 1.1rem;
+      padding: 0.85rem;
+    }
+
+    /* ── Toast / alert ── */
+    #toast {
+      position: fixed;
+      bottom: 2rem;
+      left: 50%;
+      transform: translateX(-50%) translateY(120%);
+      background: var(--success);
+      color: #fff;
+      padding: 0.75rem 1.5rem;
+      border-radius: 100px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: transform 0.3s;
+      white-space: nowrap;
+      z-index: 100;
+    }
+
+    #toast.error { background: var(--danger); }
+    #toast.show { transform: translateX(-50%) translateY(0); }
+
+    /* ── Closed banner ── */
+    #closed-banner {
+      display: none;
+      text-align: center;
+      padding: 2rem 1rem;
+    }
+
+    #closed-banner .icon { font-size: 3rem; margin-bottom: 0.75rem; }
+    #closed-banner h2 { font-size: 1.25rem; font-weight: 700; margin-bottom: 0.5rem; }
+    #closed-banner p { color: var(--text-muted); font-size: 0.9rem; }
+
+    /* ── Spinner ── */
+    .spinner {
+      width: 20px; height: 20px;
+      border: 2px solid rgba(255,255,255,0.3);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+    }
+
+    @keyframes spin { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+
+<div id="toast"></div>
+
+<header>
+  <h1>⚔️ Inscription compétiteur</h1>
+  <p id="subtitle">Remplissez le formulaire puis prenez un selfie</p>
+</header>
+
+<!-- Closed state -->
+<div id="closed-banner">
+  <div class="icon">🔒</div>
+  <h2>Inscription fermée</h2>
+  <p>Les poules ont été générées.<br>Contactez l'organisateur pour toute modification.</p>
+</div>
+
+<!-- Form -->
+<div class="card" id="form-card">
+  <form id="reg-form" novalidate>
+
+    <div class="row-2">
+      <div class="form-group">
+        <label for="lastName">Nom <span class="req">*</span></label>
+        <input id="lastName" type="text" autocomplete="family-name" autocapitalize="words" placeholder="DUPONT" required />
+      </div>
+      <div class="form-group">
+        <label for="firstName">Prénom <span class="req">*</span></label>
+        <input id="firstName" type="text" autocomplete="given-name" autocapitalize="words" placeholder="Jean" required />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="gender">Genre <span class="req">*</span></label>
+      <select id="gender" required>
+        <option value="">— Sélectionner —</option>
+        <option value="M">Homme</option>
+        <option value="F">Femme</option>
+        <option value="X">Autre</option>
+      </select>
+    </div>
+
+    <div class="row-2">
+      <div class="form-group">
+        <label for="club">Club</label>
+        <input id="club" type="text" autocapitalize="words" placeholder="Nom du club" />
+      </div>
+      <div class="form-group">
+        <label for="license">Licence</label>
+        <input id="license" type="text" placeholder="N° licence" />
+      </div>
+    </div>
+
+    <div class="row-2">
+      <div class="form-group">
+        <label for="nationality">Nationalité</label>
+        <input id="nationality" type="text" maxlength="3" placeholder="FRA" style="text-transform:uppercase" />
+      </div>
+      <div class="form-group">
+        <label for="birthDate">Date naissance</label>
+        <input id="birthDate" type="date" />
+      </div>
+    </div>
+
+    <!-- Camera -->
+    <div class="photo-section">
+      <h2>📷 Photo (selfie)</h2>
+      <div id="placeholder-area" style="text-align:center;padding:1.5rem 0;color:var(--text-muted);font-size:0.875rem;">
+        Aucune photo — optionnelle
+      </div>
+      <div id="camera-area">
+        <video id="video" autoplay playsinline muted></video>
+      </div>
+      <div id="preview-area">
+        <img id="preview-img" src="" alt="selfie" />
+      </div>
+      <canvas id="canvas"></canvas>
+
+      <div class="camera-btns" id="camera-btns-open" style="margin-top:0.75rem;">
+        <button type="button" class="btn btn-secondary" id="btn-open-camera">📷 Ouvrir caméra</button>
+      </div>
+      <div class="camera-btns" id="camera-btns-live" style="display:none;">
+        <button type="button" class="btn btn-secondary" id="btn-capture">📸 Prendre selfie</button>
+        <button type="button" class="btn btn-danger-outline" id="btn-cancel-camera">✕ Annuler</button>
+      </div>
+      <div class="camera-btns" id="camera-btns-preview" style="display:none;">
+        <button type="button" class="btn btn-secondary" id="btn-retake">🔄 Reprendre</button>
+        <button type="button" class="btn btn-danger-outline" id="btn-remove-photo">✕ Supprimer</button>
+      </div>
+    </div>
+
+    <button type="submit" class="btn btn-primary btn-submit" id="btn-submit">
+      ✅ S'inscrire
+    </button>
+
+  </form>
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  let photoBase64 = null;
+  let stream = null;
+  const video = document.getElementById('video');
+  const canvas = document.getElementById('canvas');
+  const previewImg = document.getElementById('preview-img');
+  const cameraArea = document.getElementById('camera-area');
+  const previewArea = document.getElementById('preview-area');
+  const placeholderArea = document.getElementById('placeholder-area');
+  const cameraBtnsOpen = document.getElementById('camera-btns-open');
+  const cameraBtnsLive = document.getElementById('camera-btns-live');
+  const cameraBtnsPreview = document.getElementById('camera-btns-preview');
+  const btnSubmit = document.getElementById('btn-submit');
+
+  // ── Check registration status ──────────────────────────────────────────────
+  async function checkStatus() {
+    try {
+      const res = await fetch('/api/register/status');
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      if (!data.open) showClosed();
+    } catch {
+      // network issue, assume open
+    }
+  }
+
+  function showClosed() {
+    document.getElementById('form-card').style.display = 'none';
+    document.getElementById('closed-banner').style.display = 'block';
+    document.getElementById('subtitle').textContent = 'Inscription fermée';
+    stopCamera();
+  }
+
+  // ── Camera helpers ─────────────────────────────────────────────────────────
+  function stopCamera() {
+    if (stream) {
+      stream.getTracks().forEach(t => t.stop());
+      stream = null;
+    }
+  }
+
+  function showPlaceholder() {
+    placeholderArea.style.display = 'block';
+    cameraArea.style.display = 'none';
+    previewArea.style.display = 'none';
+    cameraBtnsOpen.style.display = 'flex';
+    cameraBtnsLive.style.display = 'none';
+    cameraBtnsPreview.style.display = 'none';
+  }
+
+  function showLive() {
+    placeholderArea.style.display = 'none';
+    cameraArea.style.display = 'block';
+    previewArea.style.display = 'none';
+    cameraBtnsOpen.style.display = 'none';
+    cameraBtnsLive.style.display = 'flex';
+    cameraBtnsPreview.style.display = 'none';
+  }
+
+  function showPreview() {
+    placeholderArea.style.display = 'none';
+    cameraArea.style.display = 'none';
+    previewArea.style.display = 'block';
+    cameraBtnsOpen.style.display = 'none';
+    cameraBtnsLive.style.display = 'none';
+    cameraBtnsPreview.style.display = 'flex';
+  }
+
+  document.getElementById('btn-open-camera').addEventListener('click', async () => {
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' }, audio: false });
+      video.srcObject = stream;
+      showLive();
+    } catch {
+      showToast('Caméra non disponible', 'error');
+    }
+  });
+
+  document.getElementById('btn-capture').addEventListener('click', () => {
+    canvas.width = video.videoWidth || 640;
+    canvas.height = video.videoHeight || 480;
+    const ctx = canvas.getContext('2d');
+    // Mirror (selfie)
+    ctx.translate(canvas.width, 0);
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, 0, 0);
+    // Compress to JPEG, max ~400 KB → quality 0.7
+    photoBase64 = canvas.toDataURL('image/jpeg', 0.7);
+    previewImg.src = photoBase64;
+    stopCamera();
+    showPreview();
+  });
+
+  document.getElementById('btn-cancel-camera').addEventListener('click', () => {
+    stopCamera();
+    photoBase64 = null;
+    showPlaceholder();
+  });
+
+  document.getElementById('btn-retake').addEventListener('click', async () => {
+    photoBase64 = null;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' }, audio: false });
+      video.srcObject = stream;
+      showLive();
+    } catch {
+      showPlaceholder();
+      showToast('Caméra non disponible', 'error');
+    }
+  });
+
+  document.getElementById('btn-remove-photo').addEventListener('click', () => {
+    photoBase64 = null;
+    showPlaceholder();
+  });
+
+  // ── Toast ──────────────────────────────────────────────────────────────────
+  let toastTimer = null;
+  function showToast(msg, type) {
+    const el = document.getElementById('toast');
+    el.textContent = msg;
+    el.className = type === 'error' ? 'error show' : 'show';
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { el.className = el.className.replace(' show', '').replace('show', ''); }, 3500);
+  }
+
+  // ── Form submit ────────────────────────────────────────────────────────────
+  document.getElementById('reg-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+
+    const lastName = document.getElementById('lastName').value.trim();
+    const firstName = document.getElementById('firstName').value.trim();
+    const gender = document.getElementById('gender').value;
+
+    if (!lastName || !firstName || !gender) {
+      showToast('Nom, prénom et genre sont obligatoires', 'error');
+      return;
+    }
+
+    // Sanitize: strip HTML tags
+    function strip(s) { return s.replace(/<[^>]*>/g, '').substring(0, 100); }
+
+    const payload = {
+      lastName: strip(lastName).toUpperCase(),
+      firstName: strip(firstName),
+      gender,
+      club: strip(document.getElementById('club').value.trim()),
+      license: strip(document.getElementById('license').value.trim()),
+      nationality: document.getElementById('nationality').value.trim().toUpperCase().substring(0, 3) || 'FRA',
+      birthDate: document.getElementById('birthDate').value || null,
+      photo: photoBase64 || null,
+    };
+
+    btnSubmit.disabled = true;
+    btnSubmit.innerHTML = '<div class="spinner"></div>';
+
+    try {
+      const res = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await res.json();
+
+      if (res.status === 403 && data.registrationClosed) {
+        showClosed();
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error(data.error || 'Erreur serveur');
+      }
+
+      // Success
+      showToast(`✅ ${payload.firstName} ${payload.lastName} inscrit(e) !`, 'success');
+      stopCamera();
+      photoBase64 = null;
+      document.getElementById('reg-form').reset();
+      showPlaceholder();
+
+    } catch (err) {
+      showToast(err.message || 'Erreur réseau', 'error');
+    } finally {
+      btnSubmit.disabled = false;
+      btnSubmit.innerHTML = '✅ S\'inscrire';
+    }
+  });
+
+  // ── Init ───────────────────────────────────────────────────────────────────
+  checkStatus();
+  showPlaceholder();
+
+  // Nationalité : auto-majuscules
+  document.getElementById('nationality').addEventListener('input', function () {
+    this.value = this.value.toUpperCase();
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -112,6 +112,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     content: string;
   } | null>(null);
   const [isRemoteActive, setIsRemoteActive] = useState(false);
+  const [remoteServerUrl, setRemoteServerUrl] = useState<string | null>(null);
   const [remoteArenaCount, setRemoteArenaCount] = useState<number>(1);
   const [showThirdPlaceDialog, setShowThirdPlaceDialog] = useState(false);
   const [tableauMatches, setTableauMatches] = useState<TableauMatch[]>([]);
@@ -294,9 +295,22 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     window.electronAPI.remote.getServerInfo(competition.id).then((res: any) => {
       if (res?.success && res.serverInfo) {
         setIsRemoteActive(true);
+        setRemoteServerUrl(res.serverInfo.url);
       }
     });
   }, [competition.id]);
+
+  // Mettre à jour l'URL du serveur distant quand il devient actif
+  useEffect(() => {
+    if (!isRemoteActive || !window.electronAPI?.remote) return;
+    // Petit délai pour laisser le serveur démarrer si besoin
+    const timer = setTimeout(() => {
+      window.electronAPI.remote.getServerInfo(competition.id).then((res: any) => {
+        if (res?.success && res.serverInfo) setRemoteServerUrl(res.serverInfo.url);
+      });
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [isRemoteActive, competition.id]);
 
   // Écouter les mises à jour des matches distants
   // Note: pas de garde sur currentPhase car la phase 'remote' affiche le panel de saisie distante
@@ -479,6 +493,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     const newPools = generatePoolsHook(checkedIn);
     if (newPools) {
       await persistPoolsToDB(newPools);
+      // Fermer l'inscription distante dès que les poules sont générées
+      if (isRemoteActive && window.electronAPI?.remote?.setRegistrationEnabled) {
+        window.electronAPI.remote.setRegistrationEnabled(competition.id, false).catch(() => {});
+      }
       setCurrentPhase('poolprep');
     }
   };
@@ -697,6 +715,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       setCurrentPhase('checkin');
     }
   }, [phaseOrder]);
+
+  // Synchroniser l'état d'inscription distante avec la phase courante
+  useEffect(() => {
+    if (!isRemoteActive || !window.electronAPI?.remote?.setRegistrationEnabled) return;
+    const enabled = currentPhase === 'checkin';
+    window.electronAPI.remote.setRegistrationEnabled(competition.id, enabled).catch(() => {});
+  }, [currentPhase, isRemoteActive, competition.id]);
 
   const handleGoBack = () => {
     if (skipPoolPhase && currentPhase === 'ranking') {
@@ -943,6 +968,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             competitionId={competition.id}
             onCheckIn={handleCheckInFencer}
             onAddFencer={() => setShowAddFencerModal(true)}
+            registerUrl={isRemoteActive && remoteServerUrl ? `${remoteServerUrl}/register` : undefined}
+            onFencersChanged={loadFencers}
             onEditFencer={updateFencer}
             onDeleteFencer={deleteFencer}
             onDeleteAllFencers={deleteAllFencers}

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useRef, useEffect, useMemo } from 'react';
+import QRCode from 'qrcode';
 import { Fencer, FencerStatus } from '../../shared/types';
 import EditFencerModal from './EditFencerModal';
 import { useTranslation } from '../hooks/useTranslation';
@@ -23,6 +24,10 @@ interface FencerListProps {
   onSetFencerStatus?: (id: string, status: FencerStatus) => void;
   onImport?: (type: 'xml' | 'fff' | 'ranking') => void;
   onFencersImported?: () => void;
+  /** URL de la page d'inscription distante (ex: http://192.168.x.x:8066/register) */
+  registerUrl?: string;
+  /** Callback pour recharger la liste après inscription distante */
+  onFencersChanged?: () => void;
 }
 
 const FencerListComponent: React.FC<FencerListProps> = ({
@@ -38,6 +43,8 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   onSetFencerStatus,
   onImport,
   onFencersImported,
+  registerUrl,
+  onFencersChanged,
 }) => {
   const { t } = useTranslation();
   const { confirm } = useConfirm();
@@ -60,6 +67,8 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const exportMenuRef = useRef<HTMLDivElement>(null);
   const [importMenuOpen, setImportMenuOpen] = useState(false);
   const importMenuRef = useRef<HTMLDivElement>(null);
+  const [showRegisterQR, setShowRegisterQR] = useState(false);
+  const [registerQRDataUrl, setRegisterQRDataUrl] = useState<string | null>(null);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -73,6 +82,21 @@ const FencerListComponent: React.FC<FencerListProps> = ({
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
+
+  // Générer le QR code quand l'URL d'inscription change
+  useEffect(() => {
+    if (!registerUrl) { setRegisterQRDataUrl(null); return; }
+    QRCode.toDataURL(registerUrl, { width: 220, margin: 1 })
+      .then(setRegisterQRDataUrl)
+      .catch(() => setRegisterQRDataUrl(null));
+  }, [registerUrl]);
+
+  // Recharger la liste toutes les 5 s si le modal QR est ouvert (inscription en cours)
+  useEffect(() => {
+    if (!showRegisterQR || !onFencersChanged) return;
+    const id = setInterval(onFencersChanged, 5000);
+    return () => clearInterval(id);
+  }, [showRegisterQR, onFencersChanged]);
   const filteredFencers = useMemo(() => fencers
     .filter(f => {
       const search = searchTerm.toLowerCase();
@@ -421,11 +445,62 @@ const FencerListComponent: React.FC<FencerListProps> = ({
               </div>
             )}
           </div>
+          {registerUrl && (
+            <button
+              className="btn btn-secondary"
+              title={`Inscription tablette : ${registerUrl}`}
+              onClick={() => setShowRegisterQR(true)}
+              style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}
+            >
+              <span>📱</span> QR Inscription
+            </button>
+          )}
           <button className="btn btn-primary" onClick={onAddFencer}>
             + {t('fencer.add')}
           </button>
         </div>
       </div>
+
+      {/* Modal QR code inscription distante */}
+      {showRegisterQR && registerUrl && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+          }}
+          onClick={() => setShowRegisterQR(false)}
+        >
+          <div
+            style={{
+              background: 'var(--surface, #1e293b)', borderRadius: 16, padding: '2rem',
+              textAlign: 'center', maxWidth: 300, width: '90%',
+              border: '1px solid var(--border-color, #334155)',
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            <h3 style={{ marginBottom: '0.75rem', fontSize: '1.1rem', fontWeight: 700 }}>
+              📱 Inscription tireur
+            </h3>
+            <p style={{ fontSize: '0.8rem', color: 'var(--text-muted, #94a3b8)', marginBottom: '1rem' }}>
+              Scannez ce QR code avec la tablette pour accéder au formulaire d&apos;inscription
+            </p>
+            {registerQRDataUrl
+              ? <img src={registerQRDataUrl} alt="QR code inscription" width={220} height={220} style={{ borderRadius: 8 }} />
+              : <div style={{ width: 220, height: 220, display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto' }}>Génération…</div>
+            }
+            <code style={{ display: 'block', marginTop: '0.75rem', fontSize: '0.7rem', wordBreak: 'break-all', color: 'var(--text-muted, #94a3b8)' }}>
+              {registerUrl}
+            </code>
+            <button
+              className="btn btn-secondary"
+              style={{ marginTop: '1rem', width: '100%' }}
+              onClick={() => setShowRegisterQR(false)}
+            >
+              Fermer
+            </button>
+          </div>
+        </div>
+      )}
 
       {photoMessage && (
         <div

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -19,7 +19,7 @@ interface RemoteScoreManagerProps {
   tableauMatches?: TableauMatch[];
   consolationBrackets?: ConsolationBracket[];
   onArenaCountChange?: (count: number) => void;
-  onStartRemote: () => void;
+  onStartRemote: (serverUrl?: string) => void;
   onStopRemote: () => void;
   isRemoteActive?: boolean;
   initialStripCount?: number;

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -420,6 +420,10 @@ export interface RemoteServerAPI {
     competitionId: string,
     matchId: string
   ) => Promise<{ success: boolean; error?: string }>;
+  setRegistrationEnabled: (
+    competitionId: string,
+    enabled: boolean
+  ) => Promise<{ success: boolean; error?: string }>;
 }
 
 // ============================================================================


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Nouvelle page `/register` servie par le serveur Express distant (selfie + formulaire)
- Bouton **📱 QR Inscription** dans la liste des tireurs (phase CHECKIN) avec modal QR code
- La page est désactivée automatiquement quand les poules sont générées, réactivée si retour en CHECKIN

## Détail

**`src/remote/register.html`** (nouveau)
- Formulaire : Nom*, Prénom*, Genre*, Club, Licence, Nationalité, Date naissance
- Caméra selfie via `getUserMedia({ facingMode: 'user' })`, miroir horizontal, compression JPEG ≤ 500 KB
- `POST /api/register` → tireur créé avec statut `NOT_CHECKED_IN` (jamais pointé automatiquement)
- Si inscription fermée → 403 `{ registrationClosed: true }` → bannière « Inscription fermée »
- `GET /api/register/status` → `{ open: bool }` vérifié au chargement de la page

**`remoteScoreServer.ts`**
- Flag `private registrationEnabled: boolean = true`
- Méthode publique `setRegistrationEnabled(enabled)`
- Routes `GET /register`, `GET /inscription`, `GET /api/register/status`, `POST /api/register`
- Rate limit dédié : 5 inscriptions/IP/min (rate limiter séparé du score)
- Sanitization des champs texte (strip HTML, taille max)
- Validation photo : doit commencer par `data:image/` et < 700 000 chars

**`CompetitionView.tsx`**
- `useEffect` sur `currentPhase` → appelle `setRegistrationEnabled(true/false)` selon la phase
- `handleGeneratePools` → désactive l'inscription avant de changer de phase
- `remoteServerUrl` stocké en state, récupéré via `getServerInfo` au montage et quand `isRemoteActive` change
- Passage de `registerUrl` et `onFencersChanged` à `FencerList`

**`FencerList.tsx`**
- Import `qrcode` (lib déjà présente, même pattern que `RemoteScoreManager`)
- Bouton `📱 QR Inscription` visible uniquement si `registerUrl` est défini (serveur actif)
- Modal QR code avec image générée + URL en clair + bouton Fermer
- Auto-refresh liste toutes les 5 s quand le modal QR est ouvert

**`main.ts` / `preload.ts` / `preload.d.ts`**
- Nouveau handler IPC `remote:setRegistrationEnabled(competitionId, enabled)`
- Exposé dans `window.electronAPI.remote.setRegistrationEnabled`

## Test plan

- [ ] Démarrer le serveur distant depuis RemoteScoreManager
- [ ] Vérifier bouton "📱 QR Inscription" visible dans la liste tireurs
- [ ] Scanner QR → formulaire accessible sur tablette
- [ ] Remplir + selfie + S'inscrire → tireur apparaît dans la liste avec statut "Non pointé"
- [ ] Cliquer "Générer les poules" → `/register` sur tablette affiche "Inscription fermée"
- [ ] Revenir en phase CHECKIN → `/register` redevient actif

https://claude.ai/code/session_0113Q4U93gWsUiAgXG6QmwXC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0113Q4U93gWsUiAgXG6QmwXC)_