### PR TITLE
fix(pdf): export complet — poules/tableau + nom fichier

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -971,7 +971,7 @@ export class DatabaseManager {
   }> {
     if (!this.db) throw new Error('Database not open');
     const stmt = this.db.prepare(
-      `SELECT m.id, m.round, m.position, m.is_bye,
+      `SELECT m.id, m.round, m.position,
               m.fencer_a_id, m.fencer_b_id, m.score_a, m.score_b,
               fa.first_name AS fa_first, fa.last_name AS fa_last, fa.club AS fa_club,
               fb.first_name AS fb_first, fb.last_name AS fb_last, fb.club AS fb_club
@@ -1004,7 +1004,7 @@ export class DatabaseManager {
         id: row.id as string,
         round: row.round as number,
         position: row.position as number,
-        isBye: (row.is_bye as number) === 1,
+        isBye: (!!row.fencer_a_id) !== (!!row.fencer_b_id),
         fencerA: row.fencer_a_id ? {
           firstName: row.fa_first as string | undefined,
           lastName: (row.fa_last as string) || '',

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1924,7 +1924,6 @@ ${allBodies}
 </body>
 </html>`;
 
-  const safe = competitionTitle.replace(/[^a-z0-9]/gi, '_').toLowerCase();
-  await savePDF(combined, `export_complet_${safe}.pdf`);
+  await savePDF(combined, `export-PDF_full.pdf`);
 }
 


### PR DESCRIPTION
## Problème
Export PDF complet: poules et matchs du tableau d'élimination directe absents. Nom fichier avec accents.

## Cause
`getTableauMatchesForExport` lisait `m.is_bye` — colonne inexistante dans table `matches` (présente seulement dans `bracket_nodes`). Erreur SQL → tout l'export échouait.

## Correctifs
- Suppression de `m.is_bye` de la requête; `isBye` déduit (un seul tireur présent)
- Nom par défaut: `export-PDF_full.pdf` (sans accents)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XF9i3psjZPhAR2RB3AXHyG)_