### PR TITLE
feat: journal horodaté des décisions d'arbitre par match

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -22,6 +22,8 @@ import {
   Phase,
   PhaseType,
   Referee,
+  MatchEventEntry,
+  MatchEventType,
 } from '../shared/types';
 import { validateId, validateSessionState, sanitizeId } from './validation';
 import { logger, LogCategory } from '../shared/services/logger';
@@ -2397,6 +2399,164 @@ export class DatabaseManager {
     }
     stmt.free();
     return rows;
+  }
+
+  // ─── Match timeline (audit log) ──────────────────────────────────────────────
+
+  private parseTimelineRow(r: any): MatchEventEntry {
+    return {
+      id: r.id as string,
+      matchId: r.match_id as string,
+      eventType: r.event_type as MatchEventType,
+      timestamp: r.timestamp as string,
+      fencerId: (r.fencer_id as string) ?? null,
+      fencerLastName: (r.fencer_last_name as string) ?? null,
+      fencerFirstName: (r.fencer_first_name as string) ?? null,
+      fencerSide: (r.fencer_side as 'A' | 'B') ?? null,
+      previousScoreA: r.prev_a ? JSON.parse(r.prev_a as string) : null,
+      previousScoreB: r.prev_b ? JSON.parse(r.prev_b as string) : null,
+      newScoreA: r.new_a ? JSON.parse(r.new_a as string) : null,
+      newScoreB: r.new_b ? JSON.parse(r.new_b as string) : null,
+      changedBy: (r.changed_by as string) ?? null,
+      refereeName: (r.referee_name as string) ?? null,
+      ipAddress: (r.ip_address as string) ?? null,
+      changeReason: (r.change_reason as string) ?? null,
+      zone: (r.zone as string) ?? null,
+      points: r.points != null ? Number(r.points) : null,
+      cardType: (r.card_type as string) ?? null,
+      cardReason: (r.card_reason as string) ?? null,
+      cardGroup: r.card_group != null ? Number(r.card_group) : null,
+      resultingExclusion: r.resulting_exclusion != null ? r.resulting_exclusion === 1 : null,
+      exitType: (r.exit_type as string) ?? null,
+    };
+  }
+
+  private static readonly TIMELINE_UNION_MATCH = `
+    SELECT sal.id, sal.match_id, 'score_change' AS event_type,
+           sal.changed_at AS timestamp,
+           NULL AS fencer_id, NULL AS fencer_last_name, NULL AS fencer_first_name, NULL AS fencer_side,
+           sal.previous_score_a AS prev_a, sal.previous_score_b AS prev_b,
+           sal.new_score_a AS new_a, sal.new_score_b AS new_b,
+           sal.changed_by, sal.referee_name, sal.ip_address, sal.reason AS change_reason,
+           NULL AS zone, NULL AS points,
+           NULL AS card_type, NULL AS card_reason, NULL AS card_group, NULL AS resulting_exclusion,
+           NULL AS exit_type
+    FROM score_audit_log sal WHERE sal.match_id = ?
+    UNION ALL
+    SELECT mt.id, mt.match_id, 'touch', mt.timestamp,
+           mt.fencer_id, f.last_name, f.first_name,
+           CASE WHEN m.fencer_a_id = mt.fencer_id THEN 'A' ELSE 'B' END,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+           mt.zone, mt.points,
+           NULL, NULL, NULL, NULL, NULL
+    FROM match_touches mt
+    LEFT JOIN fencers f ON mt.fencer_id = f.id
+    LEFT JOIN matches m ON mt.match_id = m.id
+    WHERE mt.match_id = ?
+    UNION ALL
+    SELECT mc.id, mc.match_id, 'card', mc.timestamp,
+           mc.fencer_id, f.last_name, f.first_name,
+           CASE WHEN m.fencer_a_id = mc.fencer_id THEN 'A' ELSE 'B' END,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+           NULL, mc.points_awarded,
+           mc.card_type, mc.reason, mc.card_group, mc.resulting_exclusion,
+           NULL
+    FROM match_cards mc
+    LEFT JOIN fencers f ON mc.fencer_id = f.id
+    LEFT JOIN matches m ON mc.match_id = m.id
+    WHERE mc.match_id = ?
+    UNION ALL
+    SELECT mae.id, mae.match_id, 'arena_exit', mae.timestamp,
+           mae.fencer_id, f.last_name, f.first_name,
+           CASE WHEN m.fencer_a_id = mae.fencer_id THEN 'A' ELSE 'B' END,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+           NULL, mae.points_awarded,
+           NULL, NULL, NULL, NULL,
+           mae.exit_type
+    FROM match_arena_exits mae
+    LEFT JOIN fencers f ON mae.fencer_id = f.id
+    LEFT JOIN matches m ON mae.match_id = m.id
+    WHERE mae.match_id = ?
+    ORDER BY timestamp ASC
+  `;
+
+  public getMatchTimeline(matchId: string): MatchEventEntry[] {
+    if (!this.db) throw new Error('Database not open');
+    const stmt = this.db.prepare(DatabaseManager.TIMELINE_UNION_MATCH);
+    stmt.bind([matchId, matchId, matchId, matchId]);
+    const rows: any[] = [];
+    while (stmt.step()) rows.push(stmt.getAsObject());
+    stmt.free();
+    return rows.map(r => this.parseTimelineRow(r));
+  }
+
+  public getCompetitionTimeline(competitionId: string): MatchEventEntry[] {
+    if (!this.db) throw new Error('Database not open');
+    const matchSubquery = `
+      SELECT m.id FROM matches m
+        LEFT JOIN pools p ON m.pool_id = p.id
+        LEFT JOIN phases ph ON p.phase_id = ph.id
+        WHERE ph.competition_id = ?1
+      UNION
+      SELECT m.id FROM matches m
+        JOIN bracket_nodes bn ON m.id = bn.match_id
+        WHERE bn.competition_id = ?1
+    `;
+    const sql = `
+      SELECT sal.id, sal.match_id, 'score_change' AS event_type,
+             sal.changed_at AS timestamp,
+             NULL AS fencer_id, NULL AS fencer_last_name, NULL AS fencer_first_name, NULL AS fencer_side,
+             sal.previous_score_a AS prev_a, sal.previous_score_b AS prev_b,
+             sal.new_score_a AS new_a, sal.new_score_b AS new_b,
+             sal.changed_by, sal.referee_name, sal.ip_address, sal.reason AS change_reason,
+             NULL AS zone, NULL AS points,
+             NULL AS card_type, NULL AS card_reason, NULL AS card_group, NULL AS resulting_exclusion,
+             NULL AS exit_type
+      FROM score_audit_log sal
+      WHERE sal.match_id IN (${matchSubquery})
+      UNION ALL
+      SELECT mt.id, mt.match_id, 'touch', mt.timestamp,
+             mt.fencer_id, f.last_name, f.first_name,
+             CASE WHEN m.fencer_a_id = mt.fencer_id THEN 'A' ELSE 'B' END,
+             NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+             mt.zone, mt.points,
+             NULL, NULL, NULL, NULL, NULL
+      FROM match_touches mt
+      LEFT JOIN fencers f ON mt.fencer_id = f.id
+      LEFT JOIN matches m ON mt.match_id = m.id
+      WHERE mt.match_id IN (${matchSubquery})
+      UNION ALL
+      SELECT mc.id, mc.match_id, 'card', mc.timestamp,
+             mc.fencer_id, f.last_name, f.first_name,
+             CASE WHEN m.fencer_a_id = mc.fencer_id THEN 'A' ELSE 'B' END,
+             NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+             NULL, mc.points_awarded,
+             mc.card_type, mc.reason, mc.card_group, mc.resulting_exclusion,
+             NULL
+      FROM match_cards mc
+      LEFT JOIN fencers f ON mc.fencer_id = f.id
+      LEFT JOIN matches m ON mc.match_id = m.id
+      WHERE mc.match_id IN (${matchSubquery})
+      UNION ALL
+      SELECT mae.id, mae.match_id, 'arena_exit', mae.timestamp,
+             mae.fencer_id, f.last_name, f.first_name,
+             CASE WHEN m.fencer_a_id = mae.fencer_id THEN 'A' ELSE 'B' END,
+             NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+             NULL, mae.points_awarded,
+             NULL, NULL, NULL, NULL,
+             mae.exit_type
+      FROM match_arena_exits mae
+      LEFT JOIN fencers f ON mae.fencer_id = f.id
+      LEFT JOIN matches m ON mae.match_id = m.id
+      WHERE mae.match_id IN (${matchSubquery})
+      ORDER BY timestamp ASC
+    `;
+    const stmt = this.db.prepare(sql);
+    stmt.bind([competitionId]);
+    const rows: any[] = [];
+    while (stmt.step()) rows.push(stmt.getAsObject());
+    stmt.free();
+    return rows.map(r => this.parseTimelineRow(r));
   }
 
   // ─── Arena state persistence ─────────────────────────────────────────────────

