### PR TITLE
fix(remote): corriger double inversion cartons et flash de score

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -470,8 +470,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       direct: boolean;
       suivants: boolean;
     }) => ipcRenderer.invoke('remote:updateKioskViews', competitionId, views),
-    updateMatchArena: (competitionId: string, matchId: string, fromArena: number | null, toArena: number | null) =>
-      ipcRenderer.invoke('remote:updateMatchArena', competitionId, matchId, fromArena, toArena),
+    updateMatchArena: (competitionId: string, matchId: string, fromArena: number | null, toArena: number | null, fencerA?: any, fencerB?: any) =>
+      ipcRenderer.invoke('remote:updateMatchArena', competitionId, matchId, fromArena, toArena, fencerA, fencerB),
     updatePoolFencers: (competitionId: string, updates: Array<{ poolId: string; fencers: any[] }>) =>
       ipcRenderer.invoke('remote:updatePoolFencers', competitionId, updates),
     syncPoolMatches: (competitionId: string, poolsData: Array<{ poolId: string; matches: any[] }>) =>

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -41,6 +41,7 @@ export class RemoteScoreServer {
   private sessionMatches: any[] = []; // Matches passés depuis le renderer
   private arenaNextMatchIndex: Map<string, number> = new Map(); // Index du prochain match par arène
   private arenaMatchQueue: Map<string, ArenaMatch[]> = new Map(); // File d'attente DE par arène
+  private poolMatchArenaOverrides: Map<string, string> = new Map(); // matchId → arenaId (réassignation piste poule)
   private poolFencersCache: Map<string, any[]> = new Map(); // Tireurs par poolId (depuis le renderer)
   private sessionMatchScores: Map<string, { scoreA: any; scoreB: any; status: string }> = new Map(); // Scores en mémoire
   private sessionShowPhotos: boolean = false; // Afficher les photos des combattants avant le combat
@@ -2561,17 +2562,32 @@ export class RemoteScoreServer {
         // Mettre à jour les données de tireurs si le renderer fournit des données plus récentes
         if (fencerA) sm.fencerA = fencerA;
         if (fencerB) sm.fencerB = fencerB;
-        matchToMove = {
-          id: sm.id,
-          fencerA: fencerA ?? sm.fencerA,
-          fencerB: fencerB ?? sm.fencerB,
-          scoreA: 0,
-          scoreB: 0,
-          status: 'not_started',
-          startTime: null,
-          endTime: null,
-          isTableau: true,
-        };
+        if (sm.poolId) {
+          // Match de poule : conserver poolId, ne pas marquer isTableau
+          matchToMove = {
+            id: sm.id,
+            poolId: sm.poolId,
+            fencerA: fencerA ?? sm.fencerA,
+            fencerB: fencerB ?? sm.fencerB,
+            scoreA: 0,
+            scoreB: 0,
+            status: 'not_started',
+            startTime: null,
+            endTime: null,
+          };
+        } else {
+          matchToMove = {
+            id: sm.id,
+            fencerA: fencerA ?? sm.fencerA,
+            fencerB: fencerB ?? sm.fencerB,
+            scoreA: 0,
+            scoreB: 0,
+            status: 'not_started',
+            startTime: null,
+            endTime: null,
+            isTableau: true,
+          };
+        }
       } else if (fencerA && fencerB) {
         // Match DE non encore en session (ex: session de poule toujours active) → créer depuis les données passées
         matchToMove = {
@@ -2596,6 +2612,13 @@ export class RemoteScoreServer {
           `[RemoteScoreServer] Match DE ${matchId} ajouté à sessionMatches depuis updateMatchArena`
         );
       }
+    }
+
+    // Mettre à jour la map d'overrides pour les matchs de poule chargés on-demand
+    if (toArena !== null) {
+      this.poolMatchArenaOverrides.set(matchId, `arena${toArena}`);
+    } else {
+      this.poolMatchArenaOverrides.delete(matchId);
     }
 
     if (!matchToMove || !toArena) return;
@@ -2956,7 +2979,11 @@ export class RemoteScoreServer {
       const poolMatches = this.applySmartMatchOrder(rawPoolMatches as Match[]).filter(
         m => m.status !== MatchStatus.FINISHED && this.isMatchPlayable(m)
       );
-      const nextMatch = poolMatches.find(m => m.id !== currentMatchId);
+      const nextMatch = poolMatches.find(m => {
+        if (m.id === currentMatchId) return false;
+        const override = this.poolMatchArenaOverrides.get(m.id);
+        return !override || override === arenaId;
+      });
       if (nextMatch) {
         const nextReferee = this.resolveReferee((nextMatch as any).refereeId ?? nextMatch.referee?.id);
         return {
@@ -3038,7 +3065,18 @@ export class RemoteScoreServer {
         `[RemoteScoreServer] ${poolMatches.length} matches en attente dans le pool ${currentPoolId} (ordre smart)`
       );
 
-      const nextMatch = poolMatches.find(m => m.id !== currentMatchId);
+      // Respecter les overrides de piste : ignorer les matchs pré-assignés à une autre arène
+      let nextMatch = poolMatches.find(m => {
+        if (m.id === currentMatchId) return false;
+        const override = this.poolMatchArenaOverrides.get(m.id);
+        return !override || override === arenaId;
+      });
+      // Si rien de dispo pour cette arène, chercher un match explicitement redirigé ici
+      if (!nextMatch) {
+        nextMatch = poolMatches.find(m =>
+          m.id !== currentMatchId && this.poolMatchArenaOverrides.get(m.id) === arenaId
+        );
+      }
       if (nextMatch) {
         console.log(
           `[RemoteScoreServer] Chargement du match ${nextMatch.id} (pool ${currentPoolId}) sur arène ${arenaId}`
@@ -3667,6 +3705,7 @@ export class RemoteScoreServer {
     this.sessionMatches = [];
     this.arenaMatchQueue.clear();
     this.arenaNextMatchIndex.clear();
+    this.poolMatchArenaOverrides.clear();
     this.poolFencersCache.clear();
     this.poolSignaturesCache.clear();
     this.sessionMatchScores.clear();

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1639,10 +1639,10 @@
 
           // Mise à jour des scores (respecte l'inversion)
           if (data.scoreA !== undefined) {
-            document.getElementById(this.inversionEnabled ? 'score-b' : 'score-a').textContent = data.scoreA;
+            document.getElementById(this.inversionEnabled ? 'score-a' : 'score-b').textContent = data.scoreA;
           }
           if (data.scoreB !== undefined) {
-            document.getElementById(this.inversionEnabled ? 'score-a' : 'score-b').textContent = data.scoreB;
+            document.getElementById(this.inversionEnabled ? 'score-b' : 'score-a').textContent = data.scoreB;
           }
 
           // Mise à jour des cartons

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -1036,10 +1036,10 @@
           }
 
           if (data.scoreA !== undefined) {
-            document.getElementById(this.inversionEnabled ? 'score-b' : 'score-a').textContent = data.scoreA;
+            document.getElementById(this.inversionEnabled ? 'score-a' : 'score-b').textContent = data.scoreA;
           }
           if (data.scoreB !== undefined) {
-            document.getElementById(this.inversionEnabled ? 'score-a' : 'score-b').textContent = data.scoreB;
+            document.getElementById(this.inversionEnabled ? 'score-b' : 'score-a').textContent = data.scoreB;
           }
 
           if (data.cardsA) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2014,7 +2014,7 @@
           this.pushHistory('card');
           if (navigator.vibrate) navigator.vibrate(cardType === 'red' ? [100,50,100] : cardType === 'yellow' ? 80 : 40);
 
-          const ef = this._effectiveFencer(fencer);
+          const ef = fencer; // caller already resolved via _effectiveFencer
           const cards = ef === 'A' ? this.cardsA : this.cardsB;
 
           // Conversion 2ème blanc → jaune (chemin sans sélecteur de raison)
@@ -2081,7 +2081,8 @@
           this._reasonSelectorFencer = fencer;
           this._reasonSelectorOriginalType = originalCardType;
 
-          const nameEl = document.getElementById(`fencer-${fencer.toLowerCase()}-name`);
+          const displayPos = this._effectiveFencer(fencer); // _effectiveFencer is its own inverse
+          const nameEl = document.getElementById(`fencer-${displayPos.toLowerCase()}-name`);
           const fencerName = nameEl ? nameEl.textContent.trim() : `Tireur ${fencer}`;
           document.getElementById('reason-selector-title').textContent =
             `Raison du carton — ${fencerName}`;

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
 import { Competition, Fencer, FencerStatus, Match, MatchStatus, Weapon, QuestPhaseConfig, Referee } from '../../shared/types';
+import { Arena } from '../../shared/types/remote';
 import { logger, LogCategory } from '@shared/services/logger';
 import { RankingImportResult } from '../../shared/utils/fileParser';
 import FencerList from './FencerList';
@@ -117,6 +118,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const [isRemoteActive, setIsRemoteActive] = useState(false);
   const [remoteServerUrl, setRemoteServerUrl] = useState<string | null>(null);
   const [remoteArenaCount, setRemoteArenaCount] = useState<number>(1);
+  const [arenaStates, setArenaStates] = useState<Arena[]>([]);
   const [showThirdPlaceDialog, setShowThirdPlaceDialog] = useState(false);
   const [tableauMatches, setTableauMatches] = useState<TableauMatch[]>([]);
   const [consolationBrackets, setConsolationBrackets] = useState<ConsolationBracket[]>([]);
@@ -318,6 +320,29 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       });
     }, 500);
     return () => clearTimeout(timer);
+  }, [isRemoteActive, competition.id]);
+
+  // Charger les arènes quand le serveur distant devient actif et s'abonner aux updates
+  useEffect(() => {
+    if (!isRemoteActive || !competition?.id || !window.electronAPI?.remote) return;
+    window.electronAPI.remote.getArenas(competition.id).then((res: any) => {
+      if (res?.success && res.arenas) setArenaStates(res.arenas);
+    }).catch(() => {});
+    if (window.electronAPI.onRemoteArenaUpdate) {
+      window.electronAPI.onRemoteArenaUpdate((data: any) => {
+        setArenaStates(prev => {
+          const idx = prev.findIndex((a: Arena) => a.id === data.arenaId);
+          if (idx === -1) return prev;
+          const updated = [...prev];
+          updated[idx] = {
+            ...updated[idx],
+            currentMatch: data.update?.match ?? updated[idx].currentMatch,
+            status: data.update?.status ?? updated[idx].status,
+          };
+          return updated;
+        });
+      });
+    }
   }, [isRemoteActive, competition.id]);
 
   // Écouter les mises à jour des matches distants
