### PR TITLE
feat: glisser-déposer pour réordonner les colonnes — phase d'appel (#556)

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -77,6 +77,18 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const [sortBy, setSortBy] = useState<SortableCol>('ranking');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [hiddenCols, setHiddenCols] = useState<Set<string>>(new Set());
+  const [colOrder, setColOrder] = useState<SortableCol[]>(() => {
+    try {
+      const saved = localStorage.getItem('bellepoule-fencer-col-order');
+      if (saved) {
+        const parsed = JSON.parse(saved) as SortableCol[];
+        if (parsed.length === COLUMNS.length && COLUMNS.every(c => parsed.includes(c.id))) return parsed;
+      }
+    } catch { /* ignore */ }
+    return COLUMNS.map(c => c.id);
+  });
+  const [dragCol, setDragCol] = useState<SortableCol | null>(null);
+  const [dragOverCol, setDragOverCol] = useState<SortableCol | null>(null);
   const [colMenuOpen, setColMenuOpen] = useState(false);
   const colMenuRef = useRef<HTMLDivElement>(null);
   const [photoMessage, setPhotoMessage] = useState<string | null>(null);
@@ -118,6 +130,31 @@ const FencerListComponent: React.FC<FencerListProps> = ({
     const id = setInterval(onFencersChanged, 5000);
     return () => clearInterval(id);
   }, [showRegisterQR, onFencersChanged]);
+
+  useEffect(() => {
+    localStorage.setItem('bellepoule-fencer-col-order', JSON.stringify(colOrder));
+  }, [colOrder]);
+
+  const handleColDragStart = (id: SortableCol) => setDragCol(id);
+  const handleColDragOver = (e: React.DragEvent, id: SortableCol) => {
+    e.preventDefault();
+    setDragOverCol(id);
+  };
+  const handleColDrop = (targetId: SortableCol) => {
+    if (!dragCol || dragCol === targetId) return;
+    setColOrder(prev => {
+      const next = [...prev];
+      const from = next.indexOf(dragCol);
+      const to = next.indexOf(targetId);
+      next.splice(from, 1);
+      next.splice(to, 0, dragCol);
+      return next;
+    });
+    setDragCol(null);
+    setDragOverCol(null);
+  };
+  const handleColDragEnd = () => { setDragCol(null); setDragOverCol(null); };
+
   const filteredFencers = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
     return fencers
@@ -324,13 +361,14 @@ const FencerListComponent: React.FC<FencerListProps> = ({
     }
   }, [sortBy]);
 
-  const handleExportPDF = async () => {
-    const visibleColIds = COLUMNS.filter(c => !hiddenCols.has(c.id)).map(c => c.id);
-    await exportAppelToPDF(filteredFencers, visibleColIds);
-  };
+  const visibleCols = colOrder
+    .map(id => COLUMNS.find(c => c.id === id)!)
+    .filter(c => c && !hiddenCols.has(c.id));
+  const colSpanTotal = visibleCols.length + 1;
 
-  const visibleCols = COLUMNS.filter(c => !hiddenCols.has(c.id));
-  const colSpanTotal = visibleCols.length + 1; // +1 for Actions
+  const handleExportPDF = async () => {
+    await exportAppelToPDF(filteredFencers, visibleCols.map(c => c.id));
+  };
 
   return (
     <div className="content">
@@ -490,6 +528,14 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                     {col.label}
                   </label>
                 ))}
+                <div style={{ borderTop: '1px solid var(--border-color, #444)', margin: '4px 0' }} />
+                <button
+                  className="btn btn-ghost"
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '6px 16px', borderRadius: 0, fontSize: '0.8rem', color: 'var(--text-muted, #94a3b8)' }}
+                  onClick={() => setColOrder(COLUMNS.map(c => c.id))}
+                >
+                  ↺ Réinitialiser l&apos;ordre
+                </button>
               </div>
             )}
           </div>
@@ -672,7 +718,17 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                   {visibleCols.map(col => (
                     <th
                       key={col.id}
-                      style={{ cursor: 'pointer', userSelect: 'none' }}
+                      draggable
+                      onDragStart={() => handleColDragStart(col.id)}
+                      onDragOver={e => handleColDragOver(e, col.id)}
+                      onDrop={() => handleColDrop(col.id)}
+                      onDragEnd={handleColDragEnd}
+                      style={{
+                        cursor: 'grab',
+                        userSelect: 'none',
+                        opacity: dragCol === col.id ? 0.4 : 1,
+                        borderLeft: dragOverCol === col.id && dragCol !== col.id ? '2px solid var(--primary, #6366f1)' : undefined,
+                      }}
                       onClick={() => handleSort(col.id)}
                     >
                       {col.label}{sortBy === col.id ? (sortOrder === 'asc' ? ' ▲' : ' ▼') : ''}
@@ -703,7 +759,18 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                     {visibleCols.map(col => (
                       <th
                         key={col.id}
-                        style={{ width: col.width, cursor: 'pointer', userSelect: 'none' }}
+                        draggable
+                        onDragStart={() => handleColDragStart(col.id)}
+                        onDragOver={e => handleColDragOver(e, col.id)}
+                        onDrop={() => handleColDrop(col.id)}
+                        onDragEnd={handleColDragEnd}
+                        style={{
+                          width: col.width,
+                          cursor: 'grab',
+                          userSelect: 'none',
+                          opacity: dragCol === col.id ? 0.4 : 1,
+                          borderLeft: dragOverCol === col.id && dragCol !== col.id ? '2px solid var(--primary, #6366f1)' : undefined,
+                        }}
                         onClick={() => handleSort(col.id)}
                       >
                         {col.label}{sortBy === col.id ? (sortOrder === 'asc' ? ' ▲' : ' ▼') : ''}


### PR DESCRIPTION
## Résumé

- Ajout du glisser-déposer natif HTML5 sur les en-têtes de colonne de la phase d'appel (`FencerList.tsx`)
- L'ordre choisi est persisté en `localStorage` (clé `bellepoule-fencer-col-order`) et restauré au rechargement
- Indicateur visuel pendant le drag : colonne déplacée semi-transparente, bordure bleue sur la cible
- Bouton « ↺ Réinitialiser l'ordre » dans le menu Colonnes ▾
- L'export PDF (appel) respecte le nouvel ordre des colonnes

## Test

1. Ouvrir une compétition → phase d'appel
2. Glisser « Prénom » avant « Nom » dans l'en-tête du tableau
3. Recharger → l'ordre est conservé
4. Exporter PDF → colonnes dans le même ordre qu'à l'écran
5. Menu Colonnes ▾ → « Réinitialiser l'ordre » remet l'ordre d'origine

Fixes #556

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjiCyNtwQyvkqGYo9y9Q6d)_