### PR TITLE
Fix lisibilité dropdown Colonnes

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -511,6 +511,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                       padding: '6px 16px',
                       cursor: 'pointer',
                       fontSize: '0.875rem',
+                      color: 'var(--text-primary, #e2e8f0)',
                     }}
                   >
                     <input


### PR DESCRIPTION
Ajout `color: var(--text-primary, #e2e8f0)` sur les labels du dropdown Colonnes dans `FencerList.tsx` — texte illisible sur fond sombre.

---
_Generated by [Claude Code](https://claude.ai/code/session_016q3xuUxsWCQTZsgeoZ4CeS)_