### PR TITLE
fix(#559): export complet PDF — feuille d'appel, poules et tableau absents

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -962,6 +962,68 @@ export class DatabaseManager {
     this.save();
   }
 
+  public getTableauMatchesForExport(competitionId: string): Array<{
+    id: string; round: number; position: number; isBye: boolean;
+    fencerA: { firstName?: string; lastName: string; club?: string } | null;
+    fencerB: { firstName?: string; lastName: string; club?: string } | null;
+    scoreA: number | null; scoreB: number | null;
+    winner: { id: string } | null;
+  }> {
+    if (!this.db) throw new Error('Database not open');
+    const stmt = this.db.prepare(
+      `SELECT m.id, m.round, m.position, m.is_bye,
+              m.fencer_a_id, m.fencer_b_id, m.score_a, m.score_b,
+              fa.first_name AS fa_first, fa.last_name AS fa_last, fa.club AS fa_club,
+              fb.first_name AS fb_first, fb.last_name AS fb_last, fb.club AS fb_club
+       FROM matches m
+       LEFT JOIN fencers fa ON fa.id = m.fencer_a_id
+       LEFT JOIN fencers fb ON fb.id = m.fencer_b_id
+       WHERE m.table_id = ? AND m.round IS NOT NULL
+       ORDER BY m.round, m.position`
+    );
+    stmt.bind([competitionId]);
+    const results: ReturnType<typeof this.getTableauMatchesForExport> = [];
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      let scoreAVal: number | null = null;
+      let scoreBVal: number | null = null;
+      let winner: { id: string } | null = null;
+      try {
+        if (row.score_a) {
+          const sa = JSON.parse(row.score_a as string);
+          scoreAVal = sa.value ?? null;
+          if (sa.isVictory && row.fencer_a_id) winner = { id: row.fencer_a_id as string };
+        }
+        if (row.score_b) {
+          const sb = JSON.parse(row.score_b as string);
+          scoreBVal = sb.value ?? null;
+          if (sb.isVictory && row.fencer_b_id) winner = { id: row.fencer_b_id as string };
+        }
+      } catch { /* skip bad score JSON */ }
+      results.push({
+        id: row.id as string,
+        round: row.round as number,
+        position: row.position as number,
+        isBye: (row.is_bye as number) === 1,
+        fencerA: row.fencer_a_id ? {
+          firstName: row.fa_first as string | undefined,
+          lastName: (row.fa_last as string) || '',
+          club: row.fa_club as string | undefined,
+        } : null,
+        fencerB: row.fencer_b_id ? {
+          firstName: row.fb_first as string | undefined,
+          lastName: (row.fb_last as string) || '',
+          club: row.fb_club as string | undefined,
+        } : null,
+        scoreA: scoreAVal,
+        scoreB: scoreBVal,
+        winner,
+      });
+    }
+    stmt.free();
+    return results;
+  }
+
   public getMatch(id: string): Match | null {
     if (!this.db) throw new Error('Database not open');
     const stmt = this.db.prepare('SELECT * FROM matches WHERE id = ?');

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1002,6 +1002,10 @@ ipcMain.handle('db:upsertMultipleTableauMatches', async (_, competitionId: strin
   return db.upsertMultipleTableauMatches(competitionId, matches);
 });
 
+ipcMain.handle('db:getTableauMatchesForExport', async (_, competitionId: string) => {
+  return db.getTableauMatchesForExport(competitionId);
+});
+
 // Session State handlers
 ipcMain.handle('db:saveSessionState', async (_, competitionId, state) => {
   return db.saveSessionState(competitionId, state);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -141,6 +141,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     upsertTableauMatch: (params: any) => ipcRenderer.invoke('db:upsertTableauMatch', params),
     upsertMultipleTableauMatches: (competitionId: string, matches: any[]) =>
       ipcRenderer.invoke('db:upsertMultipleTableauMatches', competitionId, matches),
+    getTableauMatchesForExport: (competitionId: string) =>
+      ipcRenderer.invoke('db:getTableauMatchesForExport', competitionId),
 
     // Pools
     createPool: (phaseId: string, number: number, poolId?: string) => {

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -739,6 +739,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       };
     });
 
+    setPoolHistory(prev => [...prev, pools]);
     setPools(newPools);
     setCurrentPoolRound(prev => prev + 1);
   };
