### PR TITLE
feat(kiosk): vue tableau d'élimination directe (SVG animé)

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -59,11 +59,13 @@ export class RemoteScoreServer {
     classement: boolean;
     direct: boolean;
     suivants: boolean;
+    tableau: boolean;
   } = {
     poules: true,
     classement: true,
     direct: true,
     suivants: true,
+    tableau: true,
   };
 
   // Inscription distante : actif pendant la phase CHECKIN, désactivé après génération des poules
@@ -1733,6 +1735,97 @@ export class RemoteScoreServer {
         res.json({ upcoming });
       } catch (error) {
         console.error('[RemoteScoreServer] Erreur upcoming-matches:', error);
+        res.status(500).json({ error: 'Erreur interne' });
+      }
+    });
+
+    // Données du tableau d'élimination directe pour le kiosk
+    this.app.get('/api/bracket', (req, res) => {
+      try {
+        if (!this.session) return res.status(404).json({ error: 'Aucune session active' });
+
+        const deMatches = (this.sessionMatches as any[]).filter((m: any) => m.isTableau);
+
+        if (deMatches.length === 0) {
+          return res.json({ tableSize: 0, currentRound: null, rounds: [] });
+        }
+
+        const roundLabels: Record<number, string> = {
+          1: 'Finale',
+          2: 'Demi-finales',
+          4: 'Quarts de finale',
+          8: '8èmes de finale',
+          16: '16èmes de finale',
+          32: '32èmes de finale',
+          64: '64èmes de finale',
+          128: '128èmes de finale',
+        };
+
+        // Arène par matchId pour l'affichage
+        const arenaByMatchId = new Map<string, string>();
+        for (const [arenaId, arena] of this.arenas.entries()) {
+          if (arena.currentMatch) {
+            const num = parseInt(arenaId.replace('arena', ''), 10);
+            arenaByMatchId.set(arena.currentMatch.id, `Piste ${num}`);
+          }
+        }
+
+        // Déterminer la taille du tableau (plus grande puissance de 2 couvrant tous les rounds)
+        // maxRound (sans petite finale round=3) = taille du tableau (puissance de 2)
+        const mainRounds = deMatches.filter((m: any) => m.round !== 3);
+        const maxRound = mainRounds.length > 0 ? Math.max(...mainRounds.map((m: any) => m.round || 1)) : 4;
+        const tableSize = maxRound;
+
+        // Grouper par round, enrichir avec scores live
+        const roundMap = new Map<number, any[]>();
+        for (const m of deMatches) {
+          const round = m.round || 1;
+          if (!roundMap.has(round)) roundMap.set(round, []);
+          const live = this.sessionMatchScores.get(m.id);
+          const isFinished =
+            (live?.status ?? m.status) === 'finished' ||
+            (live?.status ?? m.status) === MatchStatus.FINISHED ||
+            !!m.winner;
+          const isLive =
+            !isFinished &&
+            ((live?.status ?? m.status) === 'in_progress' ||
+              (live?.status ?? m.status) === MatchStatus.IN_PROGRESS ||
+              arenaByMatchId.has(m.id));
+          roundMap.get(round)!.push({
+            id: m.id,
+            position: m.position || 1,
+            fencerA: m.fencerA
+              ? { lastName: m.fencerA.lastName, firstName: m.fencerA.firstName, club: m.fencerA.club ?? '', id: m.fencerA.id }
+              : null,
+            fencerB: m.fencerB
+              ? { lastName: m.fencerB.lastName, firstName: m.fencerB.firstName, club: m.fencerB.club ?? '', id: m.fencerB.id }
+              : null,
+            scoreA: live?.scoreA ?? m.scoreA ?? null,
+            scoreB: live?.scoreB ?? m.scoreB ?? null,
+            winnerId: m.winner?.id ?? null,
+            status: isFinished ? 'finished' : isLive ? 'live' : 'pending',
+            isBye: !!m.isBye,
+            arenaName: arenaByMatchId.get(m.id) ?? null,
+          });
+        }
+
+        // Trier les rounds du plus grand (tour initial) au plus petit (finale)
+        const rounds = Array.from(roundMap.entries())
+          .sort(([a], [b]) => b - a)
+          .map(([round, matches]) => ({
+            round,
+            label: roundLabels[round] ?? `Tour de ${round}`,
+            matches: matches.sort((a: any, b: any) => a.position - b.position),
+          }));
+
+        // Round actif = premier round non entièrement terminé (du plus grand au plus petit)
+        const currentRound =
+          rounds.find(r => r.matches.some((m: any) => m.status !== 'finished' && !m.isBye))
+            ?.round ?? null;
+
+        res.json({ tableSize, currentRound, rounds });
+      } catch (error) {
+        console.error('[RemoteScoreServer] Erreur /api/bracket:', error);
         res.status(500).json({ error: 'Erreur interne' });
       }
     });
