### PR TITLE
fix: actualisation automatique des tablettes au changement de tour DE

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3937,13 +3937,6 @@ export class RemoteScoreServer {
     for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
 
     for (const match of pending) {
-      // Ne distribuer automatiquement que les matchs explicitement assignés à une piste.
-      // Les matchs sans piste restent dans sessionMatches mais ne sont pas auto-assignés
-      // (le DT les assignera manuellement depuis l'interface tableau).
-      if (!match.arena) {
-        rrIndex++;
-        continue;
-      }
       const preferred = `arena${match.arena}`;
       const targetId = this.arenas.has(preferred) ? preferred : `arena${(rrIndex % strips) + 1}`;
       queuesByArena.get(targetId)!.push({


### PR DESCRIPTION
## Problème

Au changement de tour (64→32→16…), les tablettes arbitres ne s'actualisaient pas et restaient bloquées en état "idle". L'utilisateur devait relancer la saisie distante manuellement.

## Cause

Dans `refreshDeMatches()`, un guard rejetait tous les matchs sans piste explicite (`match.arena` non défini) :

```typescript
if (!match.arena) {
  rrIndex++;
  continue;  // nouveaux matchs du tour suivant tous ignorés
}
```

Les matchs du nouveau tour n'ayant pas encore de piste assignée, aucun n'était distribué dans `queuesByArena`. Les arènes idle ne recevaient jamais `assignMatchToArena` → pas de `broadcastArenaUpdate` → tablettes bloquées.

## Fix

Suppression du guard. La logique round-robin existante gère déjà le fallback :

```typescript
const preferred = `arena${match.arena}`;  // 'arenaundefined' si pas de piste
const targetId = this.arenas.has(preferred) ? preferred : `arena${(rrIndex % strips) + 1}`;
```

- Matchs **avec** piste explicite → affectés à la bonne arène (inchangé)
- Matchs **sans** piste → distribués round-robin aux arènes disponibles
- Arène idle + match en queue → `assignMatchToArena` → `broadcastArenaUpdate` → tablettes actualisées

https://claude.ai/code/session_01VPRMvBnnq8F4QxWsbt2dey

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPRMvBnnq8F4QxWsbt2dey)_