### PR TITLE
feat: critère 3 — meilleur score en un match (remplace l'indice TD-TR)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.890",
+  "version": "1.0.3-build.894",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.890",
+      "version": "1.0.3-build.894",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -218,6 +218,7 @@ export interface PoolStats {
   index: number; // Indice (TD - TR)
   matchesPlayed: number; // Matchs joués
   victoryRatio: number; // V/M (ratio victoires/matchs)
+  maxSingleMatchScore?: number; // Meilleur score marqué en un seul match
   poolRank?: number; // Rang dans la poule
   overallRank?: number; // Rang général après poules
 }
@@ -320,6 +321,7 @@ export interface PoolRanking {
   questVictories2?: number; // Nombre de victoires à 2 points (écart 4-7)
   questVictories1?: number; // Nombre de victoires à 1 point (écart ≤3)
   totalCards?: number;      // Nombre total de cartons reçus (critère de départage Quest)
+  maxSingleMatchScore?: number; // Meilleur score marqué en un seul match
 }
 
 // ============================================================================

--- a/src/shared/utils/poolCalculations.test.ts
+++ b/src/shared/utils/poolCalculations.test.ts
@@ -142,6 +142,7 @@ describe('calculateFencerPoolStats', () => {
     expect(stats.index).toBe(5);
     expect(stats.matchesPlayed).toBe(2);
     expect(stats.victoryRatio).toBe(1);
+    expect(stats.maxSingleMatchScore).toBe(5); // max(5, 5) = 5
   });
 
   it('should calculate stats correctly for a loser', () => {
@@ -159,6 +160,7 @@ describe('calculateFencerPoolStats', () => {
     expect(stats.index).toBe(-2);
     expect(stats.matchesPlayed).toBe(1);
     expect(stats.victoryRatio).toBe(0);
+    expect(stats.maxSingleMatchScore).toBe(3);
   });
 
   it('should ignore unfinished matches', () => {
@@ -279,6 +281,49 @@ describe('calculatePoolRanking', () => {
     expect(ranking[0].ratio).toBeCloseTo(1.0);
     expect(ranking[1].fencer.id).toBe(fencerA.id); // ratio 0.667 (2V/3M)
     expect(ranking[1].ratio).toBeCloseTo(2 / 3);
+  });
+
+  it('should rank by maxSingleMatchScore when V/M ratio is tied', () => {
+    // Round-robin à 3 : A vs B, A vs C, B vs C
+    // A : bat B 5-1, perd vs C 4-5  → 1V/2M ratio=0.5, maxSingle=5
+    // B : perd vs A 1-5, bat C 4-3  → 1V/2M ratio=0.5, maxSingle=4
+    // C : bat A 5-4, perd vs B 3-4  → 1V/2M ratio=0.5, maxSingle=5
+    // C et A ont maxSingle=5 mais A a battu B (5-1) et C a perdu vs B →
+    //   en confrontation directe A vs C : C a gagné → C devant A
+    // → classement : C (ratio=0.5,max=5) > A (ratio=0.5,max=5) > B (ratio=0.5,max=4)
+    const fA = createMockFencer('fA', 1, 'FencerA');
+    const fB = createMockFencer('fB', 2, 'FencerB');
+    const fC = createMockFencer('fC', 3, 'FencerC');
+
+    const matches: Match[] = [
+      createMockMatch('m1', fA, fB, 5, 1), // A beats B (maxA=5, maxB=1)
+      createMockMatch('m2', fC, fA, 5, 4), // C beats A (maxC=5, maxA stays 5)
+      createMockMatch('m3', fB, fC, 4, 3), // B beats C (maxB=4, maxC stays 5)
+    ];
+
+    const pool: Pool = {
+      id: 'p1',
+      number: 1,
+      phaseId: 'ph1',
+      fencers: [fA, fB, fC],
+      matches,
+      referees: [],
+      isComplete: true,
+      hasError: false,
+      ranking: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const ranking = calculatePoolRanking(pool);
+
+    // B doit être dernier (maxSingle=4, les deux autres ont 5)
+    expect(ranking[2].fencer.id).toBe(fB.id);
+    expect(ranking[2].maxSingleMatchScore).toBe(4);
+    // A et C sont devant B
+    const posA = ranking.findIndex(r => r.fencer.id === fA.id);
+    const posB = ranking.findIndex(r => r.fencer.id === fB.id);
+    expect(posA).toBeLessThan(posB);
   });
 
   it('should rank active fencer first and append excluded/forfeit/abandoned at the end', () => {

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -161,6 +161,7 @@ export function calculateFencerPoolStats(fencer: Fencer, matches: Match[]): Pool
   let touchesScored = 0;
   let touchesReceived = 0;
   let matchesPlayed = 0;
+  let maxSingleMatchScore = 0;
 
   for (const match of matches) {
     // Vérifier si le tireur est dans ce match
@@ -186,6 +187,7 @@ export function calculateFencerPoolStats(fencer: Fencer, matches: Match[]): Pool
     }
 
     matchesPlayed++;
+    maxSingleMatchScore = Math.max(maxSingleMatchScore, myScore.value ?? 0);
 
     // Gestion des cas spéciaux
     if (myScore.isAbstention || myScore.isExclusion || myScore.isForfait) {
@@ -218,6 +220,7 @@ export function calculateFencerPoolStats(fencer: Fencer, matches: Match[]): Pool
     index,
     matchesPlayed,
     victoryRatio,
+    maxSingleMatchScore,
   };
 }
 
@@ -235,9 +238,9 @@ function assignRanks(rankings: PoolRanking[]): void {
       const sameVictories = prev.ratio === curr.ratio;
       const sameQuest = (prev.questPoints ?? 0) === (curr.questPoints ?? 0);
       const sameCards = (prev.totalCards ?? 0) === (curr.totalCards ?? 0);
-      const sameIndex = prev.index === curr.index;
+      const sameSingleMatch = (prev.maxSingleMatchScore ?? 0) === (curr.maxSingleMatchScore ?? 0);
 
-      if (sameVictories && sameQuest && sameCards && sameIndex) {
+      if (sameVictories && sameQuest && sameCards && sameSingleMatch) {
         rankings[i].rank = rankings[i - 1].rank;
       } else {
         rankings[i].rank = currentRank;
@@ -316,6 +319,7 @@ export function calculatePoolRanking(pool: Pool): PoolRanking[] {
       index: stats.index,
       ratio: stats.victoryRatio,
       questPoints: questStats.questPoints,
+      maxSingleMatchScore: stats.maxSingleMatchScore ?? 0,
     });
   }
 
@@ -343,9 +347,11 @@ export function calculatePoolRanking(pool: Pool): PoolRanking[] {
       return bQuest - aQuest;
     }
 
-    // 3. Indice (TD - TR) (décroissant)
-    if (a.index !== b.index) {
-      return b.index - a.index;
+    // 3. Meilleur score en un match (décroissant)
+    const aMax = a.maxSingleMatchScore ?? 0;
+    const bMax = b.maxSingleMatchScore ?? 0;
+    if (aMax !== bMax) {
+      return bMax - aMax;
     }
 
     // 4. Confrontation directe — O(1) grâce à la Map
@@ -899,6 +905,10 @@ function mergeFencerRankings(rankings: PoolRanking[]): PoolRanking[] {
       existing.index = existing.touchesScored - existing.touchesReceived;
       existing.ratio =
         existing.matchesPlayed > 0 ? existing.victories / existing.matchesPlayed : 0;
+      existing.maxSingleMatchScore = Math.max(
+        existing.maxSingleMatchScore ?? 0,
+        r.maxSingleMatchScore ?? 0
+      );
       existing.questPoints = (existing.questPoints ?? 0) + (r.questPoints ?? 0);
       existing.questVictories4 = (existing.questVictories4 ?? 0) + (r.questVictories4 ?? 0);
       existing.questVictories3 = (existing.questVictories3 ?? 0) + (r.questVictories3 ?? 0);
@@ -941,9 +951,11 @@ export function calculateOverallRanking(pools: Pool[]): PoolRanking[] {
     if (aQuest !== bQuest) {
       return bQuest - aQuest;
     }
-    // 3. Indice (TD-TR)
-    if (a.index !== b.index) {
-      return b.index - a.index;
+    // 3. Meilleur score en un match
+    const aMax = a.maxSingleMatchScore ?? 0;
+    const bMax = b.maxSingleMatchScore ?? 0;
+    if (aMax !== bMax) {
+      return bMax - aMax;
     }
     // 4. Égalité parfaite - garder l'ordre
     return 0;


### PR DESCRIPTION
## Résumé

- Remplace le critère 3 de classement des poules (indice TD−TR) par le **meilleur score marqué en un seul match** (`maxSingleMatchScore`)
- Nouvel ordre : V/M → Quest Points → maxSingleMatchScore → Confrontation directe → Classement initial
- Appliqué dans `calculatePoolRanking`, `calculateOverallRanking`, `assignRanks`, et `mergeFencerRankings` (fusion multi-poules : prend le max, pas la somme)

## Fichiers modifiés

- `src/shared/types/index.ts` — champ `maxSingleMatchScore` ajouté à `PoolStats` et `PoolRanking`
- `src/shared/utils/poolCalculations.ts` — calcul + tri mis à jour
- `src/shared/utils/poolCalculations.test.ts` — assertions `maxSingleMatchScore` + test de classement dédié

## Plan de test

- [ ] `npm run test:run` → 23/23 tests poolCalculations passent ✅
- [ ] `npm run type-check` → aucune erreur TypeScript ✅
- [ ] Test manuel : poule où deux tireurs ont même V/M → celui avec le meilleur score en un match est devant

https://claude.ai/code/session_019AGFKZWxwHtanPtXe2wDBF

---
_Generated by [Claude Code](https://claude.ai/code/session_019AGFKZWxwHtanPtXe2wDBF)_