### PR TITLE
Fix: matchs du tableau d'élimination perdus en lecture seule

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -222,7 +222,15 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   }, [matches, onMatchesChange, onMatchArenaChange]);
 
   useEffect(() => {
-    if (readOnly) return;
+    if (readOnly) {
+      // En lecture seule, ne pas régénérer le tableau, mais déduire sa taille
+      // des matches existants pour permettre l'affichage des rounds.
+      if (matches.length > 0) {
+        const currentSize = Math.max(...matches.filter(m => m.round !== 3).map(m => m.round));
+        setTableauSize(currentSize);
+      }
+      return;
+    }
     const eligibleCount = ranking.filter(
       r =>
         r.fencer.status !== FencerStatus.ABANDONED &&


### PR DESCRIPTION
## Bug
Après génération des résultats, retour sur la phase tableau d'élimination : mode lecture seule, aucun match affiché.

## Cause
`TableauView.tsx` — l'effet d'init sort tôt si `readOnly`, donc `tableauSize` reste à 0. Le tableau de rounds est vide → aucun match rendu.

## Fix
En lecture seule, déduire `tableauSize` depuis les matchs existants au lieu de sortir tôt. Les matchs réapparaissent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SEfqFXGr57LQ3qjhtf7qPH)_