### PR TITLE
Fix DE queue matches disappearing from referee tablet after first match ends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.894",
+  "version": "1.0.3-build.917",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.894",
+      "version": "1.0.3-build.917",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1203,7 +1203,7 @@ export class RemoteScoreServer {
               `[RemoteScoreServer] Fallback match courant pour arène ${arenaId}: ${arena.currentMatch.id}`
             );
             const queueMatches = (this.arenaMatchQueue.get(arenaId) || [])
-              .filter(m => !m.isTableau || (m.fencerA && m.fencerB && !this.isDeMatchBlocked(m.id)))
+              .filter(m => m.fencerA && m.fencerB)
               .map(m => ({
                 id: m.id,
                 poolId: m.poolId,
@@ -1239,7 +1239,7 @@ export class RemoteScoreServer {
             `[RemoteScoreServer] ${arenaQueue.length} matchs en file DE pour arène ${arenaId}`
           );
           const queueMatches = arenaQueue
-            .filter(m => !m.isTableau || (m.fencerA && m.fencerB && !this.isDeMatchBlocked(m.id)))
+            .filter(m => m.fencerA && m.fencerB)
             .map(m => ({
               id: m.id,
               poolId: m.poolId,
@@ -3020,11 +3020,6 @@ export class RemoteScoreServer {
     const deQueue = this.arenaMatchQueue.get(arenaId) || [];
     if (deQueue.length > 0) {
       const nextDeMatch = deQueue[0];
-      const nextMatchData = this.sessionMatches.find((m: any) => m.id === nextDeMatch.id);
-      if (nextMatchData?.round !== undefined) {
-        const blockedByEarlierRound = this.isDeMatchBlocked(nextDeMatch.id);
-        if (blockedByEarlierRound) return null;
-      }
       return nextDeMatch;
     }
 
@@ -3123,21 +3118,6 @@ export class RemoteScoreServer {
     const deQueue = this.arenaMatchQueue.get(arenaId) || [];
     if (deQueue.length > 0) {
       const nextDeMatch = deQueue[0];
-
-      // Bloquer si des matchs d'un round antérieur (valeur plus grande) sont encore en cours
-      const nextMatchData = this.sessionMatches.find((m: any) => m.id === nextDeMatch.id);
-      if (nextMatchData?.round !== undefined) {
-        const blockedByEarlierRound = this.isDeMatchBlocked(nextDeMatch.id);
-        if (blockedByEarlierRound) {
-          console.log(
-            `[RemoteScoreServer] Match DE ${nextDeMatch.id} (round ${nextMatchData.round}) bloqué — round antérieur encore en cours`
-          );
-          arena.currentMatch = null;
-          arena.status = 'idle';
-          this.updateArena(arenaId, { currentMatch: null, status: 'idle' });
-          return;
-        }
-      }
 
       this.arenaMatchQueue.set(arenaId, deQueue.slice(1));
       console.log(
@@ -3648,9 +3628,7 @@ export class RemoteScoreServer {
       for (const [arenaId, queue] of queuesByArena) {
         const arena = this.arenas.get(arenaId);
         if (!arena) continue;
-        const firstPlayable = !arena.currentMatch
-          ? queue.find(m => !m.isTableau || !this.isDeMatchBlocked(m.id))
-          : undefined;
+        const firstPlayable = !arena.currentMatch && queue.length > 0 ? queue[0] : undefined;
         if (firstPlayable) {
           // Arène libre → charger le premier match non bloqué directement
           this.assignMatchToArena(arenaId, firstPlayable);
@@ -4027,9 +4005,7 @@ export class RemoteScoreServer {
         }
       }
 
-      const firstPlayable = arenaEffectivelyFree
-        ? queue.find(m => !m.isTableau || !this.isDeMatchBlocked(m.id))
-        : undefined;
+      const firstPlayable = arenaEffectivelyFree && queue.length > 0 ? queue[0] : undefined;
       if (firstPlayable) {
         this.assignMatchToArena(arenaId, firstPlayable);
         const rest = queue.filter(m => m.id !== firstPlayable.id);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `isDeMatchBlocked()` incorrectly blocked user-assigned QF/SF matches whenever any earlier-round match was still pending in `sessionMatches` (e.g. first-round matches running in parallel on other arenas), even when those pending matches were not prerequisites for the blocked match
- This caused queued DE matches to vanish from the referee tablet after the first match in the queue finished
- Fix: remove `isDeMatchBlocked` from all queue-processing paths in `remoteScoreServer.ts` — the arena match queue is built exclusively from user-assigned matches (via `match.arena`), which already have both fencers resolved, so round-based blocking is incorrect

## Root cause detail

When arena1 has [QF1, QF2, QF3] queued and QF1 finishes, `refreshDeMatches` rebuilds `sessionMatches` with all pending DE matches including unrelated first-round matches (FR7, FR8) still running on other arenas. `isDeMatchBlocked(QF2)` then finds FR7 with a higher round number and returns `true`, causing the arena to stay idle and the GET endpoint to return an empty list — the matches "disappear."

## Test plan

- [ ] Assign 3+ DE matches to one arena; finish the first match; verify the remaining matches still appear on the referee tablet
- [ ] Verify matches advance through the queue correctly
- [ ] Verify existing unit tests are not regressed (`npm run test:run` — pre-existing failures are unchanged at 41)

https://claude.ai/code/session_016fa5eXWpgbxtWyfgBuhJH8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016fa5eXWpgbxtWyfgBuhJH8)_