### PR TITLE
Carton noir distant : exclure le combattant de la compétition

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1271,7 +1271,7 @@ export class RemoteScoreServer {
       }
       try {
         const { matchId } = req.params;
-        const { scoreA: rawA, scoreB: rawB, cardsA, cardsB, winner: winnerOverride } = req.body;
+        const { scoreA: rawA, scoreB: rawB, cardsA, cardsB, winner: winnerOverride, blackCardFencer } = req.body;
 
         const scoreA = Number(rawA);
         const scoreB = Number(rawB);
@@ -1300,12 +1300,15 @@ export class RemoteScoreServer {
         const winner =
           scoreA > scoreB ? 'A' : scoreB > scoreA ? 'B' : (winnerOverride === 'A' || winnerOverride === 'B' ? winnerOverride : null);
 
+        // Carton noir : le combattant fautif est exclu de la compétition
+        const blackCarded = blackCardFencer === 'A' || blackCardFencer === 'B' ? blackCardFencer : null;
+
         // Créer les objets Score
         const scoreAObj = {
           value: scoreA,
           isVictory: winner === 'A',
           isAbstention: false,
-          isExclusion: false,
+          isExclusion: blackCarded === 'A',
           isForfait: false,
         };
 
@@ -1313,7 +1316,7 @@ export class RemoteScoreServer {
           value: scoreB,
           isVictory: winner === 'B',
           isAbstention: false,
-          isExclusion: false,
+          isExclusion: blackCarded === 'B',
           isForfait: false,
         };
 
@@ -1359,6 +1362,23 @@ export class RemoteScoreServer {
               arena.currentMatch.scoreB = scoreB;
               this.finishArenaMatch(arenaId);
               break;
+            }
+          }
+        }
+
+        // Carton noir : exclure le combattant fautif de la compétition
+        if (blackCarded) {
+          const matchObj: any = dbMatch || inMemoryMatch;
+          const culpritId =
+            blackCarded === 'A'
+              ? matchObj?.fencerA?.id ?? matchObj?.fencerAId
+              : matchObj?.fencerB?.id ?? matchObj?.fencerBId;
+          if (culpritId) {
+            try {
+              this.db.updateFencer(culpritId, { status: FencerStatus.EXCLUDED });
+              console.log(`[RemoteScoreServer] Carton noir : combattant ${culpritId} exclu`);
+            } catch (e) {
+              console.error('[RemoteScoreServer] Erreur exclusion combattant:', e);
             }
           }
         }

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2274,6 +2274,7 @@
                 cardsA: this.cardsA,
                 cardsB: this.cardsB,
                 winner: ef === 'A' ? 'B' : 'A',
+                blackCardFencer: ef,
               }),
             });
           } catch (e) {


### PR DESCRIPTION
## Problème
En saisie distante, confirmer le 2ème carton rouge (carton noir) terminait le match mais n'excluait pas le combattant fautif de la compétition.

## Correctif
- `referee.html` : envoi de `blackCardFencer` au endpoint `/finish`
- `remoteScoreServer.ts` : `isExclusion` sur le score du fautif + passage du statut combattant à `EXCLUDED`

https://claude.ai/code/session_01NeRPK7dkoSP4VL8y5fW64R

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeRPK7dkoSP4VL8y5fW64R)_