### PR TITLE
fix: rouge à gauche par défaut sur arbitre, arène et public

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1236,25 +1236,25 @@
       <!-- Affichage du match -->
       <div class="match-display" id="match-display">
         <div class="fencers-row">
-          <!-- Tireur A (Vert) -->
-          <div id="fencer-a-display" class="fencer-display green-side">
-            <div id="color-badge-a" class="color-badge green"></div>
+          <!-- Tireur A (Rouge) -->
+          <div id="fencer-a-display" class="fencer-display red-side">
+            <div id="color-badge-a" class="color-badge red"></div>
             <div class="fencer-name" id="fencer-a-name">-</div>
             <div class="fencer-club" id="fencer-a-club">-</div>
             <div class="cards-container" id="fencer-a-cards"></div>
-            <div class="score-big green" id="score-a">0</div>
+            <div class="score-big red" id="score-a">0</div>
           </div>
 
           <!-- VS -->
           <div class="vs-divider">VS</div>
 
-          <!-- Tireur B (Rouge) -->
-          <div id="fencer-b-display" class="fencer-display red-side">
-            <div id="color-badge-b" class="color-badge red"></div>
+          <!-- Tireur B (Vert) -->
+          <div id="fencer-b-display" class="fencer-display green-side">
+            <div id="color-badge-b" class="color-badge green"></div>
             <div class="fencer-name" id="fencer-b-name">-</div>
             <div class="fencer-club" id="fencer-b-club">-</div>
             <div class="cards-container" id="fencer-b-cards"></div>
-            <div class="score-big red" id="score-b">0</div>
+            <div class="score-big green" id="score-b">0</div>
           </div>
         </div>
 
@@ -1713,8 +1713,8 @@
 
           const fA = this.currentMatch.fencerA || {};
           const fB = this.currentMatch.fencerB || {};
-          const left  = this.inversionEnabled ? fB : fA;
-          const right = this.inversionEnabled ? fA : fB;
+          const left  = this.inversionEnabled ? fA : fB;
+          const right = this.inversionEnabled ? fB : fA;
 
           document.getElementById('fencer-a-name').textContent =
             `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
@@ -1728,8 +1728,8 @@
           const sB = this.currentMatch.scoreB;
           const valA = (typeof sA === 'object' ? (sA?.value ?? 0) : sA) ?? 0;
           const valB = (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
-          document.getElementById('score-a').textContent = this.inversionEnabled ? valB : valA;
-          document.getElementById('score-b').textContent = this.inversionEnabled ? valA : valB;
+          document.getElementById('score-a').textContent = this.inversionEnabled ? valA : valB;
+          document.getElementById('score-b').textContent = this.inversionEnabled ? valB : valA;
 
           this.applyInversionColors();
         }
@@ -1738,16 +1738,16 @@
           const inv = this.inversionEnabled;
           const dispA = document.getElementById('fencer-a-display');
           const dispB = document.getElementById('fencer-b-display');
-          if (dispA) dispA.className = `fencer-display ${inv ? 'red-side' : 'green-side'}`;
-          if (dispB) dispB.className = `fencer-display ${inv ? 'green-side' : 'red-side'}`;
+          if (dispA) dispA.className = `fencer-display ${inv ? 'green-side' : 'red-side'}`;
+          if (dispB) dispB.className = `fencer-display ${inv ? 'red-side' : 'green-side'}`;
           const badgeA = document.getElementById('color-badge-a');
           const badgeB = document.getElementById('color-badge-b');
-          if (badgeA) badgeA.className = `color-badge ${inv ? 'red' : 'green'}`;
-          if (badgeB) badgeB.className = `color-badge ${inv ? 'green' : 'red'}`;
+          if (badgeA) badgeA.className = `color-badge ${inv ? 'green' : 'red'}`;
+          if (badgeB) badgeB.className = `color-badge ${inv ? 'red' : 'green'}`;
           const scoreA = document.getElementById('score-a');
           const scoreB = document.getElementById('score-b');
-          if (scoreA) { scoreA.className = scoreA.className.replace(/\b(green|red)\b/, inv ? 'red' : 'green'); }
-          if (scoreB) { scoreB.className = scoreB.className.replace(/\b(green|red)\b/, inv ? 'green' : 'red'); }
+          if (scoreA) { scoreA.className = scoreA.className.replace(/\b(green|red)\b/, inv ? 'green' : 'red'); }
+          if (scoreB) { scoreB.className = scoreB.className.replace(/\b(green|red)\b/, inv ? 'red' : 'green'); }
         }
 
         updateCardsDisplay() {
@@ -1759,8 +1759,8 @@
               )
               .join('');
 
-          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsB : this.cardsA);
-          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsA : this.cardsB);
+          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsA : this.cardsB);
+          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsB : this.cardsA);
         }
 
         updateTimerDisplay(timerStatus) {
@@ -1871,8 +1871,8 @@
           if (!this.nextMatch) return;
           const fA = this.nextMatch.fencerA || {};
           const fB = this.nextMatch.fencerB || {};
-          const left  = this.inversionEnabled ? fB : fA;
-          const right = this.inversionEnabled ? fA : fB;
+          const left  = this.inversionEnabled ? fA : fB;
+          const right = this.inversionEnabled ? fB : fA;
 
           document.getElementById('next-name-a').textContent =
             `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
