### PR TITLE
fix: répercuter tri et colonnes de l'appel dans Export complet PDF

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -125,6 +125,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const [tableauMatches, setTableauMatches] = useState<TableauMatch[]>([]);
   const [consolationBrackets, setConsolationBrackets] = useState<ConsolationBracket[]>([]);
   const [finalResults, setFinalResults] = useState<FinalResult[]>([]);
+  const [appelFencers, setAppelFencers] = useState<Fencer[]>([]);
+  const [appelVisibleColumns, setAppelVisibleColumns] = useState<string[]>([]);
   const [tableauEditUnlocked, setTableauEditUnlocked] = useState(false);
   const [showFencerComparison, setShowFencerComparison] = useState(false);
   const [showAnalytics, setShowAnalytics] = useState(false);
@@ -1026,6 +1028,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onUncheckAll={uncheckAll}
             onImport={(type) => handleOpenImportDialog(type)}
             onFencersImported={loadFencers}
+            onAppelStateChange={(f, cols) => { setAppelFencers(f); setAppelVisibleColumns(cols); }}
             onSetFencerStatus={(id, status) => {
               // Si forfait, abandon ou exclusion, mettre à jour tous les matchs du tireur
               if (status === FencerStatus.FORFAIT) {
@@ -1307,6 +1310,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             tableauMatches={tableauMatches as TableauMatchForPDF[]}
             consolationBrackets={consolationBrackets}
             isLaserSabre={isLaserSabre}
+            appelFencers={appelFencers.length > 0 ? appelFencers : undefined}
+            appelVisibleColumns={appelVisibleColumns.length > 0 ? appelVisibleColumns : undefined}
           />
         )}
 

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -42,6 +42,8 @@ interface FencerListProps {
   registerUrl?: string;
   /** Callback pour recharger la liste après inscription distante */
   onFencersChanged?: () => void;
+  /** Notifie le parent des tireurs triés/filtrés et des colonnes visibles actuels */
+  onAppelStateChange?: (fencers: Fencer[], visibleColumns: string[]) => void;
 }
 
 const FencerListComponent: React.FC<FencerListProps> = ({
@@ -59,6 +61,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   onFencersImported,
   registerUrl,
   onFencersChanged,
+  onAppelStateChange,
 }) => {
   const { t } = useTranslation();
   const { confirm } = useConfirm();
@@ -365,6 +368,11 @@ const FencerListComponent: React.FC<FencerListProps> = ({
     .map(id => COLUMNS.find(c => c.id === id)!)
     .filter(c => c && !hiddenCols.has(c.id));
   const colSpanTotal = visibleCols.length + 1;
+
+  const visibleColIds = useMemo(() => visibleCols.map(c => c.id), [visibleCols]);
+  useEffect(() => {
+    onAppelStateChange?.(filteredFencers, visibleColIds);
+  }, [filteredFencers, visibleColIds, onAppelStateChange]);
 
   const handleExportPDF = async () => {
     await exportAppelToPDF(filteredFencers, visibleCols.map(c => c.id));

--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -29,6 +29,10 @@ interface ResultsViewProps {
   tableauMatches?: TableauMatchForPDF[];
   consolationBrackets?: ConsolationBracket[];
   isLaserSabre?: boolean;
+  /** Tireurs triés/filtrés tels qu'affichés dans l'appel */
+  appelFencers?: Fencer[];
+  /** Colonnes visibles telles que configurées dans l'appel */
+  appelVisibleColumns?: string[];
 }
 
 // ─── Static style constants ───────────────────────────────────────────────────
@@ -77,6 +81,7 @@ const RV_STYLES = {
 const ResultsView: React.FC<ResultsViewProps> = ({
   competition, poolRanking, finalResults,
   fencers, pools, tableauMatches, consolationBrackets, isLaserSabre,
+  appelFencers, appelVisibleColumns,
 }) => {
   const { showToast } = useToast();
   const rankingTemplate = usePdfTemplateStore(s => s.templates.ranking);
@@ -191,9 +196,11 @@ const ResultsView: React.FC<ResultsViewProps> = ({
     try {
       const api = (window as any).electronAPI;
 
-      const effectiveFencers = (fencers && fencers.length > 0)
-        ? fencers
-        : await api?.db?.getFencersByCompetition?.(competition.id) ?? [];
+      const effectiveFencers = (appelFencers && appelFencers.length > 0)
+        ? appelFencers
+        : (fencers && fencers.length > 0)
+          ? fencers
+          : await api?.db?.getFencersByCompetition?.(competition.id) ?? [];
 
       const effectiveTableauMatches = (tableauMatches && tableauMatches.length > 0)
         ? tableauMatches
@@ -209,6 +216,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({
 
       await exportFullCompetitionPDF({
         fencers: effectiveFencers,
+        appelVisibleColumns,
         pools: effectivePools,
         overallRanking: poolRanking,
         tableauMatches: effectiveTableauMatches as TableauMatchForPDF[],

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1814,6 +1814,8 @@ function extractStyleContent(html: string): string {
 
 export interface FullCompetitionExportData {
   fencers: Fencer[];
+  /** Colonnes visibles de la feuille d'appel (respecte la config UI) */
+  appelVisibleColumns?: string[];
   pools: Pool[];
   overallRanking: PoolRanking[];
   tableauMatches: TableauMatchForPDF[];
@@ -1827,19 +1829,23 @@ export interface FullCompetitionExportData {
 export async function exportFullCompetitionPDF(data: FullCompetitionExportData): Promise<void> {
   const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
   const {
-    fencers, pools, overallRanking, tableauMatches, consolationBrackets,
+    fencers, appelVisibleColumns, pools, overallRanking, tableauMatches, consolationBrackets,
     finalResults, competitionTitle, isLaserSabre = false, template,
   } = data;
 
   const sections: string[] = [];
 
   if (fencers.length > 0) {
-    const sorted = [...fencers].sort(
-      (a, b) => (a.ranking ?? Infinity) - (b.ranking ?? Infinity) || a.lastName.localeCompare(b.lastName)
-    );
+    const appelCols = appelVisibleColumns ?? ['ref', 'lastName', 'firstName', 'birthDate', 'club', 'ranking', 'status'];
+    // Si les tireurs viennent de l'appel, ils sont déjà triés ; sinon tri par défaut
+    const appelFencerList = appelVisibleColumns
+      ? fencers
+      : [...fencers].sort(
+          (a, b) => (a.ranking ?? Infinity) - (b.ranking ?? Infinity) || a.lastName.localeCompare(b.lastName)
+        );
     sections.push(generateAppelHTML(
-      sorted,
-      ['ref', 'lastName', 'firstName', 'birthDate', 'club', 'ranking', 'status'],
+      appelFencerList,
+      appelCols,
       `Feuille d'appel — ${competitionTitle}`,
       competitionTitle, logo, undefined
     ));


### PR DESCRIPTION
## Problème
L'Export complet PDF (depuis la vue Résultats) ignorait la configuration de l'onglet Appel : colonnes masquées et tri personnalisé n'étaient pas répercutés.

## Solution
- `FencerList` expose un callback `onAppelStateChange(fencers, visibleColumns)` appelé à chaque changement de tri ou de visibilité de colonnes
- `CompetitionView` stocke cet état et le passe à `ResultsView`
- `ResultsView` utilise les tireurs déjà triés (priorité sur le fetch DB) et transmet `appelVisibleColumns` à `exportFullCompetitionPDF`
- `exportFullCompetitionPDF` utilise les colonnes et l'ordre transmis ; si absent (export standalone), repli sur le comportement précédent

## Fichiers modifiés
- `src/renderer/components/FencerList.tsx`
- `src/renderer/components/CompetitionView.tsx`
- `src/renderer/components/ResultsView.tsx`
- `src/shared/utils/pdfExport.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXEtoQ2xEDMXsdcQxwH8o6)_