@@ -3960,9 +4053,10 @@ export class RemoteScoreServer {
     classement: boolean;
     direct: boolean;
     suivants: boolean;
+    tableau?: boolean;
   }): void {
     if (!this.session) throw new Error('Aucune session active');
-    this.sessionKioskViews = views;
+    this.sessionKioskViews = { tableau: true, ...views };
   }
 
   public updatePoolFencers(updates: Array<{ poolId: string; fencers: any[] }>): void {
@@ -4147,6 +4241,9 @@ export class RemoteScoreServer {
     console.log(
       `[RemoteScoreServer] refreshDeMatches: ${deMatches.length} matchs DE, ${pending.length} distribués`
     );
+
+    // Notifier le kiosk que le bracket a changé
+    this.io.emit('bracket:update');
   }
 
   public getSession(): RemoteSession | null {

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kiosk - BellePoule Modern</title>
+    <script src="/socket.io/socket.io.js"></script>
     <script src="/i18n.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -674,6 +675,151 @@
       color: #94a3b8;
       font-style: italic;
     }
+      /* ── Vue Tableau d'élimination directe ─────────────────────────────── */
+      #view-tableau .bracket-outer {
+        flex: 1;
+        overflow-x: auto;
+        overflow-y: hidden;
+        position: relative;
+        scroll-behavior: smooth;
+      }
+
+      #view-tableau .bracket-inner {
+        position: relative;
+        display: inline-block;
+        min-width: 100%;
+      }
+
+      .bracket-round-labels {
+        position: relative;
+        height: 28px;
+        margin-bottom: 6px;
+        flex-shrink: 0;
+      }
+
+      .bracket-round-label {
+        position: absolute;
+        text-align: center;
+        font-size: 0.62rem;
+        font-weight: 700;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        padding: 0.2rem 0;
+        border-radius: 0.3rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .bracket-round-label.active-round {
+        color: #fbbf24;
+        background: rgba(251, 191, 36, 0.08);
+      }
+
+      .bracket-matches-layer {
+        position: relative;
+        flex-shrink: 0;
+      }
+
+      .bracket-match {
+        position: absolute;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.10);
+        border-radius: 0.5rem;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        transition: border-color 0.3s;
+      }
+
+      .bracket-match.match--live {
+        border-color: rgba(16, 185, 129, 0.6);
+        background: rgba(16, 185, 129, 0.06);
+        animation: bracket-pulse 2s ease infinite;
+      }
+
+      .bracket-match.match--finished {
+        border-color: rgba(100, 116, 139, 0.25);
+      }
+
+      .bracket-match.match--bye {
+        opacity: 0.2;
+      }
+
+      @keyframes bracket-pulse {
+        0%, 100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.3); }
+        50%       { box-shadow: 0 0 0 8px rgba(16, 185, 129, 0); }
+      }
+
+      .bm-row {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 0.4rem;
+        gap: 0.25rem;
+        min-width: 0;
+      }
+
+      .bm-winner { background: rgba(251, 191, 36, 0.12); }
+      .bm-loser  { opacity: 0.38; }
+
+      .bm-name {
+        font-size: 0.75rem;
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+        flex: 1;
+      }
+
+      .bm-score {
+        font-size: 0.88rem;
+        font-weight: 900;
+        color: #fbbf24;
+        min-width: 1.1rem;
+        text-align: right;
+        flex-shrink: 0;
+      }
+
+      .bm-divider {
+        height: 1px;
+        background: rgba(255, 255, 255, 0.07);
+        flex-shrink: 0;
+      }
+
+      .bm-arena {
+        font-size: 0.55rem;
+        color: #475569;
+        text-align: center;
+        padding: 0.05rem 0;
+        flex-shrink: 0;
+      }
+
+      .bracket-svg {
+        position: absolute;
+        top: 0;
+        left: 0;
+        overflow: visible;
+        pointer-events: none;
+      }
+
+      .bracket-trophy-banner {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.3rem 0.6rem;
+        background: rgba(251, 191, 36, 0.12);
+        border-radius: 0.4rem;
+        font-size: 0.7rem;
+        font-weight: 700;
+        color: #fbbf24;
+        margin-top: 4px;
+        flex-shrink: 0;
+      }
     </style>
   </head>
   <body>
