### PR TITLE
Afficher le club des combattants sur la phase de tableau

### DIFF
--- a/src/renderer/components/Bracket.tsx
+++ b/src/renderer/components/Bracket.tsx
@@ -36,7 +36,7 @@ interface MatchPosition {
 }
 
 const MATCH_WIDTH = 200;
-const MATCH_HEIGHT = 50;
+const MATCH_HEIGHT = 70;
 const HORIZONTAL_GAP = 80;
 const VERTICAL_GAP = 10;
 
@@ -141,6 +141,16 @@ const Bracket: React.FC<BracketProps> = ({
         >
           {fencer ? `${fencer.lastName} ${fencer.firstName.charAt(0)}.` : 'TBD'}
         </text>
+        {fencer?.club && (
+          <text
+            x={10}
+            y={isTop ? MATCH_HEIGHT / 4 + 16 : (MATCH_HEIGHT * 3) / 4 + 16}
+            fill="#6c757d"
+            fontSize={9}
+          >
+            {fencer.club}
+          </text>
+        )}
         <rect
           x={MATCH_WIDTH - 40}
           y={isTop ? 0 : MATCH_HEIGHT / 2}

--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -68,7 +68,12 @@ const MatchCard: React.FC<MatchCardProps> = ({
       <div className={`match-fencer ${winnerA ? 'match-fencer-winner' : ''} ${!match.fencerA ? 'match-fencer-empty' : ''}`}>
         <div className="match-fencer-info">
           {winnerA && <span className="match-winner-crown">🥇</span>}
-          <span className="match-fencer-name">{fencerName(match.fencerA)}</span>
+          <div className="match-fencer-details">
+            <span className="match-fencer-name">{fencerName(match.fencerA)}</span>
+            {match.fencerA?.club && (
+              <span className="match-fencer-club">{match.fencerA.club}</span>
+            )}
+          </div>
           {match.fencerA?.ranking && (
             <span className="match-fencer-seed">#{match.fencerA.ranking}</span>
           )}
@@ -87,7 +92,12 @@ const MatchCard: React.FC<MatchCardProps> = ({
       <div className={`match-fencer ${winnerB ? 'match-fencer-winner' : ''} ${!match.fencerB ? 'match-fencer-empty' : ''}`}>
         <div className="match-fencer-info">
           {winnerB && <span className="match-winner-crown">🥇</span>}
-          <span className="match-fencer-name">{fencerName(match.fencerB)}</span>
+          <div className="match-fencer-details">
+            <span className="match-fencer-name">{fencerName(match.fencerB)}</span>
+            {match.fencerB?.club && (
+              <span className="match-fencer-club">{match.fencerB.club}</span>
+            )}
+          </div>
           {match.fencerB?.ranking && (
             <span className="match-fencer-seed">#{match.fencerB.ranking}</span>
           )}

--- a/src/renderer/components/tableau/SeedingTable.tsx
+++ b/src/renderer/components/tableau/SeedingTable.tsx
@@ -38,7 +38,8 @@ const SeedingTable: React.FC<SeedingTableProps> = ({ ranking, tableauSize }) => 
               {r.fencer.lastName} {r.fencer.firstName}
             </span>
             <span style={{ fontSize: '0.625rem', color: '#6b7280' }}>
-              {r.fencer.birthDate && `${new Date(r.fencer.birthDate).getFullYear()}`}
+              {r.fencer.club && r.fencer.club}
+              {r.fencer.birthDate && ` • ${new Date(r.fencer.birthDate).getFullYear()}`}
               {r.fencer.ranking && ` • #${r.fencer.ranking}`}
             </span>
           </div>

--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -1242,7 +1242,7 @@ select:focus {
   justify-content: space-between;
   padding: 0.4375rem 0.625rem;
   gap: 0.5rem;
-  min-height: 36px;
+  min-height: 44px;
   transition: background var(--duration-fast) ease;
 }
 
@@ -1260,6 +1260,21 @@ select:focus {
   gap: 0.375rem;
   min-width: 0;
   flex: 1;
+}
+
+.match-fencer-details {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.match-fencer-club {
+  font-size: 0.625rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .match-winner-crown {

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -517,8 +517,8 @@ export interface TableauMatchForPDF {
   id: string;
   round: number;
   position: number;
-  fencerA: { firstName?: string; lastName: string } | null;
-  fencerB: { firstName?: string; lastName: string } | null;
+  fencerA: { firstName?: string; lastName: string; club?: string } | null;
+  fencerB: { firstName?: string; lastName: string; club?: string } | null;
   scoreA: number | null;
   scoreB: number | null;
   winner: { id: string } | null;
@@ -556,6 +556,8 @@ export function generateTableauHTML(
     const roundName = getTableauRoundName(match.round);
     const nameA = `${match.fencerA!.lastName.toUpperCase()} ${match.fencerA!.firstName ?? ''}`.trim();
     const nameB = `${match.fencerB!.lastName.toUpperCase()} ${match.fencerB!.firstName ?? ''}`.trim();
+    const clubA = match.fencerA!.club ?? '';
+    const clubB = match.fencerB!.club ?? '';
     const pisteLabel = match.arena != null ? `Piste ${match.arena}` : 'Piste ___';
     return `
 <div class="match-card">
@@ -581,13 +583,13 @@ export function generateTableauHTML(
     <tbody>
       <tr class="row-a">
         <td class="row-letter">A</td>
-        <td class="fencer-name">${nameA}</td>
+        <td class="fencer-name">${nameA}${clubA ? `<br><span class="fencer-club">${clubA}</span>` : ''}</td>
         <td class="score-box"></td>
         <td class="sig-box"></td>
       </tr>
       <tr class="row-b">
         <td class="row-letter">B</td>
-        <td class="fencer-name">${nameB}</td>
+        <td class="fencer-name">${nameB}${clubB ? `<br><span class="fencer-club">${clubB}</span>` : ''}</td>
         <td class="score-box"></td>
         <td class="sig-box"></td>
       </tr>
@@ -780,6 +782,11 @@ export function generateTableauHTML(
       font-weight: 700;
       letter-spacing: 0.2px;
       vertical-align: middle;
+    }
+    .fencer-club {
+      font-size: 8pt;
+      font-weight: 400;
+      color: var(--gray-dark);
     }
     .score-box {
       border-left: 1px solid var(--border);


### PR DESCRIPTION
## Résumé

- `MatchCard` : club affiché sous le nom (`NOM P.` / club) via `.match-fencer-club`
- `SeedingTable` : club ajouté dans la ligne secondaire du classement avant le bracket
- `Bracket` SVG : club en sous-texte dans chaque slot fenceur (`MATCH_HEIGHT` 50→70px)
- `design.css` : nouvelles classes `.match-fencer-details` et `.match-fencer-club`, `min-height` 36→44px

## Test

Créer une compétition, saisir des tireurs avec club, lancer la phase de tableau — vérifier que le club apparaît sous le nom dans les MatchCards et dans la vue SVG.

https://claude.ai/code/session_019UEZDKHg1QB3oZSY31WpKK

---
_Generated by [Claude Code](https://claude.ai/code/session_019UEZDKHg1QB3oZSY31WpKK)_