@@ -1103,6 +1128,20 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                           setPools(prev =>
                             prev.map(p => (p.id === updatedPool.id ? updatedPool : p))
                           );
+                        }}
+                        arenaCount={remoteArenaCount}
+                        arenas={arenaStates}
+                        isRemoteActive={isRemoteActive}
+                        onMatchArenaChange={(matchId, oldArena, newArena, fencerA, fencerB) => {
+                          if (!isRemoteActive || !competition?.id) return;
+                          window.electronAPI.remote.updateMatchArena(
+                            competition.id,
+                            matchId,
+                            oldArena,
+                            newArena,
+                            fencerA ?? undefined,
+                            fencerB ?? undefined
+                          ).catch(() => {});
                         }}
                       />
                     </div>

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useModalResize } from '../hooks/useModalResize';
 import { Pool, Fencer, MatchStatus, Score, Weapon, FencerStatus } from '../../shared/types';
+import { Arena } from '../../shared/types/remote';
 import { logger, LogCategory } from '@shared/services/logger';
 import { useToast } from './Toast';
 import { useConfirm } from './ConfirmDialog';
@@ -37,6 +38,16 @@ interface PoolViewProps {
   onFencerChangePool?: (fencer: Fencer) => void;
   onFencerStatusChange?: (fencerId: string, status: 'abandon' | 'forfait' | 'exclusion') => void;
   onFencerAdded?: (updatedPool: Pool) => void;
+  arenaCount?: number;
+  arenas?: Arena[];
+  isRemoteActive?: boolean;
+  onMatchArenaChange?: (
+    matchId: string,
+    oldArena: number,
+    newArena: number | null,
+    fencerA?: Fencer | null,
+    fencerB?: Fencer | null
+  ) => void;
 }
 
 type ViewMode = 'grid' | 'matches';