@@ -702,6 +848,7 @@
         <button id="btn-classement" onclick="switchView('classement')" data-i18n="kiosk.ranking">Classement</button>
         <button id="btn-direct" onclick="switchView('direct')" data-i18n="kiosk.live">Matchs en direct</button>
         <button id="btn-suivants" onclick="switchView('suivants')" data-i18n="kiosk.next_matches">Matchs suivants</button>
+        <button id="btn-tableau" onclick="switchView('tableau')">Tableau DE</button>
       </div>
       <div style="position:relative;margin-left:0.5rem">
         <button id="btn-settings" class="settings-btn" title="Configurer les vues">⚙</button>
@@ -718,6 +865,9 @@
           </label>
           <label class="settings-item">
             <input type="checkbox" id="cb-suivants" checked> Matchs suivants
+          </label>
+          <label class="settings-item">
+            <input type="checkbox" id="cb-tableau" checked> Tableau DE
           </label>
           <hr style="border:none;border-top:1px solid rgba(255,255,255,0.1);margin:0.5rem 0">
           <div class="settings-title" data-i18n="kiosk.rotation_label">Rafraîchissement</div>
@@ -802,6 +952,26 @@
       </div>
     </div>
 
+    <!-- Vue Tableau d'élimination directe -->
+    <div id="view-tableau" class="kiosk-view">
+      <div class="view-header">
+        <div>
+          <div class="view-title">Tableau d'Élimination</div>
+          <div class="view-subtitle" id="tableau-subtitle">Tableau direct</div>
+        </div>
+        <div class="view-badge" id="tableau-badge">—</div>
+      </div>
+      <div class="bracket-outer" id="bracket-outer">
+        <div class="bracket-inner" id="bracket-inner">
+          <div class="no-data">
+            <div class="no-data-icon">🏆</div>
+            <h3>Tableau non disponible</h3>
+            <p>Le tableau apparaîtra lors de la phase d'élimination directe</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Vue Matchs en direct -->
     <div id="view-direct" class="kiosk-view">
       <div class="view-header">
@@ -822,23 +992,26 @@
 
     <script>
       // ─── État ────────────────────────────────────────────────────────────────
