### PR TITLE
Fix crash ajout tireur manuel (issue #478)

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1089,6 +1089,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                           }
                         }}
                         onFencerAdded={updatedPool => {
+                          updatedPool.ranking = computePoolRanking(updatedPool);
                           setPools(prev =>
                             prev.map(p => (p.id === updatedPool.id ? updatedPool : p))
                           );

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -148,7 +148,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
 
       {fencers.map((rowFencer, rowIndex) => {
         const stats = calculateFencerStats(rowFencer);
-        const rankEntry = pool.ranking.find(r => r.fencer.id === rowFencer.id);
+        const rankEntry = pool.ranking?.find(r => r.fencer.id === rowFencer.id);
         const rankRatio = (rankEntry?.rank ?? fencers.length) / fencers.length;
         const rowBg =
           rankRatio <= 0.7


### PR DESCRIPTION
## Cause du bug

`addFencerToPoolMidCompetition` retourne un pool reconstruit depuis la DB (via `getPoolsByPhase`) sans le champ `ranking` — ce champ est calculé côté renderer par `computePoolRanking`.

`PoolScoreMatrix` accédait à `pool.ranking.find(...)` → `TypeError: Cannot read properties of undefined` → la `CompetitionErrorBoundary` attrapait l'erreur → affichage « Erreur de compétition ».

## Fix

- `CompetitionView` : calcul `computePoolRanking(updatedPool)` dans `onFencerAdded` avant `setPools`
- `PoolScoreMatrix` : guard `pool.ranking?.find()` (défense en profondeur)

Fixes #478

---
_Generated by [Claude Code](https://claude.ai/code/session_01UA4Wwng84urt8qiEegs9z4)_