### PR TITLE
feat: sous-titres de phase dans le PDF groupé par arène

### DIFF
--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -664,9 +664,14 @@ export function generateTableauHTML(
 
   let globalMatchNum = 0;
   const pagesHTML = pages.map((page, pageIdx) => {
+    let lastRound: number | null = null;
     const cards = page.matches.map(match => {
       globalMatchNum++;
-      return renderMatchCard(match, globalMatchNum);
+      const roundHeader = match.round !== lastRound
+        ? `<div class="round-sub-header">${getTableauRoundName(match.round)}</div>`
+        : '';
+      lastRound = match.round;
+      return roundHeader + renderMatchCard(match, globalMatchNum);
     }).join('');
 
     const sectionHeader = page.label
@@ -723,6 +728,17 @@ export function generateTableauHTML(
       padding: 2mm 4mm;
       border-radius: 4px;
       margin-bottom: 4mm;
+    }
+
+    .round-sub-header {
+      color: var(--navy);
+      font-weight: 600;
+      font-size: 9pt;
+      letter-spacing: 0.3px;
+      padding: 1mm 3mm;
+      margin-top: 3mm;
+      margin-bottom: 2mm;
+      border-left: 3px solid var(--gold);
     }
 
     .match-card {


### PR DESCRIPTION
## Résumé

- Le groupement par arène existait déjà (`hasArenas` branch dans `pdfExport.ts`)
- Ajout de **sous-titres de phase** (ex: « Tableau de 32 ») à chaque changement de round au sein d'une même page/groupe
- Style : filet gauche doré + texte navy, discret mais lisible
- Fonctionne avec ou sans arènes assignées

## Rendu PDF

```
┌────────────────────────────────┐
│ PISTE 1  — 4 combats           │  ← piste-section-header (navy)
├────────────────────────────────┤
│ Tableau de 64                  │  ← round-sub-header (filet doré)
│ [Match card] [Match card]      │
│ Tableau de 32                  │  ← round-sub-header
│ [Match card]                   │
└────────────────────────────────┘
```

## Plan de test

- [ ] Assigner des arènes à des matchs du tableau
- [ ] Exporter PDF → vérifier les headers "Piste X" et sous-titres de phase
- [ ] Sans arènes → sous-titres de phase au changement de round (même logique)

https://claude.ai/code/session_01T1mopVczi86jz4Arf4onLj

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1mopVczi86jz4Arf4onLj)_