### PR TITLE
fix(pdf/pool): Quest column, position rang, Club/Nation, prénom complet

### DIFF
--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -144,6 +144,24 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
             Rg
           </div>
         )}
+        {isVisible('club') && (
+          <div
+            className="pool-cell pool-cell-header"
+            onContextMenu={e => { e.preventDefault(); toggleColumn('pool', 'club'); }}
+            title="Clic droit pour masquer"
+          >
+            Club
+          </div>
+        )}
+        {isVisible('nation') && (
+          <div
+            className="pool-cell pool-cell-header"
+            onContextMenu={e => { e.preventDefault(); toggleColumn('pool', 'nation'); }}
+            title="Clic droit pour masquer"
+          >
+            Nat
+          </div>
+        )}
       </div>
 
       {fencers.map((rowFencer, rowIndex) => {
@@ -339,6 +357,16 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
             {isVisible('rank') && (
               <div className="pool-cell" style={{ fontWeight: 600 }}>
                 {rankEntry?.rank || '-'}
+              </div>
+            )}
+            {isVisible('club') && (
+              <div className="pool-cell" style={{ fontSize: '0.75rem', color: '#6b7280' }}>
+                {rowFencer.club ?? ''}
+              </div>
+            )}
+            {isVisible('nation') && (
+              <div className="pool-cell" style={{ fontWeight: 600, textTransform: 'uppercase' }}>
+                {rowFencer.nationality ?? ''}
               </div>
             )}
           </div>

--- a/src/renderer/hooks/useColumnVisibility.ts
+++ b/src/renderer/hooks/useColumnVisibility.ts
@@ -14,7 +14,8 @@ export type ColumnId =
   | 'rank'
   | 'firstName'
   | 'lastName'
-  | 'club';
+  | 'club'
+  | 'nation';
 
 export interface ColumnDefinition {
   id: ColumnId;
@@ -28,8 +29,10 @@ export const POOL_COLUMNS: ColumnDefinition[] = [
   { id: 'td', label: 'TD (Touches données)', labelShort: 'TD' },
   { id: 'tr', label: 'TR (Touches reçues)', labelShort: 'TR' },
   { id: 'quest', label: 'Quest', labelShort: 'Quest' },
-  { id: 'index', label: 'Indice (TD-TR)', labelShort: 'Ind' },
-  { id: 'rank', label: 'Rang', labelShort: 'Rg' },
+  { id: 'index',  label: 'Indice (TD-TR)', labelShort: 'Ind' },
+  { id: 'rank',   label: 'Rang',           labelShort: 'Rg' },
+  { id: 'club',   label: 'Club',           labelShort: 'Club' },
+  { id: 'nation', label: 'Nation',         labelShort: 'Nat' },
 ];
 
 export const RANKING_COLUMNS: ColumnDefinition[] = [

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -5,6 +5,7 @@
  */
 
 import { Pool, Match, MatchStatus, Fencer, PoolRanking, Weapon } from '../types';
+import { calculateFencerQuestStats } from './poolCalculations';
 import type { PdfTemplate } from '../types/pdfTemplate.types';
 
 export interface PoolExportOptions {
@@ -246,15 +247,18 @@ const BASE_CSS = `
 
 // ─── HTML Poule ───────────────────────────────────────────────────────────────
 
-type RankData = { fencer: Fencer; stats: ReturnType<typeof calculateFencerStats>; rank: number };
+type RankData = { fencer: Fencer; stats: ReturnType<typeof calculateFencerStats>; rank: number; questPoints: number };
 
 const STAT_COLS: { id: string; header: string; cls: string; render: (d: RankData) => string }[] = [
-  { id: 'victories', header: 'V',   cls: 'stat-cell', render: d => `${d.stats.v}` },
-  { id: 'ratio',     header: 'V/M', cls: 'stat-cell', render: d => d.stats.ratio.toFixed(2) },
-  { id: 'td',        header: 'TD',  cls: 'stat-cell', render: d => `${d.stats.td}` },
-  { id: 'tr',        header: 'TR',  cls: 'stat-cell', render: d => `${d.stats.tr}` },
-  { id: 'index',     header: 'Ind', cls: 'stat-cell', render: d => d.stats.ind >= 0 ? `+${d.stats.ind}` : `${d.stats.ind}` },
-  { id: 'rank',      header: 'Rg',  cls: 'rank-cell', render: d => `${d.rank}` },
+  { id: 'victories', header: 'V',      cls: 'stat-cell', render: d => `${d.stats.v}` },
+  { id: 'ratio',     header: 'V/M',    cls: 'stat-cell', render: d => d.stats.ratio.toFixed(2) },
+  { id: 'td',        header: 'TD',     cls: 'stat-cell', render: d => `${d.stats.td}` },
+  { id: 'tr',        header: 'TR',     cls: 'stat-cell', render: d => `${d.stats.tr}` },
+  { id: 'index',     header: 'Ind',    cls: 'stat-cell', render: d => d.stats.ind >= 0 ? `+${d.stats.ind}` : `${d.stats.ind}` },
+  { id: 'rank',      header: 'Rg',     cls: 'rank-cell', render: d => `${d.rank}` },
+  { id: 'quest',     header: 'Quest',  cls: 'stat-cell', render: d => `${d.questPoints}` },
+  { id: 'club',      header: 'Club',   cls: 'name-cell', render: d => d.fencer.club ?? '' },
+  { id: 'nation',    header: 'Nation', cls: 'stat-cell', render: d => d.fencer.nationality ?? '' },
 ];
 
 export function generatePoolHTML(pool: Pool, options: PoolExportOptions, template?: PdfTemplate): string {
@@ -266,13 +270,15 @@ export function generatePoolHTML(pool: Pool, options: PoolExportOptions, templat
   const finishedCount = matches.filter(m => m.status === MatchStatus.FINISHED).length;
   const now = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
 
+  const isLaserSabre = options.weapon === 'L';
   const activeCols = options.visibleColumns
-    ? STAT_COLS.filter(c => options.visibleColumns!.includes(c.id))
-    : STAT_COLS;
+    ? STAT_COLS.filter(c => options.visibleColumns!.includes(c.id) && (c.id !== 'quest' || isLaserSabre))
+    : STAT_COLS.filter(c => c.id !== 'quest' || isLaserSabre);
 
   const rankings = fencers.map(f => ({
     fencer: f,
     stats: calculateFencerStats(f, matches),
+    questPoints: calculateFencerQuestStats(f, matches).questPoints,
     rank: 0,
   }));
   rankings.sort((a, b) => {
@@ -300,7 +306,7 @@ export function generatePoolHTML(pool: Pool, options: PoolExportOptions, templat
     return `
       <tr>
         <td class="num-cell">${row + 1}</td>
-        <td class="name-cell">${fencer.lastName.toUpperCase()} ${fencer.firstName?.charAt(0) ?? ''}.</td>
+        <td class="name-cell">(${data.rank}) ${fencer.lastName.toUpperCase()} ${fencer.firstName ?? ''}</td>
         ${cells}
         ${statCells}
         ${sigCell}


### PR DESCRIPTION
## Résumé

- **Bug fix** : colonne Quest absente du PDF de poule même quand sélectionnée — la colonne n'était pas dans `STAT_COLS`
- **Feature** : rang du combattant dans la poule entre parenthèses devant le nom dans le PDF : `(2) VADER Anakin`
- **Feature** : prénom complet dans le PDF (plus juste l'initiale)
- **Feature** : colonnes Club et Nation ajoutées dans l'affichage UI de la grille de poule et dans l'export PDF (masquables au clic droit)

## Fichiers modifiés

- `src/shared/utils/pdfExport.ts` — fix Quest + ajout colonnes club/nation dans STAT_COLS, rang+prénom dans le nom
- `src/renderer/hooks/useColumnVisibility.ts` — type ColumnId + POOL_COLUMNS étendus avec club/nation
- `src/renderer/components/pool/PoolScoreMatrix.tsx` — headers et cellules Club/Nat

## Test plan

- [ ] Poule Laser Sabre : colonne Quest visible si sélectionnée, absente sinon
- [ ] PDF poule : nom affiché `(2) VADER Anakin` (rang + prénom complet)
- [ ] UI grille de poule : colonnes Club et Nat visibles et masquables au clic droit
- [ ] PDF poule : colonnes Club / Nation présentes si sélectionnées

https://claude.ai/code/session_013BXUR5RCNvB2Za8GpSE9QV

---
_Generated by [Claude Code](https://claude.ai/code/session_013BXUR5RCNvB2Za8GpSE9QV)_