@@ -53,6 +64,10 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   onFencerChangePool,
   onFencerStatusChange,
   onFencerAdded,
+  arenaCount,
+  arenas,
+  isRemoteActive,
+  onMatchArenaChange,
 }) => {
   const { showToast } = useToast();
   const { confirm } = useConfirm();
@@ -70,6 +85,29 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const [matchesUpdateTrigger, setMatchesUpdateTrigger] = useState(0);
   const [keyboardFocusField, setKeyboardFocusField] = useState<'A' | 'B'>('A');
   const [signedFencerIds, setSignedFencerIds] = useState<string[]>([]);
+  const [matchArenaOverrides, setMatchArenaOverrides] = useState<Map<string, number>>(new Map());
+
+  const defaultArena = pool.strip ?? pool.number;
+
+  const handleMatchArenaChange = useCallback((
+    matchId: string,
+    oldArena: number,
+    newArena: number | null,
+    fencerA?: Fencer | null,
+    fencerB?: Fencer | null
+  ) => {
+    setMatchArenaOverrides(prev => {
+      const next = new Map(prev);
+      if (newArena === null) {
+        next.delete(matchId);
+      } else {
+        next.set(matchId, newArena);
+      }
+      return next;
+    });
+    onMatchArenaChange?.(matchId, oldArena, newArena, fencerA, fencerB);
+  }, [onMatchArenaChange]);
+
 
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
   const [showPoolConfetti, setShowPoolConfetti] = useState(false);
@@ -1288,6 +1326,12 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
             isLocked={isLocked}
             openScoreModal={openScoreModal}
             onMatchReset={onMatchReset}
+            defaultArena={defaultArena}
+            arenaCount={arenaCount}
+            arenas={arenas}
+            isRemoteActive={isRemoteActive}
+            matchArenaOverrides={matchArenaOverrides}
+            onMatchArenaChange={handleMatchArenaChange}
           />
 )}
         {renderScoreModal()}

