### PR TITLE
fix: sécurité et performance — 9 corrections

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -25,7 +25,7 @@ import {
   MatchEventEntry,
   MatchEventType,
 } from '../shared/types';
-import { validateId, validateSessionState, sanitizeId } from './validation';
+import { validateId, validateSessionState, sanitizeId, validateCompetitionData } from './validation';
 import { logger, LogCategory } from '../shared/services/logger';
 import { MigrationManager } from './migrations';
 import { ALL_MIGRATIONS } from './migrations/migrations';
@@ -295,6 +295,15 @@ export class DatabaseManager {
     if (!this.db) throw new Error('Database not open');
     const now = new Date().toISOString();
     const id = comp.id || uuidv4();
+    const normalized: Partial<Competition> = {
+      ...comp,
+      title: comp.title || 'Nouvelle compétition',
+      date: comp.date || new Date(now),
+      weapon: comp.weapon || ('E' as any),
+      gender: comp.gender || ('M' as any),
+      category: comp.category || ('SEN' as any),
+    };
+    validateCompetitionData(normalized);
 
     this.run(
       `

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -481,7 +481,7 @@ function createWindow(): void {
         ...details.responseHeaders,
         'Content-Security-Policy': [
           "default-src 'self'; " +
-            "script-src 'self' https://cdn.socket.io; " +
+            "script-src 'self'; " +
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
             "font-src 'self' https://fonts.gstatic.com; " +
             "img-src 'self' data: blob:; " +
@@ -1138,7 +1138,15 @@ ipcMain.handle('file:import', async (_, filepath) => {
 
 // File content write handler
 ipcMain.handle('file:writeContent', async (_, filepath: string, content: string) => {
-  fs.writeFileSync(filepath, content, 'utf-8');
+  if (!filepath || typeof filepath !== 'string' || !path.isAbsolute(filepath)) {
+    throw new Error('Invalid file path');
+  }
+  const resolved = path.resolve(filepath);
+  const appDir = path.resolve(app.getAppPath());
+  if (resolved.startsWith(appDir)) {
+    throw new Error('Writing inside app directory is not allowed');
+  }
+  fs.writeFileSync(resolved, content, 'utf-8');
 });
 
 // Photo ZIP export handler

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -132,6 +132,14 @@ export class RemoteScoreServer {
       },
     });
 
+    // Purge des entrées expirées dans loginAttempts toutes les 5 minutes
+    setInterval(() => {
+      const now = Date.now();
+      for (const [ip, attempt] of this.loginAttempts) {
+        if (now >= attempt.resetAt) this.loginAttempts.delete(ip);
+      }
+    }, 5 * 60_000);
+
     // Charger les fichiers HTML en mémoire au démarrage
     this.loadHtmlFiles();
 
@@ -234,9 +242,13 @@ export class RemoteScoreServer {
     for (const part of header.split(';')) {
       const idx = part.indexOf('=');
       if (idx < 0) continue;
-      const key = decodeURIComponent(part.slice(0, idx).trim());
-      const val = decodeURIComponent(part.slice(idx + 1).trim());
-      if (key) result[key] = val;
+      try {
+        const key = decodeURIComponent(part.slice(0, idx).trim());
+        const val = decodeURIComponent(part.slice(idx + 1).trim());
+        if (key) result[key] = val;
+      } catch {
+        // Ignore malformed cookie parts
+      }
     }
     return result;
   }
@@ -775,11 +787,16 @@ export class RemoteScoreServer {
 
       try {
         const strip = (s: string | null | undefined, max = 100) =>
-          s ? s.replace(/<[^>]*>/g, '').trim().substring(0, max) : undefined;
+          s ? s.replace(/<[^>]*>/g, '').replace(/&[a-z]+;/gi, '').trim().substring(0, max) : undefined;
+
+        const strippedLast = strip(lastName, 100);
+        const strippedFirst = strip(firstName, 100);
+        if (!strippedLast) return res.status(400).json({ error: 'Nom invalide après nettoyage' });
+        if (!strippedFirst) return res.status(400).json({ error: 'Prénom invalide après nettoyage' });
 
         const fencerData = {
-          lastName: strip(lastName, 100)!.toUpperCase(),
-          firstName: strip(firstName, 100)!,
+          lastName: strippedLast.toUpperCase(),
+          firstName: strippedFirst,
           gender,
           club: strip(club) || undefined,
           license: strip(license, 50) || undefined,

--- a/src/shared/services/cloudSyncService.ts
+++ b/src/shared/services/cloudSyncService.ts
@@ -151,7 +151,8 @@ export class CloudSyncService {
         return jwk;
       }
     }
-    // Fallback (ex. environnement web sans safeStorage) : stockage clair
+    // Fallback (ex. environnement web sans safeStorage) : stockage clair — à éviter en production
+    logger.warn(LogCategory.SYSTEM, 'Clé AES stockée en clair dans localStorage (safeStorage indisponible)');
     localStorage.setItem(legacyKey, JSON.stringify(jwk));
     return jwk;
   }

--- a/src/shared/services/ffeConnectService.ts
+++ b/src/shared/services/ffeConnectService.ts
@@ -32,7 +32,14 @@ export class FFEConnectService {
 
   constructor(config?: FFEConnectConfig) {
     this.apiKey = config?.apiKey;
-    this.baseUrl = config?.baseUrl ?? DEFAULT_BASE_URL;
+    const base = config?.baseUrl ?? DEFAULT_BASE_URL;
+    try {
+      const parsed = new URL(base);
+      if (parsed.protocol !== 'https:') throw new Error('HTTPS requis pour l\'API FFE');
+    } catch (e) {
+      throw new Error(`URL API FFE invalide: ${e instanceof Error ? e.message : e}`);
+    }
+    this.baseUrl = base;
   }
 
   async importParticipants(competitionCode: string): Promise<{
@@ -70,8 +77,11 @@ export class FFEConnectService {
         };
       }
 
-      const data = (await response.json()) as FFEParticipant[];
-      return { success: true, participants: data, errors: [] };
+      const data = await response.json();
+      if (!Array.isArray(data)) {
+        return { success: false, participants: [], errors: ['Réponse API invalide: tableau attendu'] };
+      }
+      return { success: true, participants: data as FFEParticipant[], errors: [] };
     } catch (err: unknown) {
       clearTimeout(timeoutId);
       if (err instanceof Error && err.name === 'AbortError') {

--- a/src/shared/utils/tableCalculations.ts
+++ b/src/shared/utils/tableCalculations.ts
@@ -87,6 +87,12 @@ export function placeFencersInTable(fencers: Fencer[], tableSize: number): (Fenc
   const placements: (Fencer | null)[] = new Array(tableSize).fill(null);
   const seedingChart = generateSeedingChart(tableSize);
 
+  // Précalcule seed→position en O(n) pour éviter indexOf en boucle
+  const seedToPosition = new Map<number, number>();
+  for (let pos = 0; pos < seedingChart.length; pos++) {
+    seedToPosition.set(seedingChart[pos], pos);
+  }
+
   // Trier les tireurs par classement général (après poules)
   const sortedFencers = [...fencers].sort(
     (a, b) => (a.poolStats?.overallRank ?? 999) - (b.poolStats?.overallRank ?? 999)
@@ -94,8 +100,8 @@ export function placeFencersInTable(fencers: Fencer[], tableSize: number): (Fenc
 
   // Placer chaque tireur selon son seed
   for (let i = 0; i < sortedFencers.length; i++) {
-    const position = seedingChart.indexOf(i + 1);
-    if (position !== -1) {
+    const position = seedToPosition.get(i + 1);
+    if (position !== undefined) {
       placements[position] = sortedFencers[i];
     }
   }


### PR DESCRIPTION
$(cat <<'EOF'
## Corrections sécurité

| # | Fichier | Problème | Fix |
|---|---------|---------|-----|
| 1 | `main/main.ts` | CSP incluait `https://cdn.socket.io` inutilement dans `script-src` | Retiré |
| 2 | `main/main.ts` | `file:writeContent` acceptait tout path absolu (y.c. app dir) | Reject si path relatif ou dans app dir |
| 3 | `remoteScoreServer.ts` | `decodeURIComponent` dans `parseCookies` pouvait lever exception sur cookie malformé | try/catch ajouté |
| 4 | `remoteScoreServer.ts` | `strip()` pouvait retourner chaîne vide après suppression tags HTML (`<html>` → `""`) | Validation post-strip |
| 5 | `remoteScoreServer.ts` | `loginAttempts` Map croissait sans borne (fuite mémoire sur longue session) | Cleanup périodique toutes les 5 min |
| 6 | `database/index.ts` | `validateCompetitionData()` existait mais n'était jamais appelée | Appelée sur données normalisées dans `createCompetition` |
| 7 | `cloudSyncService.ts` | Fallback stockage clé AES en clair dans localStorage sans avertissement | `logger.warn` ajouté |
| 8 | `ffeConnectService.ts` | URL API non vérifiée HTTPS + réponse JSON parsée sans `Array.isArray` | Les deux validations ajoutées |

## Correction performance

| # | Fichier | Problème | Fix |
|---|---------|---------|-----|
| 9 | `tableCalculations.ts` | `seedingChart.indexOf(i+1)` en boucle = O(n²) pour placement tableau | Map `seed→position` précalculée en O(n) |

https://claude.ai/code/session_014Ptd69pS6A3UQLx41b7qmA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ptd69pS6A3UQLx41b7qmA)_