### PR TITLE
feat: export complet compétition en un seul PDF

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -8,6 +8,7 @@ import { Competition, Fencer, FencerStatus, Match, MatchStatus, Weapon, QuestPha
 import { Arena } from '../../shared/types/remote';
 import { logger, LogCategory } from '@shared/services/logger';
 import { RankingImportResult } from '../../shared/utils/fileParser';
+import type { TableauMatchForPDF } from '../../shared/utils/pdfExport';
 import FencerList from './FencerList';
 import { TableauMatch, FinalResult, propagateWinners, ConsolationBracket } from './tableau/tableauTypes';
 import PoolRankingView from './PoolRankingView';
@@ -1254,6 +1255,11 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             competition={competition}
             poolRanking={overallRanking}
             finalResults={finalResults}
+            fencers={fencers}
+            pools={pools}
+            tableauMatches={tableauMatches as TableauMatchForPDF[]}
+            consolationBrackets={consolationBrackets}
+            isLaserSabre={isLaserSabre}
           />
         )}
 

--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -6,10 +6,13 @@
 
 import React from 'react';
 import { Fencer, PoolRanking, Competition, FencerStatus } from '../../shared/types';
+import type { Pool } from '../../shared/types';
 import { useToast } from './Toast';
 import { exportResultsXMLFFE } from '../../shared/utils/multiFormatExport';
