### PR TITLE
fix: tirage au sort - combattant VERT incohérent tablette vs arène

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1477,13 +1477,12 @@
           const result   = document.getElementById('coin-result');
           if (!overlay || !coin || !nameGreen || !nameRed || !result) return;
 
-          // Noms des tireurs (respecte l'inversion de l'affichage)
-          const fA = this.inversionEnabled ? fencerB : fencerA;
-          const fB = this.inversionEnabled ? fencerA : fencerB;
-          const nameA = fA ? `${fA.lastName || ''} ${fA.firstName || ''}`.trim() || 'VERT'   : 'VERT';
-          const nameB = fB ? `${fB.lastName || ''} ${fB.firstName || ''}`.trim() || 'ROUGE'  : 'ROUGE';
-          nameGreen.textContent = nameA;
-          nameRed.textContent   = nameB;
+          // fencerA est TOUJOURS VERT, fencerB est TOUJOURS ROUGE
+          // (l'inversion ne change que la position gauche/droite, pas la couleur)
+          const nameGreenStr = fencerA ? `${fencerA.lastName || ''} ${fencerA.firstName || ''}`.trim() || 'VERT'  : 'VERT';
+          const nameRedStr   = fencerB ? `${fencerB.lastName || ''} ${fencerB.firstName || ''}`.trim() || 'ROUGE' : 'ROUGE';
+          nameGreen.textContent = nameGreenStr;
+          nameRed.textContent   = nameRedStr;
 
           // Réinitialiser l'état visuel
           result.className = 'hidden';
@@ -1494,15 +1493,10 @@
           // Afficher l'overlay
           overlay.classList.remove('hidden');
 
-          // Calculer les rotations : 10 tours + face gagnante
-          // Face verte = 0° / 360°, face rouge = 180°
-          // winner 'A' → face verte → 3600° (10 tours)
-          // winner 'B' → face rouge → 3600° + 180° = 3780°
-          // Si l'affichage est inversé : winner 'A' = tireur B visuel = face rouge
-          const visualWinner = this.inversionEnabled
-            ? (winner === 'A' ? 'B' : 'A')
-            : winner;
-          const finalDeg = visualWinner === 'A' ? 3600 : 3780;
+          // winner 'A' = fencerA (VERT) → face verte (3600°)
+          // winner 'B' = fencerB (ROUGE) → face rouge (3780°)
+          const isGreenWinner = winner === 'A';
+          const finalDeg = isGreenWinner ? 3600 : 3780;
 
           requestAnimationFrame(() => {
             requestAnimationFrame(() => {
@@ -1513,9 +1507,9 @@
 
           // Afficher le résultat après l'animation
           setTimeout(() => {
-            const winnerName = visualWinner === 'A' ? nameA : nameB;
-            const colorClass  = visualWinner === 'A' ? 'winner-green' : 'winner-red';
-            const colorLabel  = visualWinner === 'A' ? 'VERT' : 'ROUGE';
+            const winnerName = isGreenWinner ? nameGreenStr : nameRedStr;
+            const colorClass  = isGreenWinner ? 'winner-green' : 'winner-red';
+            const colorLabel  = isGreenWinner ? 'VERT' : 'ROUGE';
             result.textContent = `🏆 ${winnerName} gagne ! (${colorLabel})`;
             result.className   = colorClass;
           }, 3600);

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2582,8 +2582,11 @@
         }
 
         showCoinFlipConfirm(winner) {
-          const nameEl = document.getElementById(`fencer-${winner.toLowerCase()}-name`);
-          const winnerName = nameEl ? nameEl.textContent.trim() : `Tireur ${winner}`;
+          const winnerFencer = winner === 'A' ? this.currentMatch?.fencerA : this.currentMatch?.fencerB;
+          const winnerName = winnerFencer
+            ? `${winnerFencer.lastName || ''} ${winnerFencer.firstName || ''}`.trim() || `Tireur ${winner}`
+            : `Tireur ${winner}`;
+          // fencerA est toujours côté VERT (logical), fencerB toujours ROUGE
           const colorLabel = winner === 'A' ? 'VERT' : 'ROUGE';
 
           const nameDisplay = document.getElementById('coin-flip-confirm-name');


### PR DESCRIPTION
## Problème

En cas d'égalité après prolongation, le combattant annoncé VERT (vainqueur du tirage au sort) était différent sur la **tablette arbitre** et sur l'**écran public** (arène).

## Cause racine — deux bugs indépendants

### 1. `arena.html` — `showCoinFlipAnimation`

L'inversion d'affichage (gauche ↔ droite) était appliquée à tort sur :
- Les noms des faces de la pièce → le nom du tireur VERT/ROUGE était échangé
- Le sens de rotation de la pièce → la face verte gagnait quand c'était la rouge qui aurait dû gagner

**Réalité invariante** : `fencerA` est TOUJOURS VERT, `fencerB` est TOUJOURS ROUGE. L'inversion ne change que la position physique gauche/droite, pas la couleur. Le tirage au sort n'a donc pas à tenir compte de `inversionEnabled`.

### 2. `referee.html` — `showCoinFlipConfirm`

Le nom du vainqueur était lu via l'élément DOM `fencer-a-name` / `fencer-b-name`, mais ces éléments affichent le tireur selon sa **position visuelle** (gauche/droite), pas son identifiant logique. Par défaut (non-swappé), `fencer-a-name` contient le nom de `fencerB` — le mauvais nom était donc affiché.

## Correction

- `arena.html` : suppression de toute logique basée sur `inversionEnabled` dans l'animation — `fencerA` → face VERT, `fencerB` → face ROUGE, `winner='A'` → 3600°, `winner='B'` → 3780°.
- `referee.html` : lecture directe depuis `this.currentMatch.fencerA/B` au lieu du DOM.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VemNPsPJZagpBW4MfYgAAP)_