### PR TITLE
feat: assignation d'arbitres aux poules et matchs de tableau (#588)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1430,6 +1430,13 @@ export class DatabaseManager {
     this.save();
   }
 
+  public updatePoolReferee(poolId: string, refereeId: string | null): void {
+    if (!this.db) throw new Error('Database not open');
+    const now = new Date().toISOString();
+    this.run('UPDATE pools SET referee_id = ?, updated_at = ? WHERE id = ?', [refereeId, now, poolId]);
+    this.save();
+  }
+
   // ─── Pool CRUD ──────────────────────────────────────────────────────────────
 
   public clearPoolsForPhase(phaseId: string): void {
@@ -1521,7 +1528,7 @@ export class DatabaseManager {
     if (!this.db) throw new Error('Database not open');
     const results: Pool[] = [];
     const stmt = this.db.prepare(
-      'SELECT id, phase_id, number, is_complete, has_error, created_at, updated_at FROM pools WHERE phase_id = ? ORDER BY number'
+      'SELECT id, phase_id, number, is_complete, has_error, referee_id, created_at, updated_at FROM pools WHERE phase_id = ? ORDER BY number'
     );
     stmt.bind([phaseId]);
     while (stmt.step()) {
@@ -1529,12 +1536,18 @@ export class DatabaseManager {
       const poolId = row.id as string;
       const fencers = this.getPoolFencers(poolId);
       const matches = this.getMatchesByPool(poolId);
+      let referees: Referee[] = [];
+      if (row.referee_id) {
+        const ref = this.getReferee(row.referee_id as string);
+        if (ref) referees = [ref];
+      }
       results.push({
         id: poolId,
         phaseId: row.phase_id as string,
         number: row.number as number,
         fencers,
         matches,
+        referees,
         isComplete: row.is_complete === 1,
         hasError: row.has_error === 1,
         createdAt: new Date(row.created_at as string),

--- a/src/database/migrations/migrations.ts
+++ b/src/database/migrations/migrations.ts
@@ -297,4 +297,11 @@ export const ALL_MIGRATIONS: Migration[] = [
       db.run(`CREATE INDEX IF NOT EXISTS idx_formula_snapshots_comp ON formula_snapshots(competition_id)`);
     },
   },
+  {
+    version: 9,
+    description: 'Arbitre assigné à une poule (referee_id sur pools)',
+    up(db) {
+      try { db.run(`ALTER TABLE pools ADD COLUMN referee_id TEXT`); } catch { /* */ }
+    },
+  },
 ];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1000,6 +1000,9 @@ ipcMain.handle('db:clearSessionState', async (_, competitionId) => {
 ipcMain.handle('db:updatePool', async (_, pool) => {
   return db.updatePool(pool);
 });
+ipcMain.handle('db:updatePoolReferee', async (_, poolId, refereeId) => {
+  return db.updatePoolReferee(poolId, refereeId);
+});
 ipcMain.handle('db:createPool', async (_, phaseId, number, poolId) => {
   return db.createPool(phaseId, number, poolId);
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -195,6 +195,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
     getPoolsByPhase: (phaseId: string) => ipcRenderer.invoke('db:getPoolsByPhase', phaseId),
     getPoolSignatures: (poolId: string) => ipcRenderer.invoke('db:getPoolSignatures', poolId),
+    updatePoolReferee: (poolId: string, refereeId: string | null) =>
+      ipcRenderer.invoke('db:updatePoolReferee', poolId, refereeId),
 
     // Phases
     createPhase: (competitionId: string, type: string, order: number, name: string) =>

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1275,6 +1275,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             playAllPositions={playAllPositions}
             arenaCount={remoteArenaCount}
             readOnly={finalResults.length > 0}
+            competitionId={competition.id}
             onComplete={results => {
               setFinalResults(results);
               setTableauEditUnlocked(false);
@@ -1292,6 +1293,9 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                   fencerBParam ?? match?.fencerB ?? null
                 );
               }
+            }}
+            onMatchRefereeChange={(matchId, refereeId) => {
+              window.electronAPI.db.updateMatch(matchId, { refereeId: refereeId ?? undefined });
             }}
           />
           </Suspense>

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useModalResize } from '../hooks/useModalResize';
-import { Pool, Fencer, MatchStatus, Score, Weapon, FencerStatus } from '../../shared/types';
+import { Pool, Fencer, MatchStatus, Score, Weapon, FencerStatus, Referee } from '../../shared/types';
 import { Arena } from '../../shared/types/remote';
 import { logger, LogCategory } from '@shared/services/logger';
 import { useToast } from './Toast';
@@ -89,6 +89,9 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const [keyboardFocusField, setKeyboardFocusField] = useState<'A' | 'B'>('A');
   const [signedFencerIds, setSignedFencerIds] = useState<string[]>([]);
   const [matchArenaOverrides, setMatchArenaOverrides] = useState<Map<string, number>>(new Map());
+  const [showRefereeModal, setShowRefereeModal] = useState(false);
+  const [competitionReferees, setCompetitionReferees] = useState<Referee[]>([]);
+  const [assignedReferee, setAssignedReferee] = useState<Referee | null>(pool.referees?.[0] ?? null);
 
   const defaultArena = (pool.strip != null && pool.strip > 0 ? pool.strip : pool.number) ?? 1;
 
@@ -111,6 +114,23 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     onMatchArenaChange?.(matchId, oldArena, newArena, fencerA, fencerB);
   }, [onMatchArenaChange]);
 
+
+  const openRefereeModal = useCallback(() => {
+    if (competitionId) {
+      window.electronAPI.db.getRefereesByCompetition(competitionId).then(refs => {
+        setCompetitionReferees(refs);
+        setShowRefereeModal(true);
+      });
+    } else {
+      setShowRefereeModal(true);
+    }
+  }, [competitionId]);
+
+  const handleAssignReferee = useCallback((referee: Referee | null) => {
+    window.electronAPI.db.updatePoolReferee(pool.id, referee?.id ?? null);
+    setAssignedReferee(referee);
+    setShowRefereeModal(false);
+  }, [pool.id]);
 
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
   const [showPoolConfetti, setShowPoolConfetti] = useState(false);
@@ -1163,6 +1183,25 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
               </span>
             );
           })()}
