### PR TITLE
feat: bouton signature plein-écran après fin de poule

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3259,6 +3259,7 @@ export class RemoteScoreServer {
 
     const currentMatchId = arena.currentMatch?.id;
     const currentPoolId = arena.currentMatch?.poolId;
+    let completedPoolId: string | null = null;
 
     console.log(
       `[RemoteScoreServer] loadNextMatch: arena=${arenaId}, pool=${currentPoolId}, total=${this.sessionMatches.length}`
@@ -3334,6 +3335,19 @@ export class RemoteScoreServer {
       console.log(
         `[RemoteScoreServer] Plus de matches dans le pool ${currentPoolId} pour l'arène ${arenaId}`
       );
+
+      // Vérifier si la poule est entièrement terminée (tous matchs FINISHED en DB)
+      try {
+        const allPoolMatches = this.db.getMatchesByPool(currentPoolId);
+        if (
+          allPoolMatches.length > 0 &&
+          allPoolMatches.every(m => m.status === MatchStatus.FINISHED)
+        ) {
+          completedPoolId = currentPoolId;
+        }
+      } catch (e) {
+        console.warn('[RemoteScoreServer] pool completion check failed:', e);
+      }
     }
 
     // Vérifier la file d'attente DE avant de marquer l'arène comme vide
@@ -3358,6 +3372,7 @@ export class RemoteScoreServer {
       currentMatch: null,
       status: 'idle',
       startTime: null,
+      ...(completedPoolId ? { poolComplete: true, completedPoolId } : {}),
     });
     this.persistArenaState(arenaId);
     console.log(`[RemoteScoreServer] Arène ${arenaId} marquée comme vide`);

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -72,6 +72,19 @@
         border-color: rgba(34, 197, 94, 0.4);
       }
 
