### PR TITLE
fix(arena): retour écran idle quand plus de match après fin de combat (#557)

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1842,14 +1842,18 @@
             matchDisplay.classList.add('active');
             nextPanel.classList.add('hidden');
           } else if (this.matchStatus === 'finished') {
-            waitingScreen.classList.add('hidden');
             photoIntro.classList.add('hidden');
-            matchDisplay.classList.add('active');
             if (this.nextMatch) {
+              waitingScreen.classList.add('hidden');
+              matchDisplay.classList.add('active');
               this.updateNextMatchPanel();
               nextPanel.classList.remove('hidden');
             } else {
+              // Aucun match suivant : retour à l'écran idle (arène X)
+              waitingScreen.classList.remove('hidden');
+              matchDisplay.classList.remove('active');
               nextPanel.classList.add('hidden');
+              this.updateIdleNextMatchDisplay();
             }
           } else {
             // 'ready' sans photos : écran d'attente (combat pas encore démarré)


### PR DESCRIPTION
## Problème

Issue #557 : après la fin du dernier match sur une arène (tableau élim. direct, assignation manuelle), le score restait affiché au lieu de revenir à l'écran "Arène X".

## Cause

Dans `updateVisibility()` (`src/remote/arena.html`), la branche `status === 'finished'` activait toujours `matchDisplay` même quand `nextMatch === null`.

## Fix

Quand `status === 'finished'` ET `nextMatch === null` → afficher l'écran idle (Arène X) au lieu du score.

```diff
} else if (this.matchStatus === 'finished') {
-   waitingScreen.classList.add('hidden');
    photoIntro.classList.add('hidden');
-   matchDisplay.classList.add('active');
    if (this.nextMatch) {
+     waitingScreen.classList.add('hidden');
+     matchDisplay.classList.add('active');
      this.updateNextMatchPanel();
      nextPanel.classList.remove('hidden');
    } else {
-     nextPanel.classList.add('hidden');
+     waitingScreen.classList.remove('hidden');
+     matchDisplay.classList.remove('active');
+     nextPanel.classList.add('hidden');
+     this.updateIdleNextMatchDisplay();
    }
```

https://claude.ai/code/session_013GQNCvoALQazbFgZMb7RGH

---
_Generated by [Claude Code](https://claude.ai/code/session_013GQNCvoALQazbFgZMb7RGH)_