### PR TITLE
feat: export arbre du tableau d'élimination directe en PDF

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -11,7 +11,7 @@ import { TableauMatch, FinalResult, ConsolationBracket, propagateWinners } from 
 import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
 import Bracket from './Bracket';
-import { exportTableauToPDF, printTableauHTML, MAX_MATCHES_PER_PAGE_TABLEAU } from '../../shared/utils/pdfExport';
+import { exportTableauToPDF, printTableauHTML, MAX_MATCHES_PER_PAGE_TABLEAU, exportBracketTreeToPDF } from '../../shared/utils/pdfExport';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import MatchCard from './tableau/MatchCard';
 import SeedingTable from './tableau/SeedingTable';
@@ -912,6 +912,16 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     }
   };
 
+  const handleExportTree = async () => {
+    const title = `Arbre — Tableau de ${tableauSize}`;
+    const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+    try {
+      await exportBracketTreeToPDF(matches, title, logo, tableauTemplate);
+    } catch (e) {
+      showToast((e as Error).message, 'error');
+    }
+  };
+
   const handleSpecialStatus = (status: 'abandon' | 'forfait' | 'exclusion') => {
     if (!editingMatch) return;
 
@@ -1394,6 +1404,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
           setSelectedRounds(new Set(rounds));
           setShowPdfModal(true);
         }}
+        onExportTreeClick={handleExportTree}
         champion={champion}
       />
 

--- a/src/renderer/components/tableau/TableauToolbar.tsx
+++ b/src/renderer/components/tableau/TableauToolbar.tsx
@@ -20,6 +20,7 @@ interface TableauToolbarProps {
   onPyramidViewModeToggle: () => void;
   onPrintClick: () => void;
   onExportPdfClick: () => void;
+  onExportTreeClick: () => void;
   champion: Fencer | null | undefined;
 }
 
@@ -36,6 +37,7 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
   onPyramidViewModeToggle,
   onPrintClick,
   onExportPdfClick,
