### PR TITLE
fix(remote): couleurs A/B inversées dans affichage public et overlay (#488)

### DIFF
--- a/src/remote/overlay.html
+++ b/src/remote/overlay.html
@@ -56,11 +56,11 @@
         --overlay-border: rgba(255,255,255,0.15);
         --name-color: #ffffff;
         --club-color: rgba(255,255,255,0.75);
-        --score-a-color: #00e640;
-        --score-b-color: #ff2200;
+        --score-a-color: #ff2200;
+        --score-b-color: #00e640;
         --score-bg: rgba(0,0,0,0.65);
-        --score-glow-a: rgba(0,230,64,0.7);
-        --score-glow-b: rgba(255,34,0,0.7);
+        --score-glow-a: rgba(255,34,0,0.7);
+        --score-glow-b: rgba(0,230,64,0.7);
         --timer-color: #ffaa00;
         --timer-bg: rgba(0,0,0,0.6);
         --timer-glow: rgba(255,170,0,0.8);
@@ -78,10 +78,10 @@
       }
       [data-theme="neon"] {
         --bg: #0a0a0a;
-        --score-a-color: #00ff88;
-        --score-b-color: #ff4444;
-        --score-glow-a: rgba(0,255,136,0.8);
-        --score-glow-b: rgba(255,68,68,0.8);
+        --score-a-color: #ff4444;
+        --score-b-color: #00ff88;
+        --score-glow-a: rgba(255,68,68,0.8);
+        --score-glow-b: rgba(0,255,136,0.8);
         --timer-color: #00ccff;
         --timer-glow: rgba(0,204,255,0.9);
         --panel-bg: rgba(0,0,0,0.85);
@@ -91,10 +91,10 @@
         --bg: linear-gradient(135deg, #e8edf5 0%, #c8d8f0 100%);
         --name-color: #111827;
         --club-color: #374151;
-        --score-a-color: #059669;
-        --score-b-color: #dc2626;
-        --score-glow-a: rgba(5,150,105,0.5);
-        --score-glow-b: rgba(220,38,38,0.5);
+        --score-a-color: #dc2626;
+        --score-b-color: #059669;
+        --score-glow-a: rgba(220,38,38,0.5);
+        --score-glow-b: rgba(5,150,105,0.5);
         --timer-color: #d97706;
         --timer-glow: rgba(217,119,6,0.7);
         --score-bg: rgba(255,255,255,0.85);

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -519,8 +519,8 @@
         flex: 1;
       }
 
-      .photo-card-a { color: #22c55e; }
-      .photo-card-b { color: #ef4444; }
+      .photo-card-a { color: #ef4444; }
+      .photo-card-b { color: #22c55e; }
 
       .photo-circle {
         width: min(30vw, 42vh);
@@ -822,25 +822,25 @@
       <!-- Affichage du match -->
       <div class="match-display" id="match-display">
         <div class="fencers-row">
-          <!-- Tireur A (Vert) -->
-          <div id="fencer-a-display" class="fencer-display green-side">
-            <div id="color-badge-a" class="color-badge green"></div>
+          <!-- Tireur A (Rouge) -->
+          <div id="fencer-a-display" class="fencer-display red-side">
+            <div id="color-badge-a" class="color-badge red"></div>
             <div class="fencer-name" id="fencer-a-name">-</div>
             <div class="fencer-club" id="fencer-a-club">-</div>
             <div class="cards-container" id="fencer-a-cards"></div>
-            <div class="score-big green" id="score-a">0</div>
+            <div class="score-big red" id="score-a">0</div>
           </div>
 
           <!-- VS -->
           <div class="vs-divider">VS</div>
 
-          <!-- Tireur B (Rouge) -->
-          <div id="fencer-b-display" class="fencer-display red-side">
-            <div id="color-badge-b" class="color-badge red"></div>
+          <!-- Tireur B (Vert) -->
+          <div id="fencer-b-display" class="fencer-display green-side">
+            <div id="color-badge-b" class="color-badge green"></div>
             <div class="fencer-name" id="fencer-b-name">-</div>
             <div class="fencer-club" id="fencer-b-club">-</div>
             <div class="cards-container" id="fencer-b-cards"></div>
-            <div class="score-big red" id="score-b">0</div>
+            <div class="score-big green" id="score-b">0</div>
           </div>
         </div>
 
@@ -958,8 +958,8 @@
 
           setTimeout(() => {
             const winnerName = visualWinner === 'A' ? nameA : nameB;
-            const colorClass  = visualWinner === 'A' ? 'winner-green' : 'winner-red';
-            const colorLabel  = visualWinner === 'A' ? 'VERT' : 'ROUGE';
+            const colorClass  = visualWinner === 'A' ? 'winner-red' : 'winner-green';
+            const colorLabel  = visualWinner === 'A' ? 'ROUGE' : 'VERT';
             result.textContent = `🏆 ${winnerName} gagne ! (${colorLabel})`;
             result.className   = colorClass;
           }, 3600);
@@ -1119,16 +1119,16 @@
           const inv = this.inversionEnabled;
           const dispA = document.getElementById('fencer-a-display');
           const dispB = document.getElementById('fencer-b-display');
-          if (dispA) dispA.className = `fencer-display ${inv ? 'red-side' : 'green-side'}`;
-          if (dispB) dispB.className = `fencer-display ${inv ? 'green-side' : 'red-side'}`;
+          if (dispA) dispA.className = `fencer-display ${inv ? 'green-side' : 'red-side'}`;
+          if (dispB) dispB.className = `fencer-display ${inv ? 'red-side' : 'green-side'}`;
           const badgeA = document.getElementById('color-badge-a');
           const badgeB = document.getElementById('color-badge-b');
-          if (badgeA) badgeA.className = `color-badge ${inv ? 'red' : 'green'}`;
-          if (badgeB) badgeB.className = `color-badge ${inv ? 'green' : 'red'}`;
+          if (badgeA) badgeA.className = `color-badge ${inv ? 'green' : 'red'}`;
+          if (badgeB) badgeB.className = `color-badge ${inv ? 'red' : 'green'}`;
           const scoreA = document.getElementById('score-a');
           const scoreB = document.getElementById('score-b');
-          if (scoreA) { scoreA.className = scoreA.className.replace(/\b(green|red)\b/, inv ? 'red' : 'green'); }
-          if (scoreB) { scoreB.className = scoreB.className.replace(/\b(green|red)\b/, inv ? 'green' : 'red'); }
+          if (scoreA) { scoreA.className = scoreA.className.replace(/\b(green|red)\b/, inv ? 'green' : 'red'); }
+          if (scoreB) { scoreB.className = scoreB.className.replace(/\b(green|red)\b/, inv ? 'red' : 'green'); }
         }
 
         updateCardsDisplay() {


### PR DESCRIPTION
Fixes #488

## Problème
`public.html` et `overlay.html` affichaient tireur A en vert et B en rouge, alors que la vue arbitre (`arena.html`) montre A en rouge (gauche) et B en vert (droite).

## Changements
- `public.html` : swap des couleurs par défaut (A=rouge, B=vert) + inversion de la logique `applyInversionColors()` + coin flip
- `overlay.html` : swap des variables CSS `--score-a-color` / `--score-b-color` dans les 3 thèmes (default, neon, light)

La fonction "Inverser" reste fonctionnelle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBQYUFoyWQGK8zyJgFsMBQ)_