### PR TITLE
Fix: V devant le score du vainqueur dans l'export PDF Full (tableau)

### DIFF
--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -574,8 +574,11 @@ export function generateTableauHTML(
     const clubA = match.fencerA!.club ?? '';
     const clubB = match.fencerB!.club ?? '';
     const pisteLabel = match.arena != null ? `Piste ${match.arena}` : 'Piste ___';
-    const scoreCellA = showScores && match.scoreA != null ? String(match.scoreA) : '';
-    const scoreCellB = showScores && match.scoreB != null ? String(match.scoreB) : '';
+    const winnerId = match.winner?.id;
+    const isWinnerA = winnerId != null && winnerId === (match.fencerA as any)?.id;
+    const isWinnerB = winnerId != null && winnerId === (match.fencerB as any)?.id;
+    const scoreCellA = showScores && match.scoreA != null ? `${isWinnerA ? 'V' : ''}${match.scoreA}` : '';
+    const scoreCellB = showScores && match.scoreB != null ? `${isWinnerB ? 'V' : ''}${match.scoreB}` : '';
     return `
 <div class="match-card">
   <div class="match-card-header">


### PR DESCRIPTION
Export PDF Full, tableau élimination directe : score vainqueur sans "V".

Fix : préfixe "V" ajouté devant le score du gagnant dans `generateTableauHTML` (utilisé par l'export Full avec `showScores=true`).

https://claude.ai/code/session_01LzHNN5MXkGbpe6zQY8LMS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzHNN5MXkGbpe6zQY8LMS7)_