### PR TITLE
fix(kiosk): supprime les médailles du classement intermédiaire

### DIFF
--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -1209,14 +1209,10 @@
           return;
         }
 
-        const medals = ['🥇', '🥈', '🥉'];
         tbody.innerHTML = ranking.map((r, i) => {
           const ind = (r.index >= 0 ? '+' : '') + (r.index || 0);
-          const topClass = i < 3 ? ' class="top-row"' : '';
-          const rankDisplay = i < 3
-            ? `<span class="rank-medal">${medals[i]}</span>`
-            : `<span style="color:#64748b;font-weight:700">${i + 1}</span>`;
-          return `<tr${topClass}>
+          const rankDisplay = `<span style="color:#64748b;font-weight:700">${i + 1}</span>`;
+          return `<tr>
             <td>${rankDisplay}</td>
             <td>
               <div style="font-weight:500">${escHtml(r.lastName)} ${escHtml(r.firstName || '')}</div>


### PR DESCRIPTION
## Résumé

- Supprime les émojis 🥇🥈🥉 et le fond doré pour le top 3 dans `renderRanking()`
- Tous les tireurs affichés avec le même style (numéro gris, pas de distinction)
- Concerne uniquement le classement kiosk **avant** le tableau final

## Test

Lancer une compétition avec poules terminées → onglet Classement du kiosk → aucune médaille visible, tous les rangs identiques visuellement.

https://claude.ai/code/session_01Uz6qFFY2mP6twXNYr9AEbH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uz6qFFY2mP6twXNYr9AEbH)_