### PR TITLE
Fix: coupures multipage arbre ED sur des matches

### DIFF
--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1160,8 +1160,20 @@ export function generateBracketTreeMultiPageHTML(
   const firstRoundCount = tableauSize / 2;
   const USABLE_H = SVG_H - TOP_MARGIN - BOT_MARGIN;
   const SLOT_H   = USABLE_H / firstRoundCount;
-  const ROW_H    = Math.max(16, Math.min(32, Math.floor(SLOT_H * 0.55)));
+  const ROW_H    = Math.max(10, Math.min(32, Math.floor(SLOT_H * 0.45)));
   const MATCH_H  = ROW_H * 2;
+
+  // Snap page split to nearest inter-match gap to avoid cutting through match boxes
+  const splitIdx    = Math.round((qH - TOP_MARGIN) / SLOT_H - 0.5);
+  const nearMatchCY = TOP_MARGIN + (splitIdx + 0.5) * SLOT_H;
+  const cutY        = Math.abs(qH - nearMatchCY) < MATCH_H / 2
+    ? Math.round(
+        Math.abs(TOP_MARGIN + splitIdx * SLOT_H - qH) <=
+        Math.abs(TOP_MARGIN + (splitIdx + 1) * SLOT_H - qH)
+          ? TOP_MARGIN + splitIdx * SLOT_H
+          : TOP_MARGIN + (splitIdx + 1) * SLOT_H
+      )
+    : qH;
 
   // ── Helpers ──────────────────────────────────────────────────────────────────
   const truncate = (s: string, n: number) => s.length > n ? s.slice(0, n - 1) + '…' : s;
@@ -1206,7 +1218,7 @@ export function generateBracketTreeMultiPageHTML(
   }).join('\n  ');
 
   const roundLabels = mkRoundLabels(TOP_MARGIN - 7)
-    + '\n  ' + mkRoundLabels(qH + LABEL_H - 5);
+    + '\n  ' + mkRoundLabels(cutY + LABEL_H - 5);
 
   const petiteFinaleLabel = petiteFinale ? `
   <text x="${colX(2) + MATCH_W / 2}" y="${SVG_H - BOT_MARGIN - MATCH_H - 10}"
@@ -1347,7 +1359,7 @@ export function generateBracketTreeMultiPageHTML(
   </div>
   <div class="bracket-view">
     <svg xmlns="http://www.w3.org/2000/svg"
-         viewBox="${col * qW} ${row * qH} ${qW} ${qH}"
+         viewBox="${col * qW} ${row === 0 ? 0 : cutY} ${qW} ${row === 0 ? cutY : SVG_H - cutY}"
          preserveAspectRatio="xMinYMin meet">
       ${svgContent}
     </svg>


### PR DESCRIPTION
## Problème

Pour les tableaux ≥ 64 tireurs, la coupure entre pages du poster multipage (`generateBracketTreeMultiPageHTML`) tombait à l'intérieur d'une boîte de match. Deux causes combinées :

1. **ROW_H trop grand** — coefficient `0.55` produisait `MATCH_H > SLOT_H` (matches qui se chevauchent visuellement, pas d'espace entre eux)
2. **Coupure non alignée** — `qH` dérivé du ratio A4 ne coïncidait pas avec le milieu d'un espace inter-match

Exemple concret 64-bracket : `qH = 670`, match p=15 occupait `[633, 673]` (avec ancien `MATCH_H = 40`) → la coupure à 670 était **à l'intérieur** du match.

## Correctif (`src/shared/utils/pdfExport.ts`)

- **ROW_H** : coefficient `0.55 → 0.45`, minimum `16 → 10` — garantit `MATCH_H < SLOT_H` pour toutes tailles de tableau
- **cutY** : calcul du milieu du gap inter-match le plus proche de `qH` — si `qH` est déjà dans un espace libre, `cutY = qH` (pas de régression 32-bracket)
- `viewBox` et labels de rounds de la 2ᵉ rangée mis à jour pour utiliser `cutY`

## Impact numérique

| Tableau | Ancien cutY | Nouveau cutY | Δ échelle |
|---------|------------|--------------|-----------|
| 32 | 1112 (inchangé) | 1112 | 0 % |
| 64 | 670 (dans match) | 672 (dans espace) | 0.3 % |
| 128 | 784 (dans match) | 789 (dans espace) | 0.6 % |

https://claude.ai/code/session_01R5q7qBZraQXEZbWXcH11H2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5q7qBZraQXEZbWXcH11H2)_