### PR TITLE
fix: build error - revert onStartRemote signature

### DIFF
--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -19,7 +19,7 @@ interface RemoteScoreManagerProps {
   tableauMatches?: TableauMatch[];
   consolationBrackets?: ConsolationBracket[];
   onArenaCountChange?: (count: number) => void;
-  onStartRemote: (serverUrl?: string) => void;
+  onStartRemote: () => void;
   onStopRemote: () => void;
   isRemoteActive?: boolean;
   initialStripCount?: number;


### PR DESCRIPTION
Corrige l'erreur de build TS2322 introduite par le changement de signature de `onStartRemote`.

Le type `(serverUrl?: string) => void` est incompatible avec `MouseEventHandler<HTMLButtonElement>` car le bouton passe un `MouseEvent`, pas une string. Revenu à `() => void`.

https://claude.ai/code/session_0113Q4U93gWsUiAgXG6QmwXC

---
_Generated by [Claude Code](https://claude.ai/code/session_0113Q4U93gWsUiAgXG6QmwXC)_