-import { exportResultsToPDF } from '../../shared/utils/pdfExport';
+import { exportResultsToPDF, exportFullCompetitionPDF } from '../../shared/utils/pdfExport';
+import type { TableauMatchForPDF, FinalResultForPDF } from '../../shared/utils/pdfExport';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
+import type { ConsolationBracket } from './tableau/tableauTypes';
 
 interface FinalResult {
   rank: number;
@@ -21,6 +24,11 @@ interface ResultsViewProps {
   competition: Competition;
   poolRanking: PoolRanking[];
   finalResults: FinalResult[];
+  fencers?: Fencer[];
+  pools?: Pool[];
+  tableauMatches?: TableauMatchForPDF[];
+  consolationBrackets?: ConsolationBracket[];
+  isLaserSabre?: boolean;
 }
 
 // ─── Static style constants ───────────────────────────────────────────────────
@@ -62,10 +70,14 @@ const RV_STYLES = {
   btnCsv: { padding: '0.75rem 1.5rem', background: '#f59e0b', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
   btnXml: { padding: '0.75rem 1.5rem', background: '#8b5cf6', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
   btnPdf: { padding: '0.75rem 1.5rem', background: '#ef4444', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
+  btnFullPdf: { padding: '0.75rem 1.5rem', background: '#166534', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
   legend: { textAlign: 'center' as const, marginTop: '1.5rem', fontSize: '0.875rem', color: '#6b7280' } satisfies React.CSSProperties,
 } satisfies Record<string, React.CSSProperties>;
 
-const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, finalResults }) => {
+const ResultsView: React.FC<ResultsViewProps> = ({
+  competition, poolRanking, finalResults,
+  fencers, pools, tableauMatches, consolationBrackets, isLaserSabre,
+}) => {
   const { showToast } = useToast();
   const rankingTemplate = usePdfTemplateStore(s => s.templates.ranking);
 
@@ -172,6 +184,28 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
     link.download = `resultats_${competition.title.replace(/[^a-z0-9]/gi, '_')}.xml`;
     link.click();
     showToast('Export XML réussi !', 'success');
+  };
+
+  const exportFullPDF = async () => {
+    try {
+      await exportFullCompetitionPDF({
+        fencers: fencers ?? [],
+        pools: pools ?? [],
+        overallRanking: poolRanking,
+        tableauMatches: tableauMatches ?? [],
+        consolationBrackets: (consolationBrackets ?? []).map(b => ({
+          id: b.id,
+          name: b.name,
+          matches: b.matches as TableauMatchForPDF[],
+        })),
+        finalResults: resultsToDisplay as FinalResultForPDF[],
+        competitionTitle: competition.title,
+        isLaserSabre,
+        template: rankingTemplate,
+      });
+    } catch (e) {
+      showToast((e as Error).message, 'error');
+    }
   };
 
   const champion = resultsToDisplay.find(r => r.rank === 1);
@@ -292,6 +326,9 @@ const ResultsView: React.FC<ResultsViewProps> = ({ competition, poolRanking, fin
         </button>
         <button onClick={exportPDF} style={RV_STYLES.btnPdf}>
           📄 PDF
+        </button>
+        <button onClick={exportFullPDF} style={RV_STYLES.btnFullPdf}>
+          📦 Export complet PDF
         </button>
       </div>
 

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1554,7 +1554,7 @@ export async function exportRankingToPDF(
 
 // ─── Export Résultats Finaux ───────────────────────────────────────────────────
 
-interface FinalResultForPDF {
+export interface FinalResultForPDF {
   rank: number;
   fencer: Fencer;
   eliminatedAt?: string;
@@ -1783,5 +1783,125 @@ export async function exportAppelToPDF(
   if (fencers.length === 0) throw new Error("Aucun tireur dans la liste d'appel");
   const html = generateAppelHTML(fencers, visibleColumns, title, competitionName, logoBase64, template);
   await savePDF(html, 'appel.pdf');
+}
+
+// ─── Export complet compétition ───────────────────────────────────────────────
+
+function extractBodyContent(html: string): string {
+  const m = /<body[^>]*>([\s\S]*?)<\/body>/i.exec(html);
+  return m ? m[1].trim() : '';
+}
+
+function extractStyleContent(html: string): string {
+  const re = /<style[^>]*>([\s\S]*?)<\/style>/gi;
+  const parts: string[] = [];
+  let m;
+  while ((m = re.exec(html)) !== null) parts.push(m[1]);
+  return parts.join('\n');
+}
+
+export interface FullCompetitionExportData {
+  fencers: Fencer[];
+  pools: Pool[];
+  overallRanking: PoolRanking[];
+  tableauMatches: TableauMatchForPDF[];
+  consolationBrackets: { id: string; name: string; matches: TableauMatchForPDF[] }[];
+  finalResults: FinalResultForPDF[];
+  competitionTitle: string;
+  isLaserSabre?: boolean;
+  template?: PdfTemplate;
+}
+
+export async function exportFullCompetitionPDF(data: FullCompetitionExportData): Promise<void> {
+  const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+  const {
+    fencers, pools, overallRanking, tableauMatches, consolationBrackets,
+    finalResults, competitionTitle, isLaserSabre = false, template,
+  } = data;
+
+  const sections: string[] = [];
+
+  if (fencers.length > 0) {
+    const sorted = [...fencers].sort(
+      (a, b) => (a.ranking ?? Infinity) - (b.ranking ?? Infinity) || a.lastName.localeCompare(b.lastName)
+    );
+    sections.push(generateAppelHTML(
+      sorted,
+      ['ref', 'lastName', 'firstName', 'birthDate', 'club', 'ranking', 'status'],
+      `Feuille d'appel — ${competitionTitle}`,
+      competitionTitle, logo, template
+    ));
+  }
+
+  for (const pool of pools) {
+    sections.push(generatePoolHTML(
+      pool,
+      { title: `Poule ${pool.number} — ${competitionTitle}`, logoBase64: logo, competitionName: competitionTitle },
+      template
+    ));
+  }
+
+  if (overallRanking.length > 0) {
+    const rankCols = isLaserSabre
+      ? ['rank', 'lastName', 'firstName', 'club', 'victories', 'ratio', 'td', 'tr', 'quest', 'index']
+      : ['rank', 'lastName', 'firstName', 'club', 'victories', 'ratio', 'td', 'tr', 'index'];
+    sections.push(generateRankingHTML(
+      overallRanking, `Classement provisoire — ${competitionTitle}`,
+      isLaserSabre, rankCols, logo, template
+    ));
+  }
+
+  const rounds = [...new Set(tableauMatches.map(m => m.round))].sort((a, b) => b - a);
+  for (const round of rounds) {
+    const roundMatches = tableauMatches.filter(m => m.round === round && !m.isBye);
+    if (roundMatches.length === 0) continue;
+    sections.push(generateTableauHTML(
+      roundMatches, MAX_MATCHES_PER_PAGE_TABLEAU,
+      `${getTableauRoundName(round)} — ${competitionTitle}`,
+      logo, template
+    ));
+  }
+
+  for (const bracket of consolationBrackets) {
+    const bRounds = [...new Set(bracket.matches.map(m => m.round))].sort((a, b) => b - a);
+    for (const round of bRounds) {
+      const roundMatches = bracket.matches.filter(m => m.round === round && !m.isBye);
+      if (roundMatches.length === 0) continue;
+      sections.push(generateTableauHTML(
+        roundMatches, MAX_MATCHES_PER_PAGE_TABLEAU,
+        `${bracket.name} — ${getTableauRoundName(round)} — ${competitionTitle}`,
+        logo, template
+      ));
+    }
+  }
+
+  if (finalResults.length > 0) {
+    sections.push(generateResultsHTML(finalResults, `Classement final — ${competitionTitle}`, logo, template));
+  }
+
+  if (sections.length === 0) throw new Error('Aucune donnée à exporter');
+
+  const allStyles = sections.map(extractStyleContent).join('\n');
+  const allBodies = sections
+    .map((html, i) => (i === 0 ? '' : '<div class="full-export-break"></div>\n') + extractBodyContent(html))
+    .join('\n');
+
+  const combined = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Export complet — ${competitionTitle}</title>
+  <style>
+    ${allStyles}
+    .full-export-break { break-before: page; }
+  </style>
+</head>
+<body>
+${allBodies}
+</body>
+</html>`;
+
+  const safe = competitionTitle.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+  await savePDF(combined, `export_complet_${safe}.pdf`);
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Nouveau bouton **"📦 Export complet PDF"** sur l'onglet Résultats (fin de compétition)
- Génère un seul PDF multi-pages contenant dans l'ordre :
  1. Feuille d'appel (tireurs triés par classement initial)
  2. Résultats de chaque poule (grille de scores + matchs)
  3. Classement provisoire (après les poules)
  4. Feuilles de match du tableau éliminatoire (T64 → T32 → … → Finale)
  5. Brackets de consolation (après le tableau principal)
  6. Classement final

## Fichiers modifiés

- `src/shared/utils/pdfExport.ts` — Nouvelle fonction `exportFullCompetitionPDF()` + interface `FullCompetitionExportData` + export de `FinalResultForPDF`
- `src/renderer/components/ResultsView.tsx` — Nouvelles props optionnelles (`fencers`, `pools`, `tableauMatches`, `consolationBrackets`, `isLaserSabre`) + bouton + handler
- `src/renderer/components/CompetitionView.tsx` — Passage des nouvelles props à `<ResultsView>`

## Plan de test

- [ ] Ouvrir une compétition avec poules + tableau terminé, aller sur Résultats, cliquer "Export complet PDF"
- [ ] Vérifier que le PDF contient toutes les sections dans l'ordre
- [ ] Tester avec une compétition sans tableau (poules uniquement) — les sections absentes doivent être omises silencieusement
- [ ] Tester avec Sabre Laser (colonnes Quest dans le classement)

https://claude.ai/code/session_015bnVdZDLa4URntkkyDWaHL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bnVdZDLa4URntkkyDWaHL)_