### PR TITLE
fix: PDF export vide — délai avant printToPDF

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1288,15 +1288,17 @@ ipcMain.handle('file:printHtml', async (_, html: string) => {
     printWin.loadFile(tmpFile);
 
     printWin.webContents.once('did-finish-load', () => {
-      printWin.webContents.print({ silent: false, printBackground: true }, (success: boolean) => {
-        try {
-          fs.unlinkSync(tmpFile);
-        } catch {
-          /* ignore */
-        }
-        printWin.destroy();
-        resolve({ success });
-      });
+      setTimeout(() => {
+        printWin.webContents.print({ silent: false, printBackground: true }, (success: boolean) => {
+          try {
+            fs.unlinkSync(tmpFile);
+          } catch {
+            /* ignore */
+          }
+          printWin.destroy();
+          resolve({ success });
+        });
+      }, 800);
     });
 
     printWin.webContents.once('did-fail-load', () => {
@@ -1337,6 +1339,7 @@ ipcMain.handle('file:printHtmlToPDF', async (_, html: string, outputPath: string
     pdfWin.loadFile(tmpFile);
 
     pdfWin.webContents.once('did-finish-load', () => {
+      setTimeout(() => {
       pdfWin.webContents
         .printToPDF({
           printBackground: true,
@@ -1369,6 +1372,7 @@ ipcMain.handle('file:printHtmlToPDF', async (_, html: string, outputPath: string
           pdfWin.destroy();
           resolve({ success: false, error: err.message });
         });
+      }, 800);
     });
 
     pdfWin.webContents.once('did-fail-load', () => {


### PR DESCRIPTION
## Problème\n`did-finish-load` se déclenche avant que le CSS print (`@page`, `@media print`) soit appliqué → contenu vide dans le PDF.\n\n## Fix\nAjout d'un délai de 800ms après `did-finish-load` avant d'appeler `printToPDF` / `print`, dans `file:printHtmlToPDF` et `file:printHtml`.\n\nConcerne : feuille d'appel, grilles de poule, classement, tableau ED.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfmBwydPMs5BD4pKQSm7JP)_