--- a/src/renderer/components/pool/PoolMatchList.tsx
+++ b/src/renderer/components/pool/PoolMatchList.tsx
@@ -3,8 +3,9 @@
  * Licensed under GPL-3.0
  */
 
-import React from 'react';
-import { Match, FencerStatus, MatchStatus } from '../../../shared/types';
+import React, { useState } from 'react';
+import { Match, Fencer, FencerStatus } from '../../../shared/types';
+import { Arena } from '../../../shared/types/remote';
 
 interface OrderedMatchEntry {
   match: Match;
@@ -23,7 +24,81 @@ interface PoolMatchListProps {
   isLocked: boolean;
   openScoreModal: (index: number) => void;
   onMatchReset?: (index: number) => void;
+  defaultArena?: number;
+  arenaCount?: number;
+  arenas?: Arena[];
+  isRemoteActive?: boolean;
+  matchArenaOverrides?: Map<string, number>;
+  onMatchArenaChange?: (
+    matchId: string,
+    oldArena: number,
+    newArena: number | null,
+    fencerA?: Fencer | null,
+    fencerB?: Fencer | null
+  ) => void;
 }
+
+interface ArenaBadgeProps {
+  match: Match;
+  defaultArena: number;
+  matchArenaOverrides?: Map<string, number>;
+  isRemoteActive: boolean;
+  arenaCount: number;
+  dark?: boolean;
+  onClick: (e: React.MouseEvent) => void;
+}
+
+const ArenaBadge: React.FC<ArenaBadgeProps> = ({
+  match,
+  defaultArena,
+  matchArenaOverrides,
+  isRemoteActive,
+  arenaCount,
+  dark = false,
+  onClick,
+}) => {
+  if (arenaCount <= 0) return null;
+  const assignedArena = matchArenaOverrides?.get(match.id) ?? defaultArena;
+  const isOverridden = matchArenaOverrides?.has(match.id) ?? false;
+
+  const baseStyle: React.CSSProperties = {
+    padding: '0.15rem 0.45rem',
+    fontSize: '0.7rem',
+    fontWeight: '600',
+    borderRadius: '4px',
+    flexShrink: 0,
+    cursor: isRemoteActive ? 'pointer' : 'not-allowed',
+  };
+
+  const activeStyle: React.CSSProperties = dark
+    ? {
+        border: isOverridden ? '1px solid #f59e0b' : '1px solid rgba(255,255,255,0.4)',
+        background: isOverridden ? '#fef3c7' : 'rgba(255,255,255,0.2)',
+        color: isOverridden ? '#92400e' : 'white',
+      }
+    : {
+        border: isOverridden ? '1px solid #f59e0b' : '1px solid #d1d5db',
+        background: isOverridden ? '#fef3c7' : '#f3f4f6',
+        color: isOverridden ? '#92400e' : '#374151',
+      };
+
+  const inactiveStyle: React.CSSProperties = {
+    border: '1px solid #e5e7eb',
+    background: '#f9fafb',
+    color: '#9ca3af',
+  };
+
+  return (
+    <button
+      onClick={isRemoteActive ? onClick : undefined}
+      title={isRemoteActive ? `Piste ${assignedArena} — Cliquer pour réassigner` : 'Serveur distant non démarré'}
+      disabled={!isRemoteActive}
+      style={{ ...baseStyle, ...(isRemoteActive ? activeStyle : inactiveStyle) }}
+    >
+      🏟 {assignedArena}
+    </button>
+  );
+};
 
 const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
   orderedMatches,
@@ -31,7 +106,36 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
   isLocked,
   openScoreModal,
   onMatchReset,
-}) => (
+  defaultArena = 1,
+  arenaCount = 0,
+  arenas = [],
+  isRemoteActive = false,
+  matchArenaOverrides,
+  onMatchArenaChange,
+}) => {
+  const [showArenaModal, setShowArenaModal] = useState(false);
+  const [selectedMatch, setSelectedMatch] = useState<Match | null>(null);
+
+  const openArenaModal = (match: Match, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!isRemoteActive || arenaCount <= 0) return;
+    setSelectedMatch(match);
+    setShowArenaModal(true);
+  };
+
+  const closeArenaModal = () => {
+    setShowArenaModal(false);
+    setSelectedMatch(null);
+  };
+
+  const handleAssignArena = (arenaNum: number | null) => {
+    if (!selectedMatch) return;
+    const currentArena = matchArenaOverrides?.get(selectedMatch.id) ?? defaultArena;
+    onMatchArenaChange?.(selectedMatch.id, currentArena, arenaNum, selectedMatch.fencerA, selectedMatch.fencerB);
+    closeArenaModal();
+  };
+
+  return (
   <div>
     {/* Prochain match en gros */}
     {orderedMatches.pending.length > 0 &&
@@ -65,9 +169,12 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                   textTransform: 'uppercase',
                   opacity: 0.8,
                   marginBottom: '0.5rem',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
                 }}
               >
