### PR TITLE
Bouton "Désaffecter tout" dans le tableau d'élimination

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -202,6 +202,16 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     [arenaCount, distributeArenasRoundRobin, matches, onMatchesChange, onMatchArenaChange]
   );
 
+  const handleBulkDeassign = useCallback(() => {
+    const updated = matches.map(m => ({ ...m, arena: null as number | null }));
+    onMatchesChange(updated);
+    matches.forEach(m => {
+      if (m.arena != null) {
+        onMatchArenaChange?.(m.id, m.arena, null);
+      }
+    });
+  }, [matches, onMatchesChange, onMatchArenaChange]);
+
   useEffect(() => {
     const eligibleCount = ranking.filter(
       r =>
@@ -1387,6 +1397,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         arenaCount={arenaCount}
         autoAssignArenas={autoAssignArenas}
         onAutoAssignToggle={handleAutoAssignToggle}
+        onBulkDeassign={handleBulkDeassign}
         onAutoFillScores={handleAutoFillScores}
         viewMode={viewMode}
         onViewModeToggle={() => setViewMode(viewMode === 'full' ? 'pending' : 'full')}

--- a/src/renderer/components/tableau/TableauToolbar.tsx
+++ b/src/renderer/components/tableau/TableauToolbar.tsx
@@ -13,6 +13,7 @@ interface TableauToolbarProps {
   arenaCount: number;
   autoAssignArenas: boolean;
   onAutoAssignToggle: (enabled: boolean) => void;
+  onBulkDeassign: () => void;
   onAutoFillScores: () => void;
   viewMode: 'full' | 'pending';
   onViewModeToggle: () => void;
@@ -30,6 +31,7 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
   arenaCount,
   autoAssignArenas,
   onAutoAssignToggle,
+  onBulkDeassign,
   onAutoFillScores,
   viewMode,
   onViewModeToggle,
@@ -54,30 +56,51 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
       </h2>
       <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
         {arenaCount > 0 && (
-          <label
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.4rem',
-              fontSize: '0.875rem',
-              color: '#374151',
-              cursor: 'pointer',
-              padding: '0.5rem 0.75rem',
-              background: autoAssignArenas ? '#eff6ff' : '#f3f4f6',
-              border: `1px solid ${autoAssignArenas ? '#3b82f6' : '#d1d5db'}`,
-              borderRadius: '6px',
-              userSelect: 'none',
-            }}
-            title="Assigne automatiquement les matchs aux arènes disponibles en round-robin"
-          >
-            <input
-              type="checkbox"
-              checked={autoAssignArenas}
-              onChange={e => onAutoAssignToggle(e.target.checked)}
-              style={{ cursor: 'pointer' }}
-            />
-            <span>🏟️ Assignation auto</span>
-          </label>
+          <>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.4rem',
+                fontSize: '0.875rem',
+                color: '#374151',
+                cursor: 'pointer',
+                padding: '0.5rem 0.75rem',
+                background: autoAssignArenas ? '#eff6ff' : '#f3f4f6',
+                border: `1px solid ${autoAssignArenas ? '#3b82f6' : '#d1d5db'}`,
+                borderRadius: '6px',
+                userSelect: 'none',
+              }}
+              title="Assigne automatiquement les matchs aux arènes disponibles en round-robin"
+            >
+              <input
+                type="checkbox"
+                checked={autoAssignArenas}
+                onChange={e => onAutoAssignToggle(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span>🏟️ Assignation auto</span>
+            </label>
+            <button
+              onClick={onBulkDeassign}
+              style={{
+                background: '#ef4444',
+                color: 'white',
+                border: 'none',
+                padding: '0.5rem 0.75rem',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                fontSize: '0.875rem',
+                fontWeight: '500',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.25rem',
+              }}
+              title="Désaffecter tous les matches de toutes les arènes"
+            >
+              ❌ Désaffecter tout
+            </button>
+          </>
         )}
         <button
           onClick={onAutoFillScores}


### PR DESCRIPTION
## Résumé

- Ajoute un bouton **❌ Désaffecter tout** dans la barre d'outils du tableau d'élimination directe
- Visible uniquement quand `arenaCount > 0` (même condition que le checkbox "Assignation auto")
- Désaffecte en masse tous les matches de toutes les arènes en un clic, via la même chaîne de callbacks qu'une désaffectation unitaire (`onMatchArenaChange` → `remote.updateMatchArena(..., null)`)

## Fichiers modifiés

- `src/renderer/components/tableau/TableauToolbar.tsx` — prop `onBulkDeassign` + bouton rouge
- `src/renderer/components/TableauView.tsx` — handler `handleBulkDeassign` + passage du prop

## Plan de test

- [ ] Configurer une compétition avec arènes
- [ ] Générer le tableau, affecter des matches à des arènes
- [ ] Cliquer "❌ Désaffecter tout" → toutes les badges d'arènes disparaissent
- [ ] Vérifier pas de régression sur l'auto-assign (checkbox toujours fonctionnelle)

https://claude.ai/code/session_01LHVP2MfetUbJe4nwv9MEQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHVP2MfetUbJe4nwv9MEQq)_