### PR TITLE
kiosk: classement provisoire + classement final

### DIFF
--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -272,6 +272,7 @@
       /* Vue Classement */
       #view-classement {
         overflow: hidden;
+        gap: 0.75rem;
       }
 
       .ranking-scroll-wrapper {
@@ -280,7 +281,58 @@
         border-radius: 0.75rem;
         border: 1px solid rgba(255, 255, 255, 0.08);
         background: rgba(255, 255, 255, 0.03);
+        min-height: 0;
       }
+
+      /* Classement final */
+      .final-ranking-section {
+        flex-shrink: 0;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(255, 255, 255, 0.03);
+        overflow: hidden;
+      }
+
+      .final-ranking-title {
+        padding: 0.5rem 1rem;
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+        background: rgba(0,0,0,0.15);
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .final-ranking-not-done {
+        padding: 0.75rem 1.25rem;
+        color: #475569;
+        font-size: 0.9rem;
+        font-style: italic;
+      }
+
+      .final-podium {
+        display: flex;
+        gap: 0;
+      }
+
+      .podium-entry {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.6rem 1rem;
+        border-right: 1px solid rgba(255,255,255,0.05);
+      }
+      .podium-entry:last-child { border-right: none; }
+
+      .podium-medal { font-size: 1.3rem; flex-shrink: 0; }
+      .podium-info { min-width: 0; }
+      .podium-name { font-weight: 600; font-size: 0.9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .podium-club { font-size: 0.72rem; color: #64748b; }
 
       .ranking-scroll-inner {
         /* auto-scroll via JS */
@@ -906,8 +958,8 @@
     <div id="view-classement" class="kiosk-view">
       <div class="view-header">
         <div>
-          <div class="view-title">Classement Général</div>
-          <div class="view-subtitle">Tous tireurs confondus</div>
+          <div class="view-title">Classement Provisoire</div>
+          <div class="view-subtitle">Résultats des poules</div>
         </div>
         <div class="view-badge" id="classement-badge">—</div>
       </div>
@@ -930,6 +982,13 @@
               </tr>
             </tbody>
           </table>
+        </div>
+      </div>
+      <!-- Classement Final -->
+      <div class="final-ranking-section">
+        <div class="final-ranking-title">🏆 Classement Final</div>
+        <div id="final-ranking-body">
+          <div class="final-ranking-not-done">⏳ Compétition non terminée</div>
         </div>
       </div>
     </div>
@@ -1417,6 +1476,55 @@
             <td style="text-align:center;color:#94a3b8">${r.touchesFor || 0}</td>
           </tr>`;
         }).join('');
+        renderFinalRanking();
+      }
+
+      // ─── Rendu Classement Final ──────────────────────────────────────────────
+      function renderFinalRanking() {
+        const el = document.getElementById('final-ranking-body');
+        if (!el) return;
+
+        const data = state.bracketData;
+        if (!data?.rounds?.length) {
+          el.innerHTML = '<div class="final-ranking-not-done">⏳ Compétition non terminée</div>';
+          return;
+        }
+
+        // Finale (round=2, position=1) et petite finale (round=3, position=1)
+        const finaleRound = data.rounds.find(r => r.round === 2);
+        const pfRound = data.rounds.find(r => r.round === 3);
+        const finaleMatch = finaleRound?.matches?.[0];
+        const pfMatch = pfRound?.matches?.[0];
+
+        if (!finaleMatch?.winnerId) {
+          el.innerHTML = '<div class="final-ranking-not-done">⏳ Compétition non terminée</div>';
+          return;
+        }
+
+        const winner1 = finaleMatch.winnerId === finaleMatch.fencerA?.id ? finaleMatch.fencerA : finaleMatch.fencerB;
+        const winner2 = finaleMatch.winnerId === finaleMatch.fencerA?.id ? finaleMatch.fencerB : finaleMatch.fencerA;
+        const winner3 = pfMatch?.winnerId
+          ? (pfMatch.winnerId === pfMatch.fencerA?.id ? pfMatch.fencerA : pfMatch.fencerB)
+          : null;
+        const winner4 = pfMatch?.winnerId
+          ? (pfMatch.winnerId === pfMatch.fencerA?.id ? pfMatch.fencerB : pfMatch.fencerA)
+          : null;
+
+        const fencerHtml = (f, medal) => f ? `
+          <div class="podium-entry">
+            <span class="podium-medal">${medal}</span>
+            <div class="podium-info">
+              <div class="podium-name">${escHtml(f.lastName + ' ' + (f.firstName || ''))}</div>
+              <div class="podium-club">${escHtml(f.club || '—')}</div>
+            </div>
+          </div>` : '';
+
+        el.innerHTML = `<div class="final-podium">
+          ${fencerHtml(winner1, '🥇')}
+          ${fencerHtml(winner2, '🥈')}
+          ${winner3 ? fencerHtml(winner3, '🥉') : ''}
+          ${winner4 ? fencerHtml(winner4, '4️⃣') : ''}
+        </div>`;
       }
 
       // ─── Rendu Matchs suivants ───────────────────────────────────────────────
@@ -1774,6 +1882,7 @@
         document.getElementById('tableau-subtitle').textContent =
           data.currentRound ? orderedRounds.find(r => r.round === data.currentRound)?.label || 'En cours' : 'Phase terminée';
 
+        renderFinalRanking();
         container.style.width = totalW + 'px';
         container.style.minWidth = '';
         container.innerHTML = `


### PR DESCRIPTION
## Changements

- Vue classement : titre renommé "Classement Provisoire" (résultats des poules)
- Ajout section "Classement Final" en bas de la même vue :
  - Affiche "⏳ Compétition non terminée" tant que la finale n'a pas de vainqueur
  - Affiche le podium 🥇🥈🥉4️⃣ dès que la finale et petite finale sont jouées
- Se met à jour automatiquement via `renderFinalRanking()` à chaque refresh du bracket

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3vASdsPCtiVKeD5o1hhYa)_