### PR TITLE
feat: mode escrime moderne – piste, +1 uniquement, cartons adaptés (#388)

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1119,13 +1119,13 @@
     <div id="card-announcement-banner" class="card-announcement-banner"></div>
 
     <div class="arena-number-strip">
-      Arène <span id="arena-strip-number">1</span>
+      <span class="arena-word-label">Arène</span> <span id="arena-strip-number">1</span>
     </div>
 
     <div class="header">
       <div class="arena-title">
         <span>⚔️</span>
-        <span>Arène <span id="arena-number">1</span></span>
+        <span><span class="arena-word-label">Arène</span> <span id="arena-number">1</span></span>
       </div>
       <div class="status-section">
         <div class="inversion-toggle">
@@ -1188,7 +1188,7 @@
         </div>
         <!-- Grand numéro (visible quand pas de nextMatch) -->
         <div class="arena-idle-number" id="arena-idle-number">1</div>
-        <div class="arena-idle-label" data-i18n="remote.arena">Arène</div>
+        <div class="arena-idle-label arena-word-label" data-i18n="remote.arena">Arène</div>
       </div>
 
       <!-- Écran d'intro photo (affiché quand showPhotos=true et statut ready) -->
@@ -1342,6 +1342,14 @@
           this.applyTheme(this.theme);
           this.setupHeaderAutoHide();
           this.setupSocketListeners();
+          fetch('/api/session')
+            .then(r => (r.ok ? r.json() : null))
+            .then(s => {
+              if (s && ['E', 'F', 'S'].includes(s.weapon)) {
+                document.querySelectorAll('.arena-word-label').forEach(el => (el.textContent = 'Piste'));
+              }
+            })
+            .catch(() => {});
         }
 
         applyTheme(theme, customTheme) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1030,7 +1030,7 @@
     <div class="header">
       <h1>
         <span>⚔️</span>
-        <span>Arène <span id="arena-number">1</span></span>
+        <span><span id="arena-label">Arène</span> <span id="arena-number">1</span></span>
       </h1>
       <div class="connection-status">
         <button id="btn-swap" class="swap-btn" onclick="refereeApp.toggleSwap()" data-i18n-title="referee.swap_colors" title="Inverser rouge/vert">⇄</button>
@@ -1536,7 +1536,14 @@
           fetch('/api/session')
             .then(r => (r.ok ? r.json() : null))
             .then(s => {
-              if (s) this.isLaserSabre = s.weapon === 'L';
+              if (s) {
+              this.isLaserSabre = s.weapon === 'L';
+              this.isModernFencing = ['E', 'F', 'S'].includes(s.weapon);
+              if (this.isModernFencing) {
+                document.getElementById('arena-label').textContent = 'Piste';
+                document.querySelectorAll('.btn-plus-3, .btn-plus-5').forEach(b => (b.style.display = 'none'));
+              }
+            }
             })
             .catch(() => {});
           // Service Worker PWA
@@ -2015,7 +2022,14 @@
 
           cards.push(cardType);
 
-          if (cardType === 'yellow') {
+          if (this.isModernFencing) {
+            if (cardType === 'red') {
+              if (ef === 'A') this.scoreB += 1;
+              else this.scoreA += 1;
+              this.showNotification("🟥 +1 point pour l'adversaire");
+            }
+            // jaune = avertissement sans point en escrime moderne
+          } else if (cardType === 'yellow') {
             if (ef === 'A') this.scoreB += 3;
             else this.scoreA += 3;
             this.showNotification("🟨 +3 points pour l'adversaire");


### PR DESCRIPTION
## Résumé

Implémente le mode escrime moderne (fix #388) déclenché automatiquement quand l'arme est Épée, Fleuret ou Sabre.

- **"Piste N"** remplace "Arène N" dans l'interface arbitre et le display arène
- **Seul le +1** est affiché (boutons +3 et +5 masqués)
- **Cartons adaptés** : jaune = avertissement sans point, rouge = +1 à l'adversaire
- Laser Sabre : aucune régression, logique inchangée

## Fichiers modifiés

- `src/remote/referee.html` – détection `isModernFencing`, label, boutons, cartons
- `src/remote/arena.html` – label "Piste" via fetch `/api/session`

## Plan de test

- [ ] Compétition Épée → interface arbitre : "Piste N", seul +1 visible
- [ ] Carton jaune → 0pt ; carton rouge → +1 adversaire
- [ ] Compétition Laser Sabre → "Arène N", +1/+3/+5 présents, mort subite inchangée

---
_Generated by [Claude Code](https://claude.ai/code/session_014rFTSWuey79hRo4aPLoHC8)_