### PR TITLE
fix(tableau): phase visible en lecture seule après résultats finaux (#560)

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -783,9 +783,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const isLastPoolRound = currentPoolRound >= poolRounds;
   const isResultsLocked = hasDirectElimination && finalResults.length === 0;
   // En mode quest-sans-poules, le tableau se débloque par la complétion de la quête (rankingValidated)
-  const isTableauUnlocked = questNoPool
+  // Le tableau reste accessible en lecture seule si les résultats finaux existent déjà
+  const isTableauUnlocked = finalResults.length > 0 || (questNoPool
     ? rankingValidated
-    : canAdvanceFromPools && rankingValidated;
+    : canAdvanceFromPools && rankingValidated);
 
   // Réinitialiser la validation du classement si les poules ne sont plus toutes terminées
   // (sauf en mode quest-sans-poules ou si on est déjà en phase tableau/résultats)
@@ -1222,6 +1223,42 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
         {currentPhase === 'tableau' && (
           <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>Chargement tableau…</div>}>
+          {finalResults.length > 0 && (
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '1rem',
+              padding: '0.625rem 1rem',
+              marginBottom: '0.75rem',
+              background: '#fef9c3',
+              border: '1px solid #fde047',
+              borderRadius: '6px',
+              fontSize: '0.875rem',
+              color: '#713f12',
+            }}>
+              <span>🔒 Tableau en lecture seule — résultats finaux générés.</span>
+              <button
+                onClick={() => {
+                  if (window.confirm('Modifier le tableau effacera les résultats finaux. Continuer ?')) {
+                    setFinalResults([]);
+                  }
+                }}
+                style={{
+                  marginLeft: 'auto',
+                  background: '#f59e0b',
+                  color: 'white',
+                  border: 'none',
+                  padding: '0.375rem 0.75rem',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  fontSize: '0.8rem',
+                  fontWeight: '600',
+                }}
+              >
+                ✏️ Modifier le tableau
+              </button>
+            </div>
+          )}
           <TableauView
             ranking={overallRanking}
             matches={tableauMatches}
@@ -1232,6 +1269,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             thirdPlaceMatch={thirdPlaceMatch}
             playAllPositions={playAllPositions}
             arenaCount={remoteArenaCount}
+            readOnly={finalResults.length > 0}
             onComplete={results => {
               setFinalResults(results);
               setCurrentPhase('results');

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -44,6 +44,7 @@ interface TableauViewProps {
   onMatchArenaChange?: (matchId: string, oldArena: number | null, newArena: number | null, fencerA?: any, fencerB?: any) => void;
   consolationBrackets?: ConsolationBracket[];
   onConsolationBracketsChange?: (brackets: ConsolationBracket[]) => void;
+  readOnly?: boolean;
 }
 
 // ─── Static style constants ───────────────────────────────────────────────────
@@ -105,6 +106,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   onMatchArenaChange,
   consolationBrackets: consolationBracketsprop = [],
   onConsolationBracketsChange,
+  readOnly = false,
 }) => {
   const { showToast } = useToast();
   const tableauTemplate = usePdfTemplateStore(s => s.templates.tableau);
@@ -241,7 +243,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     // Robuste au double-invoke de React StrictMode : le ref de montage reste stable
     // entre les deux passes, contrairement à un booléen consommé au premier run.
     if (matches === mountMatchesRef.current) return;
-    if (matches.length === 0 || !onComplete) return;
+    if (readOnly || matches.length === 0 || !onComplete) return;
     const champion = matches.find(m => m.round === 2)?.winner;
     if (!champion) return;
     const thirdPlaceEntry = matches.find(m => m.round === 3);
@@ -251,11 +253,11 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     }
     // calculateFinalResults et onComplete sont stables pendant la phase tableau
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [matches]);
+  }, [matches, readOnly]);
 
   // playAllPositions : déclencher onComplete quand le tableau principal ET tous les brackets de consolation sont terminés
   useEffect(() => {
-    if (!playAllPositions || !onComplete || matches.length === 0) return;
+    if (readOnly || !playAllPositions || !onComplete || matches.length === 0) return;
     // Ignorer au montage (données déjà complètes restaurées depuis DB)
     if (matches === mountMatchesRef.current) return;
     const mainFinalDone = !!matches.find(m => m.round === 2)?.winner;
@@ -1219,6 +1221,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         setSelectedMatchForArena(id);
         setShowArenaModal(true);
       }}
+      readOnly={readOnly}
     />
   );
 
@@ -1499,6 +1502,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                       baseMatchHeight={BASE_MATCH_HEIGHT}
                       onMatchClick={openScoreModal}
                       onArenaClick={id => { setSelectedMatchForArena(id); setShowArenaModal(true); }}
+                      readOnly={readOnly}
                     />
                   ))}
                 </div>
@@ -1560,6 +1564,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                                   setSelectedMatchConsolationBracketId(bracket.id);
                                   setShowArenaModal(true);
                                 } : () => {}}
+                                readOnly={readOnly}
                               />
                             ))}
                           </div>

--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -8,6 +8,7 @@ interface MatchCardProps {
   baseMatchHeight: number;
   onMatchClick: (match: TableauMatch) => void;
   onArenaClick: (matchId: string) => void;
+  readOnly?: boolean;
 }
 
 const BASE_MATCH_HEIGHT = 100;
@@ -19,8 +20,9 @@ const MatchCard: React.FC<MatchCardProps> = ({
   baseMatchHeight,
   onMatchClick,
   onArenaClick,
+  readOnly = false,
 }) => {
-  const canEdit = !!(match.fencerA && match.fencerB && !match.isBye);
+  const canEdit = !readOnly && !!(match.fencerA && match.fencerB && !match.isBye);
   const hasScore = match.scoreA !== null && match.scoreB !== null;
   const isMatchComplete = match.winner !== null;
 


### PR DESCRIPTION
## Résumé

- Tableau débloqué (`disabled: false`) dès que `finalResults.length > 0` — plus jamais grisé après génération des résultats
- Prop `readOnly` propagée de `CompetitionView` → `TableauView` → `MatchCard` : clics de saisie désactivés, arena-button masqué
- Filets de sécurité `onComplete` skippés en `readOnly` : pas de redirection involontaire vers la phase résultats
- Bannière jaune + bouton **✏️ Modifier le tableau** : efface `finalResults` après confirmation `window.confirm`, repasse en mode édition

## Test plan

- [ ] Terminer un tableau → résultats générés → onglet Tableau toujours cliquable
- [ ] Naviguer vers l'onglet Tableau après résultats → bannière jaune visible, aucun match cliquable
- [ ] Cliquer "Modifier le tableau" → confirmer → bannière disparaît, clics réactivés
- [ ] Annuler le confirm → aucun changement
- [ ] Redémarrer l'app avec résultats déjà présents → tableau toujours accessible en lecture seule

Fixes #560

https://claude.ai/code/session_01VymwxJe7M34jEUCs4KUEZH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VymwxJe7M34jEUCs4KUEZH)_