+      .back-to-referee-btn {
+        font-size: 0.8rem;
+        padding: 0.3rem 0.8rem;
+        border-radius: 0.5rem;
+        background: rgba(255, 255, 255, 0.1);
+        color: #cbd5e1;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        cursor: pointer;
+        white-space: nowrap;
+        transition: background 0.15s;
+      }
+      .back-to-referee-btn:hover { background: rgba(255, 255, 255, 0.2); }
+
       /* ── Tabs ── */
       .tabs {
         display: flex;
@@ -652,6 +665,7 @@
         <div class="header-title" id="pool-title" data-i18n="pool.loading">Chargement…</div>
         <div class="header-badge" id="match-count-badge" style="display:none"></div>
       </div>
+      <button class="back-to-referee-btn" onclick="goBackToReferee()">← Arbitre</button>
       <div class="connection-badge" id="connection-badge">⚡ Connexion…</div>
     </div>
 
@@ -726,6 +740,11 @@
       let currentTab = 'tableau';
       let signaturesData = {};   // { fencerId: dataURL }
       let signingFencer = null;
+
+      // ── Navigation ──
+      function goBackToReferee() {
+        window.location.href = `/arene${arenaNumber}/arbitre`;
+      }
 
       // ── Onglets ──
       function switchTab(tab) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1030,6 +1030,47 @@
         .final-score { background: #111827; color: #f3f4f6; }
         .next-matches-screen { background: rgba(0,0,0,0.5); }
       }
+
+      /* ── Overlay fin de poule / signature ── */
+      .pool-complete-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        z-index: 900;
+        background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 100%);
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        text-align: center;
+        padding: 2rem;
+      }
+      .pool-complete-overlay.visible { display: flex; }
+      .pco-icon { font-size: 4rem; margin-bottom: 1rem; }
+      .pco-title {
+        font-size: 2rem;
+        font-weight: 900;
+        color: #e2e8f0;
+        margin-bottom: 0.5rem;
+        letter-spacing: 0.04em;
+      }
+      .pco-sub { color: #94a3b8; margin-bottom: 2.5rem; font-size: 1rem; }
+      .pco-btn {
+        font-size: 1.8rem;
+        font-weight: 700;
+        padding: 1.2rem 3rem;
+        background: #4f46e5;
+        color: #fff;
+        border: none;
+        border-radius: 1rem;
+        cursor: pointer;
+        animation: pco-pulse 2s ease-in-out infinite;
+        letter-spacing: 0.05em;
+      }
+      .pco-btn:hover { background: #4338ca; }
+      @keyframes pco-pulse {
+        0%, 100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(79,70,229,0.5); }
+        50% { transform: scale(1.03); box-shadow: 0 0 0 16px rgba(79,70,229,0); }
+      }
     </style>
   </head>
   <body>
@@ -2940,6 +2981,11 @@
 
           // Arène libérée par le serveur (match saisi depuis l'application principale)
           if (data.status === 'idle') {
+            if (data.poolComplete) {
+              this._clearActiveMatch();
+              this.showPoolCompleteOverlay();
+              return;
+            }
             if (this.matchStatus === 'in_progress') {
               this.showNotification('⚠️ Match clôturé depuis l\'application principale');
               this.stopTimer();
@@ -2956,6 +3002,7 @@
 
           // Nouveau match prêt côté serveur (chargement automatique après fin de match)
           if (data.status === 'ready' && data.match && data.match.id) {
+            this.hidePoolCompleteOverlay();
             // Ignorer si c'est déjà notre match actuel
             if (this.currentMatch && this.currentMatch.id === data.match.id) return;
             // Notifier sans interrompre un match en cours
@@ -3079,6 +3126,18 @@
 
         hideNextMatchesScreen() {
           document.getElementById('next-matches-screen').classList.remove('visible');
+        }
+
+        showPoolCompleteOverlay() {
+          document.getElementById('pool-complete-overlay').classList.add('visible');
+        }
+
+        hidePoolCompleteOverlay() {
+          document.getElementById('pool-complete-overlay').classList.remove('visible');
+        }
+
+        goToSignature() {
+          window.location.href = `/arene${this.arenaNumber}/poule`;
         }
 
         async loadNextMatches() {
@@ -3210,6 +3269,16 @@
           ✕ Annuler — carton donné sans annonce
         </button>
       </div>
+    </div>
+
+    <!-- Overlay plein-écran : fin de poule / signature -->
+    <div id="pool-complete-overlay" class="pool-complete-overlay">
+      <div class="pco-icon">✍️</div>
+      <h1 class="pco-title">POULE TERMINÉE</h1>
+      <p class="pco-sub">Tous les matchs sont terminés</p>
+      <button class="pco-btn" onclick="refereeApp.goToSignature()">
+        ✍️ SIGNATURE
+      </button>
     </div>
   </body>
 </html>

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -164,6 +164,8 @@ export interface ArenaUpdate {
   refereeFeatureEnabled?: boolean; // fonctionnalité arbitres activée
   referees?: RemoteReferee[]; // liste de tous les arbitres de la compétition
   timerDuration?: number; // durée du chrono en secondes pour ce match
+  poolComplete?: boolean; // vrai quand tous les matchs de la poule sont terminés
+  completedPoolId?: string; // id de la poule terminée
 }
 
 export interface RefereeControl {


### PR DESCRIPTION
## Résumé

- Quand tous les matchs d'une poule sont terminés, la vue arbitre (`/arene{N}/arbitre`) affiche un overlay plein-écran avec un bouton **✍️ SIGNATURE** pulsant
- Ce bouton redirige vers `/arene{N}/poule` pour la signature des tireurs
- La vue poule gagne un bouton **← Arbitre** permanent dans le header pour revenir à la vue arbitre

## Détail technique

- `ArenaUpdate` (`src/shared/types/remote.ts`) : ajout de `poolComplete?` et `completedPoolId?`
- `loadNextMatch` (`src/main/remoteScoreServer.ts`) : quand la poule est épuisée, vérifie en DB via `getMatchesByPool` que tous les matchs sont `FINISHED`, puis propage `poolComplete: true` dans le broadcast idle
- `referee.html` : overlay `.pool-complete-overlay` (position fixed, z-index 900) + méthodes `showPoolCompleteOverlay`, `hidePoolCompleteOverlay`, `goToSignature`
- `pool.html` : bouton `.back-to-referee-btn` dans le header + fonction `goBackToReferee()`

## Plan de test

- [ ] Démarrer le serveur distant, créer une poule avec 2-3 tireurs
- [ ] Saisir tous les matchs via la vue arbitre
- [ ] Vérifier que l'overlay plein-écran apparaît après le dernier match
- [ ] Cliquer **SIGNATURE** → redirection vers `/arene1/poule`
- [ ] Vérifier le bouton **← Arbitre** dans le header de la vue poule
- [ ] Cliquer **← Arbitre** → retour vers `/arene1/arbitre`

https://claude.ai/code/session_0198m2dT8yayS2egaybhdYvi

---
_Generated by [Claude Code](https://claude.ai/code/session_0198m2dT8yayS2egaybhdYvi)_