+  onExportTreeClick,
   champion,
 }) => {
   return (
@@ -174,6 +176,25 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
           title="Exporter les feuilles de match en PDF"
         >
           📄 Export PDF
+        </button>
+        <button
+          onClick={onExportTreeClick}
+          style={{
+            background: '#0d9488',
+            color: 'white',
+            border: 'none',
+            padding: '0.5rem 0.75rem',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            fontWeight: '500',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+          }}
+          title="Exporter l'arbre du tableau en PDF"
+        >
+          🌲 Arbre PDF
         </button>
         {champion && (
           <div

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -857,6 +857,256 @@ export async function printTableauHTML(
   }
 }
 
+// ─── Export Arbre (Bracket Tree) ─────────────────────────────────────────────
+
+export function generateBracketTreeHTML(
+  matches: TableauMatchForPDF[],
+  title: string,
+  logoBase64?: string,
+  template?: PdfTemplate
+): string {
+  // ── Layout constants ────────────────────────────────────────────────────────
+  const MATCH_W  = 175;
+  const H_GAP    = 55;
+  const SCORE_W  = 26;
+  const HEADER_H = 60;
+  const GOLD_H   = 4;
+  const LABEL_H  = 24;
+  const TOP_MARGIN = HEADER_H + GOLD_H + LABEL_H;
+  const BOT_MARGIN = 20;
+  const MARGIN_L   = 16;
+  const SVG_H      = 750;
+
+  // ── Separate petite-finale from main bracket ────────────────────────────────
+  const petiteFinale = matches.find(m => m.round === 3);
+  const mainMatches  = matches.filter(m => m.round !== 3 && m.round >= 2);
+
+  if (mainMatches.length === 0) {
+    throw new Error('Aucun match dans le tableau principal');
+  }
+
+  const tableauSize = Math.max(...mainMatches.map(m => m.round));
+  const numRounds   = Math.round(Math.log2(tableauSize));
+
+  // ── Vertical slot height (adapts to bracket size) ──────────────────────────
+  const firstRoundCount = tableauSize / 2;
+  const USABLE_H = SVG_H - TOP_MARGIN - BOT_MARGIN;
+  const SLOT_H   = USABLE_H / firstRoundCount;
+  const ROW_H    = Math.max(14, Math.min(26, Math.floor(SLOT_H * 0.44)));
+  const MATCH_H  = ROW_H * 2;
+
+  // ── SVG viewBox width ───────────────────────────────────────────────────────
+  const naturalW = MARGIN_L + numRounds * MATCH_W + (numRounds - 1) * H_GAP + MARGIN_L;
+  const VBW      = Math.max(900, naturalW);
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+  const truncate = (s: string, n: number) => s.length > n ? s.slice(0, n - 1) + '…' : s;
+
+  const colX = (r: number): number => {
+    const colIndex = Math.round(Math.log2(tableauSize / r));
+    return MARGIN_L + colIndex * (MATCH_W + H_GAP);
+  };
+
+  const matchCenterY = (r: number, p: number): number =>
+    TOP_MARGIN + (p + 0.5) * (tableauSize / r) * SLOT_H;
+
+  const matchTopY = (r: number, p: number): number =>
+    matchCenterY(r, p) - MATCH_H / 2;
+
+  // ── Colour helpers (resolve from template, fallback to defaults) ────────────
+  const navy  = template?.colors.navy  ?? '#1a2e4a';
+  const gold  = template?.colors.gold  ?? '#c9a227';
+  const green = template?.colors.green ?? '#166534';
+  const now   = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
+
+  // ── SVG: header ─────────────────────────────────────────────────────────────
+  const svgHeader = `
+  <rect x="0" y="0" width="${VBW}" height="${HEADER_H}" fill="${navy}"/>
+  ${logoBase64 ? `<image href="${logoBase64}" x="10" y="8" width="44" height="44" preserveAspectRatio="xMinYMid meet"/>` : ''}
+  <text x="${logoBase64 ? 62 : VBW / 2}" y="33"
+        font-family="'Segoe UI',Arial,sans-serif" font-size="16" font-weight="700" fill="white"
+        ${logoBase64 ? '' : 'text-anchor="middle"'}>${title}</text>
+  <text x="${logoBase64 ? 62 : VBW / 2}" y="52"
+        font-family="'Segoe UI',Arial,sans-serif" font-size="9" fill="#f5e6a3"
+        ${logoBase64 ? '' : 'text-anchor="middle"'}>Tableau d'élimination directe — ${now}</text>
+  <text x="${VBW - 14}" y="40" font-family="'Segoe UI',Arial,sans-serif"
+        font-size="22" font-weight="900" fill="${gold}" text-anchor="end">ED</text>`;
+
+  // ── SVG: gold bar ───────────────────────────────────────────────────────────
+  const svgGoldBar = `
+  <rect x="0" y="${HEADER_H}" width="${VBW}" height="${GOLD_H}" fill="${gold}"/>`;
+
+  // ── SVG: round labels ───────────────────────────────────────────────────────
+  const roundNums = [...new Set(mainMatches.map(m => m.round))].sort((a, b) => b - a);
+  const labelY    = TOP_MARGIN - 6;
+  const roundLabels = roundNums.map(r => {
+    const cx = colX(r) + MATCH_W / 2;
+    return `<text x="${cx}" y="${labelY}" font-family="'Segoe UI',Arial,sans-serif"
+        font-size="9" font-weight="600" fill="${navy}" text-anchor="middle">${getTableauRoundName(r)}</text>`;
+  }).join('\n  ');
+
+  const petiteFinaleLabel = petiteFinale ? `
+  <text x="${colX(2) + MATCH_W / 2}" y="${SVG_H - BOT_MARGIN - MATCH_H - 8}"
+        font-family="'Segoe UI',Arial,sans-serif"
+        font-size="8" font-weight="600" fill="${navy}" text-anchor="middle">Petite finale</text>` : '';
+
+  // ── SVG: connection lines ───────────────────────────────────────────────────
+  const connectors = mainMatches
+    .filter(m => m.round > 2)
+    .map(m => {
+      const { round: r, position: p } = m;
+      const x   = colX(r);
+      const cy  = matchCenterY(r, p);
+      const midX = x + MATCH_W + H_GAP / 2;
+      const parentX = colX(r / 2);
+
+      const stubH = `<line x1="${x + MATCH_W}" y1="${cy}" x2="${midX}" y2="${cy}" stroke="#94a3b8" stroke-width="1.5"/>`;
+
+      if (p % 2 !== 0) return stubH;
+
+      const sibCy    = matchCenterY(r, p + 1);
+      const parentY  = (cy + sibCy) / 2;
+      return `${stubH}
+    <line x1="${midX}" y1="${cy}" x2="${midX}" y2="${sibCy}" stroke="#94a3b8" stroke-width="1.5"/>
+    <line x1="${midX}" y1="${parentY}" x2="${parentX}" y2="${parentY}" stroke="#94a3b8" stroke-width="1.5"/>`;
+    }).join('\n  ');
+
+  // ── SVG: match box renderer ─────────────────────────────────────────────────
+  const renderMatchBox = (match: TableauMatchForPDF, x: number, yTop: number): string => {
+    const { fencerA, fencerB, scoreA, scoreB, winner, isBye } = match;
+    const fa_id = (fencerA as any)?.id as string | undefined;
+    const fb_id = (fencerB as any)?.id as string | undefined;
+    const wid   = winner?.id;
+    const winA  = !!(wid && fa_id && wid === fa_id);
+    const winB  = !!(wid && fb_id && wid === fb_id);
+
+    const nameW   = MATCH_W - SCORE_W;
+    const fs      = Math.max(7, Math.min(9, Math.floor(ROW_H * 0.42)));
+    const clubFs  = Math.max(6, fs - 2);
+    const scoreFs = Math.max(8, Math.min(11, Math.floor(ROW_H * 0.5)));
+    const showClub = ROW_H >= 20;
+
+    if (isBye) {
+      const byeName = fencerA
+        ? truncate(`${fencerA.lastName.toUpperCase()} ${fencerA.firstName?.charAt(0) ?? ''}.`, 22)
+        : fencerB
+        ? truncate(`${fencerB.lastName.toUpperCase()} ${fencerB.firstName?.charAt(0) ?? ''}.`, 22)
+        : '';
+      return `<g>
+        <rect x="${x}" y="${yTop}" width="${MATCH_W}" height="${MATCH_H}" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1" rx="2"/>
+        ${byeName ? `<text x="${x + MATCH_W / 2}" y="${yTop + MATCH_H / 2 - 3}"
+              text-anchor="middle" dominant-baseline="auto"
+              font-family="'Segoe UI',Arial,sans-serif" font-size="${fs}" fill="#475569" font-weight="600">${byeName}</text>` : ''}
+        <text x="${x + MATCH_W / 2}" y="${yTop + MATCH_H / 2 + fs + 2}"
+              text-anchor="middle"
+              font-family="'Segoe UI',Arial,sans-serif" font-size="${clubFs}" fill="#94a3b8" font-style="italic">Exempté</text>
+      </g>`;
+    }
+
+    const mkRow = (
+      fencer: TableauMatchForPDF['fencerA'],
+      score: number | null,
+      isWinner: boolean,
+      rowY: number
+    ): string => {
+      const name = fencer
+        ? truncate(`${fencer.lastName.toUpperCase()} ${fencer.firstName?.charAt(0) ?? ''}.`, 22)
+        : 'TBD';
+      const club = showClub && fencer?.club ? truncate(fencer.club, 20) : '';
+      const bg   = isWinner ? '#dcfce7' : fencer ? (rowY === yTop ? '#f0f7ff' : '#ffffff') : '#f8fafc';
+      const tc   = isWinner ? green : '#1e293b';
+      const fw   = isWinner ? '700' : '500';
+      const nameY = rowY + (club ? ROW_H * 0.38 : ROW_H * 0.5);
+      const clubY = rowY + ROW_H * 0.75;
+
+      return `<rect x="${x}" y="${rowY}" width="${nameW}" height="${ROW_H}" fill="${bg}"/>
+        <rect x="${x + nameW}" y="${rowY}" width="${SCORE_W}" height="${ROW_H}" fill="${bg}"/>
+        <text x="${x + 4}" y="${nameY}" dominant-baseline="middle"
+              font-family="'Segoe UI',Arial,sans-serif" font-size="${fs}" font-weight="${fw}" fill="${tc}">${name}</text>
+        ${club ? `<text x="${x + 4}" y="${clubY}" dominant-baseline="middle"
+              font-family="'Segoe UI',Arial,sans-serif" font-size="${clubFs}" fill="#94a3b8">${club}</text>` : ''}
+        <text x="${x + nameW + SCORE_W / 2}" y="${rowY + ROW_H / 2}" text-anchor="middle" dominant-baseline="middle"
+              font-family="'Segoe UI',Arial,sans-serif" font-size="${scoreFs}" font-weight="700" fill="${tc}">${score !== null ? score : ''}</text>`;
+    };
+
+    return `<g>
+      <rect x="${x}" y="${yTop}" width="${MATCH_W}" height="${MATCH_H}" fill="white" stroke="#e2e8f0" stroke-width="0.75" rx="2"/>
+      ${mkRow(fencerA, scoreA, winA, yTop)}
+      <line x1="${x}" y1="${yTop + ROW_H}" x2="${x + MATCH_W}" y2="${yTop + ROW_H}" stroke="#e2e8f0" stroke-width="0.75"/>
+      <line x1="${x + nameW}" y1="${yTop}" x2="${x + nameW}" y2="${yTop + MATCH_H}" stroke="#e2e8f0" stroke-width="0.75"/>
+      ${mkRow(fencerB, scoreB, winB, yTop + ROW_H)}
+      <rect x="${x}" y="${yTop}" width="${MATCH_W}" height="${MATCH_H}" fill="none" stroke="#94a3b8" stroke-width="1" rx="2"/>
+    </g>`;
+  };
+
+  // ── SVG: all match boxes ────────────────────────────────────────────────────
+  const matchBoxes = [
+    ...mainMatches.map(m => renderMatchBox(m, colX(m.round), matchTopY(m.round, m.position))),
+    ...(petiteFinale ? [renderMatchBox(petiteFinale, colX(2), SVG_H - BOT_MARGIN - MATCH_H)] : []),
+  ].join('\n  ');
+
+  // ── SVG: footer ─────────────────────────────────────────────────────────────
+  const svgFooter = `
+  <line x1="${MARGIN_L}" y1="${SVG_H - 10}" x2="${VBW - MARGIN_L}" y2="${SVG_H - 10}" stroke="#e2e8f0" stroke-width="0.75"/>
+  <text x="${MARGIN_L}" y="${SVG_H - 3}" font-family="'Segoe UI',Arial,sans-serif" font-size="7" fill="#94a3b8">BellePoule Modern</text>
+  <text x="${VBW - MARGIN_L}" y="${SVG_H - 3}" font-family="'Segoe UI',Arial,sans-serif" font-size="7" fill="#94a3b8" text-anchor="end">${now}</text>`;
+
+  // ── Assemble ─────────────────────────────────────────────────────────────────
+  const cssOverrides = template ? buildCssOverrides(template) : '';
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>${title}</title>
+  <style>
+    ${cssOverrides}
+    @page { size: A4 landscape; margin: 0; }
+    @media print { body { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { width: 297mm; height: 210mm; overflow: hidden; }
+    svg { display: block; width: 100%; height: 100%; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 ${VBW} ${SVG_H}"
+     preserveAspectRatio="xMinYMid meet">
+  ${svgHeader}
+  ${svgGoldBar}
+  ${roundLabels}
+  ${petiteFinaleLabel}
+  <g id="connectors">${connectors}</g>
+  <g id="matches">${matchBoxes}</g>
+  ${svgFooter}
+</svg>
+</body>
+</html>`;
+}
+
+export async function exportBracketTreeToPDF(
+  matches: TableauMatchForPDF[],
+  title: string = 'Arbre — Élimination Directe',
+  logoBase64?: string,
+  template?: PdfTemplate
+): Promise<void> {
+  const html = generateBracketTreeHTML(matches, title, logoBase64, template);
+  await savePDF(html, 'arbre-elimination.pdf');
+}
+
+export async function printBracketTreeHTML(
+  matches: TableauMatchForPDF[],
+  title: string = 'Arbre — Élimination Directe',
+  logoBase64?: string,
+  template?: PdfTemplate
+): Promise<void> {
+  const html = generateBracketTreeHTML(matches, title, logoBase64, template);
+  const api = (window as any).electronAPI;
+  if (!api?.file?.printHtml) throw new Error('API Electron non disponible');
+  const res = await api.file.printHtml(html);
+  if (!res?.success) throw new Error(res?.error ?? "Échec de l'impression");
+}
+
 // ─── Export Classement Général ───────────────────────────────────────────────
 
 export function generateRankingHTML(


### PR DESCRIPTION
## Résumé

- Ajoute `generateBracketTreeHTML()` dans `pdfExport.ts` : génère un SVG complet du bracket tree (tous les rounds, lignes de connexion classiques, gauche = premier tour, droite = finale)
- Gagnants surlignés en vert, byes affichés "Exempté" en gris, petite finale positionnée sous la colonne finale
- Scaling automatique via `viewBox` pour les grands tableaux (T64/T128)
- Bouton **🌲 Arbre PDF** dans la barre d'outils du tableau

## Plan de test

- [ ] Ouvrir un tournoi avec tableau d'élimination actif
- [ ] Cliquer "🌲 Arbre PDF" dans la barre d'outils
- [ ] Vérifier que le dialogue de sauvegarde s'ouvre
- [ ] Vérifier que le PDF affiche le bracket tree complet (rounds connectés, noms, scores)
- [ ] Tester avec T8, T16, T32 — vérifier les proportions
- [ ] Tester avec byes — cases grisées "Exempté"
- [ ] Tester avec un champion connu — rangée verte sur le gagnant

https://claude.ai/code/session_017GEbRfjouWLdzgGC6ebFum

---
_Generated by [Claude Code](https://claude.ai/code/session_017GEbRfjouWLdzgGC6ebFum)_