### PR TITLE
fix: préserver classement manuel — kiosk + génération unique

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1505,6 +1505,16 @@ export class RemoteScoreServer {
               rankings,
             };
           });
+          const overallRanking = (sessionState?.overallRanking || []).map((r: any) => ({
+            id: r.fencer?.id ?? '',
+            lastName: r.fencer?.lastName ?? '',
+            firstName: r.fencer?.firstName ?? '',
+            club: r.fencer?.club ?? '',
+            victories: r.victories ?? 0,
+            index: r.index ?? 0,
+            touchesFor: r.touchesScored ?? 0,
+            touchesAgainst: r.touchesReceived ?? 0,
+          }));
           return res.json({
             competition: {
               id: competition.id,
@@ -1513,6 +1523,7 @@ export class RemoteScoreServer {
               weapon: competition.weapon,
             },
             pools: poolResults,
+            overallRanking,
           });
         }
 

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -1099,7 +1099,11 @@
           if (poolsRes.ok) {
             const data = await poolsRes.json();
             state.poolsData = data.pools || [];
-            buildOverallRanking();
+            if (data.overallRanking && data.overallRanking.length > 0) {
+              state.overallRanking = data.overallRanking;
+            } else {
+              buildOverallRanking();
+            }
             renderPools();
             renderRanking();
           }

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -636,8 +636,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   );
 
   const handleGoToRanking = () => {
-    const ranking = computeOverallRanking(pools);
-    setOverallRanking(ranking);
+    if (overallRanking.length === 0) {
+      const ranking = computeOverallRanking(pools);
+      setOverallRanking(ranking);
+    }
     setCurrentPhase('ranking');
   };
 


### PR DESCRIPTION
## Problème

Le classement modifié à la main n'apparaissait pas dans le kiosk/vision, et le bouton "Voir le classement" régénérait le classement à chaque appel, écrasant les éditions manuelles.

## Corrections

- **CompetitionView.tsx** — `handleGoToRanking` ne recalcule depuis les poules que si `overallRanking` est vide (première entrée). Les accès suivants conservent le classement existant (incluant éditions manuelles).
- **remoteScoreServer.ts** — L'endpoint `/results-data` inclut maintenant `overallRanking` depuis le `session_state` (classement sauvegardé, potentiellement édité à la main).
- **kiosk.html** — Utilise `overallRanking` fourni par l'API si disponible ; repli sur `buildOverallRanking()` seulement si absent.

## Test plan
- [ ] Terminer les poules → aller au classement → vérifier généré une fois
- [ ] Modifier manuellement le classement → sauvegarder
- [ ] Vérifier kiosk affiche le classement modifié
- [ ] Cliquer "Recalculer" → classement recalculé depuis scores
- [ ] Revenir aux poules puis retourner au classement → éditions manuelles conservées

https://claude.ai/code/session_01LjS6oqfzrU2PiDc4uA75KN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjS6oqfzrU2PiDc4uA75KN)_