### PR TITLE
fix(FencerList): prénom affiché sous "Né(e)" quand liste < 50 tireurs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.873",
+  "version": "1.0.3-build.890",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.873",
+      "version": "1.0.3-build.890",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -573,26 +573,64 @@ const FencerListComponent: React.FC<FencerListProps> = ({
         </div>
       ) : (
         <div className="card">
-          <table className="table" style={useVirtual ? { tableLayout: 'fixed' } : undefined}>
-            <thead>
-              <tr>
-                <th style={{ width: '50px' }}>N°</th>
-                <th>Nom</th>
-                <th>Prénom</th>
-                <th>Né(e)</th>
-                <th>Club</th>
-                <th>Classement</th>
-                <th>Statut</th>
-                <th style={{ width: '250px' }}>Actions</th>
-              </tr>
-            </thead>
-          </table>
+          {useVirtual && (
+            <table className="table" style={{ tableLayout: 'fixed' }}>
+              <colgroup>
+                <col style={{ width: '50px' }} />
+                <col />
+                <col />
+                <col style={{ width: '70px' }} />
+                <col />
+                <col style={{ width: '110px' }} />
+                <col style={{ width: '90px' }} />
+                <col style={{ width: '250px' }} />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>N°</th>
+                  <th>Nom</th>
+                  <th>Prénom</th>
+                  <th>Né(e)</th>
+                  <th>Club</th>
+                  <th>Classement</th>
+                  <th>Statut</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+            </table>
+          )}
           <div
             ref={useVirtual ? virtual.containerRef : undefined}
             onScroll={useVirtual ? virtual.onScroll : undefined}
             style={useVirtual ? { height: CONTAINER_HEIGHT, overflowY: 'auto' } : undefined}
           >
             <table className="table" style={useVirtual ? { tableLayout: 'fixed' } : undefined}>
+              {useVirtual && (
+                <colgroup>
+                  <col style={{ width: '50px' }} />
+                  <col />
+                  <col />
+                  <col style={{ width: '70px' }} />
+                  <col />
+                  <col style={{ width: '110px' }} />
+                  <col style={{ width: '90px' }} />
+                  <col style={{ width: '250px' }} />
+                </colgroup>
+              )}
+              {!useVirtual && (
+                <thead>
+                  <tr>
+                    <th style={{ width: '50px' }}>N°</th>
+                    <th>Nom</th>
+                    <th>Prénom</th>
+                    <th>Né(e)</th>
+                    <th>Club</th>
+                    <th>Classement</th>
+                    <th>Statut</th>
+                    <th style={{ width: '250px' }}>Actions</th>
+                  </tr>
+                </thead>
+              )}
             <tbody>
               {useVirtual && virtual.state.offsetY > 0 && (
                 <tr style={{ height: virtual.state.offsetY }}><td colSpan={8} /></tr>


### PR DESCRIPTION
$(cat <<'EOF'
## Problème

Lors de l'import d'un fichier `.fff`, le prénom des tireurs apparaissait visuellement dans la colonne **Né(e)** au lieu de la colonne **Prénom** (ex : "Louis" dans la colonne année pour SALIOU).

## Cause racine

**Bug d'affichage dans `FencerList.tsx`**, pas dans le parsing FFF.

Le composant utilisait **deux `<table>` HTML séparées** :
- Table 1 : `<thead>` seul (en-têtes)
- Table 2 : `<tbody>` seul (données)

Quand `useVirtual = false` (seuil = 50 tireurs, cas d'un fichier à 39 tireurs), aucune contrainte `tableLayout: fixed` n'était appliquée. Le navigateur calculait les largeurs de colonnes indépendamment pour chaque table → décalage.

La colonne **N°** du header est fixée à `50px`, mais dans le body elle s'auto-dimensionne à ~25-30px selon le contenu (`"1"`, `"12"`). Toutes les colonnes suivantes décalent d'environ 20-25px vers la droite → le prénom (col 3 du body) apparaît sous l'en-tête "Né(e)" (col 4 du header).

## Fix

- **`useVirtual = false`** : le `<thead>` est maintenant dans la **même `<table>`** que le `<tbody>` → le navigateur calcule un layout cohérent pour l'ensemble.
- **`useVirtual = true`** : les deux tables séparées (nécessaires pour le header fixe + scroll) partagent désormais un **`<colgroup>` identique** avec des largeurs explicites pour garantir l'alignement.

## Test

1. Importer un `.fff` avec < 50 tireurs
2. Vérifier PRÉNOM = prénom, NÉ(E) = année de naissance

https://claude.ai/code/session_01MeUTqrjkoSRBs5ZA1aBhNf
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeUTqrjkoSRBs5ZA1aBhNf)_