### PR TITLE
fix: supprimer pistes fantômes lors réduction du nombre d'arènes

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -586,16 +586,20 @@ export class RemoteScoreServer {
     // Support both /arena1 and /arene1 formats
     this.app.get('/arena:arenaId', (req, res) => {
       const arenaId = req.params.arenaId;
+      if (!this.arenas.has(`arena${arenaId}`)) {
+        return res.status(404).send('Arène non trouvée');
+      }
       console.log(`[RemoteScoreServer] Accès à l'arène ${arenaId}`);
-
       this.sendHtmlFromMemory('arena.html', res);
     });
 
     // Alias /arene pour compatibilité française
     this.app.get('/arene:arenaId', (req, res) => {
       const arenaId = req.params.arenaId;
+      if (!this.arenas.has(`arena${arenaId}`)) {
+        return res.status(404).send('Arène non trouvée');
+      }
       console.log(`[RemoteScoreServer] Accès à l'arène (arene) ${arenaId}`);
-
       this.sendHtmlFromMemory('arena.html', res);
     });
 
@@ -2383,6 +2387,9 @@ export class RemoteScoreServer {
       if (arena.password) savedPasswords.set(id, arena.password);
     });
     this.arenas.clear();
+    this.arenaEventBuffer.clear();
+    this.arenaMatchQueue.clear();
+    this.arenaNextMatchIndex.clear();
 
     for (let i = 1; i <= arenaCount; i++) {
       const arena: Arena = {
@@ -2445,6 +2452,7 @@ export class RemoteScoreServer {
   public setArenaCount(count: number): void {
     console.log(`[RemoteScoreServer] Mise à jour du nombre d'arènes: ${count}`);
     this.initializeArenas(count);
+    this.io?.emit('arenas:updated', this.getAllArenas());
   }
 
   public getArenaCount(): number {
@@ -3714,6 +3722,17 @@ export class RemoteScoreServer {
       this.session.strips.forEach((strip, idx) => {
         strip.number = idx + 1;
       });
+
+      // Supprimer les arènes au-delà du nouveau count
+      for (let i = newCount + 1; i <= currentCount; i++) {
+        const arenaId = `arena${i}`;
+        this.arenas.delete(arenaId);
+        this.arenaMatchQueue.delete(arenaId);
+        this.arenaEventBuffer.delete(arenaId);
+        this.arenaNextMatchIndex.delete(arenaId);
+      }
+      this.arenaCount = newCount;
+      this.io?.emit('arenas:updated', this.getAllArenas());
     }
 
     return this.session;


### PR DESCRIPTION
## Problème

Lancer saisie distante avec 6 arènes, arrêter, relancer avec 5 → la piste 6 restait visible/accessible.

**Cause** : `updateStripCount()` ne mettait à jour que `session.strips` mais pas la Map `arenas`. Les arènes supprimées restaient dans `arenas`, `arenaMatchQueue`, `arenaEventBuffer`, et les routes `/arene6` continuaient à servir du HTML.

## Corrections (`remoteScoreServer.ts`)

- **`updateStripCount()`** : supprime les entrées `arenas`, `arenaMatchQueue`, `arenaEventBuffer`, `arenaNextMatchIndex` pour les arènes au-delà du nouveau count ; émet `arenas:updated` via Socket.IO
- **`initializeArenas()`** : vide `arenaEventBuffer`, `arenaMatchQueue`, `arenaNextMatchIndex` avant recréation (évite pollution inter-sessions)
- **`setArenaCount()`** : émet `arenas:updated` après réinitialisation pour notifier les clients connectés
- **Routes `/arena:N` et `/arene:N`** : retournent 404 si l'arène n'existe pas dans la Map

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtecSmhnJuVV3cUe8va8rW)_