### PR TITLE
perf: démarrage non-bloquant + lazy loading composants lourds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.835",
+  "version": "1.0.3-build.873",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.835",
+      "version": "1.0.3-build.873",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -29,6 +29,14 @@ import { MigrationManager } from './migrations';
 import { ALL_MIGRATIONS } from './migrations/migrations';
 
 let SQL: any = null;
+let sqlInitPromise: Promise<any> | null = null;
+
+/** Démarre le chargement du WASM sql.js en avance, sans bloquer. */
+export function prewarmSqlJs(): void {
+  if (!sqlInitPromise) {
+    sqlInitPromise = initSqlJs().then(s => { SQL = s; return s; });
+  }
+}
 
 export class DatabaseManager {
   private db: any = null;
@@ -48,21 +56,21 @@ export class DatabaseManager {
     if (dbPath) this.dbPath = dbPath;
 
     if (!SQL) {
-      SQL = await initSqlJs();
+      SQL = sqlInitPromise ? await sqlInitPromise : await initSqlJs();
     }
 
     const dir = path.dirname(this.dbPath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
     if (fs.existsSync(this.dbPath)) {
-      const fileBuffer = fs.readFileSync(this.dbPath);
+      const fileBuffer = await fs.promises.readFile(this.dbPath);
       this.db = new SQL.Database(fileBuffer);
     } else {
       this.db = new SQL.Database();
     }
 
-    this.runMigrations();
-    this.save();
+    const migrationsApplied = this.runMigrations();
+    if (migrationsApplied > 0) this.save();
   }
 
   public close(): void {
@@ -219,9 +227,9 @@ export class DatabaseManager {
     return this.db !== null;
   }
 
-  private runMigrations(): void {
+  private runMigrations(): number {
     if (!this.db) throw new Error('Database not open');
-    new MigrationManager(this.db).run(ALL_MIGRATIONS);
+    return new MigrationManager(this.db).run(ALL_MIGRATIONS);
   }
 
   // Session State Management

--- a/src/database/migrations/index.ts
+++ b/src/database/migrations/index.ts
@@ -12,7 +12,7 @@ export interface Migration {
 export class MigrationManager {
   constructor(private db: any) {}
 
-  run(migrations: Migration[]): void {
+  run(migrations: Migration[]): number {
     this.ensureMigrationsTable();
     const applied = this.getAppliedVersions();
     const pending = migrations
@@ -28,6 +28,7 @@ export class MigrationManager {
     if (pending.length > 0) {
       console.log(`[DB] ${pending.length} migration(s) appliquée(s)`);
     }
+    return pending.length;
   }
 
   private ensureMigrationsTable(): void {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import JSZip from 'jszip';
-import { DatabaseManager } from '../database';
+import { DatabaseManager, prewarmSqlJs } from '../database';
 import { RemoteScoreServer } from './remoteScoreServer';
 import { AutoUpdater } from './autoUpdater';
 import { Competition, Fencer, FencerStatus, Match, MatchStatus, Pool } from '../shared/types';
@@ -1954,6 +1954,9 @@ if (process.platform === 'linux') {
 }
 
 app.whenReady().then(async () => {
+  // Préchauffer sql.js WASM en parallèle avec la création de la fenêtre
+  prewarmSqlJs();
+
   // Initialize database dans un répertoire inscriptible (userData)
   // Sur Windows, process.cwd() peut pointer vers C:\Windows\System32 (non inscriptible)
   const userDataPath = app.getPath('userData');
@@ -1971,10 +1974,14 @@ app.whenReady().then(async () => {
     }
   }
 
+  // Créer la fenêtre immédiatement pendant que la DB se charge
+  createWindow();
+
   await db.open(dbPath);
   console.log('Base de données ouverte:', db.getPath());
 
-  createWindow();
+  // Signaler au renderer que la DB est prête
+  mainWindow?.webContents.send('db:ready');
 
   // Initialize auto updater
   if (mainWindow) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -406,6 +406,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('file:saved', (_, filepath) => callback(filepath)),
   onAutosaveCompleted: (callback: () => void) => ipcRenderer.on('autosave:completed', callback),
   onAutosaveFailed: (callback: () => void) => ipcRenderer.on('autosave:failed', callback),
+  onDbReady: (callback: () => void) => ipcRenderer.once('db:ready', callback),
 
   // Utility functions
   print: () => ipcRenderer.invoke('window:print'),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,7 +8,7 @@ import { Competition, PhaseType } from '../shared/types';
 import type { CompetitionCreateData } from '../shared/types/preload';
 import { logger, LogCategory } from '@shared/services/logger';
 import CompetitionList from './components/CompetitionList';
-import CompetitionView from './components/CompetitionView';
+const CompetitionView = React.lazy(() => import('./components/CompetitionView'));
 const CommandPalette = React.lazy(() => import('./components/CommandPalette'));
 const NewCompetitionModal = React.lazy(() => import('./components/NewCompetitionModal'));
 const ReportIssueModal = React.lazy(() => import('./components/ReportIssueModal'));
@@ -66,11 +66,23 @@ const AppContent: React.FC = () => {
     handleTabSwitch,
   } = useAppState(showToast);
 
-  // Load competitions on mount
+  // Load competitions on mount — attendre db:ready si la fenêtre s'ouvre avant la DB
   useEffect(() => {
-    loadCompetitions();
+    if (window.electronAPI?.onDbReady) {
+      // Si la DB n'est pas encore prête, attendre l'event puis charger
+      let loaded = false;
+      const tryLoad = () => { if (!loaded) { loaded = true; loadCompetitions(); } };
+      window.electronAPI.onDbReady(tryLoad);
+      // Charger quand même après 1s au cas où db:ready est déjà passé
+      const fallback = setTimeout(tryLoad, 1000);
+      return () => clearTimeout(fallback);
+    } else {
+      loadCompetitions();
+    }
+  }, []);
 
-    // Listen for menu events
+  // Listen for menu events
+  useEffect(() => {
     if (window.electronAPI) {
       window.electronAPI.onMenuNewCompetition(() => setShowNewCompetitionModal(true));
       window.electronAPI.onMenuReportIssue(() => setShowReportIssueModal(true));
@@ -543,12 +555,14 @@ const AppContent: React.FC = () => {
 
           {view === 'competition' && currentCompetition && activeTabId && (
             <CompetitionErrorBoundary key={currentCompetition.id}>
-              <CompetitionView
-                competition={currentCompetition}
-                onUpdate={handleUpdateCompetition}
-                requestPhase={requestedPhase ?? undefined}
-                onPhaseApplied={() => setRequestedPhase(null)}
-              />
+              <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>Chargement…</div>}>
+                <CompetitionView
+                  competition={currentCompetition}
+                  onUpdate={handleUpdateCompetition}
+                  requestPhase={requestedPhase ?? undefined}
+                  onPhaseApplied={() => setRequestedPhase(null)}
+                />
+              </Suspense>
             </CompetitionErrorBoundary>
           )}
         </main>

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -3,20 +3,18 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
 import { Competition, Fencer, FencerStatus, Match, MatchStatus, Weapon, QuestPhaseConfig, Referee } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { RankingImportResult } from '../../shared/utils/fileParser';
 import FencerList from './FencerList';
-import PoolView from './PoolView';
-import TableauView, { TableauMatch, FinalResult, propagateWinners, ConsolationBracket } from './TableauView';
+import { TableauMatch, FinalResult, propagateWinners, ConsolationBracket } from './tableau/tableauTypes';
 import PoolRankingView from './PoolRankingView';
 import ResultsView from './ResultsView';
 import AddFencerModal from './AddFencerModal';
 import CompetitionPropertiesModal from './CompetitionPropertiesModal';
 import ImportModal from './ImportModal';
 import PoolPrepView from './PoolPrepView';
-import RemoteScoreManager from './RemoteScoreManager';
 import { useToast } from './Toast';
 import { useTranslation } from '../hooks/useTranslation';
 import { useCompetitionSession, Phase } from '../hooks/useCompetitionSession';
@@ -30,18 +28,22 @@ import {
   generatePoolMatchOrder,
   generateInitialRanking,
 } from '../../shared/utils/poolCalculations';
-import { FencerComparison } from './FencerComparison';
-import { AnalyticsDashboard } from './AnalyticsDashboard';
 import { QRCodeShare } from './QRCodeShare';
 import { TouchOptimizedReferee } from './TouchOptimizedReferee';
-import { PresentationMode } from './PresentationMode';
-import KioskDisplay from './KioskDisplay';
 import { FencerPhoto } from './FencerPhoto';
-import QuestPhaseView from './QuestPhaseView';
 import { ScoreAuditLog } from './ScoreAuditLog';
 import { RefereeManagerComponent } from './RefereeManager';
 import CompetitionHeader from './competition/CompetitionHeader';
 import CompetitionNav from './competition/CompetitionNav';
+
+const PoolView = React.lazy(() => import('./PoolView'));
+const TableauView = React.lazy(() => import('./TableauView'));
+const RemoteScoreManager = React.lazy(() => import('./RemoteScoreManager'));
+const KioskDisplay = React.lazy(() => import('./KioskDisplay'));
+const FencerComparison = React.lazy(() => import('./FencerComparison').then(m => ({ default: m.FencerComparison })));
+const AnalyticsDashboard = React.lazy(() => import('./AnalyticsDashboard').then(m => ({ default: m.AnalyticsDashboard })));
+const PresentationMode = React.lazy(() => import('./PresentationMode').then(m => ({ default: m.PresentationMode })));
+const QuestPhaseView = React.lazy(() => import('./QuestPhaseView'));
 
 interface CompetitionViewProps {
   competition: Competition;
@@ -1054,6 +1056,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                     gridTemplateColumns: `repeat(auto-fill, minmax(min(100%, ${Math.max(480, 280 + (pools[0]?.fencers?.length ?? 6) * 38)}px), 1fr))`,
                   }}
                 >
+                  <Suspense fallback={null}>
                   {pools.map((pool, poolIndex) => (
                     <div key={pool.id} style={{ minWidth: 0, overflow: 'auto' }}>
                       <PoolView
@@ -1099,6 +1102,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                       />
                     </div>
                   ))}
+                  </Suspense>
                 </div>
               </>
             )}
@@ -1126,6 +1130,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
         {questEnabled && questConfig && (
           <div style={currentPhase === 'quest' ? undefined : CV_STYLES.questWrapper}>
+            <Suspense fallback={null}>
             <QuestPhaseView
               fencers={(() => {
                 const checked = getCheckedInFencers();
@@ -1156,10 +1161,12 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               }}
               onConfigUpdate={handleQuestConfigUpdate}
             />
+            </Suspense>
           </div>
         )}
 
         {currentPhase === 'tableau' && (
+          <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>Chargement tableau…</div>}>
           <TableauView
             ranking={overallRanking}
             matches={tableauMatches}
@@ -1188,6 +1195,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               }
             }}
           />
+          </Suspense>
         )}
 
         {currentPhase === 'results' && (
@@ -1198,7 +1206,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
           />
         )}
 
-        <div style={{ display: currentPhase === 'remote' ? '' : 'none' }}>
+        {currentPhase === 'remote' && (
+          <Suspense fallback={null}>
           <RemoteScoreManager
             competition={competition}
             pools={pools}
@@ -1210,7 +1219,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onStopRemote={() => setIsRemoteActive(false)}
             isRemoteActive={isRemoteActive}
           />
-        </div>
+          </Suspense>
+        )}
 
         {currentPhase === 'logs' && (
           <ScoreAuditLog competitionId={competition.id} />
@@ -1291,44 +1301,52 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
       {/* Nouveaux modals */}
       {showFencerComparison && (
-        <FencerComparison
-          fencers={fencers}
-          pools={pools}
-          tableauMatches={tableauMatches}
-          onClose={() => setShowFencerComparison(false)}
-        />
+        <Suspense fallback={null}>
+          <FencerComparison
+            fencers={fencers}
+            pools={pools}
+            tableauMatches={tableauMatches}
+            onClose={() => setShowFencerComparison(false)}
+          />
+        </Suspense>
       )}
 
       {showAnalytics && (
-        <AnalyticsDashboard
-          competition={competition}
-          pools={pools}
-          matches={pools.flatMap(p => p.matches ?? [])}
-          fencers={fencers}
-          onClose={() => setShowAnalytics(false)}
-        />
+        <Suspense fallback={null}>
+          <AnalyticsDashboard
+            competition={competition}
+            pools={pools}
+            matches={pools.flatMap(p => p.matches ?? [])}
+            fencers={fencers}
+            onClose={() => setShowAnalytics(false)}
+          />
+        </Suspense>
       )}
 
       {showQRCode && <QRCodeShare competition={competition} onClose={() => setShowQRCode(false)} />}
 
       {/* Mode Présentation */}
       {showPresentation && (
-        <PresentationMode
-          competition={competition}
-          pools={pools}
-          onClose={() => setShowPresentation(false)}
-        />
+        <Suspense fallback={null}>
+          <PresentationMode
+            competition={competition}
+            pools={pools}
+            onClose={() => setShowPresentation(false)}
+          />
+        </Suspense>
       )}
 
       {/* Mode Kiosk Public - Affichage grand écran */}
       {showKioskDisplay && (
-        <KioskDisplay
-          competition={competition}
-          pools={pools}
-          weapon={competition.weapon}
-          tableauMatches={tableauMatches}
-          onClose={() => setShowKioskDisplay(false)}
-        />
+        <Suspense fallback={null}>
+          <KioskDisplay
+            competition={competition}
+            pools={pools}
+            weapon={competition.weapon}
+            tableauMatches={tableauMatches}
+            onClose={() => setShowKioskDisplay(false)}
+          />
+        </Suspense>
       )}
 
       {/* Mode Kiosk - Interface tablette arbitre */}

--- a/src/renderer/components/FencerComparison.tsx
+++ b/src/renderer/components/FencerComparison.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useMemo , memo} from 'react';
 import { Fencer, Pool } from '../../shared/types';
-import { TableauMatch } from './TableauView';
+import { TableauMatch } from './tableau/tableauTypes';
 import { FencerStatsCalculator } from '../../shared/utils/fencerStatsCalculator';
 
 interface FencerComparisonProps {

--- a/src/renderer/components/KioskDisplay.tsx
+++ b/src/renderer/components/KioskDisplay.tsx
@@ -8,7 +8,7 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { Competition, Pool, Weapon, MatchStatus, Fencer } from '../../shared/types';
 import { OrgNote } from '../../shared/types/remote';
-import { TableauMatch } from './TableauView';
+import { TableauMatch } from './tableau/tableauTypes';
 import {
   calculateOverallRanking,
   calculateOverallRankingQuest,

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import QRCode from 'qrcode';
 import { Competition, Pool } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
-import { TableauMatch, ConsolationBracket } from './TableauView';
+import { TableauMatch, ConsolationBracket } from './tableau/tableauTypes';
 import { useToast } from './Toast';
 import ThemeEditor from './ThemeEditor';
 import { CustomTheme, DisplayTheme } from '../../shared/types/remote';

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -6,6 +6,8 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Fencer, FencerStatus, PoolRanking } from '../../shared/types';
+export { TableauMatch, FinalResult, ConsolationBracket, propagateWinners } from './tableau/tableauTypes';
+import { TableauMatch, FinalResult, ConsolationBracket, propagateWinners } from './tableau/tableauTypes';
 import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
 import Bracket from './Bracket';
@@ -29,38 +31,6 @@ interface BracketMatch {
   isBye?: boolean;
 }
 
-export interface TableauMatch {
-  id: string;
-  round: number;
-  position: number;
-  fencerA: Fencer | null;
-  fencerB: Fencer | null;
-  scoreA: number | null;
-  scoreB: number | null;
-  winner: Fencer | null;
-  isBye: boolean;
-  arena?: number | null;
-}
-
-export interface FinalResult {
-  rank: number;
-  fencer: Fencer;
-  eliminatedAt: string;
-  poolTouches?: number; // Touches marquées en poules
-  tableTouches?: number; // Touches marquées en tableau
-  totalTouches?: number; // Total pour départage (poules + tableau)
-}
-
-export interface ConsolationBracket {
-  id: string;
-  name: string;
-  firstPlace: number;
-  matches: TableauMatch[];
-  size: number;
-  isComplete: boolean;
-  sourceRound: number; // round du bracket parent qui a généré ce bracket
-  parentBracketId: string; // 'main' ou id d'un bracket de consolation
-}
 
 interface TableauViewProps {
   ranking: PoolRanking[];
@@ -122,88 +92,6 @@ const TV_STYLES = {
 const BASE_MATCH_HEIGHT = 100;
 const SLOT_HEIGHT = BASE_MATCH_HEIGHT + 50; // hauteur d'un créneau dans la première colonne
 
-export function propagateWinners(matchList: TableauMatch[], size: number): void {
-  let currentRound = size;
-
-  while (currentRound > 2) {
-    const nextRound = currentRound / 2;
-    const currentMatches = matchList.filter(m => m.round === currentRound);
-    const nextMatches = matchList.filter(m => m.round === nextRound);
-
-    // Première passe : propager tous les gagnants (y compris les exempts)
-    currentMatches.forEach((match, idx) => {
-      if (match.winner) {
-        const nextMatchIdx = Math.floor(idx / 2);
-        const nextMatch = nextMatches[nextMatchIdx];
-        if (nextMatch) {
-          if (idx % 2 === 0) {
-            nextMatch.fencerA = match.winner;
-          } else {
-            nextMatch.fencerB = match.winner;
-          }
-        }
-      }
-    });
-
-    // Deuxième passe : vérifier les exempts au tour suivant
-    nextMatches.forEach((nextMatch, nextIdx) => {
-      // Ne pas modifier les matchs déjà joués
-      if (nextMatch.scoreA !== null && nextMatch.scoreB !== null) return;
-
-      const feederA = currentMatches[nextIdx * 2];
-      const feederB = currentMatches[nextIdx * 2 + 1];
-
-      // Vérifier si les deux matchs sources sont résolus
-      const feederAResolved =
-        !feederA ||
-        feederA.winner !== null ||
-        (feederA.isBye && !feederA.fencerA && !feederA.fencerB);
-      const feederBResolved =
-        !feederB ||
-        feederB.winner !== null ||
-        (feederB.isBye && !feederB.fencerA && !feederB.fencerB);
-
-      if (feederAResolved && feederBResolved) {
-        if (nextMatch.fencerA && !nextMatch.fencerB) {
-          nextMatch.winner = nextMatch.fencerA;
-          nextMatch.isBye = true;
-        } else if (!nextMatch.fencerA && nextMatch.fencerB) {
-          nextMatch.winner = nextMatch.fencerB;
-          nextMatch.isBye = true;
-        } else if (nextMatch.fencerA && nextMatch.fencerB) {
-          nextMatch.isBye = false;
-          nextMatch.winner = null;
-        }
-      }
-    });
-
-    currentRound = nextRound;
-  }
-
-  // Gérer le match de 3ème place si présent dans matchList
-  const thirdPlaceMatchEntry = matchList.find(m => m.round === 3);
-  if (thirdPlaceMatchEntry && size >= 4) {
-    const semiFinalMatches = matchList.filter(m => m.round === 4);
-
-    if (semiFinalMatches.length === 2) {
-      // Assigner les perdants des demi-finales au match de 3ème place
-      const losers: Fencer[] = [];
-
-      semiFinalMatches.forEach(semiFinal => {
-        if (semiFinal.winner) {
-          const loser =
-            semiFinal.fencerA?.id === semiFinal.winner.id ? semiFinal.fencerB : semiFinal.fencerA;
-          if (loser) losers.push(loser);
-        }
-      });
-
-      if (losers.length === 2) {
-        thirdPlaceMatchEntry.fencerA = losers[0];
-        thirdPlaceMatchEntry.fencerB = losers[1];
-      }
-    }
-  }
-}
 
 const TableauViewComponent: React.FC<TableauViewProps> = ({
   ranking,

--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableauMatch } from '../TableauView';
+import { TableauMatch } from './tableauTypes';
 
 interface MatchCardProps {
   match: TableauMatch;

--- a/src/renderer/components/tableau/TableauPendingSection.tsx
+++ b/src/renderer/components/tableau/TableauPendingSection.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { TableauMatch } from '../TableauView';
+import { TableauMatch } from './tableauTypes';
 
 interface TableauPendingSectionProps {
   round: number;

--- a/src/renderer/components/tableau/TableauScoreModal.tsx
+++ b/src/renderer/components/tableau/TableauScoreModal.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { TableauMatch } from '../TableauView';
+import { TableauMatch } from './tableauTypes';
 
 interface TableauScoreModalProps {
   match: TableauMatch;

--- a/src/renderer/components/tableau/tableauTypes.ts
+++ b/src/renderer/components/tableau/tableauTypes.ts
@@ -1,0 +1,116 @@
+/**
+ * BellePoule Modern - Types et utilitaires partagés du tableau d'élimination directe
+ * Séparé de TableauView pour permettre le lazy-loading du composant.
+ */
+
+import { Fencer } from '../../../shared/types';
+
+export interface TableauMatch {
+  id: string;
+  round: number;
+  position: number;
+  fencerA: Fencer | null;
+  fencerB: Fencer | null;
+  scoreA: number | null;
+  scoreB: number | null;
+  winner: Fencer | null;
+  isBye: boolean;
+  arena?: number | null;
+}
+
+export interface FinalResult {
+  rank: number;
+  fencer: Fencer;
+  eliminatedAt: string;
+  poolTouches?: number;
+  tableTouches?: number;
+  totalTouches?: number;
+}
+
+export interface ConsolationBracket {
+  id: string;
+  name: string;
+  firstPlace: number;
+  matches: TableauMatch[];
+  size: number;
+  isComplete: boolean;
+  sourceRound: number;
+  parentBracketId: string;
+}
+
+export function propagateWinners(matchList: TableauMatch[], size: number): void {
+  let currentRound = size;
+
+  while (currentRound > 2) {
+    const nextRound = currentRound / 2;
+    const currentMatches = matchList.filter(m => m.round === currentRound);
+    const nextMatches = matchList.filter(m => m.round === nextRound);
+
+    currentMatches.forEach((match, idx) => {
+      if (match.winner) {
+        const nextMatchIdx = Math.floor(idx / 2);
+        const nextMatch = nextMatches[nextMatchIdx];
+        if (nextMatch) {
+          if (idx % 2 === 0) {
+            nextMatch.fencerA = match.winner;
+          } else {
+            nextMatch.fencerB = match.winner;
+          }
+        }
+      }
+    });
+
+    nextMatches.forEach((nextMatch, nextIdx) => {
+      if (nextMatch.scoreA !== null && nextMatch.scoreB !== null) return;
+
+      const feederA = currentMatches[nextIdx * 2];
+      const feederB = currentMatches[nextIdx * 2 + 1];
+
+      const feederAResolved =
+        !feederA ||
+        feederA.winner !== null ||
+        (feederA.isBye && !feederA.fencerA && !feederA.fencerB);
+      const feederBResolved =
+        !feederB ||
+        feederB.winner !== null ||
+        (feederB.isBye && !feederB.fencerA && !feederB.fencerB);
+
+      if (feederAResolved && feederBResolved) {
+        if (nextMatch.fencerA && !nextMatch.fencerB) {
+          nextMatch.winner = nextMatch.fencerA;
+          nextMatch.isBye = true;
+        } else if (!nextMatch.fencerA && nextMatch.fencerB) {
+          nextMatch.winner = nextMatch.fencerB;
+          nextMatch.isBye = true;
+        } else if (nextMatch.fencerA && nextMatch.fencerB) {
+          nextMatch.isBye = false;
+          nextMatch.winner = null;
+        }
+      }
+    });
+
+    currentRound = nextRound;
+  }
+
+  const thirdPlaceMatchEntry = matchList.find(m => m.round === 3);
+  if (thirdPlaceMatchEntry && size >= 4) {
+    const semiFinalMatches = matchList.filter(m => m.round === 4);
+
+    if (semiFinalMatches.length === 2) {
+      const losers: Fencer[] = [];
+
+      semiFinalMatches.forEach(semiFinal => {
+        if (semiFinal.winner) {
+          const loser =
+            semiFinal.fencerA?.id === semiFinal.winner.id ? semiFinal.fencerB : semiFinal.fencerA;
+          if (loser) losers.push(loser);
+        }
+      });
+
+      if (losers.length === 2) {
+        thirdPlaceMatchEntry.fencerA = losers[0];
+        thirdPlaceMatchEntry.fencerB = losers[1];
+      }
+    }
+  }
+}

--- a/src/renderer/hooks/useCompetitionSession.ts
+++ b/src/renderer/hooks/useCompetitionSession.ts
@@ -7,7 +7,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Pool, PoolRanking } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
-import { TableauMatch, FinalResult } from '../components/TableauView';
+import { TableauMatch, FinalResult } from '../components/tableau/tableauTypes';
 
 export type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs' | 'referees';
 

--- a/src/renderer/hooks/useExport.ts
+++ b/src/renderer/hooks/useExport.ts
@@ -7,7 +7,7 @@
 import { useCallback } from 'react';
 import { Competition, Fencer, Pool, PoolRanking, FencerStatus } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
-import { FinalResult } from '../components/TableauView';
+import { FinalResult } from '../components/tableau/tableauTypes';
 import { exportFencersToTXT, exportFencersToFFF } from '../../shared/utils/fencerExport';
 import { exportMultiplePoolsToPDF } from '../../shared/utils/pdfExport';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';

--- a/src/renderer/hooks/useMenuEvents.ts
+++ b/src/renderer/hooks/useMenuEvents.ts
@@ -7,7 +7,7 @@
 import { useEffect, useCallback } from 'react';
 import { PoolRanking } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
-import { FinalResult } from '../components/TableauView';
+import { FinalResult } from '../components/tableau/tableauTypes';
 
 type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs' | 'referees';
 

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -613,6 +613,7 @@ export interface MenuAPI {
   onFileSaved: (callback: (filepath: string) => void) => void;
   onAutosaveCompleted: (callback: () => void) => void;
   onAutosaveFailed: (callback: () => void) => void;
+  onDbReady: (callback: () => void) => void;
 }
 
 export interface UtilityAPI {


### PR DESCRIPTION
## Résumé

- **DB async** : sql.js WASM préchauffé en parallèle avec la fenêtre (`prewarmSqlJs`), lecture du fichier DB en async (`fs.promises.readFile`), save après migrations seulement si nécessaire
- **Fenêtre avant DB** : la fenêtre s'affiche immédiatement, DB ouvre en arrière-plan, event `db:ready` envoyé quand prête
- **Lazy loading** : `CompetitionView` (57KB), `PoolView` (46KB), `TableauView` (77KB), `RemoteScoreManager` (52KB), `KioskDisplay` (45KB), `AnalyticsDashboard`, `PresentationMode`, `FencerComparison`, `QuestPhaseView` — tous chargés à la demande
- **Refactoring** : types et `propagateWinners` extraits de `TableauView` vers `tableau/tableauTypes.ts` pour permettre le lazy-loading sans casser les imports existants

## Impact estimé

| Métrique | Avant | Après |
|----------|-------|-------|
| Time-to-window | ~400-800ms | ~50ms |
| Bundle initial renderer | ~1.52MB | ~800KB (estimation) |
| Premier rendu compétition | sync | lazy (Suspense) |

## Test

1. `npm run build:main && npm start` → vérifier que la fenêtre apparaît immédiatement
2. `npm run analyze` → vérifier les chunks séparés pour TableauView, PoolView, etc.
3. Ouvrir une compétition → vérifier que PoolView et TableauView chargent correctement
4. Tester RemoteScoreManager, KioskDisplay, AnalyticsDashboard (accès conditionnel)

https://claude.ai/code/session_018VjSj1W9SyHCRXKSXBSsPW

---
_Generated by [Claude Code](https://claude.ai/code/session_018VjSj1W9SyHCRXKSXBSsPW)_