### PR TITLE
fix: perte des scores barrage au changement d'onglet (jouer toutes les places)

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -205,6 +205,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     overallRanking,
     tableauMatches,
     finalResults,
+    consolationBrackets,
     skipPoolPhase,
     remoteArenaCount,
     poolPrepParams,
@@ -247,6 +248,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       if (restoredState.overallRanking) setOverallRanking(restoredState.overallRanking);
       if (restoredState.tableauMatches) setTableauMatches(restoredState.tableauMatches);
       if (restoredState.finalResults) setFinalResults(restoredState.finalResults);
+      if (restoredState.consolationBrackets?.length) setConsolationBrackets(restoredState.consolationBrackets);
       if (restoredState.poolPrepParams) {
         setMinFencersPerPool(restoredState.poolPrepParams.minFencersPerPool);
         setMaxFencersPerPool(restoredState.poolPrepParams.maxFencersPerPool);

--- a/src/renderer/hooks/useCompetitionSession.ts
+++ b/src/renderer/hooks/useCompetitionSession.ts
@@ -7,7 +7,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Pool, PoolRanking } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
-import { TableauMatch, FinalResult } from '../components/tableau/tableauTypes';
+import { TableauMatch, FinalResult, ConsolationBracket } from '../components/tableau/tableauTypes';
 
 export type Phase = 'checkin' | 'poolprep' | 'pools' | 'ranking' | 'quest' | 'tableau' | 'results' | 'remote' | 'logs' | 'referees';
 
@@ -18,6 +18,7 @@ interface SessionState {
   overallRanking: PoolRanking[];
   tableauMatches: TableauMatch[];
   finalResults: FinalResult[];
+  consolationBrackets: ConsolationBracket[];
   currentPoolRound: number;
   skipPoolPhase: boolean;
   remoteArenaCount?: number;
@@ -42,6 +43,7 @@ interface UseCompetitionSessionProps {
   overallRanking: PoolRanking[];
   tableauMatches: TableauMatch[];
   finalResults: FinalResult[];
+  consolationBrackets: ConsolationBracket[];
   skipPoolPhase: boolean;
   remoteArenaCount: number;
   poolPrepParams: {
@@ -99,6 +101,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
       overallRanking: p.overallRanking,
       tableauMatches: p.tableauMatches,
       finalResults: p.finalResults,
+      consolationBrackets: p.consolationBrackets,
       currentPoolRound: p.currentPoolRound,
       skipPoolPhase: p.skipPoolPhase,
       remoteArenaCount: p.remoteArenaCount,
@@ -141,6 +144,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
           overallRanking: typedState.overallRanking || [],
           tableauMatches: typedState.tableauMatches || [],
           finalResults: typedState.finalResults || [],
+          consolationBrackets: typedState.consolationBrackets || [],
           currentPoolRound: typedState.uiState?.currentPoolRound || 1,
           skipPoolPhase: typedState.skipPoolPhase ?? false,
           remoteArenaCount: typedState.remoteArenaCount,
@@ -184,6 +188,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
         overallRanking: p.overallRanking,
         tableauMatches: p.tableauMatches,
         finalResults: p.finalResults,
+        consolationBrackets: p.consolationBrackets,
         currentPoolRound: p.currentPoolRound,
         skipPoolPhase: p.skipPoolPhase,
         remoteArenaCount: p.remoteArenaCount,
@@ -223,6 +228,7 @@ export const useCompetitionSession = (props: UseCompetitionSessionProps) => {
     props.overallRanking,
     props.tableauMatches,
     props.finalResults,
+    props.consolationBrackets,
     props.skipPoolPhase,
     props.remoteArenaCount,
     props.poolPrepParams,


### PR DESCRIPTION
## Problème

En mode "jouer toutes les places", les scores saisis dans les matchs de barrage/consolation étaient perdus lors d'un changement d'onglet.

## Cause racine

`CompetitionView` est keyed par `competition.id` dans App.tsx — il se démonte entièrement au changement d'onglet. `tableauMatches` survivait car persisté dans `useCompetitionSession`, mais `consolationBrackets` (qui contient tous les matchs + scores des brackets de consolation et barrages) n'y était pas inclus. Au remontage, il repartait à `[]`.

## Fix

Ajout de `consolationBrackets` dans `useCompetitionSession` :
- `SessionState` et `UseCompetitionSessionProps` (types)
- Sérialisation async (`saveState`) et sync (`beforeunload`)
- Désérialisation (`restoreState`)
- Dépendances du useEffect de sauvegarde

Restauration dans `CompetitionView` au même endroit que `tableauMatches`.

## Test

1. Tableau avec "jouer toutes les places", assez de tireurs pour générer barrages
2. Saisir + valider des scores dans les matchs de barrage/consolation
3. Changer d'onglet (autre compétition ouverte)
4. Revenir → scores présents ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_016D16SxPLBfrX6PjXieigqZ)_