@@ -1299,7 +1300,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             poolRanking={overallRanking}
             finalResults={finalResults}
             fencers={fencers}
-            pools={pools}
+            pools={[...poolHistory.flat(), ...pools]}
             tableauMatches={tableauMatches as TableauMatchForPDF[]}
             consolationBrackets={consolationBrackets}
             isLaserSabre={isLaserSabre}

--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -188,11 +188,21 @@ const ResultsView: React.FC<ResultsViewProps> = ({
 
   const exportFullPDF = async () => {
     try {
+      const api = (window as any).electronAPI;
+
+      const effectiveFencers = (fencers && fencers.length > 0)
+        ? fencers
+        : await api?.db?.getFencersByCompetition?.(competition.id) ?? [];
+
+      const effectiveTableauMatches = (tableauMatches && tableauMatches.length > 0)
+        ? tableauMatches
+        : await api?.db?.getTableauMatchesForExport?.(competition.id) ?? [];
+
       await exportFullCompetitionPDF({
-        fencers: fencers ?? [],
+        fencers: effectiveFencers,
         pools: pools ?? [],
         overallRanking: poolRanking,
-        tableauMatches: tableauMatches ?? [],
+        tableauMatches: effectiveTableauMatches as TableauMatchForPDF[],
         consolationBrackets: (consolationBrackets ?? []).map(b => ({
           id: b.id,
           name: b.name,

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -479,6 +479,13 @@ export interface DatabaseAPI {
       isBye?: boolean;
     }>
   ) => Promise<void>;
+  getTableauMatchesForExport: (competitionId: string) => Promise<Array<{
+    id: string; round: number; position: number; isBye: boolean;
+    fencerA: { firstName?: string; lastName: string; club?: string } | null;
+    fencerB: { firstName?: string; lastName: string; club?: string } | null;
+    scoreA: number | null; scoreB: number | null;
+    winner: { id: string } | null;
+  }>>;
 
   // Pools
   createPool: (phaseId: string, number: number, poolId?: string) => Promise<Pool>;


### PR DESCRIPTION
$(cat <<'EOF'
## Problème

L'export complet PDF ne contenait que le classement provisoire et le classement final. Trois sections étaient absentes :
- Feuille d'appel
- Feuilles de poule
- Matchs du tableau d'élimination

## Causes identifiées

1. **Feuille d'appel** : le tableau `fencers` peut être vide si `loadFencers()` (async) n'a pas encore terminé au moment du clic — fallback DB ajouté.

2. **Feuilles de poule** : seul le tour courant (`pools`) était passé à l'export, pas les tours précédents (`poolHistory`). De plus, `handleNextPoolRound` n'appelait pas `setPoolHistory`, donc l'historique des tours était toujours vide.

3. **Matchs tableau** : `tableauMatches` n'avait aucun fallback DB en cas de perte de la session state. Nouvelle méthode `getTableauMatchesForExport` ajoutée (JOIN fencers pour firstName/lastName/club).

## Changements

- `src/database/index.ts` : nouvelle méthode `getTableauMatchesForExport(competitionId)`
- `src/main/main.ts` : handler IPC `db:getTableauMatchesForExport`
- `src/main/preload.ts` + `src/shared/types/preload.ts` : exposition + typage
- `src/renderer/components/CompetitionView.tsx` :
  - `pools={[...poolHistory.flat(), ...pools]}` → tous les tours inclus
  - `handleNextPoolRound` : appel de `setPoolHistory` manquant ajouté
- `src/renderer/components/ResultsView.tsx` : fallbacks DB pour `fencers` et `tableauMatches` si vides

## Test plan

- [ ] Export complet sur compétition à 1 tour de poules + tableau → feuille d'appel, poules, tableau présents
- [ ] Export complet sur compétition à 2 tours de poules → poules des 2 tours présentes
- [ ] Export complet après réouverture de l'app (session state rechargée) → tout présent
- [ ] Export complet sans tableau (skip) → feuille d'appel + poules présents, pas de section tableau

https://claude.ai/code/session_011E6fN5TJbBusK3JQa3fQQP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011E6fN5TJbBusK3JQa3fQQP)_