### PR TITLE
fix: arènes vides au démarrage tableau quand auto-assign désactivé

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3571,42 +3571,24 @@ export class RemoteScoreServer {
       console.log(
         `[RemoteScoreServer] ${deMatches.length} matchs DE à distribuer sur ${strips} arènes`
       );
-      let rrIndex = 0;
       const queuesByArena = new Map<string, ArenaMatch[]>();
       for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
 
       for (const match of deMatches) {
-        const targetArenaId = match.arena
-          ? `arena${match.arena}`
-          : `arena${(rrIndex % strips) + 1}`;
-        if (!queuesByArena.has(targetArenaId)) {
-          // arène hors plage → round-robin sur arènes disponibles
-          const fallbackId = `arena${(rrIndex % strips) + 1}`;
-          queuesByArena.get(fallbackId)!.push({
-            id: match.id,
-            fencerA: match.fencerA,
-            fencerB: match.fencerB,
-            scoreA: 0,
-            scoreB: 0,
-            status: 'not_started',
-            startTime: null,
-            endTime: null,
-            isTableau: true,
-          });
-        } else {
-          queuesByArena.get(targetArenaId)!.push({
-            id: match.id,
-            fencerA: match.fencerA,
-            fencerB: match.fencerB,
-            scoreA: 0,
-            scoreB: 0,
-            status: 'not_started',
-            startTime: null,
-            endTime: null,
-            isTableau: true,
-          });
-        }
-        rrIndex++;
+        if (!match.arena) continue; // pas d'arène assignée → attente d'affectation manuelle
+        const targetArenaId = `arena${match.arena}`;
+        if (!queuesByArena.has(targetArenaId)) continue; // hors plage → ignorer
+        queuesByArena.get(targetArenaId)!.push({
+          id: match.id,
+          fencerA: match.fencerA,
+          fencerB: match.fencerB,
+          scoreA: 0,
+          scoreB: 0,
+          status: 'not_started',
+          startTime: null,
+          endTime: null,
+          isTableau: true,
+        });
       }
 
       for (const [arenaId, queue] of queuesByArena) {
@@ -3940,14 +3922,14 @@ export class RemoteScoreServer {
     }
 
     const pending = deMatches.filter(m => !activeMatchIds.has(m.id));
-    let rrIndex = 0;
     const queuesByArena = new Map<string, ArenaMatch[]>();
     for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
 
     for (const match of pending) {
+      if (!match.arena) continue; // pas d'arène assignée → attente d'affectation manuelle
       const preferred = `arena${match.arena}`;
-      const targetId = this.arenas.has(preferred) ? preferred : `arena${(rrIndex % strips) + 1}`;
-      queuesByArena.get(targetId)!.push({
+      if (!this.arenas.has(preferred)) continue; // hors plage → ignorer
+      queuesByArena.get(preferred)!.push({
         id: match.id,
         fencerA: match.fencerA,
         fencerB: match.fencerB,
@@ -3958,7 +3940,6 @@ export class RemoteScoreServer {
         endTime: null,
         isTableau: true,
       });
-      rrIndex++;
     }
 
     for (const [arenaId, queue] of queuesByArena) {


### PR DESCRIPTION
## Problème

En phase tableau d'élimination directe, même avec l'auto-assignation des arènes **désactivée** (comportement par défaut), les arènes 1 et 2 se retrouvaient chargées de 4 matchs chacune dès l'entrée en phase tableau.

## Cause racine

Dans `remoteScoreServer.ts`, deux fonctions (`startSession` et `refreshDeMatches`) appliquaient un fallback round-robin quand `match.arena` était `null` :

```typescript
// Avant — round-robin même si pas d'arène assignée
const targetArenaId = match.arena
  ? `arena${match.arena}`
  : `arena${(rrIndex % strips) + 1}`;  // ← toujours exécuté
```

Quand `autoAssignArenas = false` dans `TableauView.tsx`, `distributeArenasRoundRobin()` n'est pas appelée, donc `match.arena` reste `null`. Mais le serveur distribuait quand même en round-robin.

## Fix

Suppression du fallback round-robin dans les deux fonctions : si `match.arena` est `null`, le match reste dans `sessionMatches` sans être mis en file d'aucune arène. L'opérateur l'assigne ensuite manuellement depuis l'app (`updateMatchArena`).

| État `match.arena` | Avant | Après |
|---|---|---|
| `null` (auto-assign OFF) | Round-robin → arène 1, 2… | Skip → arène vide |
| `1`, `2`… (auto-assign ON ou assignation manuelle) | Respecté | Respecté |
| Hors plage | Round-robin fallback | Skip |

## Test

- Auto-assign OFF → passage en tableau → arènes vides ✓
- Assigner manuellement un match → apparaît sur la tablette ✓
- Auto-assign ON → matchs distribués en round-robin normalement ✓

https://claude.ai/code/session_01XEM3VPTaZwcqwzn98vTxGj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEM3VPTaZwcqwzn98vTxGj)_