### PR TITLE
feat(pools): bouton global colonnes + indépendance par poule

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -37,6 +37,7 @@ import { ScoreAuditLog } from './ScoreAuditLog';
 import { RefereeManagerComponent } from './RefereeManager';
 import CompetitionHeader from './competition/CompetitionHeader';
 import CompetitionNav from './competition/CompetitionNav';
+import GlobalPoolColumnsMenu from './pool/GlobalPoolColumnsMenu';
 
 const PoolView = React.lazy(() => import('./PoolView'));
 const TableauView = React.lazy(() => import('./TableauView'));
@@ -1089,13 +1090,22 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               </div>
             ) : (
               <>
-                {pools.length > 1 && (
-                  <div style={CV_STYLES.poolsExportRow}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    gap: '0.75rem',
+                    marginBottom: '2rem',
+                  }}
+                >
+                  <GlobalPoolColumnsMenu isLaserSabre={isLaserSabre} />
+                  {pools.length > 1 && (
                     <button className="btn btn-success" onClick={handleExportAllPoolsPDF}>
                       📄 Exporter toutes les poules en PDF
                     </button>
-                  </div>
-                )}
+                  )}
+                </div>
                 <div
                   style={{
                     display: 'grid',

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -153,9 +153,9 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const isVisible = useCallback(
     (columnId: ColumnId): boolean => {
       if (columnId === 'quest' && !isLaserSabre) return false;
-      return isColumnVisible('pool', columnId);
+      return isColumnVisible('pool', columnId, pool.id);
     },
-    [isLaserSabre, isColumnVisible]
+    [isLaserSabre, isColumnVisible, pool.id]
   );
 
   const columnMenuRef = useRef<HTMLDivElement>(null);
@@ -573,7 +573,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           includePoolStats: true,
           logoBase64: logo,
           competitionName,
-          visibleColumns: getVisibleColumns('pool'),
+          visibleColumns: getVisibleColumns('pool', pool.id),
           signatures,
         },
         poolTemplate
@@ -968,7 +968,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         pool={pool}
         isLaserSabre={isLaserSabre}
         isVisible={isVisible}
-        toggleColumn={toggleColumn}
+        toggleColumn={(context, columnId) => toggleColumn(context, columnId, pool.id)}
         onCellClick={handleCellClick}
         onFencerChangePool={onFencerChangePool}
         isLocked={isLocked}
@@ -1368,7 +1368,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
                     <input
                       type="checkbox"
                       checked={isVisible(col.id)}
-                      onChange={() => toggleColumn('pool', col.id)}
+                      onChange={() => toggleColumn('pool', col.id, pool.id)}
                       style={{ cursor: 'pointer' }}
                     />
                     {col.label}

--- a/src/renderer/components/pool/GlobalPoolColumnsMenu.tsx
+++ b/src/renderer/components/pool/GlobalPoolColumnsMenu.tsx
@@ -1,0 +1,99 @@
+/**
+ * BellePoule Modern - Global Pool Columns Menu
+ * Bouton global pour choisir les colonnes affichées dans toutes les poules.
+ * Applique le choix à l'ensemble des poules et efface les réglages propres à chaque poule.
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useRef, useEffect } from 'react';
+import { useColumnVisibility, POOL_COLUMNS, ColumnId } from '../../hooks/useColumnVisibility';
+
+interface GlobalPoolColumnsMenuProps {
+  isLaserSabre: boolean;
+}
+
+const GlobalPoolColumnsMenu: React.FC<GlobalPoolColumnsMenuProps> = ({ isLaserSabre }) => {
+  const { visibility, setAllPoolColumns } = useColumnVisibility();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const columns = POOL_COLUMNS.filter(col => col.id !== 'quest' || isLaserSabre);
+
+  const toggle = (id: ColumnId) => {
+    const current = visibility.pool;
+    const next = current.includes(id) ? current.filter(c => c !== id) : [...current, id];
+    setAllPoolColumns(next);
+  };
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button className="btn btn-secondary" onClick={() => setOpen(o => !o)}>
+        🧱 Colonnes (toutes les poules)
+      </button>
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            marginTop: '0.25rem',
+            background: 'white',
+            border: '1px solid #e5e7eb',
+            borderRadius: '6px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+            zIndex: 100,
+            minWidth: '220px',
+            padding: '0.5rem',
+          }}
+        >
+          <div
+            style={{
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              padding: '0.25rem 0.5rem',
+              borderBottom: '1px solid #e5e7eb',
+              marginBottom: '0.25rem',
+            }}
+          >
+            Colonnes — appliqué à toutes les poules
+          </div>
+          {columns.map(col => (
+            <label
+              key={col.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+                padding: '0.375rem 0.5rem',
+                cursor: 'pointer',
+                borderRadius: '4px',
+                fontSize: '0.8rem',
+              }}
+              onMouseEnter={e => (e.currentTarget.style.background = '#f3f4f6')}
+              onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+            >
+              <input
+                type="checkbox"
+                checked={visibility.pool.includes(col.id)}
+                onChange={() => toggle(col.id)}
+                style={{ cursor: 'pointer' }}
+              />
+              {col.label}
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GlobalPoolColumnsMenu;

--- a/src/renderer/hooks/useColumnVisibility.ts
+++ b/src/renderer/hooks/useColumnVisibility.ts
@@ -52,13 +52,15 @@ export const RANKING_COLUMNS: ColumnDefinition[] = [
 ];
 
 interface VisibilityState {
-  pool: ColumnId[];
+  pool: ColumnId[]; // défaut global appliqué aux poules sans réglage propre
   ranking: ColumnId[];
+  pools: Record<string, ColumnId[]>; // réglages indépendants par poule (clé = pool.id)
 }
 
 const DEFAULT_VISIBILITY: VisibilityState = {
   pool: POOL_COLUMNS.map(c => c.id),
   ranking: RANKING_COLUMNS.map(c => c.id),
+  pools: {},
 };
 
 const loadFromStorage = (): VisibilityState => {
@@ -69,6 +71,7 @@ const loadFromStorage = (): VisibilityState => {
       return {
         pool: parsed.pool || DEFAULT_VISIBILITY.pool,
         ranking: parsed.ranking || DEFAULT_VISIBILITY.ranking,
+        pools: parsed.pools || {},
       };
     }
   } catch (e) {
@@ -112,27 +115,59 @@ export const useColumnVisibility = () => {
     }));
   }, []);
 
-  const toggleColumn = useCallback((type: 'pool' | 'ranking', columnId: ColumnId) => {
-    setState(prev => {
-      const current = prev[type];
-      const isVisible = current.includes(columnId);
-      const newColumns = isVisible ? current.filter(id => id !== columnId) : [...current, columnId];
-      return {
-        ...prev,
-        [type]: newColumns,
-      };
-    });
+  // poolId optionnel : si fourni, le réglage est propre à cette poule (indépendance).
+  const toggleColumn = useCallback(
+    (type: 'pool' | 'ranking', columnId: ColumnId, poolId?: string) => {
+      setState(prev => {
+        if (type === 'pool' && poolId) {
+          const current = prev.pools[poolId] ?? prev.pool;
+          const isVisible = current.includes(columnId);
+          const newColumns = isVisible
+            ? current.filter(id => id !== columnId)
+            : [...current, columnId];
+          return {
+            ...prev,
+            pools: { ...prev.pools, [poolId]: newColumns },
+          };
+        }
+        const current = prev[type];
+        const isVisible = current.includes(columnId);
+        const newColumns = isVisible
+          ? current.filter(id => id !== columnId)
+          : [...current, columnId];
+        return {
+          ...prev,
+          [type]: newColumns,
+        };
+      });
+    },
+    []
+  );
+
+  // Bouton global : applique le choix à toutes les poules et efface les réglages propres.
+  const setAllPoolColumns = useCallback((columns: ColumnId[]) => {
+    setState(prev => ({
+      ...prev,
+      pool: columns,
+      pools: {},
+    }));
   }, []);
 
   const isColumnVisible = useCallback(
-    (type: 'pool' | 'ranking', columnId: ColumnId): boolean => {
+    (type: 'pool' | 'ranking', columnId: ColumnId, poolId?: string): boolean => {
+      if (type === 'pool' && poolId && visibility.pools[poolId]) {
+        return visibility.pools[poolId].includes(columnId);
+      }
       return visibility[type].includes(columnId);
     },
     [visibility]
   );
 
   const getVisibleColumns = useCallback(
-    (type: 'pool' | 'ranking'): ColumnId[] => {
+    (type: 'pool' | 'ranking', poolId?: string): ColumnId[] => {
+      if (type === 'pool' && poolId && visibility.pools[poolId]) {
+        return visibility.pools[poolId];
+      }
       return visibility[type];
     },
     [visibility]
@@ -146,6 +181,7 @@ export const useColumnVisibility = () => {
     visibility,
     setVisibleColumns,
     toggleColumn,
+    setAllPoolColumns,
     isColumnVisible,
     getVisibleColumns,
     resetToDefaults,


### PR DESCRIPTION
## Demande
Bouton global pour choisir les colonnes de **toutes les poules** d'un coup, tout en **conservant l'indépendance** de chaque poule.

## Changements
- **Bouton global** « 🧱 Colonnes (toutes les poules) » dans la barre d'outils de la phase de poules (`CompetitionView`). Applique le choix à toutes les poules et réinitialise les réglages propres → nouveau composant `GlobalPoolColumnsMenu`.
- **Indépendance par poule** : le menu colonnes d'une poule écrit dans un override `pools[pool.id]`, sans affecter les autres.
- `useColumnVisibility` : défaut global `pool` + overrides `pools` par `pool.id`. Nouvelles signatures `toggleColumn/isColumnVisible/getVisibleColumns` avec `poolId` optionnel, et `setAllPoolColumns`.
- PoolView lit/écrit via `pool.id` (affichage + export PDF).

Persistance localStorage conservée.

https://claude.ai/code/session_01NE32GuNE6kk6Zjk94EnVhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NE32GuNE6kk6Zjk94EnVhe)_