### PR TITLE
Confirmation fin de match : score rouge puis vert

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2773,8 +2773,9 @@
             this.pausedForModal = true;
           }
 
-          document.getElementById('final-score-display').textContent =
-            `${this.scoreA} - ${this.scoreB}`;
+          document.getElementById('final-score-display').textContent = this.swapped
+            ? `${this.scoreA} - ${this.scoreB}`
+            : `${this.scoreB} - ${this.scoreA}`;
           document.getElementById('finish-modal').classList.add('active');
         }
 


### PR DESCRIPTION
Inverse l'ordre d'affichage du score dans la modal de confirmation de fin de match : rouge (gauche) affiché en premier, vert (droite) en second. Le swap est pris en compte.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5HqGbMzFKbkmJrfqSVpE5)_