### PR TITLE
fix(kiosk): tableau manquant dans le fallback sessionKioskViews

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3629,12 +3629,12 @@ export class RemoteScoreServer {
     this.sessionRefereeFeatureEnabled = competition.settings?.refereeFeatureEnabled ?? false;
 
     // Stocker les vues kiosk activées
-    this.sessionKioskViews = kioskViews ?? {
+    this.sessionKioskViews = { tableau: true, ...(kioskViews ?? {
       poules: true,
       classement: true,
       direct: true,
       suivants: true,
-    };
+    }) };
 
     // Stocker le type d'arme pour l'arrêt automatique à 15 points en Laser Sabre
     this.sessionWeapon = competition.weapon || null;


### PR DESCRIPTION
## Fix build:ci

Corrige l'erreur TS2741 remontée par le build CI :

```
Property 'tableau' is missing in type '{ poules, classement, direct, suivants }'
but required in type '{ ..., tableau: boolean }'
```

Le fallback dans `startSession` (ligne ~3632) assignait `sessionKioskViews` sans le champ `tableau` ajouté lors du PR précédent.

**Fix :** spread du fallback avec `tableau: true` en valeur par défaut.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrJMG2Vk4jzB84tSm16NGF)_