### PR TITLE
fix(pdf): pagination tableau — respecter matchesPerPage + en-tête répété

### DIFF
--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -652,18 +652,25 @@ export function generateTableauHTML(
       }
     }
   } else {
-    // No arenas: simple chunking, first page gets one fewer match to account for the doc header
-    const firstPageCount = Math.max(1, matchesPerPage - 1);
     const sorted = [...real].sort((a, b) => b.round - a.round || a.position - b.position);
-    let i = 0;
-    if (sorted.length > 0) {
-      pages.push({ matches: sorted.slice(0, firstPageCount) });
-      i = firstPageCount;
-    }
-    for (; i < sorted.length; i += matchesPerPage) {
+    for (let i = 0; i < sorted.length; i += matchesPerPage) {
       pages.push({ matches: sorted.slice(i, i + matchesPerPage) });
     }
   }
+
+  const effectiveTitle = template?.customTitle?.trim() || title;
+  const cssOverrides = template ? buildCssOverrides(template) : '';
+
+  const pageHeaderHTML = `
+  <div class="doc-header doc-header--compact">
+    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
+    <div class="doc-header-left">
+      <h1>${effectiveTitle}</h1>
+      <div class="subtitle">Feuilles d'arbitrage — Élimination directe</div>
+    </div>
+    <div class="doc-header-badge">ED</div>
+  </div>
+  <div class="gold-bar"></div>`;
 
   let globalMatchNum = 0;
   const pagesHTML = pages.map((page, pageIdx) => {
@@ -682,23 +689,10 @@ export function generateTableauHTML(
       : '';
 
     const isLast = pageIdx === pages.length - 1;
-    return `<div class="page${isLast ? '' : ' page-break'}">${sectionHeader}${cards}</div>`;
+    return `<div class="page${isLast ? '' : ' page-break'}">${pageHeaderHTML}${sectionHeader}${cards}</div>`;
   }).join('');
 
-  const effectiveTitle = template?.customTitle?.trim() || title;
-  const cssOverrides = template ? buildCssOverrides(template) : '';
-
   const sections: Record<string, string> = {
-    'header': `
-  <div class="doc-header">
-    ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
-    <div class="doc-header-left">
-      <h1>${effectiveTitle}</h1>
-      <div class="subtitle">Feuilles d'arbitrage — Élimination directe</div>
-    </div>
-    <div class="doc-header-badge" style="font-size:11pt">ED</div>
-  </div>`,
-    'gold-bar': `  <div class="gold-bar"></div>`,
     'match-cards': `  ${pagesHTML}`,
     'footer': `
   <div class="doc-footer">
@@ -707,7 +701,7 @@ export function generateTableauHTML(
   </div>`,
   };
 
-  const defaultOrder = ['header', 'gold-bar', 'match-cards', 'footer'];
+  const defaultOrder = ['match-cards', 'footer'];
   const body = assembleBody(sections, template, defaultOrder);
 
   return `<!DOCTYPE html>
@@ -721,6 +715,25 @@ export function generateTableauHTML(
     @page { size: A4; margin: 12mm 10mm; }
 
     .page-break { page-break-after: always; }
+
+    .doc-header--compact {
+      padding: 2.5mm 4mm;
+    }
+    .doc-header--compact .doc-header-left h1 {
+      font-size: 11pt;
+    }
+    .doc-header--compact .doc-header-badge {
+      font-size: 9pt;
+      min-width: 10mm;
+      height: 10mm;
+    }
+    .doc-header--compact .doc-header-logo {
+      max-height: 7mm;
+    }
+    .doc-header--compact .subtitle {
+      font-size: 7.5pt;
+      margin-top: 0.8mm;
+    }
 
     .piste-section-header {
       background: var(--navy);


### PR DESCRIPTION
## Problèmes corrigés

- **Pagination incorrecte** : la première page recevait `matchesPerPage - 1` matchs au lieu de `matchesPerPage` (hack `-1` censé compenser l'espace de l'en-tête global)
- **En-tête absent des pages suivantes** : l'en-tête était rendu une seule fois avant tous les `.page`, donc absent à partir de la page 2

## Changements

- Suppression du hack `firstPageCount = matchesPerPage - 1` dans le chemin sans arènes
- Déplacement de `effectiveTitle`/`cssOverrides` avant la génération des pages
- Injection d'un `pageHeaderHTML` dans chaque `<div class="page">` (en-tête répété à chaque page imprimée)
- Classe `.doc-header--compact` : padding réduit (2.5mm vs 5mm), h1 à 11pt vs 15pt, badge 10mm vs 16mm, logo max 7mm — conserve la lisibilité sans empiéter trop sur les matchs
- Sections `header` et `gold-bar` supprimées du dict `sections` (maintenant embarquées dans chaque page)

https://claude.ai/code/session_016L45B6WxfpskEEkrZ2y7jF

---
_Generated by [Claude Code](https://claude.ai/code/session_016L45B6WxfpskEEkrZ2y7jF)_