+          <button
+            onClick={openRefereeModal}
+            title={assignedReferee ? `Arbitre : ${assignedReferee.lastName} ${assignedReferee.firstName}` : 'Assigner un arbitre'}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.25rem',
+              padding: '0.2rem 0.5rem',
+              borderRadius: '12px',
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              cursor: 'pointer',
+              background: assignedReferee ? '#dbeafe' : '#f3f4f6',
+              color: assignedReferee ? '#1d4ed8' : '#6b7280',
+              border: `1px solid ${assignedReferee ? '#93c5fd' : '#e5e7eb'}`,
+            }}
+          >
+            🧑‍⚖️ {assignedReferee ? `${assignedReferee.lastName}` : '+Arbitre'}
+          </button>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
           <button
@@ -1411,6 +1450,46 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
       <React.Suspense fallback={null}>
         <MatchAuditLog matchId={auditMatchId} onClose={() => setAuditMatchId(null)} />
       </React.Suspense>
+    )}
+    {showRefereeModal && (
+      <div className="modal-overlay" onClick={() => setShowRefereeModal(false)}>
+        <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '400px' }}>
+          <div className="modal-header">
+            <h3 className="modal-title">Assigner un arbitre</h3>
+            <button className="btn-close" onClick={() => setShowRefereeModal(false)}>&times;</button>
+          </div>
+          <div className="modal-body" style={{ padding: '1.5rem' }}>
+            <p style={{ marginBottom: '1rem', color: '#6b7280', fontSize: '0.875rem' }}>
+              Sélectionnez l'arbitre pour la poule {pool.number} :
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <button
+                className={`btn ${!assignedReferee ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => handleAssignReferee(null)}
+                style={{ padding: '0.75rem', fontSize: '0.875rem' }}
+              >
+                ✕ Aucun arbitre
+              </button>
+              {competitionReferees.length === 0 && (
+                <p style={{ color: '#9ca3af', fontSize: '0.875rem', textAlign: 'center' }}>
+                  Aucun arbitre enregistré pour cette compétition
+                </p>
+              )}
+              {competitionReferees.map(ref => (
+                <button
+                  key={ref.id}
+                  className={`btn ${assignedReferee?.id === ref.id ? 'btn-primary' : 'btn-secondary'}`}
+                  onClick={() => handleAssignReferee(ref)}
+                  style={{ padding: '0.75rem', fontSize: '0.875rem', textAlign: 'left' }}
+                >
+                  🧑‍⚖️ {ref.lastName} {ref.firstName}
+                  {ref.club && <span style={{ marginLeft: '0.5rem', opacity: 0.6, fontSize: '0.8rem' }}>({ref.club})</span>}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
     )}
     </>
   );

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -42,6 +42,8 @@ interface TableauViewProps {
   playAllPositions?: boolean;
   arenaCount?: number;
   onMatchArenaChange?: (matchId: string, oldArena: number | null, newArena: number | null, fencerA?: any, fencerB?: any) => void;
+  onMatchRefereeChange?: (matchId: string, refereeId: string | null) => void;
+  competitionId?: string;
   consolationBrackets?: ConsolationBracket[];
   onConsolationBracketsChange?: (brackets: ConsolationBracket[]) => void;
   readOnly?: boolean;
@@ -104,6 +106,8 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   playAllPositions = false,
   arenaCount = 4,
   onMatchArenaChange,
+  onMatchRefereeChange,
+  competitionId,
   consolationBrackets: consolationBracketsprop = [],
   onConsolationBracketsChange,
   readOnly = false,
@@ -123,6 +127,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const [expandedRounds, setExpandedRounds] = useState<Set<number>>(new Set());
   const [showArenaModal, setShowArenaModal] = useState(false);
   const [selectedMatchForArena, setSelectedMatchForArena] = useState<string | null>(null);
+  const [showRefereeModal, setShowRefereeModal] = useState(false);
+  const [selectedMatchForReferee, setSelectedMatchForReferee] = useState<string | null>(null);
+  const [competitionReferees, setCompetitionReferees] = useState<Array<{ id: string; firstName: string; lastName: string; club?: string }>>([]);
   const [selectedMatchConsolationBracketId, setSelectedMatchConsolationBracketId] = useState<string | null>(null);
   const [pyramidViewMode, setPyramidViewMode] = useState<boolean>(false);
   const [showPdfModal, setShowPdfModal] = useState(false);
@@ -1224,6 +1231,15 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         setSelectedMatchForArena(id);
         setShowArenaModal(true);
       }}
+      onRefereeClick={id => {
+        if (competitionId) {
+          window.electronAPI.db.getRefereesByCompetition(competitionId).then(refs => {
+            setCompetitionReferees(refs.map(r => ({ id: r.id, firstName: r.firstName, lastName: r.lastName, club: r.club })));
+          });
+        }
+        setSelectedMatchForReferee(id);
+        setShowRefereeModal(true);
+      }}
       readOnly={readOnly}
     />
   );
@@ -1505,6 +1521,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                       baseMatchHeight={BASE_MATCH_HEIGHT}
                       onMatchClick={openScoreModal}
                       onArenaClick={id => { setSelectedMatchForArena(id); setShowArenaModal(true); }}
+                      onRefereeClick={id => { setSelectedMatchForReferee(id); setShowRefereeModal(true); }}
                       readOnly={readOnly}
                     />
                   ))}
@@ -1567,6 +1584,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                                   setSelectedMatchConsolationBracketId(bracket.id);
                                   setShowArenaModal(true);
                                 } : () => {}}
+                                onRefereeClick={match.winner === null ? () => { setSelectedMatchForReferee(match.id); setShowRefereeModal(true); } : undefined}
                                 readOnly={readOnly}
                               />
                             ))}
@@ -1770,6 +1788,65 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                       </button>
                     );
                   })}
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
+
+      {showRefereeModal && selectedMatchForReferee && (() => {
+        const currentReferee = matches.find(m => m.id === selectedMatchForReferee)?.referee ?? null;
+
+        const closeModal = () => {
+          setShowRefereeModal(false);
+          setSelectedMatchForReferee(null);
+        };
+
+        const assignReferee = (ref: { id: string; firstName: string; lastName: string } | null) => {
+          const updatedMatches = matches.map(m =>
+            m.id === selectedMatchForReferee ? { ...m, referee: ref } : m
+          );
+          onMatchesChange(updatedMatches);
+          onMatchRefereeChange?.(selectedMatchForReferee!, ref?.id ?? null);
+          closeModal();
+        };
+
+        return (
+          <div className="modal-overlay" onClick={closeModal}>
+            <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '400px' }}>
+              <div className="modal-header">
+                <h3 className="modal-title">Assigner un arbitre</h3>
+                <button className="btn-close" onClick={closeModal}>&times;</button>
+              </div>
+              <div className="modal-body" style={{ padding: '1.5rem' }}>
+                <p style={{ marginBottom: '1rem', color: '#6b7280', fontSize: '0.875rem' }}>
+                  Sélectionnez l'arbitre pour ce match :
+                </p>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                  <button
+                    className={`btn ${!currentReferee ? 'btn-primary' : 'btn-secondary'}`}
+                    onClick={() => assignReferee(null)}
+                    style={{ padding: '0.75rem', fontSize: '0.875rem' }}
+                  >
+                    ✕ Aucun arbitre
+                  </button>
+                  {competitionReferees.length === 0 && (
+                    <p style={{ color: '#9ca3af', fontSize: '0.875rem', textAlign: 'center' }}>
+                      Aucun arbitre enregistré pour cette compétition
+                    </p>
+                  )}
+                  {competitionReferees.map(ref => (
+                    <button
+                      key={ref.id}
+                      className={`btn ${currentReferee?.id === ref.id ? 'btn-primary' : 'btn-secondary'}`}
+                      onClick={() => assignReferee(ref)}
+                      style={{ padding: '0.75rem', fontSize: '0.875rem', textAlign: 'left' }}
+                    >
+                      🧑‍⚖️ {ref.lastName} {ref.firstName}
+                      {ref.club && <span style={{ marginLeft: '0.5rem', opacity: 0.6, fontSize: '0.8rem' }}>({ref.club})</span>}
+                    </button>
+                  ))}
                 </div>
               </div>
             </div>

--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -8,6 +8,7 @@ interface MatchCardProps {
   baseMatchHeight: number;
   onMatchClick?: (match: TableauMatch) => void;
   onArenaClick?: (matchId: string) => void;
+  onRefereeClick?: (matchId: string) => void;
   readOnly?: boolean;
 }
 
@@ -20,6 +21,7 @@ const MatchCard: React.FC<MatchCardProps> = ({
   baseMatchHeight,
   onMatchClick,
   onArenaClick,
+  onRefereeClick,
   readOnly = false,
 }) => {
   const canEdit = !readOnly && !!(match.fencerA && match.fencerB && !match.isBye) && !!onMatchClick;
@@ -32,6 +34,11 @@ const MatchCard: React.FC<MatchCardProps> = ({
   const handleArenaClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     onArenaClick?.(match.id);
+  };
+
+  const handleRefereeClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRefereeClick?.(match.id);
   };
 
   const fencerName = (f: typeof match.fencerA) =>
@@ -63,6 +70,18 @@ const MatchCard: React.FC<MatchCardProps> = ({
           title={match.arena ? `Piste ${match.arena}` : 'Assigner une piste'}
         >
           {match.arena ? `P${match.arena}` : '+P'}
+        </button>
+      )}
+
+      {/* Referee badge */}
+      {canEdit && !isMatchComplete && onRefereeClick && (
+        <button
+          className={`match-arena-btn ${match.referee ? 'match-arena-btn-active' : ''}`}
+          onClick={handleRefereeClick}
+          title={match.referee ? `Arbitre : ${match.referee.lastName} ${match.referee.firstName}` : 'Assigner un arbitre'}
+          style={{ marginLeft: onArenaClick ? '0.25rem' : undefined }}
+        >
+          {match.referee ? `A:${match.referee.lastName.charAt(0)}${match.referee.firstName.charAt(0)}` : '+A'}
         </button>
       )}
 

--- a/src/renderer/components/tableau/tableauTypes.ts
+++ b/src/renderer/components/tableau/tableauTypes.ts
@@ -16,6 +16,7 @@ export interface TableauMatch {
   winner: Fencer | null;
   isBye: boolean;
   arena?: number | null;
+  referee?: { id: string; firstName: string; lastName: string } | null;
 }
 
 export interface FinalResult {

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -496,6 +496,7 @@ export interface DatabaseAPI {
   getPoolsByPhase: (phaseId: string) => Promise<Pool[]>;
   updatePool: (pool: Pool) => Promise<void>;
   getPoolSignatures: (poolId: string) => Promise<{ fencerId: string; signatureData: string }[]>;
+  updatePoolReferee: (poolId: string, refereeId: string | null) => Promise<void>;
 
   // Phases
   createPhase: (competitionId: string, type: string, order: number, name: string) => Promise<Phase>;

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -341,13 +341,18 @@ export function generatePoolHTML(pool: Pool, options: PoolExportOptions, templat
   const weaponLabel = weapon ? `<span class="chip"><strong>Arme</strong> ${weapon}</span>` : '';
   const catLabel = category ? `<span class="chip"><strong>Catégorie</strong> ${category}</span>` : '';
 
+  const assignedReferee = pool.referees?.[0];
+  const refereeLabel = assignedReferee
+    ? `<span style="font-size:0.85em;color:#4b5563;">🧑‍⚖️ ${assignedReferee.lastName} ${assignedReferee.firstName}</span>`
+    : '';
+
   const sections: Record<string, string> = {
     'header': `
   <div class="doc-header">
     ${logoBase64 ? `<img class="doc-header-logo" src="${logoBase64}" alt="Logo" />` : ''}
     <div class="doc-header-left">
       <h1>${effectiveTitle}</h1>
-      <div class="subtitle">Grille de poule • ${finishedCount}/${matches.length} matchs joués</div>
+      <div class="subtitle">Grille de poule • ${finishedCount}/${matches.length} matchs joués${refereeLabel ? ' &nbsp;' + refereeLabel : ''}</div>
     </div>
     <div class="doc-header-badge">P${pool.number}</div>
   </div>`,


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

Implémentation de l'issue #588 — assignation des arbitres.

- **Poules** : bouton `🧑‍⚖️ +Arbitre` dans l'en-tête de chaque poule → modal avec liste des arbitres de la compétition → persistance via nouvelle colonne `referee_id` sur la table `pools` (migration DB v9) → nom de l'arbitre affiché dans le PDF de la poule
- **Tableau** : bouton `+A` par match (comme le bouton piste existant) → modal arbitre → persistance via `db.updateMatch({ refereeId })`

## Plan de test

- [ ] Créer une compétition avec des arbitres enregistrés
- [ ] Phase de poules : cliquer sur `+Arbitre` → sélectionner un arbitre → vérifier badge affiché
- [ ] Exporter PDF de la poule → vérifier nom de l'arbitre dans l'en-tête
- [ ] Phase tableau : vérifier bouton `+A` sur chaque match → sélectionner arbitre → badge `A:XX` affiché
- [ ] Recharger la compétition → vérifier que les arbitres de poule sont restaurés (session state + DB)

https://claude.ai/code/session_01SrGmWBHiVHs4hzdmRvgMPb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrGmWBHiVHs4hzdmRvgMPb)_