--- a/src/features/matchAuditLog/hooks/useMatchAuditStore.ts
+++ b/src/features/matchAuditLog/hooks/useMatchAuditStore.ts
@@ -1,0 +1,83 @@
+/**
+ * BellePoule Modern - Match Audit Log Store
+ * Licensed under GPL-3.0
+ */
+
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+import { useShallow } from 'zustand/shallow';
+import type { MatchEventEntry, MatchEventType } from '../../../shared/types';
+
+interface MatchAuditState {
+  entries: MatchEventEntry[];
+  isLoading: boolean;
+  error: string | null;
+  activeMatchId: string | null;
+  activeCompetitionId: string | null;
+  filterTypes: MatchEventType[];
+}
+
+interface MatchAuditActions {
+  loadMatchTimeline: (matchId: string) => Promise<void>;
+  loadCompetitionTimeline: (competitionId: string) => Promise<void>;
+  setFilterTypes: (types: MatchEventType[]) => void;
+  clearError: () => void;
+  reset: () => void;
+}
+
+export const useMatchAuditStore = create<MatchAuditState & MatchAuditActions>()(
+  devtools(
+    immer(set => ({
+      entries: [],
+      isLoading: false,
+      error: null,
+      activeMatchId: null,
+      activeCompetitionId: null,
+      filterTypes: [],
+
+      loadMatchTimeline: async (matchId: string) => {
+        set({ isLoading: true, error: null, activeMatchId: matchId, activeCompetitionId: null });
+        try {
+          const data = await window.electronAPI.db.getMatchTimeline(matchId);
+          set({ entries: data, isLoading: false });
+        } catch (e) {
+          set({ error: e instanceof Error ? e.message : 'Erreur chargement', isLoading: false });
+        }
+      },
+
+      loadCompetitionTimeline: async (competitionId: string) => {
+        set({
+          isLoading: true,
+          error: null,
+          activeCompetitionId: competitionId,
+          activeMatchId: null,
+        });
+        try {
+          const data = await window.electronAPI.db.getCompetitionTimeline(competitionId);
+          set({ entries: data, isLoading: false });
+        } catch (e) {
+          set({ error: e instanceof Error ? e.message : 'Erreur chargement', isLoading: false });
+        }
+      },
+
+      setFilterTypes: (types: MatchEventType[]) => set({ filterTypes: types }),
+      clearError: () => set({ error: null }),
+      reset: () =>
+        set({ entries: [], isLoading: false, error: null, activeMatchId: null, activeCompetitionId: null }),
+    })),
+    { name: 'MatchAuditStore' }
+  )
+);
+
+export const useMatchAuditEntries = () => useMatchAuditStore(s => s.entries);
+export const useMatchAuditLoading = () => useMatchAuditStore(s => s.isLoading);
+export const useMatchAuditActions = () =>
+  useMatchAuditStore(
+    useShallow(s => ({
+      loadMatchTimeline: s.loadMatchTimeline,
+      loadCompetitionTimeline: s.loadCompetitionTimeline,
+      setFilterTypes: s.setFilterTypes,
+      reset: s.reset,
+    }))
+  );

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1147,6 +1147,14 @@ ipcMain.handle('db:getScoreAuditLogByCompetition', async (_, competitionId) => {
   return db.getScoreAuditLogByCompetition(competitionId);
 });
 
