### PR TITLE
fix: kiosk – poules affichées correctement (pill Terminée/En cours)

### DIFF
--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -1135,7 +1135,8 @@
 
         container.innerHTML = pools.map(pool => {
           const rankings = pool.rankings || [];
-          const isComplete = rankings.every(r => (r.matchCount || 0) > 0);
+          const expectedMatches = Math.max(0, rankings.length - 1);
+          const isComplete = rankings.length > 0 && rankings.every(r => (r.matchesPlayed || 0) >= expectedMatches);
           const rows = rankings.map((r, i) => {
             const ind = (r.index >= 0 ? '+' : '') + (r.index || 0);
             const rankClass = i < 3 ? ' rank-' + (i + 1) : '';


### PR DESCRIPTION
## Problème
Le kiosk marquait toutes les poules "Terminée" dès le chargement.

## Cause (deux bugs)
1. `r.matchCount` inexistant — l'API retourne `r.matchesPlayed`. Résultat : toujours `undefined` → `0`.
2. `[].every(fn)` retourne `true` (vérité vacuité) — poule avec rankings vides = "Terminée" à tort.

## Correctif (`kiosk.html` ligne 1138)
- Champ corrigé : `matchesPlayed`
- Guard : `rankings.length > 0` requis avant `every()`
- Logique : une poule est terminée quand chaque tireur a joué `N-1` matchs (N = taille poule)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TatMKvk3Zi8L53GUEm4Ko3)_