-                ✕ Match non disputé
+                <span>✕ Match non disputé</span>
               </div>
               <div
                 style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
@@ -126,9 +233,21 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                 textTransform: 'uppercase',
                 opacity: 0.8,
                 marginBottom: '0.5rem',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
               }}
             >
-              ⚔️ Prochain match
+              <span>⚔️ Prochain match</span>
+              <ArenaBadge
+                match={nextMatch.match}
+                defaultArena={defaultArena}
+                matchArenaOverrides={matchArenaOverrides}
+                isRemoteActive={isRemoteActive}
+                arenaCount={arenaCount}
+                dark
+                onClick={e => openArenaModal(nextMatch.match, e)}
+              />
             </div>
             <div
               style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
@@ -187,7 +306,6 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
         </h4>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
           {orderedMatches.pending.slice(1).map(({ match, index }, i) => {
-            // Vérifier si l'un des tireurs a abandonné
             const fencerAAbandoned =
               match.fencerA?.status === FencerStatus.ABANDONED ||
               match.fencerA?.status === FencerStatus.FORFAIT ||
@@ -212,6 +330,7 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                   cursor: isAbandonMatch ? 'not-allowed' : 'pointer',
                   border: isAbandonMatch ? '1px dashed #9ca3af' : '1px solid #e5e7eb',
                   opacity: isAbandonMatch ? 0.5 : 1,
+                  gap: '0.5rem',
                 }}
               >
                 <span style={{ color: '#9ca3af', fontSize: '0.875rem', minWidth: '30px' }}>
@@ -243,6 +362,14 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                   {match.fencerB?.lastName}
                   {fencerBAbandoned && ' ✕'}
                 </span>
+                <ArenaBadge
+                  match={match}
+                  defaultArena={defaultArena}
+                  matchArenaOverrides={matchArenaOverrides}
+                  isRemoteActive={isRemoteActive}
+                  arenaCount={arenaCount}
+                  onClick={e => openArenaModal(match, e)}
+                />
               </div>
             );
           })}
