### PR TITLE
fix: poules vides dans l'export PDF complet de fin de compétition

### DIFF
--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -199,9 +199,17 @@ const ResultsView: React.FC<ResultsViewProps> = ({
         ? tableauMatches
         : await api?.db?.getTableauMatchesForExport?.(competition.id) ?? [];
 
+      let effectivePools: Pool[] = pools && pools.length > 0 ? pools : [];
+      if (effectivePools.length === 0 && api?.db?.getPhasesByCompetition && api?.db?.getPoolsByPhase) {
+        const phases = await api.db.getPhasesByCompetition(competition.id);
+        const poolPhases = phases.filter((p: { type: string }) => p.type === 'pool');
+        const poolArrays = await Promise.all(poolPhases.map((ph: { id: string }) => api.db.getPoolsByPhase(ph.id)));
+        effectivePools = poolArrays.flat();
+      }
+
       await exportFullCompetitionPDF({
         fencers: effectiveFencers,
-        pools: pools ?? [],
+        pools: effectivePools,
         overallRanking: poolRanking,
         tableauMatches: effectiveTableauMatches as TableauMatchForPDF[],
         consolationBrackets: (consolationBrackets ?? []).map(b => ({


### PR DESCRIPTION
## Problème

Dans l'export PDF complet de fin de compétition, les phases de poules apparaissaient vides.

## Cause

`exportFullPDF` dans `ResultsView` avait un fallback DB pour `fencers` et `tableauMatches` (si le prop était vide, rechargement depuis la DB), mais **pas pour `pools`**. Quand l'état en mémoire était perdu (rechargement de session, navigation directe vers la phase résultats), `pools ?? []` donnait `[]` et aucune page de poule n'était générée.

## Fix

Ajout d'un fallback DB identique aux autres données : si `pools` prop est vide, charge toutes les phases de type `pool` de la compétition depuis la DB, puis récupère les poules de chaque phase (avec tireurs et scores inclus).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPRuZh1p5QpLvQbh5e2uaX)_