### PR TITLE
fix(overlay): inverser les couleurs vert/rouge avec ?swap=1

### DIFF
--- a/src/remote/overlay.html
+++ b/src/remote/overlay.html
@@ -189,6 +189,14 @@
         color: var(--score-b-color);
         text-shadow: 0 0 12px var(--score-glow-b), 0 0 28px var(--score-glow-b);
       }
+      .swapped .side-a .score-box {
+        color: var(--score-b-color);
+        text-shadow: 0 0 12px var(--score-glow-b), 0 0 28px var(--score-glow-b);
+      }
+      .swapped .side-b .score-box {
+        color: var(--score-a-color);
+        text-shadow: 0 0 12px var(--score-glow-a), 0 0 28px var(--score-glow-a);
+      }
 
       .fencer-info {
         flex: 1;
@@ -389,6 +397,9 @@
 
         /* Position du score : outer = score côté extérieur */
         if (params.get('scores') === 'outer') root.classList.add('scores-outer');
+
+        /* Inversion vert/rouge (?swap=1) */
+        if (params.get('swap') === '1') root.classList.add('swapped');
 
         /* Logo personnalisé dans le panneau central (?logo=https://...) */
         const logoUrl = params.get('logo');


### PR DESCRIPTION
## Problème

Les noms s'inversaient correctement avec `?swap=1` mais pas les couleurs : le panneau gauche restait vert et le droit restait rouge car les classes CSS `side-a`/`side-b` étaient fixes.

## Fix

Ajout de règles CSS `.swapped .side-a .score-box` et `.swapped .side-b .score-box` qui inversent les couleurs de score quand la classe `swapped` est présente sur le root. Cette classe est appliquée au chargement si `?swap=1` est dans l'URL.

## Test

1. Ouvrir l'overlay sans `?swap=1` → vert à gauche, rouge à droite
2. Ajouter `?swap=1` → rouge à gauche, vert à droite (noms ET couleurs inversés)

https://claude.ai/code/session_013Q4gQLxHE4jAtxrzf9eMMY

---
_Generated by [Claude Code](https://claude.ai/code/session_013Q4gQLxHE4jAtxrzf9eMMY)_