### PR TITLE
fix: isMatchPlayable accepte ArenaMatch — déblocage build CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.929",
+  "version": "1.0.3-build.986",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.929",
+      "version": "1.0.3-build.986",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2552,7 +2552,7 @@ export class RemoteScoreServer {
     return session;
   }
 
-  private isMatchPlayable(m: Match): boolean {
+  private isMatchPlayable(m: Match | ArenaMatch): boolean {
     const inactive = new Set([FencerStatus.ABANDONED, FencerStatus.FORFAIT, FencerStatus.EXCLUDED]);
     return (
       !inactive.has(m.fencerA?.status as FencerStatus) &&


### PR DESCRIPTION
## Problème

3 erreurs TS2345 pré-existantes bloquaient la build CI :

```
remoteScoreServer.ts(1217): error TS2345: Argument of type 'ArenaMatch' is not assignable to parameter of type 'Match'.
remoteScoreServer.ts(1222): error TS2345: ...
remoteScoreServer.ts(1258): error TS2345: ...
```

## Fix

Signature `isMatchPlayable(m: Match)` → `isMatchPlayable(m: Match | ArenaMatch)`.

`ArenaMatch` et `Match` ont tous les deux `fencerA.status` / `fencerB.status`, donc le corps de la fonction est identique — seule la signature change.

## Vérification

`npm run build:ci` → `webpack compiled successfully`

https://claude.ai/code/session_014Ptd69pS6A3UQLx41b7qmA

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ptd69pS6A3UQLx41b7qmA)_