+ipcMain.handle('db:getMatchTimeline', async (_, matchId: string) => {
+  return db.getMatchTimeline(matchId);
+});
+
+ipcMain.handle('db:getCompetitionTimeline', async (_, competitionId: string) => {
+  return db.getCompetitionTimeline(competitionId);
+});
+
 // File handlers
 ipcMain.handle('file:export', async (_, filepath) => {
   db.exportToFile(filepath);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -291,6 +291,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('db:getScoreAuditLogByCompetition', competitionId),
     deleteAbandonSnapshot: (fencerId: string) =>
       ipcRenderer.invoke('db:deleteAbandonSnapshot', fencerId),
+    getMatchTimeline: (matchId: string) =>
+      ipcRenderer.invoke('db:getMatchTimeline', matchId),
+    getCompetitionTimeline: (competitionId: string) =>
+      ipcRenderer.invoke('db:getCompetitionTimeline', competitionId),
   },
 
   // File operations with validation

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1816,6 +1816,135 @@ export class RemoteScoreServer {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.send(html);
     });
+
+    // Journal du match en cours (tablette arbitre - lecture seule)
+    this.app.get('/api/arena/:arenaId/current-match/events', (req, res) => {
+      const arena = this.arenas.get(req.params.arenaId);
+      if (!arena?.currentMatch?.id) {
+        return res.json({ success: true, events: [], matchId: null });
+      }
+      try {
+        const events = this.db.getMatchTimeline(arena.currentMatch.id);
+        res.json({ success: true, events, matchId: arena.currentMatch.id });
+      } catch (e) {
+        res.status(500).json({ success: false, error: String(e) });
+      }
+    });
+
+    // Page HTML journal (match en cours uniquement)
+    this.app.get('/arene:arenaId/journal', (req, res) => {
+      const arenaNum = req.params.arenaId;
+      const html = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Journal – Piste ${arenaNum}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; padding: 1rem; font-size: 14px; }
+    header { text-align: center; padding: 0.75rem 0 1rem; }
+    header h1 { font-size: 1.1rem; color: #f8fafc; }
+    #match-info { color: #94a3b8; font-size: 0.8rem; margin-top: 0.25rem; }
+    #status { text-align: center; color: #94a3b8; padding: 2rem; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+    th { background: #1e293b; color: #94a3b8; padding: 0.45rem 0.6rem; text-align: left; font-weight: 600; position: sticky; top: 0; }
+    td { padding: 0.4rem 0.6rem; border-bottom: 1px solid #1e293b; }
+    tr:nth-child(even) td { background: rgba(255,255,255,0.03); }
+    .badge { padding: 0.1rem 0.4rem; border-radius: 999px; font-size: 0.7rem; font-weight: 700; }
+    .badge-score_change { background: #4c1d95; color: #c4b5fd; }
+    .badge-touch { background: #1e3a5f; color: #93c5fd; }
+    .badge-card { background: #450a0a; color: #fca5a5; }
+    .badge-arena_exit { background: #451a03; color: #fcd34d; }
+    .side-a { color: #60a5fa; font-weight: 600; }
+    .side-b { color: #f87171; font-weight: 600; }
+    .ts { font-family: monospace; color: #64748b; white-space: nowrap; }
+    #last-update { position: fixed; bottom: 0.5rem; right: 0.75rem; font-size: 0.7rem; color: #475569; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Journal — Piste ${arenaNum}</h1>
+    <div id="match-info">Chargement…</div>
+  </header>
+  <div id="status"></div>
+  <table id="log-table" style="display:none">
+    <thead><tr><th>Heure</th><th>Type</th><th>Tireur</th><th>Description</th></tr></thead>
+    <tbody id="log-body"></tbody>
+  </table>
+  <div id="last-update"></div>
+  <script>
+    const arenaId = 'arena${arenaNum}';
+    let baseTs = null;
+
+    function describeEvent(e) {
+      switch (e.eventType) {
+        case 'touch': return 'Zone ' + (e.zone || '?') + ' — ' + (e.points || 0) + ' pt(s)';
+        case 'card': return 'Carton ' + (e.cardType || '') + ' — ' + (e.cardReason || '') + (e.resultingExclusion ? ' (exclusion)' : '');
+        case 'arena_exit': return (e.exitType === 'arena_exit_voluntary' ? 'Sortie volontaire' : "Sortie d'arène") + ' — +' + (e.points || 0) + ' pts adv.';
+        case 'score_change': {
+          const pA = e.previousScoreA && e.previousScoreA.value != null ? e.previousScoreA.value : '?';
+          const pB = e.previousScoreB && e.previousScoreB.value != null ? e.previousScoreB.value : '?';
+          const nA = e.newScoreA && e.newScoreA.value != null ? e.newScoreA.value : '?';
+          const nB = e.newScoreB && e.newScoreB.value != null ? e.newScoreB.value : '?';
+          return pA + '/' + pB + ' → ' + nA + '/' + nB + ' (' + (e.refereeName || e.changedBy || '?') + ')';
+        }
+        default: return '';
+      }
+    }
+
+    function formatTs(ts) {
+      const d = new Date(ts);
+      const abs = d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      if (!baseTs) return abs;
+      const diff = d.getTime() - new Date(baseTs).getTime();
+      if (diff < 0) return abs;
+      const s = Math.floor(diff / 1000) % 60;
+      const m = Math.floor(diff / 60000);
+      return abs + ' (+' + (m > 0 ? m + 'm' : '') + String(s).padStart(2,'0') + 's)';
+    }
+
+    async function refresh() {
+      try {
+        const r = await fetch('/api/arena/' + arenaId + '/current-match/events');
+        const data = await r.json();
+        const info = document.getElementById('match-info');
+        const status = document.getElementById('status');
+        const table = document.getElementById('log-table');
+        const body = document.getElementById('log-body');
+
+        if (!data.matchId || data.events.length === 0) {
+          info.textContent = 'Aucun match en cours';
+          status.textContent = data.matchId ? 'Aucun événement enregistré.' : '';
+          table.style.display = 'none';
+          baseTs = null;
+          return;
+        }
+
+        baseTs = data.events[0].timestamp;
+        info.textContent = 'Match en cours · ' + data.events.length + ' événement(s)';
+        status.textContent = '';
+        table.style.display = '';
+
+        body.innerHTML = data.events.map(e => {
+          const side = e.fencerSide ? ('<span class="side-' + e.fencerSide.toLowerCase() + '">' + e.fencerSide + ' — ' + (e.fencerLastName || '') + '</span>') : '<span style="color:#6b7280">Match</span>';
+          return '<tr><td class="ts">' + formatTs(e.timestamp) + '</td><td><span class="badge badge-' + e.eventType + '">' + e.eventType + '</span></td><td>' + side + '</td><td>' + describeEvent(e) + '</td></tr>';
+        }).reverse().join('');
+
+        document.getElementById('last-update').textContent = 'MàJ ' + new Date().toLocaleTimeString('fr-FR');
+      } catch(err) {
+        document.getElementById('status').textContent = 'Erreur de connexion';
+      }
+    }
+
+    refresh();
+    setInterval(refresh, 5000);
+  </script>
+</body>
+</html>`;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.send(html);
+    });
   }
 
   private setupSocketHandlers(): void {

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -42,6 +42,7 @@ const TableauView = React.lazy(() => import('./TableauView'));
 const RemoteScoreManager = React.lazy(() => import('./RemoteScoreManager'));
 const KioskDisplay = React.lazy(() => import('./KioskDisplay'));
 const FencerComparison = React.lazy(() => import('./FencerComparison').then(m => ({ default: m.FencerComparison })));
+const MatchAuditLog = React.lazy(() => import('./MatchAuditLog').then(m => ({ default: m.MatchAuditLog })));
 const AnalyticsDashboard = React.lazy(() => import('./AnalyticsDashboard').then(m => ({ default: m.AnalyticsDashboard })));
 const PresentationMode = React.lazy(() => import('./PresentationMode').then(m => ({ default: m.PresentationMode })));
 const QuestPhaseView = React.lazy(() => import('./QuestPhaseView'));
@@ -1271,7 +1272,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         </Suspense>
 
         {currentPhase === 'logs' && (
-          <ScoreAuditLog competitionId={competition.id} />
+          <>
+            <ScoreAuditLog competitionId={competition.id} />
+            <Suspense fallback={null}>
+              <MatchAuditLog
+                competitionId={competition.id}
+                competitionName={competition.title}
+              />
+            </Suspense>
+          </>
         )}
 
         {currentPhase === 'referees' && competition.settings?.refereeFeatureEnabled && (

--- a/src/renderer/components/MatchAuditLog.tsx
+++ b/src/renderer/components/MatchAuditLog.tsx
@@ -1,0 +1,270 @@
+/**
+ * BellePoule Modern - Journal de match (audit log)
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useEffect, useCallback, memo } from 'react';
+import type { MatchEventEntry, MatchEventType } from '../../shared/types';
+import { useMatchAuditStore } from '../../features/matchAuditLog/hooks/useMatchAuditStore';
+import { useToast } from './Toast';
+import { describeMatchEvent, exportMatchTimelineJSON } from '../../shared/utils/multiFormatExport';
+
+interface MatchAuditLogProps {
+  matchId?: string;
+  competitionId?: string;
+  matchTitle?: string;
+  competitionName?: string;
+  onClose?: () => void;
+}
+
+const EVENT_TYPE_LABELS: Record<MatchEventType, string> = {
+  score_change: 'Score',
+  touch: 'Touche',
+  card: 'Carton',
+  arena_exit: 'Sortie',
+};
+
+const EVENT_TYPE_COLORS: Record<MatchEventType, string> = {
+  score_change: '#8b5cf6',
+  touch: '#3b82f6',
+  card: '#ef4444',
+  arena_exit: '#f59e0b',
+};
+
+const ALL_TYPES: MatchEventType[] = ['touch', 'card', 'arena_exit', 'score_change'];
+
+function formatTimestamp(ts: string, baseTs: string | null): string {
+  const d = new Date(ts);
+  const abs = d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  if (!baseTs) return abs;
+  const diffMs = d.getTime() - new Date(baseTs).getTime();
+  if (diffMs < 0) return abs;
+  const s = Math.floor(diffMs / 1000) % 60;
+  const m = Math.floor(diffMs / 60000);
+  const rel = m > 0 ? `+${m}m${s.toString().padStart(2, '0')}s` : `+${s}s`;
+  return `${abs} (${rel})`;
+}
+
+function fencerLabel(entry: MatchEventEntry): { label: string; color: string } {
+  if (!entry.fencerSide) return { label: 'Match', color: '#6b7280' };
+  const name = entry.fencerLastName ?? entry.fencerSide;
+  return {
+    label: `${entry.fencerSide} — ${name}`,
+    color: entry.fencerSide === 'A' ? '#3b82f6' : '#ef4444',
+  };
+}
+
+const MatchAuditLogComponent: React.FC<MatchAuditLogProps> = ({
+  matchId,
+  competitionId,
+  matchTitle,
+  competitionName,
+  onClose,
+}) => {
+  const { showToast } = useToast();
+  const { entries, isLoading, error, filterTypes, loadMatchTimeline, loadCompetitionTimeline, setFilterTypes, reset } =
+    useMatchAuditStore();
+
+  useEffect(() => {
+    if (matchId) {
+      loadMatchTimeline(matchId);
+    } else if (competitionId) {
+      loadCompetitionTimeline(competitionId);
+    }
+    return () => { reset(); };
+  }, [matchId, competitionId]);
+
+  useEffect(() => {
+    if (error) showToast(error, 'error');
+  }, [error]);
+
+  const baseTs = entries.length > 0 ? entries[0].timestamp : null;
+
+  const filtered =
+    filterTypes.length === 0 ? entries : entries.filter(e => filterTypes.includes(e.eventType));
+
+  const toggleType = useCallback(
+    (t: MatchEventType) => {
+      if (filterTypes.includes(t)) {
+        setFilterTypes(filterTypes.filter(x => x !== t));
+      } else {
+        setFilterTypes([...filterTypes, t]);
+      }
+    },
+    [filterTypes, setFilterTypes]
+  );
+
+  const handleExportJSON = useCallback(async () => {
+    try {
+      const title = matchTitle ?? (matchId ? `match_${matchId}` : `competition_${competitionId}`);
+      const json = exportMatchTimelineJSON(entries, title, competitionName);
+      const filename = `journal_${title.replace(/\s+/g, '_')}_${Date.now()}.json`;
+      const result = await window.electronAPI.dialog.saveFile({
+        defaultPath: filename,
+        filters: [{ name: 'JSON', extensions: ['json'] }],
+      });
+      if (result?.filePath) {
+        await window.electronAPI.file.writeContent(result.filePath, json);
+        showToast('Export JSON réussi', 'success');
+      }
+    } catch {
+      showToast("Erreur lors de l'export", 'error');
+    }
+  }, [entries, matchTitle, matchId, competitionId, competitionName]);
+
+  const content = (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', gap: '1rem' }}>
+      {/* Filtres */}
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+        <span style={{ fontSize: '0.8rem', color: '#6b7280', marginRight: '0.25rem' }}>Filtrer :</span>
+        {ALL_TYPES.map(t => {
+          const active = filterTypes.length === 0 || filterTypes.includes(t);
+          return (
+            <button
+              key={t}
+              onClick={() => toggleType(t)}
+              style={{
+                padding: '0.2rem 0.6rem',
+                fontSize: '0.75rem',
+                fontWeight: '600',
+                borderRadius: '999px',
+                border: `1px solid ${EVENT_TYPE_COLORS[t]}`,
+                background: active ? EVENT_TYPE_COLORS[t] : 'transparent',
+                color: active ? 'white' : EVENT_TYPE_COLORS[t],
+                cursor: 'pointer',
+              }}
+            >
+              {EVENT_TYPE_LABELS[t]}
+            </button>
+          );
+        })}
+        <span style={{ marginLeft: 'auto', fontSize: '0.8rem', color: '#9ca3af' }}>
+          {filtered.length} événement{filtered.length !== 1 ? 's' : ''}
+        </span>
+        <button
+          onClick={handleExportJSON}
+          disabled={entries.length === 0}
+          style={{
+            padding: '0.3rem 0.75rem',
+            fontSize: '0.75rem',
+            fontWeight: '600',
+            borderRadius: '6px',
+            border: '1px solid #374151',
+            background: entries.length === 0 ? '#f3f4f6' : '#1f2937',
+            color: entries.length === 0 ? '#9ca3af' : 'white',
+            cursor: entries.length === 0 ? 'not-allowed' : 'pointer',
+          }}
+        >
+          Export JSON
+        </button>
+      </div>
+
+      {/* Tableau */}
+      <div style={{ overflowY: 'auto', flex: 1 }}>
+        {isLoading ? (
+          <div style={{ textAlign: 'center', padding: '3rem', color: '#6b7280' }}>Chargement…</div>
+        ) : filtered.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '3rem', color: '#9ca3af', fontSize: '0.875rem' }}>
+            Aucun événement enregistré pour ce match.
+          </div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+            <thead>
+              <tr style={{ background: '#f9fafb', borderBottom: '2px solid #e5e7eb' }}>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#6b7280', whiteSpace: 'nowrap' }}>
+                  Heure
+                </th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#6b7280' }}>
+                  Type
+                </th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#6b7280' }}>
+                  Tireur
+                </th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#6b7280' }}>
+                  Description
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((entry, i) => {
+                const { label, color } = fencerLabel(entry);
+                return (
+                  <tr
+                    key={entry.id}
+                    style={{
+                      borderBottom: '1px solid #f3f4f6',
+                      background: i % 2 === 0 ? 'white' : '#fafafa',
+                    }}
+                  >
+                    <td style={{ padding: '0.5rem 0.75rem', color: '#6b7280', fontFamily: 'monospace', whiteSpace: 'nowrap' }}>
+                      {formatTimestamp(entry.timestamp, baseTs)}
+                    </td>
+                    <td style={{ padding: '0.5rem 0.75rem' }}>
+                      <span
+                        style={{
+                          padding: '0.1rem 0.45rem',
+                          borderRadius: '999px',
+                          fontSize: '0.7rem',
+                          fontWeight: '700',
+                          background: `${EVENT_TYPE_COLORS[entry.eventType]}20`,
+                          color: EVENT_TYPE_COLORS[entry.eventType],
+                          border: `1px solid ${EVENT_TYPE_COLORS[entry.eventType]}40`,
+                        }}
+                      >
+                        {EVENT_TYPE_LABELS[entry.eventType]}
+                      </span>
+                    </td>
+                    <td style={{ padding: '0.5rem 0.75rem', fontWeight: '600', color }}>
+                      {label}
+                    </td>
+                    <td style={{ padding: '0.5rem 0.75rem', color: '#374151' }}>
+                      {describeMatchEvent(entry)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+
+  // Rendu inline (sans onClose = panel dans une page)
+  if (!onClose) {
+    return (
+      <div style={{ padding: '1rem' }}>
+        <h3 style={{ margin: '0 0 1rem', fontSize: '1rem', fontWeight: '600', color: '#1f2937' }}>
+          Journal du match
+        </h3>
+        {content}
+      </div>
+    );
+  }
+
+  // Rendu modal
+  return (
+    <div
+      className="modal-overlay"
+      onClick={onClose}
+      style={{ zIndex: 1000 }}
+    >
+      <div
+        className="modal modal--xl"
+        onClick={e => e.stopPropagation()}
+        style={{ maxHeight: '80vh', display: 'flex', flexDirection: 'column' }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' }}>
+          <h2 style={{ margin: 0, fontSize: '1.1rem', fontWeight: '700' }}>
+            Journal du match{matchTitle ? ` — ${matchTitle}` : ''}
+          </h2>
+          <button className="btn-close" onClick={onClose}>&times;</button>
+        </div>
+        {content}
+      </div>
+    </div>
+  );
+};
+
+export const MatchAuditLog = memo(MatchAuditLogComponent);
+export default MatchAuditLog;

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -19,6 +19,7 @@ import PoolScoreMatrix from './pool/PoolScoreMatrix';
 import PoolMatchList from './pool/PoolMatchList';
 import Confetti from './Confetti';
 import AddFencerToPoolModal from './AddFencerToPoolModal';
+import { MatchAuditLog } from './MatchAuditLog';
 
 interface PoolViewProps {
   pool: Pool;
@@ -112,6 +113,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
   const [showPoolConfetti, setShowPoolConfetti] = useState(false);
   const [showAddFencerModal, setShowAddFencerModal] = useState(false);
+  const [auditMatchId, setAuditMatchId] = useState<string | null>(null);
   const prevIsComplete = useRef(pool.isComplete);
 
   useEffect(() => {
@@ -1326,6 +1328,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
             isLocked={isLocked}
             openScoreModal={openScoreModal}
             onMatchReset={onMatchReset}
+            onShowMatchAudit={setAuditMatchId}
             defaultArena={defaultArena}
             arenaCount={arenaCount}
             arenas={arenas}
@@ -1348,6 +1351,11 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         }}
         onClose={() => setShowAddFencerModal(false)}
       />
+    )}
+    {auditMatchId && (
+      <React.Suspense fallback={null}>
+        <MatchAuditLog matchId={auditMatchId} onClose={() => setAuditMatchId(null)} />
+      </React.Suspense>
     )}
     </>
   );

--- a/src/renderer/components/pool/PoolMatchList.tsx
+++ b/src/renderer/components/pool/PoolMatchList.tsx
@@ -24,6 +24,7 @@ interface PoolMatchListProps {
   isLocked: boolean;
   openScoreModal: (index: number) => void;
   onMatchReset?: (index: number) => void;
+  onShowMatchAudit?: (matchId: string) => void;
   defaultArena?: number;
   arenaCount?: number;
   arenas?: Arena[];
@@ -106,6 +107,7 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
   isLocked,
   openScoreModal,
   onMatchReset,
+  onShowMatchAudit,
   defaultArena = 1,
   arenaCount = 0,
   arenas = [],
@@ -475,6 +477,28 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                   {fencerBAbandoned && ' ✕'}
                   {match.scoreB?.isVictory && !isAbandonMatch ? ' ✓' : ''}
                 </span>
+                {onShowMatchAudit && (
+                  <button
+                    onClick={e => {
+                      e.stopPropagation();
+                      onShowMatchAudit(match.id);
+                    }}
+                    title="Journal du match"
+                    style={{
+                      marginLeft: '0.5rem',
+                      padding: '0.25rem 0.5rem',
+                      fontSize: '0.75rem',
+                      background: 'rgba(139,92,246,0.1)',
+                      border: '1px solid rgba(139,92,246,0.3)',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      color: '#7c3aed',
+                      flexShrink: 0,
+                    }}
+                  >
+                    📋
+                  </button>
+                )}
                 {!isAbandonMatch && !isLocked && onMatchReset && (
                   <button
                     onClick={e => {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -652,3 +652,39 @@ export interface UISettings {
   autoSave: boolean;
   autoSaveInterval: number; // En secondes
 }
+
+// ============================================================================
+// Match Timeline (Audit Log) Types
+// ============================================================================
+
+export type MatchEventType = 'score_change' | 'touch' | 'card' | 'arena_exit';
+
+export interface MatchEventEntry {
+  id: string;
+  matchId: string;
+  eventType: MatchEventType;
+  timestamp: string; // ISO 8601
+  fencerId: string | null;
+  fencerLastName: string | null;
+  fencerFirstName: string | null;
+  fencerSide: 'A' | 'B' | null;
+  // score_change
+  previousScoreA: { value: number | null } | null;
+  previousScoreB: { value: number | null } | null;
+  newScoreA: { value: number | null } | null;
+  newScoreB: { value: number | null } | null;
+  changedBy: string | null;
+  refereeName: string | null;
+  ipAddress: string | null;
+  changeReason: string | null;
+  // touch
+  zone: string | null;
+  points: number | null;
+  // card
+  cardType: string | null;
+  cardReason: string | null;
+  cardGroup: number | null;
+  resultingExclusion: boolean | null;
+  // arena_exit
+  exitType: string | null;
+}

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -571,6 +571,10 @@ export interface DatabaseAPI {
 
   // Score audit log
   getScoreAuditLogByCompetition: (competitionId: string) => Promise<ScoreAuditEntry[]>;
+
+  // Match timeline
+  getMatchTimeline: (matchId: string) => Promise<import('./index').MatchEventEntry[]>;
+  getCompetitionTimeline: (competitionId: string) => Promise<import('./index').MatchEventEntry[]>;
 }
 
 export interface FileAPI {

--- a/src/shared/utils/multiFormatExport.ts
+++ b/src/shared/utils/multiFormatExport.ts
@@ -3,7 +3,7 @@
  * Licensed under GPL-3.0
  */
 
-import { Competition, Fencer, Pool, PoolRanking, FencerStatus } from '../types';
+import { Competition, Fencer, Pool, PoolRanking, FencerStatus, MatchEventEntry } from '../types';
 
 /**
  * Export results as HTML web page
@@ -338,4 +338,45 @@ function escapeXml(str: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;');
+}
+
+export function describeMatchEvent(entry: MatchEventEntry): string {
+  switch (entry.eventType) {
+    case 'touch':
+      return `Zone ${entry.zone ?? '?'} — ${entry.points ?? 0} pt(s)`;
+    case 'card': {
+      const exclusion = entry.resultingExclusion ? ' (exclusion)' : '';
+      return `Carton ${entry.cardType ?? ''} — ${entry.cardReason ?? ''}${exclusion}`;
+    }
+    case 'arena_exit':
+      return `${entry.exitType === 'arena_exit_voluntary' ? 'Sortie volontaire' : "Sortie d'arène"} — +${entry.points ?? 0} pts adv.`;
+    case 'score_change': {
+      const pA = entry.previousScoreA?.value ?? '?';
+      const pB = entry.previousScoreB?.value ?? '?';
+      const nA = entry.newScoreA?.value ?? '?';
+      const nB = entry.newScoreB?.value ?? '?';
+      const by = entry.refereeName ?? entry.changedBy ?? '?';
+      return `${pA}/${pB} → ${nA}/${nB} (${by})`;
+    }
+    default:
+      return '';
+  }
+}
+
+export function exportMatchTimelineJSON(
+  entries: MatchEventEntry[],
+  title: string,
+  competitionName?: string
+): string {
+  return JSON.stringify(
+    {
+      title,
+      competitionName: competitionName ?? null,
+      exportedAt: new Date().toISOString(),
+      eventCount: entries.length,
+      events: entries,
+    },
+    null,
+    2
+  );
 }


### PR DESCRIPTION
## Résumé

- **Journal par match** : bouton 📋 sur chaque match terminé (vue liste des poules) ouvre une modal chronologique de tous les événements (touches, cartons, corrections de score, sorties d'arène) avec timestamps absolus + temps relatif depuis le début du match
- **Journal compétition** : dans l'onglet Logs, panel inline avec tous les événements de la compétition + bouton Export JSON
- **Tablette arbitre** : endpoint `GET /api/arena/:arenaId/current-match/events` + page HTML `/arene:N/journal` — affiche uniquement le match en cours, refresh automatique toutes les 5s, lecture seule

## Détails techniques

- **Aucune migration DB** — les données existent déjà dans `score_audit_log`, `match_cards`, `match_touches`, `match_arena_exits`
- `DatabaseManager.getMatchTimeline(matchId)` : SQL UNION des 4 tables, enrichi avec noms tireurs via LEFT JOIN, trié par timestamp ASC
- `DatabaseManager.getCompetitionTimeline(competitionId)` : même UNION, couvre pools ET matchs DE (via `bracket_nodes`)
- IPC handlers + preload bindings ajoutés
- Zustand store `useMatchAuditStore` avec filtres par type d'événement
- Export JSON via `dialog.saveFile`

## Plan de test

- [ ] Match terminé en vue liste → clic 📋 → modal avec timeline
- [ ] Filtrer par type (carton uniquement) → seuls les cartons visibles
- [ ] Export JSON → fichier téléchargé avec structure `{ title, exportedAt, events[] }`
- [ ] Onglet Logs → panel journal compétition affiché sous ScoreAuditLog
- [ ] Sur tablette : `GET /api/arena/arena1/current-match/events` → JSON valide
- [ ] `/arene1/journal` → page HTML, refresh toutes les 5s
- [ ] Match sans touches/cartons (saisi manuellement) → seuls `score_change` apparaissent, pas d'erreur

https://claude.ai/code/session_012saiuxqrrivHU4VpopUJQC

---
_Generated by [Claude Code](https://claude.ai/code/session_012saiuxqrrivHU4VpopUJQC)_