@@ -1914,8 +1914,8 @@
           const fA = this.currentMatch.fencerA || {};
           const fB = this.currentMatch.fencerB || {};
 
-          const left  = this.inversionEnabled ? fB : fA;
-          const right = this.inversionEnabled ? fA : fB;
+          const left  = this.inversionEnabled ? fA : fB;
+          const right = this.inversionEnabled ? fB : fA;
 
           document.getElementById('intro-name-a').textContent =
             `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
@@ -1949,8 +1949,8 @@
           if (this.nextMatch) {
             const fA = this.nextMatch.fencerA || {};
             const fB = this.nextMatch.fencerB || {};
-            const left  = this.inversionEnabled ? fB : fA;
-            const right = this.inversionEnabled ? fA : fB;
+            const left  = this.inversionEnabled ? fA : fB;
+            const right = this.inversionEnabled ? fB : fA;
             document.getElementById('idle-name-a').textContent =
               `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
             document.getElementById('idle-club-a').textContent = left.club || '';

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -1094,8 +1094,8 @@
 
           const fA = this.currentMatch.fencerA || {};
           const fB = this.currentMatch.fencerB || {};
-          const left  = this.inversionEnabled ? fB : fA;
-          const right = this.inversionEnabled ? fA : fB;
+          const left  = this.inversionEnabled ? fA : fB;
+          const right = this.inversionEnabled ? fB : fA;
 
           document.getElementById('fencer-a-name').textContent =
             `${left.lastName || ''} ${left.firstName || ''}`.trim() || '-';
@@ -1109,8 +1109,8 @@
           const sB = this.currentMatch.scoreB;
           const valA = (typeof sA === 'object' ? (sA?.value ?? 0) : sA) ?? 0;
           const valB = (typeof sB === 'object' ? (sB?.value ?? 0) : sB) ?? 0;
-          document.getElementById('score-a').textContent = this.inversionEnabled ? valB : valA;
-          document.getElementById('score-b').textContent = this.inversionEnabled ? valA : valB;
+          document.getElementById('score-a').textContent = this.inversionEnabled ? valA : valB;
+          document.getElementById('score-b').textContent = this.inversionEnabled ? valB : valA;
 
           this.applyInversionColors();
         }
@@ -1140,8 +1140,8 @@
               )
               .join('');
 
-          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsB : this.cardsA);
-          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsA : this.cardsB);
+          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsA : this.cardsB);
+          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.inversionEnabled ? this.cardsB : this.cardsA);
         }
 
         updateTimerDisplay(timerStatus) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1069,12 +1069,12 @@
       <!-- Match actif -->
       <div class="active-match" id="active-match">
         <div class="fencers-container">
-          <!-- Tireur A (Vert) -->
-          <div class="fencer-box green-side" id="fencer-a-box">
+          <!-- Tireur A (Rouge) -->
+          <div class="fencer-box red-side" id="fencer-a-box">
             <div class="fencer-name" id="fencer-a-name">-</div>
             <div class="fencer-club" id="fencer-a-club">-</div>
             <div class="cards-display" id="fencer-a-cards"></div>
-            <div class="score-display green-score" id="score-a">0</div>
+            <div class="score-display red-score" id="score-a">0</div>
             <div class="score-buttons">
               <button id="btn-plus-1-a" class="score-btn btn-plus-1">+1</button>
               <button id="btn-plus-3-a" class="score-btn btn-plus-3">+3</button>
@@ -1111,12 +1111,12 @@
           <!-- VS -->
           <div class="vs-divider">VS</div>
 
-          <!-- Tireur B (Rouge) -->
-          <div class="fencer-box red-side" id="fencer-b-box">
+          <!-- Tireur B (Vert) -->
+          <div class="fencer-box green-side" id="fencer-b-box">
             <div class="fencer-name" id="fencer-b-name">-</div>
             <div class="fencer-club" id="fencer-b-club">-</div>
             <div class="cards-display" id="fencer-b-cards"></div>
