### PR TITLE
Fix #586 : indices négatifs en rouge dans le kiosk

### DIFF
--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -1632,7 +1632,7 @@
               </td>
               <td style="text-align:center;color:#94a3b8">${r.matchesPlayed || 0}</td>
               <td class="victories">${r.victories || 0}</td>
-              <td class="ind">${ind}</td>
+              <td class="ind" style="color:${r.index < 0 ? '#ef4444' : ''}">${ind}</td>
               <td class="td">${r.touchesFor || 0}</td>
             </tr>`;
           }).join('');
@@ -1676,7 +1676,7 @@
             </td>
             <td style="color:#64748b;font-size:0.85rem">${escHtml(r.club || '—')}</td>
             <td style="text-align:center;color:#10b981;font-weight:600">${r.victories || 0}</td>
-            <td style="text-align:center;color:#60a5fa">${ind}</td>
+            <td style="text-align:center;color:${r.index < 0 ? '#ef4444' : '#60a5fa'}">${ind}</td>
             <td style="text-align:center;color:#94a3b8">${r.touchesFor || 0}</td>
           </tr>`;
         }).join('');


### PR DESCRIPTION
Fixes #586

Indices négatifs colorés en rouge (`#ef4444`) dans les deux vues du kiosk (pools individuelles + classement général).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVVHq6TUyXd2S1UoJ3rqdZ)_