-      const ALL_VIEWS = ['poules', 'classement', 'direct', 'suivants'];
+      const ALL_VIEWS = ['poules', 'classement', 'direct', 'suivants', 'tableau'];
 
       const state = {
         currentView: 'poules',
-        views: ['poules', 'classement', 'direct', 'suivants'],
+        views: ['poules', 'classement', 'direct', 'suivants', 'tableau'],
         rotationMs: 15000,
         rotationTimer: null,
         progressTimer: null,
         progressStart: null,
         menuTimer: null,
         session: null,
-        poolsData: [],    // pools avec rankings
-        arenasData: [],   // arènes
-        upcomingData: [], // matchs suivants
+        poolsData: [],
+        arenasData: [],
+        upcomingData: [],
         overallRanking: [],
         lastUpdate: null,
-        prevArenaScores: {},  // { [arenaId]: { scoreA, scoreB } }
+        prevArenaScores: {},
+        bracketData: null,
+        bracketPanTimer: null,
+        bracketPanIndex: 0,
       };
 
       // ─── Note d'organisation ─────────────────────────────────────────────────
@@ -905,17 +1078,32 @@
       function switchView(name) {
         state.currentView = name;
 
+        // Stopper le pan du bracket si on quitte la vue tableau
+        clearInterval(state.bracketPanTimer);
+        state.bracketPanTimer = null;
+
         ALL_VIEWS.forEach(v => {
           document.getElementById('view-' + v).classList.toggle('active', v === name);
           const btn = document.getElementById('btn-' + v);
           if (btn) btn.classList.toggle('active', v === name);
         });
 
-        // Reset scroll for classement
         if (name === 'classement') {
           const wrapper = document.getElementById('ranking-scroll-wrapper');
           wrapper.scrollTop = 0;
           startAutoScroll(wrapper);
+        }
+
+        if (name === 'tableau') {
+          state.bracketPanIndex = 0;
+          if (state.bracketData) {
+            renderBracket();
+            // Scroll vers le round actif après rendu
+            setTimeout(() => {
+              if (state.bracketData?.currentRound) scrollToBracketRound(state.bracketData.currentRound);
+            }, 120);
+          }
+          startBracketPan();
         }
 
         document.getElementById('progress-bar').style.width = '0%';
@@ -1390,6 +1578,218 @@
         }
       }
 
