### PR TITLE
Ajout du V devant le vainqueur (tableau + export PDF)

### DIFF
--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -101,6 +101,7 @@ const MatchCard: React.FC<MatchCardProps> = ({
         </div>
         {hasScore && (
           <span className={`match-score ${winnerA ? 'match-score-winner' : 'match-score-loser'}`}>
+            {winnerA && <span className="match-score-victory">V</span>}
             {match.scoreA}
           </span>
         )}
@@ -125,6 +126,7 @@ const MatchCard: React.FC<MatchCardProps> = ({
         </div>
         {hasScore && (
           <span className={`match-score ${winnerB ? 'match-score-winner' : 'match-score-loser'}`}>
+            {winnerB && <span className="match-score-victory">V</span>}
             {match.scoreB}
           </span>
         )}

--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -1321,6 +1321,12 @@ select:focus {
   color: var(--color-text-muted);
 }
 
+.match-score-victory {
+  font-weight: 800;
+  margin-right: 0.15rem;
+  color: var(--color-success);
+}
+
 .match-divider {
   height: 1px;
   background: var(--color-border);

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -1066,7 +1066,7 @@ export function generateBracketTreeHTML(
         ${club ? `<text x="${x + 4}" y="${clubY}" dominant-baseline="middle"
               font-family="'Segoe UI',Arial,sans-serif" font-size="${clubFs}" fill="#94a3b8">${club}</text>` : ''}
         <text x="${x + nameW + SCORE_W / 2}" y="${rowY + ROW_H / 2}" text-anchor="middle" dominant-baseline="middle"
-              font-family="'Segoe UI',Arial,sans-serif" font-size="${scoreFs}" font-weight="700" fill="${tc}">${score !== null ? score : ''}</text>`;
+              font-family="'Segoe UI',Arial,sans-serif" font-size="${scoreFs}" font-weight="700" fill="${tc}">${score !== null ? `${isWinner ? 'V ' : ''}${score}` : isWinner ? 'V' : ''}</text>`;
     };
 
     return `<g>
@@ -1303,7 +1303,7 @@ export function generateBracketTreeMultiPageHTML(
         ${club ? `<text x="${x + 5}" y="${clubY}" dominant-baseline="middle"
               font-family="'Segoe UI',Arial,sans-serif" font-size="${clubFs}" fill="#94a3b8">${club}</text>` : ''}
         <text x="${x + nameW + SCORE_W / 2}" y="${rowY + ROW_H / 2}" text-anchor="middle" dominant-baseline="middle"
-              font-family="'Segoe UI',Arial,sans-serif" font-size="${scoreFs}" font-weight="700" fill="${tc}">${score !== null ? score : ''}</text>`;
+              font-family="'Segoe UI',Arial,sans-serif" font-size="${scoreFs}" font-weight="700" fill="${tc}">${score !== null ? `${isWinner ? 'V ' : ''}${score}` : isWinner ? 'V' : ''}</text>`;
     };
 
     return `<g>


### PR DESCRIPTION
Affiche "V" devant le score du vainqueur dans la phase de tableau.

- UI MatchCard : badge V devant le score gagnant
- Export PDF arbre (simple page)
- Export PDF arbre FULL (multi-pages)

https://claude.ai/code/session_014bxYQJ8ca8TrkejHXUdbkr

---
_Generated by [Claude Code](https://claude.ai/code/session_014bxYQJ8ca8TrkejHXUdbkr)_