### PR TITLE
ci: cache binaires Electron macOS — fix erreur 502 GitHub releases

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -168,6 +168,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
+      - name: Cache Electron binaries
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/electron
+          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+
+      - name: Cache electron-builder
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/electron-builder
+          key: ${{ runner.os }}-electron-builder-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-builder-
+
       - name: Install Dependencies
         run: |
           for i in 1 2 3; do
@@ -200,10 +216,12 @@ jobs:
           for i in 1 2 3; do
             echo "Attempt $i/3..."
             npx electron-builder --mac --x64 && break
-            [ $i -lt 3 ] && sleep 10
+            [ $i -lt 3 ] && sleep 30
           done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ELECTRON_CACHE: ~/Library/Caches/electron
+          ELECTRON_BUILDER_CACHE: ~/Library/Caches/electron-builder
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
@@ -234,6 +252,22 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+
+      - name: Cache Electron binaries
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/electron
+          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+
+      - name: Cache electron-builder
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/electron-builder
+          key: ${{ runner.os }}-electron-builder-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-builder-
 
       - name: Install Dependencies
         run: |
@@ -267,10 +301,12 @@ jobs:
           for i in 1 2 3; do
             echo "Attempt $i/3..."
             npx electron-builder --mac --arm64 && break
-            [ $i -lt 3 ] && sleep 10
+            [ $i -lt 3 ] && sleep 30
           done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ELECTRON_CACHE: ~/Library/Caches/electron
+          ELECTRON_BUILDER_CACHE: ~/Library/Caches/electron-builder
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
+      - name: Cache Electron binaries
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/electron
+          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+
+      - name: Cache electron-builder
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/electron-builder
+          key: ${{ runner.os }}-electron-builder-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-builder-
+
       - name: Install Dependencies
         run: |
           for i in 1 2 3; do
@@ -140,9 +156,16 @@ jobs:
         run: npm run build:ci
 
       - name: Package with Electron Builder
-        run: npx electron-builder --mac --x64
+        run: |
+          for i in 1 2 3; do
+            echo "Attempt $i/3..."
+            npx electron-builder --mac --x64 && break
+            [ $i -lt 3 ] && sleep 30
+          done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ELECTRON_CACHE: ~/Library/Caches/electron
+          ELECTRON_BUILDER_CACHE: ~/Library/Caches/electron-builder
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
@@ -173,6 +196,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
+      - name: Cache Electron binaries
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/electron
+          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+
+      - name: Cache electron-builder
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/electron-builder
+          key: ${{ runner.os }}-electron-builder-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-builder-
+
       - name: Install Dependencies
         run: |
           for i in 1 2 3; do
@@ -186,9 +225,16 @@ jobs:
         run: npm run build:ci
 
       - name: Package with Electron Builder
-        run: npx electron-builder --mac --arm64
+        run: |
+          for i in 1 2 3; do
+            echo "Attempt $i/3..."
+            npx electron-builder --mac --arm64 && break
+            [ $i -lt 3 ] && sleep 30
+          done || exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ELECTRON_CACHE: ~/Library/Caches/electron
+          ELECTRON_BUILDER_CACHE: ~/Library/Caches/electron-builder
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Problème

Build #910 macOS en erreur :
```
⨯ cannot resolve https://github.com/electron/electron/releases/download/v40.1.0/electron-v40.1.0-darwin-x64.zip: status code 502
```

electron-builder télécharge le binaire Electron à chaque build. Quand GitHub releases retourne un 502 (CDN instable), le build plante — même après 3 tentatives en 25s.

## Fix

**`build-dev.yml` et `build.yml` — jobs `build-macos-x64` et `build-macos-arm64`** :

1. Ajout du cache `~/Library/Caches/electron` (binaire Electron) et `~/Library/Caches/electron-builder` — une fois téléchargé, les builds suivants ne re-téléchargent plus rien.
2. Variables `ELECTRON_CACHE` / `ELECTRON_BUILDER_CACHE` exposées dans le step packaging pour que electron-builder utilise le cache.
3. Sleep de retry augmenté de 10s → 30s (laisse le temps à un 502 transitoire de se résoudre).
4. Ajout du retry loop dans `build.yml` prod (absent avant).

https://claude.ai/code/session_019NQ6ncsrQEE5SisvZcJd32

---
_Generated by [Claude Code](https://claude.ai/code/session_019NQ6ncsrQEE5SisvZcJd32)_