### PR TITLE
fix: vue poule distante ne se met pas à jour après remplissage auto

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1206,8 +1206,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
           />
         )}
 
-        {currentPhase === 'remote' && (
-          <Suspense fallback={null}>
+        <Suspense fallback={null}>
           <RemoteScoreManager
             competition={competition}
             pools={pools}
@@ -1218,9 +1217,9 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onStartRemote={() => setIsRemoteActive(true)}
             onStopRemote={() => setIsRemoteActive(false)}
             isRemoteActive={isRemoteActive}
+            isVisible={currentPhase === 'remote'}
           />
-          </Suspense>
-        )}
+        </Suspense>
 
         {currentPhase === 'logs' && (
           <ScoreAuditLog competitionId={competition.id} />

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -23,6 +23,7 @@ interface RemoteScoreManagerProps {
   onStopRemote: () => void;
   isRemoteActive?: boolean;
   initialStripCount?: number;
+  isVisible?: boolean;
 }
 
 interface RemoteSession {
@@ -99,6 +100,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   onStopRemote,
   isRemoteActive = false,
   initialStripCount,
+  isVisible = false,
 }) => {
   const { showToast } = useToast();
   const [session, setSession] = useState<RemoteSession | null>(null);
@@ -489,6 +491,9 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       </button>
     </div>
   );
+
+  // Tous les hooks ont été appelés — retour null si l'onglet n'est pas visible
+  if (!isVisible) return null;
 
   if (!isRemoteActive) {
     return (


### PR DESCRIPTION
## Problème

Après le remplissage automatique des scores (bouton 🎲 Auto), la vue `/areneN/poule` sur les tablettes ne se mettait pas à jour. Seul un arrêt/relance de la saisie distante corrigeait l'affichage.

## Cause racine

`RemoteScoreManager` était monté de façon conditionnelle :

```tsx
{currentPhase === 'remote' && <RemoteScoreManager ... />}
```

Quand l'utilisateur était sur l'onglet **Poules**, le composant était **démonté**. Ses deux `useEffect` de synchronisation ne s'exécutaient donc jamais :

- `sessionPoolsFingerprintRef` → `updatePoolFencers`
- `sessionMatchesFingerprintRef` → `syncPoolMatches`

Les modifications de scores (remplissage auto, saisie manuelle) n'étaient jamais poussées au serveur distant. Le `pool.html` sur les tablettes ne recevait aucun événement `pool:${arenaId}:update`.

## Fix

**2 fichiers modifiés, 8 lignes.**

- `CompetitionView.tsx` : `RemoteScoreManager` est toujours monté (hors condition `currentPhase`), avec `isVisible={currentPhase === 'remote'}`
- `RemoteScoreManager.tsx` : ajout prop `isVisible`, retour `null` quand caché — **après** tous les hooks, donc les rules of hooks sont respectées et les effects de sync s'exécutent toujours

## Test

1. Démarrer la saisie distante (onglet "Saisie distante")
2. Naviguer vers l'onglet "Poules"
3. Ouvrir `/arene1/poule` dans un navigateur
4. Cliquer 🎲 Auto
5. La vue tablette se met à jour **sans** arrêter/relancer la saisie

https://claude.ai/code/session_014avkbwV722zrmzYEqrn3Zk

---
_Generated by [Claude Code](https://claude.ai/code/session_014avkbwV722zrmzYEqrn3Zk)_