### PR TITLE
perf: jsPDF lazy, virtual scroll FencerList, useMemo ranking

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -3,7 +3,8 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useVirtualList } from '../../shared/services/performanceService';
 import QRCode from 'qrcode';
 import { Fencer, FencerStatus } from '../../shared/types';
 import EditFencerModal from './EditFencerModal';
@@ -120,6 +121,18 @@ const FencerListComponent: React.FC<FencerListProps> = ({
           return 0;
       }
     }), [fencers, searchTerm, sortBy]);
+
+  const VIRTUAL_THRESHOLD = 50;
+  const ROW_HEIGHT = 52;
+  const CONTAINER_HEIGHT = 520;
+
+  const virtual = useVirtualList(filteredFencers, {
+    itemHeight: ROW_HEIGHT,
+    overscan: 5,
+    containerHeight: CONTAINER_HEIGHT,
+  });
+
+  const useVirtual = filteredFencers.length > VIRTUAL_THRESHOLD;
 
   const checkedInCount = useMemo(
     () => fencers.filter(f => f.status === FencerStatus.CHECKED_IN).length,
@@ -560,7 +573,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
         </div>
       ) : (
         <div className="card">
-          <table className="table">
+          <table className="table" style={useVirtual ? { tableLayout: 'fixed' } : undefined}>
             <thead>
               <tr>
                 <th style={{ width: '50px' }}>N°</th>
@@ -573,8 +586,18 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                 <th style={{ width: '250px' }}>Actions</th>
               </tr>
             </thead>
+          </table>
+          <div
+            ref={useVirtual ? virtual.containerRef : undefined}
+            onScroll={useVirtual ? virtual.onScroll : undefined}
+            style={useVirtual ? { height: CONTAINER_HEIGHT, overflowY: 'auto' } : undefined}
+          >
+            <table className="table" style={useVirtual ? { tableLayout: 'fixed' } : undefined}>
             <tbody>
-              {filteredFencers.map(fencer => (
+              {useVirtual && virtual.state.offsetY > 0 && (
+                <tr style={{ height: virtual.state.offsetY }}><td colSpan={8} /></tr>
+              )}
+              {(useVirtual ? virtual.visibleItems : filteredFencers).map(fencer => (
                 <tr key={fencer.id}>
                   <td className="text-muted">{fencer.ref}</td>
                   <td className="font-medium">{fencer.lastName}</td>
@@ -683,8 +706,13 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                   </td>
                 </tr>
               ))}
+              {useVirtual && (() => {
+                const bottomHeight = virtual.state.totalHeight - virtual.state.offsetY - (virtual.visibleItems.length * ROW_HEIGHT);
+                return bottomHeight > 0 ? <tr style={{ height: bottomHeight }}><td colSpan={8} /></tr> : null;
+              })()}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/src/renderer/hooks/useExport.ts
+++ b/src/renderer/hooks/useExport.ts
@@ -9,7 +9,6 @@ import { Competition, Fencer, Pool, PoolRanking, FencerStatus } from '../../shar
 import { logger, LogCategory } from '@shared/services/logger';
 import { FinalResult } from '../components/tableau/tableauTypes';
 import { exportFencersToTXT, exportFencersToFFF } from '../../shared/utils/fencerExport';
-import { exportMultiplePoolsToPDF } from '../../shared/utils/pdfExport';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import { useToast } from '../components/Toast';
 import {
@@ -210,10 +209,11 @@ export const useExport = ({ competition, showToast }: UseExportProps) => {
     [competition.title, competition.date, downloadFile, showToast]
   );
 
-  // Export PDF de toutes les poules
+  // Export PDF de toutes les poules — jsPDF chargé à la demande
   const exportPoolsPDF = useCallback(
     async (pools: Pool[], currentPoolRound: number) => {
       try {
+        const { exportMultiplePoolsToPDF } = await import('../../shared/utils/pdfExport');
         const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
         await exportMultiplePoolsToPDF(
           pools,

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import {
   Pool,
   Fencer,
@@ -71,6 +71,13 @@ export const usePoolManagement = ({
       return computeOverallRanking(allPools);
     },
     [poolHistory, computeOverallRanking]
+  );
+
+  // Classement global courant mémoïsé — recalculé seulement quand pools ou poolHistory change
+  const currentOverallRanking = useMemo(
+    () => computeOverallRankingAllRounds(pools),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pools, poolHistory, isLaserSabre]
   );
 
   // Générer les poules
@@ -687,6 +694,7 @@ export const usePoolManagement = ({
     computePoolRanking,
     computeOverallRanking,
     computeOverallRankingAllRounds,
+    currentOverallRanking,
     handleFencerForfeit,
     handleUndoAbandon,
     syncFencersToPool,


### PR DESCRIPTION
## Résumé

- **jsPDF lazy** : `pdfExport` (et donc jsPDF) chargé en `import()` dynamique uniquement au clic sur "Export PDF" — absent du bundle initial
- **Virtual scroll FencerList** : au-delà de 50 tireurs, seules les lignes visibles sont dans le DOM via `useVirtualList` (performanceService.ts déjà existant, maintenant activé)
- **useMemo ranking** : `currentOverallRanking` mémoïsé dans `usePoolManagement` — recalcul seulement quand `pools` ou `poolHistory` change

## Test

1. Ouvrir une compétition avec 60+ tireurs → vérifier que la liste scrolle fluide
2. Exporter PDF de poules → vérifier que ça fonctionne (jsPDF chargé à la demande)
3. `npm run analyze` → vérifier que jsPDF/pdfTemplates est dans un chunk séparé

https://claude.ai/code/session_018VjSj1W9SyHCRXKSXBSsPW

---
_Generated by [Claude Code](https://claude.ai/code/session_018VjSj1W9SyHCRXKSXBSsPW)_