### PR TITLE
fix(pdf): export complet rend enfin poules + tableau (template mal appliqué) + animation d'attente

### DIFF
--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -77,6 +77,10 @@ const RV_STYLES = {
   btnPdf: { padding: '0.75rem 1.5rem', background: '#ef4444', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
   btnFullPdf: { padding: '0.75rem 1.5rem', background: '#166534', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' } satisfies React.CSSProperties,
   legend: { textAlign: 'center' as const, marginTop: '1.5rem', fontSize: '0.875rem', color: '#6b7280' } satisfies React.CSSProperties,
+  spinner: { display: 'inline-block', width: '14px', height: '14px', border: '2px solid rgba(255,255,255,0.4)', borderTopColor: 'white', borderRadius: '50%', animation: 'rv-spin 0.7s linear infinite' } satisfies React.CSSProperties,
+  overlay: { position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.55)', display: 'flex', flexDirection: 'column' as const, alignItems: 'center', justifyContent: 'center', gap: '1rem', zIndex: 9999 } satisfies React.CSSProperties,
+  overlaySpinner: { width: '48px', height: '48px', border: '5px solid rgba(255,255,255,0.3)', borderTopColor: '#fbbf24', borderRadius: '50%', animation: 'rv-spin 0.8s linear infinite' } satisfies React.CSSProperties,
+  overlayText: { color: 'white', fontSize: '1.1rem', fontWeight: 600 } satisfies React.CSSProperties,
 } satisfies Record<string, React.CSSProperties>;
 
 const ResultsView: React.FC<ResultsViewProps> = ({
@@ -86,6 +90,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({
 }) => {
   const { showToast } = useToast();
   const rankingTemplate = usePdfTemplateStore(s => s.templates.ranking);
+  const [isExportingFull, setIsExportingFull] = React.useState(false);
 
   const getMedalEmoji = (rank: number): string => {
     if (rank === 1) return '🥇';
@@ -194,6 +199,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({
   };
 
   const exportFullPDF = async () => {
+    setIsExportingFull(true);
     try {
       const api = (window as any).electronAPI;
 
@@ -243,6 +249,8 @@ const ResultsView: React.FC<ResultsViewProps> = ({
       });
     } catch (e) {
       showToast((e as Error).message, 'error');
+    } finally {
+      setIsExportingFull(false);
     }
   };
 
@@ -250,6 +258,13 @@ const ResultsView: React.FC<ResultsViewProps> = ({
 
   return (
     <div style={RV_STYLES.wrapper}>
+      <style>{`@keyframes rv-spin { to { transform: rotate(360deg); } }`}</style>
+      {isExportingFull && (
+        <div style={RV_STYLES.overlay}>
+          <div style={RV_STYLES.overlaySpinner} />
+          <div style={RV_STYLES.overlayText}>Génération du PDF complet…</div>
+        </div>
+      )}
       {/* En-tête avec le champion */}
       {champion && (
         <div style={RV_STYLES.champHeader}>
@@ -365,8 +380,18 @@ const ResultsView: React.FC<ResultsViewProps> = ({
         <button onClick={exportPDF} style={RV_STYLES.btnPdf}>
           📄 PDF
         </button>
-        <button onClick={exportFullPDF} style={RV_STYLES.btnFullPdf}>
-          📦 Export complet PDF
+        <button
+          onClick={exportFullPDF}
+          style={{ ...RV_STYLES.btnFullPdf, opacity: isExportingFull ? 0.6 : 1, cursor: isExportingFull ? 'wait' : 'pointer' }}
+          disabled={isExportingFull}
+        >
+          {isExportingFull ? (
+            <>
+              <span style={RV_STYLES.spinner} /> Génération…
+            </>
+          ) : (
+            '📦 Export complet PDF'
+          )}
         </button>
       </div>
 

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1860,7 +1860,7 @@ export async function exportFullCompetitionPDF(data: FullCompetitionExportData):
     sections.push(generatePoolHTML(
       pool,
       { title: `Poule ${pool.number} — ${competitionTitle}`, logoBase64: logo, competitionName: competitionTitle },
-      template
+      undefined
     ));
   }
 
@@ -1881,7 +1881,7 @@ export async function exportFullCompetitionPDF(data: FullCompetitionExportData):
     sections.push(generateTableauHTML(
       roundMatches, MAX_MATCHES_PER_PAGE_TABLEAU,
       `${getTableauRoundName(round)} — ${competitionTitle}`,
-      logo, template
+      logo, undefined
     ));
   }
 
@@ -1893,13 +1893,13 @@ export async function exportFullCompetitionPDF(data: FullCompetitionExportData):
       sections.push(generateTableauHTML(
         roundMatches, MAX_MATCHES_PER_PAGE_TABLEAU,
         `${bracket.name} — ${getTableauRoundName(round)} — ${competitionTitle}`,
-        logo, template
+        logo, undefined
       ));
     }
   }
 
   if (finalResults.length > 0) {
-    sections.push(generateResultsHTML(finalResults, `Classement final — ${competitionTitle}`, logo, template));
+    sections.push(generateResultsHTML(finalResults, `Classement final — ${competitionTitle}`, logo, undefined));
   }
 
   if (sections.length === 0) throw new Error('Aucune donnée à exporter');


### PR DESCRIPTION
## Export PDF complet — poules & tableau vides

### Cause racine (le vrai bug)
`exportFullCompetitionPDF` passait le template `ranking` à `generatePoolHTML` et `generateTableauHTML`. Or `assembleBody` réordonne/filtre les sections d'après les IDs d'éléments du template. Le template ranking ne contient que `header`, `gold-bar`, `ranking-table`, `footer` → les sections natives `score-grid` (poules) et `match-cards` (tableau) étaient filtrées et **jamais émises**. Le PDF ne contenait donc que l'en-tête, la barre dorée et le pied de page (cf. capture utilisateur).

### Correctif
- Le template n'est appliqué qu'à la section **classement**.
- Poules, tableau, brackets de consolation et résultats reçoivent `undefined` → leurs sections complètes sont rendues.

### Bonus
- Overlay + spinner d'attente pendant la génération de l'export complet (bouton désactivé + indicateur plein écran).

> Note : les correctifs précédents (#596 colonne `is_bye`, #598 isolation des fetchs) restent valides pour le chemin de secours DB, mais ne touchaient pas le chemin réel in-app qui utilise les props.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XF9i3psjZPhAR2RB3AXHyG)_