### PR TITLE
Fix feuille d'appel blanche dans l'export complet

### DIFF
--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1841,7 +1841,7 @@ export async function exportFullCompetitionPDF(data: FullCompetitionExportData):
       sorted,
       ['ref', 'lastName', 'firstName', 'birthDate', 'club', 'ranking', 'status'],
       `Feuille d'appel — ${competitionTitle}`,
-      competitionTitle, logo, template
+      competitionTitle, logo, undefined
     ));
   }
 


### PR DESCRIPTION
## Problème

Dans l'export complet compétition, la feuille d'appel était toujours blanche.

## Cause

`generateAppelHTML` recevait le `template` utilisateur (de type `pool`, `tableau` ou `ranking`). `assembleBody` utilisait alors les IDs d'éléments du template (`score-grid`, `match-cards`, `ranking-table`…) pour construire le corps de la page — aucun de ces IDs n'existe dans les sections de l'appel (`appel-table`, `header`, `gold-bar`, `footer`), donc le tableau des tireurs n'était jamais rendu.

## Fix

Passage de `undefined` au lieu du `template` dans l'appel à `generateAppelHTML` depuis `exportFullCompetitionPDF`. Aucun `PdfDocType` 'appel' n'existe, donc le template n'apporte rien ici ; `assembleBody` utilise le `defaultOrder` natif de la fonction.

https://claude.ai/code/session_01WTRXp6mPWTTH7xQKc2VKGc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTRXp6mPWTTH7xQKc2VKGc)_