### PR TITLE
fix: nombre de pistes non respecté / non persisté (saisie distante)

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3390,10 +3390,10 @@ export class RemoteScoreServer {
       matchesFromRenderer &&
       matchesFromRenderer.length > 0 &&
       matchesFromRenderer.every((m: any) => m.isTableau || m.__poolFencers);
-    if (!isDeOnlySession && (strips <= 0 || strips < poolCount)) {
+    if (!isDeOnlySession && strips <= 0) {
       const actualStrips = poolCount > 0 ? poolCount : 1;
       console.log(
-        `[RemoteScoreServer] Nombre de pistes ajusté: ${strips} -> ${actualStrips} (basé sur ${poolCount} poules)`
+        `[RemoteScoreServer] Strips invalide (${strips}), ajustement automatique: ${actualStrips} (basé sur ${poolCount} poules)`
       );
       strips = actualStrips;
     }

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -205,13 +205,18 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     poolPrepParams,
   });
 
-  // Synchroniser le nombre d'arènes avec le nombre de poules (seed initial uniquement, pas de valeur restaurée)
+  // Synchroniser le nombre d'arènes avec le nombre de poules
   useEffect(() => {
     if (!isLoaded) return;
-    if (pools.length > 0 && !restoredState?.remoteArenaCount) {
-      setRemoteArenaCount(pools.length);
+    if (pools.length > 0) {
+      if (!restoredState?.remoteArenaCount) {
+        setRemoteArenaCount(pools.length);
+      } else if (remoteArenaCount > pools.length) {
+        // Les poules ont rétréci depuis le dernier run : clamp pour éviter des arènes fantômes.
+        setRemoteArenaCount(pools.length);
+      }
     }
-  }, [isLoaded, pools.length]);
+  }, [isLoaded, pools.length, remoteArenaCount]);
 
   // Restaurer l'état au chargement
   useEffect(() => {

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -169,13 +169,17 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       .catch(() => setQrDataUrl(null));
   }, [activeQR]);
 
-  // Initialisation : priorité à initialStripCount (persisté depuis parent), puis nombre de poules
+  // Initialisation : priorité localStorage → initialStripCount (parent) → nombre de poules
   useEffect(() => {
     if (pendingCount !== null) return;
-    const initial = initialStripCount ?? (pools.length > 0 ? pools.length : 1);
+    const lsKey = `bellepoule-remote-strips-${competition.id}`;
+    const lsSaved = localStorage.getItem(lsKey);
+    const initial = lsSaved
+      ? parseInt(lsSaved, 10)
+      : (initialStripCount ?? (pools.length > 0 ? pools.length : 1));
     setPendingCount(initial);
     setCommittedCount(initial);
-  }, [initialStripCount, pools.length]);
+  }, [initialStripCount, pools.length, competition.id]);
 
   const effectivePending = pendingCount ?? pools.length ?? 1;
   const effectiveCommitted = committedCount ?? pools.length ?? 1;
@@ -355,17 +359,20 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           setSession(result.session);
           setCommittedCount(newCount);
           onArenaCountChange?.(newCount);
+          localStorage.setItem(`bellepoule-remote-strips-${competition.id}`, String(newCount));
           showToast('Nombre de pistes mis à jour', 'success');
         } else {
           showToast(`Erreur: ${result.error}`, 'error');
         }
       } catch (error) {
         logger.error(LogCategory.UI, 'Failed to update strip count', error as Error);
+        showToast('Erreur lors de la mise à jour des pistes', 'error');
       }
     } else {
       // Serveur non démarré : persister la préférence
       setCommittedCount(newCount);
       onArenaCountChange?.(newCount);
+      localStorage.setItem(`bellepoule-remote-strips-${competition.id}`, String(newCount));
       showToast('Préférence sauvegardée', 'success');
     }
   };


### PR DESCRIPTION
## Problème

L'utilisateur configure 5 pistes, mais le serveur démarre avec 6. Même après avoir arrêté la saisie distante, réduit le chiffre et cliqué "Sauvegarder", les 6 pistes restent.

## Causes racines

**RC1 — Auto-ajustement serveur abusif** (`remoteScoreServer.ts`)
La condition `strips < poolCount` forçait le serveur à remonter le count au nombre de poules en DB (qui peut être périmé). Si la DB avait 6 poules et l'utilisateur demandait 5, le serveur imposait 6 silencieusement.

**RC2 — `remoteArenaCount` périmé non clampé** (`CompetitionView.tsx`)
Si la session précédente avait 6 arènes (`restoredState.remoteArenaCount = 6`) et que les poules rétrécissaient à 5, la valeur 6 était transmise intacte comme `initialStripCount` au composant enfant.

**RC3 — Aucune persistence localStorage** (`RemoteScoreManager.tsx`)
Le port est sauvegardé en localStorage, mais pas le nombre de pistes. À chaque remontage du composant ou rechargement de l'app, le count revenait à la valeur du parent (`restoredState`) ou `pools.length`.

**RC4 — Catch silencieux dans `handleSaveStripCount`**
En cas d'erreur IPC, l'utilisateur ne voyait aucun retour visuel.

## Corrections

| Fichier | Changement |
|---------|-----------|
| `remoteScoreServer.ts` | `strips <= 0 \|\| strips < poolCount` → `strips <= 0` : on n'auto-ajuste que si invalide |
| `CompetitionView.tsx` | Clamp `remoteArenaCount` quand `pools.length < remoteArenaCount` |
| `RemoteScoreManager.tsx` | Init depuis `localStorage` en priorité ; `setItem` dans les deux branches de save ; toast d'erreur dans le catch |

https://claude.ai/code/session_01NaHRHiB4d8u4kKsgGMvvva

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaHRHiB4d8u4kKsgGMvvva)_