-            <div class="score-display red-score" id="score-b">0</div>
+            <div class="score-display green-score" id="score-b">0</div>
             <div class="score-buttons">
               <button id="btn-plus-1-b" class="score-btn btn-plus-1">+1</button>
               <button id="btn-plus-3-b" class="score-btn btn-plus-3">+3</button>
@@ -2393,22 +2393,22 @@
         }
 
         _effectiveFencer(configFencer) {
-          return this.swapped ? (configFencer === 'A' ? 'B' : 'A') : configFencer;
+          return this.swapped ? configFencer : (configFencer === 'A' ? 'B' : 'A');
         }
 
         applySwapState() {
           const boxA = document.getElementById('fencer-a-box');
           const boxB = document.getElementById('fencer-b-box');
-          if (boxA) boxA.className = `fencer-box ${this.swapped ? 'red-side' : 'green-side'}`;
-          if (boxB) boxB.className = `fencer-box ${this.swapped ? 'green-side' : 'red-side'}`;
+          if (boxA) boxA.className = `fencer-box ${this.swapped ? 'green-side' : 'red-side'}`;
+          if (boxB) boxB.className = `fencer-box ${this.swapped ? 'red-side' : 'green-side'}`;
           const scoreA = document.getElementById('score-a');
           const scoreB = document.getElementById('score-b');
-          if (scoreA) scoreA.className = `score-display ${this.swapped ? 'red-score' : 'green-score'}`;
-          if (scoreB) scoreB.className = `score-display ${this.swapped ? 'green-score' : 'red-score'}`;
+          if (scoreA) scoreA.className = `score-display ${this.swapped ? 'green-score' : 'red-score'}`;
+          if (scoreB) scoreB.className = `score-display ${this.swapped ? 'red-score' : 'green-score'}`;
 
           if (this.currentMatch) {
-            const left = this.swapped ? this.currentMatch.fencerB : this.currentMatch.fencerA;
-            const right = this.swapped ? this.currentMatch.fencerA : this.currentMatch.fencerB;
+            const left = this.swapped ? this.currentMatch.fencerA : this.currentMatch.fencerB;
+            const right = this.swapped ? this.currentMatch.fencerB : this.currentMatch.fencerA;
             const leftName = `${left?.lastName || ''} ${left?.firstName || ''}`.trim();
             const rightName = `${right?.lastName || ''} ${right?.firstName || ''}`.trim();
             const nameElA = document.getElementById('fencer-a-name');
@@ -2435,8 +2435,8 @@
             scoreAEl.classList.add('not-started');
             scoreBEl.classList.add('not-started');
           } else {
-            scoreAEl.textContent = this.swapped ? this.scoreB : this.scoreA;
-            scoreBEl.textContent = this.swapped ? this.scoreA : this.scoreB;
+            scoreAEl.textContent = this.swapped ? this.scoreA : this.scoreB;
+            scoreBEl.textContent = this.swapped ? this.scoreB : this.scoreA;
             scoreAEl.classList.remove('not-started');
             scoreBEl.classList.remove('not-started');
           }
@@ -2451,8 +2451,8 @@
               )
               .join('');
 
-          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.swapped ? this.cardsB : this.cardsA);
-          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.swapped ? this.cardsA : this.cardsB);
+          document.getElementById('fencer-a-cards').innerHTML = renderCards(this.swapped ? this.cardsA : this.cardsB);
+          document.getElementById('fencer-b-cards').innerHTML = renderCards(this.swapped ? this.cardsB : this.cardsA);
         }
 
         toggleTimer() {


### PR DESCRIPTION
## Résumé

- Par défaut : fencerB (rouge) à gauche, fencerA (vert) à droite
- Swap/inversion : fencerA (vert) à gauche
- Cohérent sur les 3 vues : arbitre, arène, public

## Fichiers modifiés

- `src/remote/referee.html` — HTML initial, `applySwapState`, `updateScores`, `updateCardsDisplay`, `_effectiveFencer`
- `src/remote/arena.html` — HTML initial, `applyInversionColors`, `updateMatchDisplay`, `updateCardsDisplay`
- `src/remote/public.html` — `updateMatchDisplay`, `updateCardsDisplay`

https://claude.ai/code/session_01NP3HYaKiYtCDTfpxeHVtJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NP3HYaKiYtCDTfpxeHVtJL)_