### PR TITLE
fix: fencerA = vert, fencerB = rouge (arbitre + arène)

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1236,25 +1236,25 @@
       <!-- Affichage du match -->
       <div class="match-display" id="match-display">
         <div class="fencers-row">
-          <!-- Tireur A (Rouge) -->
-          <div id="fencer-a-display" class="fencer-display red-side">
-            <div id="color-badge-a" class="color-badge red"></div>
+          <!-- Tireur A (Vert) -->
+          <div id="fencer-a-display" class="fencer-display green-side">
+            <div id="color-badge-a" class="color-badge green"></div>
             <div class="fencer-name" id="fencer-a-name">-</div>
             <div class="fencer-club" id="fencer-a-club">-</div>
             <div class="cards-container" id="fencer-a-cards"></div>
-            <div class="score-big red" id="score-a">0</div>
+            <div class="score-big green" id="score-a">0</div>
           </div>
 
           <!-- VS -->
           <div class="vs-divider">VS</div>
 
-          <!-- Tireur B (Vert) -->
-          <div id="fencer-b-display" class="fencer-display green-side">
-            <div id="color-badge-b" class="color-badge green"></div>
+          <!-- Tireur B (Rouge) -->
+          <div id="fencer-b-display" class="fencer-display red-side">
+            <div id="color-badge-b" class="color-badge red"></div>
             <div class="fencer-name" id="fencer-b-name">-</div>
             <div class="fencer-club" id="fencer-b-club">-</div>
             <div class="cards-container" id="fencer-b-cards"></div>
-            <div class="score-big green" id="score-b">0</div>
+            <div class="score-big red" id="score-b">0</div>
           </div>
         </div>
 
@@ -1738,16 +1738,16 @@
           const inv = this.inversionEnabled;
           const dispA = document.getElementById('fencer-a-display');
           const dispB = document.getElementById('fencer-b-display');
-          if (dispA) dispA.className = `fencer-display ${inv ? 'green-side' : 'red-side'}`;
-          if (dispB) dispB.className = `fencer-display ${inv ? 'red-side' : 'green-side'}`;
+          if (dispA) dispA.className = `fencer-display ${inv ? 'red-side' : 'green-side'}`;
+          if (dispB) dispB.className = `fencer-display ${inv ? 'green-side' : 'red-side'}`;
           const badgeA = document.getElementById('color-badge-a');
           const badgeB = document.getElementById('color-badge-b');
-          if (badgeA) badgeA.className = `color-badge ${inv ? 'green' : 'red'}`;
-          if (badgeB) badgeB.className = `color-badge ${inv ? 'red' : 'green'}`;
+          if (badgeA) badgeA.className = `color-badge ${inv ? 'red' : 'green'}`;
+          if (badgeB) badgeB.className = `color-badge ${inv ? 'green' : 'red'}`;
           const scoreA = document.getElementById('score-a');
           const scoreB = document.getElementById('score-b');
-          if (scoreA) { scoreA.className = scoreA.className.replace(/\b(green|red)\b/, inv ? 'green' : 'red'); }
-          if (scoreB) { scoreB.className = scoreB.className.replace(/\b(green|red)\b/, inv ? 'red' : 'green'); }
+          if (scoreA) { scoreA.className = scoreA.className.replace(/\b(green|red)\b/, inv ? 'red' : 'green'); }
+          if (scoreB) { scoreB.className = scoreB.className.replace(/\b(green|red)\b/, inv ? 'green' : 'red'); }
         }
 
         updateCardsDisplay() {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1069,12 +1069,12 @@
       <!-- Match actif -->
       <div class="active-match" id="active-match">
         <div class="fencers-container">
-          <!-- Tireur A (Rouge) -->
-          <div class="fencer-box red-side" id="fencer-a-box">
+          <!-- Tireur A (Vert) -->
+          <div class="fencer-box green-side" id="fencer-a-box">
             <div class="fencer-name" id="fencer-a-name">-</div>
             <div class="fencer-club" id="fencer-a-club">-</div>
             <div class="cards-display" id="fencer-a-cards"></div>
-            <div class="score-display red-score" id="score-a">0</div>
+            <div class="score-display green-score" id="score-a">0</div>
             <div class="score-buttons">
               <button id="btn-plus-1-a" class="score-btn btn-plus-1">+1</button>
               <button id="btn-plus-3-a" class="score-btn btn-plus-3">+3</button>
@@ -1111,12 +1111,12 @@
           <!-- VS -->
           <div class="vs-divider">VS</div>
 
-          <!-- Tireur B (Vert) -->
-          <div class="fencer-box green-side" id="fencer-b-box">
+          <!-- Tireur B (Rouge) -->
+          <div class="fencer-box red-side" id="fencer-b-box">
             <div class="fencer-name" id="fencer-b-name">-</div>
             <div class="fencer-club" id="fencer-b-club">-</div>
             <div class="cards-display" id="fencer-b-cards"></div>
-            <div class="score-display green-score" id="score-b">0</div>
+            <div class="score-display red-score" id="score-b">0</div>
             <div class="score-buttons">
               <button id="btn-plus-1-b" class="score-btn btn-plus-1">+1</button>
               <button id="btn-plus-3-b" class="score-btn btn-plus-3">+3</button>
@@ -2399,12 +2399,12 @@
         applySwapState() {
           const boxA = document.getElementById('fencer-a-box');
           const boxB = document.getElementById('fencer-b-box');
-          if (boxA) boxA.className = `fencer-box ${this.swapped ? 'green-side' : 'red-side'}`;
-          if (boxB) boxB.className = `fencer-box ${this.swapped ? 'red-side' : 'green-side'}`;
+          if (boxA) boxA.className = `fencer-box ${this.swapped ? 'red-side' : 'green-side'}`;
+          if (boxB) boxB.className = `fencer-box ${this.swapped ? 'green-side' : 'red-side'}`;
           const scoreA = document.getElementById('score-a');
           const scoreB = document.getElementById('score-b');
-          if (scoreA) scoreA.className = `score-display ${this.swapped ? 'green-score' : 'red-score'}`;
-          if (scoreB) scoreB.className = `score-display ${this.swapped ? 'red-score' : 'green-score'}`;
+          if (scoreA) scoreA.className = `score-display ${this.swapped ? 'red-score' : 'green-score'}`;
+          if (scoreB) scoreB.className = `score-display ${this.swapped ? 'green-score' : 'red-score'}`;
 
           if (this.currentMatch) {
             const left = this.swapped ? this.currentMatch.fencerB : this.currentMatch.fencerA;


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Le kiosk affichait correctement fencerA = vert, fencerB = rouge
- referee.html et arena.html avaient la convention inverse (A = rouge)
- Ce PR aligne les deux fichiers sur la convention du kiosk

## Fichiers modifiés

- `src/remote/referee.html` : HTML initial + logique `applySwapState`
- `src/remote/arena.html` : HTML initial + logique `applyInversionColors`

## Test

1. Démarrer un serveur remote
2. Ouvrir `/kiosk`, `/arene1`, `/arene1/arbitre`
3. Vérifier : premier tireur appelé = vert partout
4. Tester le swap sur l'arbitre — les couleurs s'inversent correctement

https://claude.ai/code/session_01NP3HYaKiYtCDTfpxeHVtJL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NP3HYaKiYtCDTfpxeHVtJL)_