### PR TITLE
fix: type onRemoteArenaUpdate — build:ci TS error

### DIFF
--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -709,7 +709,7 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   dialog: DialogAPI;
   updater: UpdaterAPI;
   remote: RemoteServerAPI;
-  onRemoteArenaUpdate: (callback: (data: any) => void) => void;
+  onRemoteArenaUpdate: (callback: (data: any) => void) => () => void;
   onRemoteMatchFinished: (callback: (data: any) => void) => void;
   onKioskNoteUpdate: (
     callback: (note: import('../types/remote').OrgNote | null) => void


### PR DESCRIPTION
Corrige l'erreur TypeScript introduite par le fix de fuite de listener (PR #537).

`onRemoteArenaUpdate` retourne désormais `() => void` (unlisten), mais le type dans `preload.ts` était resté `void`.

```
error TS2322: Type 'void' is not assignable to type '(() => void) | undefined'
```

https://claude.ai/code/session_01Vmf1SLbPX7EXhdMjRU4SET

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vmf1SLbPX7EXhdMjRU4SET)_