### PR TITLE
fix: tirage au sort — vainqueur cohérent entre tablette et affichage

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2858,9 +2858,14 @@ export class RemoteScoreServer {
       const finalMatchId = finishedMatch.id;
       const dbMatch = this.db.getMatch(finalMatchId);
       if (dbMatch && !finishedMatch.isTableau) {
-        const winner =
+        let winner: 'A' | 'B' | null =
           finishedMatch.scoreA > finishedMatch.scoreB ? 'A' :
           finishedMatch.scoreB > finishedMatch.scoreA ? 'B' : null;
+        if (!winner) {
+          const mem = this.sessionMatchScores.get(finishedMatch.id);
+          if ((mem?.scoreA as any)?.isVictory) winner = 'A';
+          else if ((mem?.scoreB as any)?.isVictory) winner = 'B';
+        }
         const scoreAObj = {
           value: finishedMatch.scoreA,
           isVictory: winner === 'A',

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -370,7 +370,12 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         const idx = prev.findIndex(m => m.id === matchId);
         if (idx === -1) return prev;
         const match = prev[idx];
-        const winner = scoreA > scoreB ? match.fencerA : scoreB > scoreA ? match.fencerB : null;
+        const winner =
+          scoreA > scoreB ? match.fencerA :
+          scoreB > scoreA ? match.fencerB :
+          winnerOverride === 'A' ? match.fencerA :
+          winnerOverride === 'B' ? match.fencerB :
+          null;
         const updated = prev.map((m, i) => (i === idx ? { ...m, scoreA, scoreB, winner } : m));
         const size = prev.length > 0 ? Math.max(...prev.map(m => m.round)) : 0;
         propagateWinners(updated, size);


### PR DESCRIPTION
## Problème

En cas d'égalité après temps supplémentaire, le tirage au sort donnait un gagnant différent selon qu'on regardait la tablette arbitre ou l'application principale/bracket DE.

## Causes

### Bug 1 — `finishArenaMatch` corrompt la DB (`remoteScoreServer.ts`)

Le endpoint `POST /api/matches/:matchId/finish` positionne correctement `isVictory` en DB via `winnerOverride`. Mais ensuite il appelle `finishArenaMatch()`, qui **recalcule le winner à partir des scores bruts** (égaux → `null`) et **réécrase la DB**, effaçant le vainqueur du tirage.

Le fallback `sessionMatchScores` sauvait le renderer IPC, mais la DB restait corrompue.

### Bug 2 — Bracket DE ignore `winnerOverride` (`CompetitionView.tsx`)

Dans `handleMatchFinished`, le winner du bracket tableau était calculé comme `null` pour les scores égaux, sans consulter `winnerOverride`. Le bon combattant n'avançait pas dans le bracket.

## Fix

- **`remoteScoreServer.ts`** : avant la mise à jour DB dans `finishArenaMatch`, consulter `sessionMatchScores` pour récupérer le gagnant du tirage si les scores sont égaux.
- **`CompetitionView.tsx`** : utiliser `winnerOverride` en fallback pour les matchs tableau à égalité.

https://claude.ai/code/session_019NQ6ncsrQEE5SisvZcJd32

---
_Generated by [Claude Code](https://claude.ai/code/session_019NQ6ncsrQEE5SisvZcJd32)_