### PR TITLE
feat: mode expert — édition pistes par poule et arbitres max (#387)

### DIFF
--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -55,6 +55,13 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
   const [refereeFeatureEnabled, setRefereeFeatureEnabled] = useState(
     competition.settings?.refereeFeatureEnabled ?? false
   );
+  const [expertMode, setExpertMode] = useState(competition.settings?.expertMode ?? false);
+  const [maxRefereesPerPool, setMaxRefereesPerPool] = useState(
+    competition.settings?.maxRefereesPerPool ?? 1
+  );
+  const [maxRefereesPerMatch, setMaxRefereesPerMatch] = useState(
+    competition.settings?.maxRefereesPerMatch ?? 1
+  );
 
   // Formule personnalisée (arme CUSTOM)
   const [customFormula, setCustomFormula] = useState<CustomFormulaConfig>(
@@ -117,6 +124,8 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
       minTeamSize: competition.settings?.minTeamSize ?? 3,
       questConfig,
       refereeFeatureEnabled,
+      expertMode,
+      ...(expertMode ? { maxRefereesPerPool, maxRefereesPerMatch } : {}),
       ...(weapon === Weapon.CUSTOM ? { customFormula } : {}),
     };
 
@@ -586,6 +595,62 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 Affiche le nom de l'arbitre sur l'arène et permet de le changer depuis la saisie distante
               </small>
             </div>
+            <div className="form-group" style={{ marginTop: '0.75rem' }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={expertMode}
+                  onChange={e => setExpertMode(e.target.checked)}
+                />
+                Mode expert
+              </label>
+              <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+                Active l'édition avancée des pistes et du nombre d'arbitres par poule / match
+              </small>
+            </div>
+            {expertMode && (
+              <div
+                style={{
+                  background: '#fefce8',
+                  border: '1px solid #fde047',
+                  borderRadius: '8px',
+                  padding: '1rem',
+                  marginTop: '0.75rem',
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 1fr',
+                  gap: '1rem',
+                }}
+              >
+                <div className="form-group">
+                  <label htmlFor="maxRefereesPerPool" style={{ fontSize: '0.875rem' }}>
+                    Arbitres max par poule
+                  </label>
+                  <input
+                    type="number"
+                    id="maxRefereesPerPool"
+                    className="form-input"
+                    value={maxRefereesPerPool}
+                    min={1}
+                    max={10}
+                    onChange={e => setMaxRefereesPerPool(Math.max(1, parseInt(e.target.value) || 1))}
+                  />
+                </div>
+                <div className="form-group">
+                  <label htmlFor="maxRefereesPerMatch" style={{ fontSize: '0.875rem' }}>
+                    Arbitres max par match (tableau)
+                  </label>
+                  <input
+                    type="number"
+                    id="maxRefereesPerMatch"
+                    className="form-input"
+                    value={maxRefereesPerMatch}
+                    min={1}
+                    max={10}
+                    onChange={e => setMaxRefereesPerMatch(Math.max(1, parseInt(e.target.value) || 1))}
+                  />
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="modal-footer">

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -91,6 +91,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const poolMaxScore = competition.settings?.defaultPoolMaxScore ?? 21;
   const tableMaxScore = competition.settings?.defaultTableMaxScore ?? 0;
   const isLaserSabre = competition.weapon === Weapon.LASER;
+  const expertMode = competition.settings?.expertMode ?? false;
 
   const auditLogEnabled = localStorage.getItem('bellepoule-audit-log-enabled') === 'true';
 
@@ -1008,6 +1009,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             maxScore={poolMaxScore}
             minFencersPerPool={minFencersPerPool}
             maxFencersPerPool={maxFencersPerPool}
+            expertMode={expertMode}
             onPoolsConfirm={confirmedPools => {
               setPools(confirmedPools);
               setSkipPoolPhase(false);

--- a/src/renderer/components/PoolPrepView.tsx
+++ b/src/renderer/components/PoolPrepView.tsx
@@ -18,6 +18,7 @@ interface PoolPrepViewProps {
   maxScore: number;
   minFencersPerPool?: number;
   maxFencersPerPool?: number;
+  expertMode?: boolean;
   onPoolsConfirm: (pools: Pool[]) => void;
   onSkipPools?: () => void;
   onSettingsChange?: (min: number, max: number) => void;
@@ -37,6 +38,7 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
   maxScore,
   minFencersPerPool: initialMin = 5,
   maxFencersPerPool: initialMax = 7,
+  expertMode = false,
   onPoolsConfirm,
   onSkipPools,
   onSettingsChange,
@@ -375,6 +377,10 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
     setPools(updatedPools);
   };
 
+  const handleStripChange = (poolIndex: number, strip: number | undefined) => {
+    setPools(pools.map((p, i) => (i === poolIndex ? { ...p, strip } : p)));
+  };
+
   const getFencerCountStats = () => {
     if (pools.length === 0) return { min: 0, max: 0, avg: 0 };
 
@@ -608,19 +614,37 @@ const PoolPrepView: React.FC<PoolPrepViewProps> = ({
                   </span>
                 )}
               </div>
-              <span
-                style={{
-                  fontSize: '0.875rem',
-                  color:
-                    pools.length > 1 &&
-                    (pool.fencers.length < minFencersPerPool ||
-                      pool.fencers.length > maxFencersPerPool)
-                      ? '#dc2626'
-                      : '#6b7280',
-                }}
-              >
-                {pool.fencers.length} tireurs
-              </span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                {expertMode && (
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', fontSize: '0.8rem', color: '#6b7280' }}>
+                    Piste
+                    <input
+                      type="number"
+                      min={1}
+                      value={pool.strip ?? ''}
+                      placeholder="–"
+                      onChange={e => {
+                        const val = e.target.value;
+                        handleStripChange(poolIndex, val === '' ? undefined : Math.max(1, parseInt(val)));
+                      }}
+                      style={{ width: '52px', padding: '0.1rem 0.3rem', fontSize: '0.8rem', border: '1px solid #d1d5db', borderRadius: '4px' }}
+                    />
+                  </label>
+                )}
+                <span
+                  style={{
+                    fontSize: '0.875rem',
+                    color:
+                      pools.length > 1 &&
+                      (pool.fencers.length < minFencersPerPool ||
+                        pool.fencers.length > maxFencersPerPool)
+                        ? '#dc2626'
+                        : '#6b7280',
+                  }}
+                >
+                  {pool.fencers.length} tireurs
+                </span>
+              </div>
             </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>

--- a/src/shared/services/refereeManager.ts
+++ b/src/shared/services/refereeManager.ts
@@ -18,6 +18,8 @@ export interface RefereeRotationConfig {
   minRestTimeMinutes: number;
   avoidSameClub: boolean;
   balanceAssignment: boolean;
+  maxRefereesPerPool?: number;
+  maxRefereesPerMatch?: number;
 }
 
 export class RefereeManager {
@@ -65,9 +67,28 @@ export class RefereeManager {
     pools: Pool[],
     currentAssignments: Map<string, Referee>
   ): Referee | null {
-    const availableReferees = this.referees.filter(referee =>
+    let availableReferees = this.referees.filter(referee =>
       this.isRefereeAvailable(referee, match, currentAssignments)
     );
+
+    // Respecte maxRefereesPerPool : si la poule a déjà atteint la limite,
+    // seuls les arbitres déjà assignés à cette poule peuvent être utilisés.
+    const maxPerPool = this.config.maxRefereesPerPool;
+    if (maxPerPool && match.poolId) {
+      const pool = pools.find(p => p.id === match.poolId);
+      if (pool) {
+        const poolMatchIds = pool.matches.map(m => m.id);
+        const assignedInPool = new Set(
+          poolMatchIds
+            .map(id => currentAssignments.get(id))
+            .filter((r): r is Referee => r !== undefined)
+            .map(r => r.id)
+        );
+        if (assignedInPool.size >= maxPerPool) {
+          availableReferees = availableReferees.filter(r => assignedInPool.has(r.id));
+        }
+      }
+    }
 
     if (availableReferees.length === 0) return null;
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -572,6 +572,9 @@ export interface CompetitionSettings {
   refereeFeatureEnabled?: boolean; // Activer la gestion des arbitres sur arènes et saisie distante
   customFormula?: CustomFormulaConfig; // Formule à la carte (arme CUSTOM uniquement)
   playAllPositions?: boolean; // Jouer toutes les places (tableaux de classement)
+  expertMode?: boolean; // Mode expert : édition avancée des pistes et arbitres
+  maxRefereesPerPool?: number; // Nombre max d'arbitres par poule (mode expert)
+  maxRefereesPerMatch?: number; // Nombre max d'arbitres par match DE (mode expert)
 }
 
 export interface Phase extends BaseEntity {


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

Implémentation du mode expert demandé dans l'issue #387.

- **`CompetitionSettings`** : 3 nouveaux champs (`expertMode`, `maxRefereesPerPool`, `maxRefereesPerMatch`)
- **`CompetitionPropertiesModal`** : toggle "Mode expert" dans la section Arbitrage, révèle deux champs numériques (arbitres max par poule / par match tableau)
- **`PoolPrepView`** : prop `expertMode` — affiche un input "Piste" par poule quand actif
- **`CompetitionView`** : passe `expertMode` à `PoolPrepView`
- **`RefereeManager`** : contrainte `maxRefereesPerPool` respectée dans l'algorithme d'assignation automatique

## Plan de test

- [ ] Créer une compétition, ouvrir les propriétés → la case "Mode expert" est visible dans la section Arbitrage
- [ ] Cocher Mode expert → deux champs apparaissent (arbitres max poule / match)
- [ ] Enregistrer, aller sur la préparation des poules → chaque poule affiche un input "Piste"
- [ ] Saisir un numéro de piste → vérifié que la valeur est conservée après confirmation des poules
- [ ] Décocher Mode expert → les champs avancés disparaissent, comportement habituel inchangé

Closes #387
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6875FUqxT3gkPfdFmusz8)_