### PR TITLE
fix(arbitre): VS en orange, tiret not-started cohérent par côté

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -195,10 +195,16 @@
       }
 
       .score-display.not-started {
-        color: #16a34a !important;
-        background-color: rgba(22, 163, 74, 0.12);
         border-radius: 10px;
         padding: 0.15rem 0.6rem;
+      }
+
+      .score-display.red-score.not-started {
+        background-color: rgba(220, 38, 38, 0.12);
+      }
+
+      .score-display.green-score.not-started {
+        background-color: rgba(22, 163, 74, 0.12);
       }
 
       /* Boutons de score */
@@ -302,7 +308,7 @@
       .vs-divider {
         font-size: 1.5rem;
         font-weight: 700;
-        color: #ef4444;
+        color: #f97316;
       }
 
       /* ── Modal sélecteur de raison ── */


### PR DESCRIPTION
## Changements

- **VS** : couleur `#ef4444` (rouge) → `#f97316` (orange), neutre et non ambigu
- **Tiret `–` avant démarrage** : suppression du `color: #16a34a !important` global ; le tiret hérite désormais de `.red-score` (rouge) ou `.green-score` (vert) selon le côté ; le fond de highlight suit la même logique

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEyW4hLCU7v9yF8J6KyG5j)_