### PR TITLE
fix: nombre de pistes = nombre de poules par défaut (saisie distante)

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -208,7 +208,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   // Synchroniser le nombre d'arènes avec le nombre de poules (seed initial uniquement, pas de valeur restaurée)
   useEffect(() => {
     if (!isLoaded) return;
-    if (pools.length > 0 && remoteArenaCount === 1 && !restoredState?.remoteArenaCount) {
+    if (pools.length > 0 && !restoredState?.remoteArenaCount) {
       setRemoteArenaCount(pools.length);
     }
   }, [isLoaded, pools.length]);


### PR DESCRIPTION
Supprime la condition `=== 1` qui bloquait la synchronisation arènes/poules quand la valeur avait déjà été modifiée. Le nombre de pistes suit maintenant toujours le nombre de poules, sauf si une valeur a été explicitement restaurée depuis l'état persisté.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hoYSLhYPZjjynirRwcgfG)_