### PR TITLE
fix(pdf): durcit l'export complet (fetchs de secours isolés)

### DIFF
--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -13,6 +13,7 @@ import { exportResultsToPDF, exportFullCompetitionPDF } from '../../shared/utils
 import type { TableauMatchForPDF, FinalResultForPDF } from '../../shared/utils/pdfExport';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import type { ConsolationBracket } from './tableau/tableauTypes';
+import { logger, LogCategory } from '@shared/services/logger';
 
 interface FinalResult {
   rank: number;
@@ -196,22 +197,32 @@ const ResultsView: React.FC<ResultsViewProps> = ({
     try {
       const api = (window as any).electronAPI;
 
+      // Chaque fetch de secours est isolé : un échec ne doit pas vider tout l'export
+      const safe = async <T,>(fn: () => Promise<T>, label: string, fallback: T): Promise<T> => {
+        try { return await fn(); } catch (e) {
+          logger.warn(LogCategory.DATABASE, `export complet — ${label} échoué`, e instanceof Error ? e : undefined);
+          return fallback;
+        }
+      };
+
       const effectiveFencers = (appelFencers && appelFencers.length > 0)
         ? appelFencers
         : (fencers && fencers.length > 0)
           ? fencers
-          : await api?.db?.getFencersByCompetition?.(competition.id) ?? [];
+          : await safe(() => api?.db?.getFencersByCompetition?.(competition.id) ?? [], 'tireurs', []);
 
       const effectiveTableauMatches = (tableauMatches && tableauMatches.length > 0)
         ? tableauMatches
-        : await api?.db?.getTableauMatchesForExport?.(competition.id) ?? [];
+        : await safe(() => api?.db?.getTableauMatchesForExport?.(competition.id) ?? [], 'matchs tableau', []);
 
       let effectivePools: Pool[] = pools && pools.length > 0 ? pools : [];
       if (effectivePools.length === 0 && api?.db?.getPhasesByCompetition && api?.db?.getPoolsByPhase) {
-        const phases = await api.db.getPhasesByCompetition(competition.id);
-        const poolPhases = phases.filter((p: { type: string }) => p.type === 'pool');
-        const poolArrays = await Promise.all(poolPhases.map((ph: { id: string }) => api.db.getPoolsByPhase(ph.id)));
-        effectivePools = poolArrays.flat();
+        effectivePools = await safe(async () => {
+          const phases = await api.db.getPhasesByCompetition(competition.id);
+          const poolPhases = phases.filter((p: { type: string }) => p.type === 'pool');
+          const poolArrays = await Promise.all(poolPhases.map((ph: { id: string }) => api.db.getPoolsByPhase(ph.id)));
+          return poolArrays.flat();
+        }, 'poules', []);
       }
 
       await exportFullCompetitionPDF({


### PR DESCRIPTION
## Suite #596 — export PDF complet toujours vide

### Cause racine confirmée
`getTableauMatchesForExport` lisait `m.is_bye`, colonne absente de la table `matches` (présente uniquement dans `bracket_nodes`). Reproduit avec `node:sqlite`: `no such column: m.is_bye`. La requête levait une exception → `exportFullPDF` avortait **avant** de générer la moindre section → PDF entièrement vide (poules ET tableau). Corrigé en #596 (suppression de `m.is_bye`, `isBye` déduit).

### Durcissement (ce PR)
Chaque fetch de secours (tireurs, matchs tableau, poules) est isolé dans un `try/catch`. Un échec d'une source ne vide plus l'intégralité du PDF — les autres sections s'exportent quand même, et l'erreur est journalisée.

> Si le PDF reste vide après merge, régénérer le build (`npm run build`) — le correctif #596 doit être présent dans le bundle exécuté.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XF9i3psjZPhAR2RB3AXHyG)_