### PR TITLE
Fix: classement final vide dans l'export complet

### DIFF
--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1619,7 +1619,7 @@ function generateResultsHTML(
     <div class="doc-header-badge" style="font-size:11pt">RF</div>
   </div>`,
     'gold-bar': `  <div class="gold-bar"></div>`,
-    'ranking-table': `
+    'results-table': `
   <table>
     <thead>
       <tr>


### PR DESCRIPTION
Bug: section `generateResultsHTML` utilisait clé `ranking-table` alors que `defaultOrder` attend `results-table`. Table jamais insérée → titre présent, contenu vide.

Fix: renommer clé en `results-table`.

https://claude.ai/code/session_011uXrkLYiYq8PXf5XG8o1DY

---
_Generated by [Claude Code](https://claude.ai/code/session_011uXrkLYiYq8PXf5XG8o1DY)_