### PR TITLE
fix(remote): couleurs vert/rouge inversées dans overlay.html

### DIFF
--- a/src/remote/overlay.html
+++ b/src/remote/overlay.html
@@ -56,11 +56,11 @@
         --overlay-border: rgba(255,255,255,0.15);
         --name-color: #ffffff;
         --club-color: rgba(255,255,255,0.75);
-        --score-a-color: #ff2200;
-        --score-b-color: #00e640;
+        --score-a-color: #00e640;
+        --score-b-color: #ff2200;
         --score-bg: rgba(0,0,0,0.65);
-        --score-glow-a: rgba(255,34,0,0.7);
-        --score-glow-b: rgba(0,230,64,0.7);
+        --score-glow-a: rgba(0,230,64,0.7);
+        --score-glow-b: rgba(255,34,0,0.7);
         --timer-color: #ffaa00;
         --timer-bg: rgba(0,0,0,0.6);
         --timer-glow: rgba(255,170,0,0.8);
@@ -78,10 +78,10 @@
       }
       [data-theme="neon"] {
         --bg: #0a0a0a;
-        --score-a-color: #ff4444;
-        --score-b-color: #00ff88;
-        --score-glow-a: rgba(255,68,68,0.8);
-        --score-glow-b: rgba(0,255,136,0.8);
+        --score-a-color: #00ff88;
+        --score-b-color: #ff4444;
+        --score-glow-a: rgba(0,255,136,0.8);
+        --score-glow-b: rgba(255,68,68,0.8);
         --timer-color: #00ccff;
         --timer-glow: rgba(0,204,255,0.9);
         --panel-bg: rgba(0,0,0,0.85);
@@ -91,10 +91,10 @@
         --bg: linear-gradient(135deg, #e8edf5 0%, #c8d8f0 100%);
         --name-color: #111827;
         --club-color: #374151;
-        --score-a-color: #dc2626;
-        --score-b-color: #059669;
-        --score-glow-a: rgba(220,38,38,0.5);
-        --score-glow-b: rgba(5,150,105,0.5);
+        --score-a-color: #059669;
+        --score-b-color: #dc2626;
+        --score-glow-a: rgba(5,150,105,0.5);
+        --score-glow-b: rgba(220,38,38,0.5);
         --timer-color: #d97706;
         --timer-glow: rgba(217,119,6,0.7);
         --score-bg: rgba(255,255,255,0.85);


### PR DESCRIPTION
## Résumé

- Le PR #538 avait établi la convention fencerA=vert / fencerB=rouge dans `public.html`, `referee.html` et `arena.html`, mais `overlay.html` avait été oublié.
- Les variables CSS `--score-a-color` / `--score-b-color` et leurs glows étaient inversées dans les 3 thèmes (transparent, neon, light).

## Changements

`src/remote/overlay.html` — CSS uniquement, aucune logique JS modifiée :

| Thème | Variable | Avant | Après |
|-------|----------|-------|-------|
| transparent | `--score-a-color` | `#ff2200` (rouge) | `#00e640` (vert) |
| transparent | `--score-b-color` | `#00e640` (vert) | `#ff2200` (rouge) |
| neon | `--score-a-color` | `#ff4444` | `#00ff88` |
| neon | `--score-b-color` | `#00ff88` | `#ff4444` |
| light | `--score-a-color` | `#dc2626` | `#059669` |
| light | `--score-b-color` | `#059669` | `#dc2626` |

(idem pour les glows correspondants)

https://claude.ai/code/session_01UmJwA2hfkm9o5JHV5xLFWW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmJwA2hfkm9o5JHV5xLFWW)_