@@ -265,7 +392,6 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
         </h4>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
           {orderedMatches.finished.map(({ match, index }) => {
-            // Vérifier si c'est un match avec abandon/forfait
             const fencerAAbandoned =
               match.fencerA?.status === FencerStatus.ABANDONED ||
               match.fencerA?.status === FencerStatus.FORFAIT ||
@@ -436,8 +562,56 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
         <div style={{ fontSize: '0.875rem' }}>Tous les matches ont été joués</div>
       </div>
     )}
+
+    {/* Modal d'assignation de piste */}
+    {showArenaModal && selectedMatch && (
+      <div className="modal-overlay" onClick={closeArenaModal}>
+        <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '400px' }}>
+          <div className="modal-header">
+            <h3 className="modal-title">Assigner à une piste</h3>
+            <button className="btn-close" onClick={closeArenaModal}>&times;</button>
+          </div>
+          <div className="modal-body" style={{ padding: '1.5rem' }}>
+            <p style={{ marginBottom: '1rem', color: '#6b7280', fontSize: '0.875rem' }}>
+              Sélectionnez la piste pour ce match :
+            </p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '0.5rem' }}>
+              <button
+                className={`btn ${!matchArenaOverrides?.has(selectedMatch.id) ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleAssignArena(null)}
+                style={{ padding: '0.75rem', gridColumn: '1 / -1', fontSize: '0.875rem' }}
+              >
+                ↩ Piste par défaut (Piste {defaultArena})
+              </button>
+              {Array.from({ length: arenaCount }, (_, i) => i + 1).map(arenaNum => {
+                const arenaObj = arenas.find(a => a.number === arenaNum);
+                const isCurrentArena = (matchArenaOverrides?.get(selectedMatch.id) ?? defaultArena) === arenaNum;
+                const statusIcon = arenaObj
+                  ? arenaObj.status === 'in_progress'
+                    ? ' ●'
+                    : arenaObj.status === 'ready'
+                      ? ' ○'
+                      : ''
+                  : '';
+                return (
+                  <button
+                    key={arenaNum}
+                    className={`btn ${isCurrentArena ? 'btn-primary' : 'btn-secondary'}`}
+                    onClick={() => handleAssignArena(arenaNum)}
+                    style={{ padding: '0.75rem', fontSize: '0.875rem' }}
+                  >
+                    Piste {arenaNum}{statusIcon}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    )}
   </div>
-);
+  );
+};
 
 const PoolMatchList = React.memo(PoolMatchListComponent);
 export default PoolMatchList;


### PR DESCRIPTION
## Résumé

Deux régressions introduites par le commit `5d807bf` (rouge à gauche par défaut).

- **Double inversion cartons** : `handleCardButtonPress` appelait `_effectiveFencer` avant de passer `ef` à `addCard`, qui l'appelait *à nouveau* en interne. Avec la nouvelle logique (inversion quand `swapped=false`), les deux appels s'annulaient → carton et points pénalité allaient au mauvais combattant.
- **Flash de score** : `updateMatchDisplay` avait été corrigé (scoreA→score-b quand non-inversé) mais pas le handler incrémental `update_score` dans `arena.html` et `public.html` → le score apparaissait brièvement sur le mauvais panneau avant correction.
- **Nom incorrect dans le sélecteur de raison** : `openReasonSelector` recevait `ef` et cherchait `fencer-b-name` pour le panneau gauche → nom du mauvais combattant affiché.

## Corrections

| Fichier | Changement |
|---|---|
| `referee.html` | `addCard` : `ef = fencer` (plus de double `_effectiveFencer`) |
| `referee.html` | `openReasonSelector` : lookup nom via `_effectiveFencer(fencer)` (involution) |
| `arena.html` | Handler incrémental : cibles `score-a`/`score-b` alignées avec `updateMatchDisplay` |
| `public.html` | Même correction que `arena.html` |

## Test

1. Ouvrir arène + arbitre, démarrer un match
2. `+1` ROUGE (gauche) → score apparaît immédiatement à gauche, pas de flash
3. Carton jaune ROUGE → carton à gauche (rouge), point pénalité au VERT (droite)
4. Répéter avec SWAP actif

https://claude.ai/code/session_01MFJuTf6STxhHdDBRdZ89Di

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFJuTf6STxhHdDBRdZ89Di)_