+      // ─── Bracket d'élimination directe ──────────────────────────────────────
+
+      function getBracketDims(data) {
+        const n = data.rounds.length > 0 ? data.rounds[0].round : 8;
+        if (n <= 8)  return { cardW: 210, cardH: 66, colGap: 70, rowGap: 10 };
+        if (n <= 16) return { cardW: 188, cardH: 60, colGap: 62, rowGap: 8 };
+        if (n <= 32) return { cardW: 158, cardH: 52, colGap: 54, rowGap: 6 };
+        return              { cardW: 130, cardH: 44, colGap: 46, rowGap: 4 };
+      }
+
+      async function fetchBracket() {
+        try {
+          const res = await fetch('/api/bracket');
+          if (!res.ok) return;
+          const data = await res.json();
+          state.bracketData = data;
+          if (state.currentView === 'tableau') renderBracket();
+        } catch { /* optionnel */ }
+      }
+
+      function startBracketPan() {
+        clearInterval(state.bracketPanTimer);
+        if (!state.bracketData?.rounds?.length) return;
+        state.bracketPanTimer = setInterval(() => {
+          if (!state.bracketData?.rounds?.length) return;
+          state.bracketPanIndex = (state.bracketPanIndex + 1) % state.bracketData.rounds.length;
+          const r = state.bracketData.rounds[state.bracketPanIndex];
+          if (r) scrollToBracketRound(r.round);
+        }, 8000);
+      }
+
+      function scrollToBracketRound(roundValue) {
+        const outer = document.getElementById('bracket-outer');
+        if (!outer || !state.bracketData?.rounds) return;
+        const { cardW, colGap } = getBracketDims(state.bracketData);
+        const orderedRounds = getBracketRoundOrder(state.bracketData.rounds);
+        const idx = orderedRounds.findIndex(r => r.round === roundValue);
+        if (idx < 0) return;
+        const colX = idx * (cardW + colGap) + colGap / 2;
+        const viewW = outer.clientWidth;
+        const targetLeft = Math.max(0, colX - viewW / 2 + cardW / 2);
+        outer.scrollTo({ left: targetLeft, behavior: 'smooth' });
+      }
+
+      function getBracketRoundOrder(rounds) {
+        // Rounds principaux (hors petite finale round=3) triés décroissants, puis petite finale à la fin
+        const main = rounds.filter(r => r.round !== 3).sort((a, b) => b.round - a.round);
+        const pf = rounds.find(r => r.round === 3);
+        return pf ? [...main, pf] : main;
+      }
+
+      function renderBracket() {
+        const container = document.getElementById('bracket-inner');
+        if (!container) return;
+
+        const data = state.bracketData;
+        if (!data || !data.rounds || data.rounds.length === 0) {
+          document.getElementById('tableau-badge').textContent = '—';
+          container.innerHTML = '<div class="no-data"><div class="no-data-icon">🏆</div><h3>Tableau non disponible</h3><p>Le tableau apparaîtra lors de la phase d\'élimination directe</p></div>';
+          return;
+        }
+
+        const orderedRounds = getBracketRoundOrder(data.rounds);
+        if (orderedRounds.length === 0) {
+          container.innerHTML = '<div class="no-data"><div class="no-data-icon">🏆</div><h3>Aucun match disponible</h3></div>';
+          return;
+        }
+
+        const { cardW, cardH, colGap, rowGap } = getBracketDims(data);
+        const firstRound = orderedRounds[0].round; // ex: 16 pour T16
+        const cardSlot = cardH + rowGap;
+
+        // Hauteur totale = nombre de matchs dans le 1er round * cardSlot
+        const firstRoundMatchCount = firstRound / 2;
+        let totalH = firstRoundMatchCount * cardSlot;
+
+        // Adapter si trop grand pour la fenêtre
+        const availH = Math.max(200, (window.innerHeight || 800) - 220);
+        let scale = 1;
+        if (totalH > availH) {
+          scale = availH / totalH;
+          totalH = availH;
+        }
+        const sCardW  = Math.round(cardW  * scale);
+        const sCardH  = Math.round(cardH  * scale);
+        const sColGap = Math.round(colGap * scale);
+
+        const totalW = orderedRounds.length * (sCardW + sColGap) + sColGap;
+        const labelH = 28;
+
+        // Fonction Y-center d'un match (pos 1-indexed, round = round value)
+        const yCenter = (pos, round) => (2 * pos - 1) / round * totalH;
+
+        let cardsHtml = '';
+        const connectors = []; // { x1, y1, x2, y2 }
+
+        for (let ci = 0; ci < orderedRounds.length; ci++) {
+          const rd = orderedRounds[ci];
+          const r = rd.round;
+          const colX = ci * (sCardW + sColGap) + sColGap / 2;
+          const isActive = r === data.currentRound;
+
+          for (const match of rd.matches) {
+            if (match.isBye) continue;
+            const p = match.position || 1;
+            const yc = yCenter(p, r);
+            const yTop = Math.round(yc - sCardH / 2);
+            const cls = [
+              'bracket-match',
+              match.status === 'live'     ? 'match--live' :
+              match.status === 'finished' ? 'match--finished' : 'match--pending',
+            ].join(' ');
+
+            const fA = match.fencerA;
+            const fB = match.fencerB;
+            const nameA = fA ? escHtml(fA.lastName + (fA.firstName ? ' ' + fA.firstName[0] + '.' : '')) : '?';
+            const nameB = fB ? escHtml(fB.lastName + (fB.firstName ? ' ' + fB.firstName[0] + '.' : '')) : (r === 2 ? 'TBD' : '?');
+            const winA = match.winnerId && fA && match.winnerId === fA.id;
+            const winB = match.winnerId && fB && match.winnerId === fB.id;
+            const sA = match.scoreA !== null && match.scoreA !== undefined ? match.scoreA : '';
+            const sB = match.scoreB !== null && match.scoreB !== undefined ? match.scoreB : '';
+
+            // Trophée finale
+            const isFinal = r === 2 && match.position === 1;
+            const winnerName = isFinal && winA ? nameA : isFinal && winB ? nameB : null;
+
+            const arenaHtml = match.arenaName
+              ? `<div class="bm-arena">${escHtml(match.arenaName)}</div>`
+              : '';
+            const fontSize = scale < 0.7 ? 'style="font-size:0.62rem"' : '';
+
+            cardsHtml += `<div class="${cls}" style="position:absolute;left:${colX}px;top:${yTop}px;width:${sCardW}px;height:${sCardH}px">
+              <div class="bm-row ${winA ? 'bm-winner' : winB ? 'bm-loser' : ''}" ${fontSize}>
+                <span class="bm-name">${nameA}</span>
+                <span class="bm-score">${sA}</span>
+              </div>
+              <div class="bm-divider"></div>
+              ${arenaHtml}
+              <div class="bm-row ${winB ? 'bm-winner' : winA ? 'bm-loser' : ''}" ${fontSize}>
+                <span class="bm-name">${nameB}</span>
+                <span class="bm-score">${sB}</span>
+              </div>
+            </div>`;
+
+            // Connecteurs SVG vers le round suivant (sauf petite finale)
+            if (ci < orderedRounds.length - 1) {
+              const nextRd = orderedRounds[ci + 1];
+              // Ne pas connecter si l'un des deux est la petite finale (round=3)
+              if (r !== 3 && nextRd.round !== 3) {
+                const nextP = Math.ceil(p / 2);
+                const nextYc = yCenter(nextP, nextRd.round);
+                connectors.push({
+                  x1: colX + sCardW,
+                  y1: Math.round(yc),
+                  x2: (ci + 1) * (sCardW + sColGap) + sColGap / 2,
+                  y2: Math.round(nextYc),
+                });
+              }
+            }
+          }
+        }
+
+        // Labels de round
+        let labelsHtml = '';
+        for (let ci = 0; ci < orderedRounds.length; ci++) {
+          const rd = orderedRounds[ci];
+          const colX = ci * (sCardW + sColGap) + sColGap / 2;
+          const isActive = rd.round === data.currentRound;
+          labelsHtml += `<div class="bracket-round-label${isActive ? ' active-round' : ''}" style="left:${colX}px;width:${sCardW}px">${escHtml(rd.label)}</div>`;
+        }
+
+        // Chemins SVG
+        const svgPaths = connectors.map(c => {
+          const xMid = Math.round((c.x1 + c.x2) / 2);
+          return `<path d="M${c.x1},${c.y1} L${xMid},${c.y1} L${xMid},${c.y2} L${c.x2},${c.y2}" />`;
+        }).join('');
+
+        // Chercher le vainqueur final
+        const finaleRound = orderedRounds.find(r => r.round === 2);
+        const finaleMatch = finaleRound?.matches?.[0];
+        let winnerBanner = '';
+        if (finaleMatch?.winnerId && (finaleMatch.fencerA || finaleMatch.fencerB)) {
+          const winner = finaleMatch.winnerId === finaleMatch.fencerA?.id
+            ? finaleMatch.fencerA : finaleMatch.fencerB;
+          if (winner) {
+            winnerBanner = `<div class="bracket-trophy-banner">🏆 ${escHtml(winner.lastName + ' ' + (winner.firstName || ''))}</div>`;
+          }
+        }
+
+        // Compter les matchs restants pour le badge
+        const pending = data.rounds.reduce((n, r) => n + r.matches.filter(m => m.status !== 'finished' && !m.isBye).length, 0);
+        const total   = data.rounds.reduce((n, r) => n + r.matches.filter(m => !m.isBye).length, 0);
+        document.getElementById('tableau-badge').textContent = 'T' + data.tableSize + ' · ' + (total - pending) + '/' + total;
+        document.getElementById('tableau-subtitle').textContent =
+          data.currentRound ? orderedRounds.find(r => r.round === data.currentRound)?.label || 'En cours' : 'Phase terminée';
+
+        container.style.width = totalW + 'px';
+        container.style.minWidth = '';
+        container.innerHTML = `
+          <div class="bracket-round-labels" style="width:${totalW}px;position:relative;height:${labelH}px;flex-shrink:0;margin-bottom:6px">
+            ${labelsHtml}
+          </div>
+          <div class="bracket-matches-layer" style="position:relative;width:${totalW}px;height:${totalH}px">
+            ${cardsHtml}
+            <svg class="bracket-svg" width="${totalW}" height="${totalH}"
+                 style="position:absolute;top:0;left:0;overflow:visible;pointer-events:none">
+              <g stroke="rgba(100,116,139,0.45)" stroke-width="1.5" fill="none">${svgPaths}</g>
+            </svg>
+          </div>
+          ${winnerBanner}`;
+      }
+
       // ─── Logo organisateur ───────────────────────────────────────────────────
       function applyLogo(logo) {
         const el = document.getElementById('org-logo');
@@ -1423,16 +1823,23 @@
       window.addEventListener('DOMContentLoaded', async () => {
         await window.initRemoteI18n();
 
-        // Restaurer et appliquer le délai de rotation depuis localStorage
         const savedSec = loadLocalRotation();
         state.rotationMs = savedSec * 1000;
         document.getElementById('rotation-input').value = savedSec;
 
         fetchData();
         fetchLogo();
+        fetchBracket();
         setInterval(fetchData, 15000);
         setInterval(fetchLogo, 30000);
+        setInterval(fetchBracket, 15000);
         startRotation();
+
+        // Socket.IO : mise à jour temps réel du bracket
+        try {
+          const socket = io();
+          socket.on('bracket:update', fetchBracket);
+        } catch { /* Socket.IO optionnel */ }
 
         // Plein écran automatique au premier clic seulement
         let _fsRequested = false;


### PR DESCRIPTION
## Résumé

- Nouvelle **5e vue en rotation** dans le kiosk : tableau d'élimination directe rendu en SVG animé
- Endpoint REST `GET /api/bracket` exposant les matchs DE groupés par round avec scores live
- Broadcast Socket.IO `bracket:update` pour mise à jour immédiate sans attendre le polling 15s

## Ce qui change

### `src/main/remoteScoreServer.ts`
- `sessionKioskViews` : ajout du champ `tableau` (default `true`)
- `updateKioskViews()` : accepte le nouveau champ optionnel
- `GET /api/bracket` : retourne `{ tableSize, currentRound, rounds[] }` depuis `sessionMatches.isTableau`, enrichi avec scores live
- `refreshDeMatches()` : émet `bracket:update` via Socket.IO après chaque mise à jour DE

### `src/remote/kiosk.html`
- Vue `#view-tableau` avec bracket SVG (cards + connecteurs)
- Bouton "Tableau DE" dans la nav + checkbox dans le settings panel
- `fetchBracket()` + `renderBracket()` : rendu adaptatif T8→T128, auto-scale hauteur
- `startBracketPan()` + `scrollToBracketRound()` : pan automatique vers le round actif toutes les 8s
- Petite finale (round=3) rendue hors arbre principal
- Socket.IO `bracket:update` → re-fetch immédiat

## Visuel
- Cards **pending** : fond neutre
- Cards **live** : bordure verte + animation pulse
- Cards **finished** : grisé, vainqueur surligné en doré
- Connecteurs SVG en L entre rounds adjacents
- Banner 🏆 + nom du champion quand la finale est terminée
- Badge `T16 · 5/8` dans l'en-tête (taille + progression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrJMG2Vk4jzB84tSm16NGF)_