### PR TITLE
i18n : compléter les traductions formula/weapons/phases (br, ca, es, zh-HK)

### DIFF
--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -38,7 +38,8 @@
     "epee": "Spes",
     "foil": "Fleuret",
     "sabre": "Sabr",
-    "laser": "Spaser Laser"
+    "laser": "Spaser Laser",
+    "custom": "Reoladur personelaet"
   },
   "genders": {
     "male": "Gourel",
@@ -104,7 +105,8 @@
     "tableau": "Taolenn",
     "results": "Disoc'hoùezioù",
     "remote": "Enrollañ a-bell",
-    "referees": "Varnourien"
+    "referees": "Varnourien",
+    "logs": "Istor"
   },
   "pools": {
     "generate": "Genelañ ar poullou",
@@ -333,5 +335,31 @@
     "timer": "Krogañ/Paouez kronometr",
     "nav_list": "Levenez en rol",
     "validate": "Gwiriañ / Digeriñ"
+  },
+  "formula": {
+    "builder_title": "Saver reoladur",
+    "add_pool_round": "Ouzhpennañ ur c’helc’hiad poull",
+    "add_de": "Ouzhpennañ dilamadur war-eeun",
+    "add_classification": "Ouzhpennañ renkadur",
+    "save_template": "Enrollañ evel patrom",
+    "load_template": "Kargañ ur patrom",
+    "advancement_rule": "Reol araokaat",
+    "advancement_all": "Pep hini a ya war-raok",
+    "advancement_percent": "Top %",
+    "advancement_fixed": "Niver fest",
+    "advancement_bracket": "Taolenn da-heul",
+    "ranking_criteria": "Dezvarennoù renkañ",
+    "criterion_vm": "V/M (feur trec’h)",
+    "criterion_index": "Menegad (TD−TR)",
+    "criterion_td": "Taolioù roet",
+    "criterion_tr": "Taolioù resevet",
+    "criterion_direct": "Emgann war-eeun",
+    "criterion_initial": "Renkadur kentañ",
+    "simulation_title": "Gwefile",
+    "pool_round_n": "Kelc’hiad poull {{n}}",
+    "scoring_standard": "Standard (1 taol = 1 poent)",
+    "scoring_zones": "Takadoù personelaet",
+    "zone_label": "Takad",
+    "zone_points": "Poentoù"
   }
 }

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -38,7 +38,8 @@
     "epee": "Espasa",
     "foil": "Floret",
     "sabre": "Sabre",
-    "laser": "Sabre Làser"
+    "laser": "Sabre Làser",
+    "custom": "Fórmula personalitzada"
   },
   "genders": {
     "male": "Masculí",
@@ -104,7 +105,8 @@
     "tableau": "Quadre",
     "results": "Resultats",
     "remote": "Entrada Remota",
-    "referees": "Àrbitres"
+    "referees": "Àrbitres",
+    "logs": "Historial"
   },
   "pools": {
     "generate": "Generar Poules",
@@ -333,5 +335,31 @@
     "timer": "Iniciar/Pausar cronòmetre",
     "nav_list": "Navegar a la llista",
     "validate": "Validar / Obrir"
+  },
+  "formula": {
+    "builder_title": "Constructor de fórmules",
+    "add_pool_round": "Afegir ronda de grups",
+    "add_de": "Afegir eliminació directa",
+    "add_classification": "Afegir classificació",
+    "save_template": "Desar com a plantilla",
+    "load_template": "Carregar una plantilla",
+    "advancement_rule": "Regla d’avançament",
+    "advancement_all": "Tots avancen",
+    "advancement_percent": "Top %",
+    "advancement_fixed": "Nombre fix",
+    "advancement_bracket": "Quadre següent",
+    "ranking_criteria": "Criteris de classificació",
+    "criterion_vm": "V/M (ràtio de victòries)",
+    "criterion_index": "Índex (TD−TR)",
+    "criterion_td": "Tocades fetes",
+    "criterion_tr": "Tocades rebudes",
+    "criterion_direct": "Enfrontament directe",
+    "criterion_initial": "Classificació inicial",
+    "simulation_title": "Simulació",
+    "pool_round_n": "Ronda de grups {{n}}",
+    "scoring_standard": "Estàndard (1 tocada = 1 punt)",
+    "scoring_zones": "Zones personalitzades",
+    "zone_label": "Zona",
+    "zone_points": "Punts"
   }
 }

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -38,7 +38,8 @@
     "epee": "Espada",
     "foil": "Florete",
     "sabre": "Sable",
-    "laser": "Sable Láser"
+    "laser": "Sable Láser",
+    "custom": "Fórmula personalizada"
   },
   "genders": {
     "male": "Masculino",
@@ -104,7 +105,8 @@
     "tableau": "Cuadro",
     "results": "Resultados",
     "remote": "Entrada Remota",
-    "referees": "Árbitros"
+    "referees": "Árbitros",
+    "logs": "Historial"
   },
   "pools": {
     "generate": "Generar Poules",
@@ -333,5 +335,31 @@
     "timer": "Iniciar/Pausar cronómetro",
     "nav_list": "Navegar en la lista",
     "validate": "Validar / Abrir"
+  },
+  "formula": {
+    "builder_title": "Constructor de fórmulas",
+    "add_pool_round": "Añadir ronda de grupos",
+    "add_de": "Añadir eliminación directa",
+    "add_classification": "Añadir clasificación",
+    "save_template": "Guardar como plantilla",
+    "load_template": "Cargar una plantilla",
+    "advancement_rule": "Regla de avance",
+    "advancement_all": "Todos avanzan",
+    "advancement_percent": "Top %",
+    "advancement_fixed": "Número fijo",
+    "advancement_bracket": "Cuadro siguiente",
+    "ranking_criteria": "Criterios de clasificación",
+    "criterion_vm": "V/M (ratio de victorias)",
+    "criterion_index": "Índice (TD−TR)",
+    "criterion_td": "Tocados dados",
+    "criterion_tr": "Tocados recibidos",
+    "criterion_direct": "Enfrentamiento directo",
+    "criterion_initial": "Clasificación inicial",
+    "simulation_title": "Simulación",
+    "pool_round_n": "Ronda de grupos {{n}}",
+    "scoring_standard": "Estándar (1 tocado = 1 punto)",
+    "scoring_zones": "Zonas personalizadas",
+    "zone_label": "Zona",
+    "zone_points": "Puntos"
   }
 }

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -38,7 +38,8 @@
     "epee": "重劍",
     "foil": "花劍",
     "sabre": "軍刀",
-    "laser": "激光軍刀"
+    "laser": "激光軍刀",
+    "custom": "自訂賽制"
   },
   "genders": {
     "male": "男子",
@@ -104,7 +105,8 @@
     "tableau": "淘汰賽",
     "results": "成績",
     "remote": "遠程輸入",
-    "referees": "裁判"
+    "referees": "裁判",
+    "logs": "歷史紀錄"
   },
   "pools": {
     "generate": "生成分組",
@@ -333,5 +335,31 @@
     "timer": "開始/暫停計時器",
     "nav_list": "在列表中導航",
     "validate": "確認 / 開啟"
+  },
+  "formula": {
+    "builder_title": "賽制編輯器",
+    "add_pool_round": "新增小組循環",
+    "add_de": "新增直接淘汰",
+    "add_classification": "新增排名",
+    "save_template": "儲存為範本",
+    "load_template": "載入範本",
+    "advancement_rule": "晉級規則",
+    "advancement_all": "全部晉級",
+    "advancement_percent": "前 %",
+    "advancement_fixed": "固定人數",
+    "advancement_bracket": "下一輪賽表",
+    "ranking_criteria": "排名準則",
+    "criterion_vm": "勝/賽 (勝率)",
+    "criterion_index": "指數 (得分−失分)",
+    "criterion_td": "得分",
+    "criterion_tr": "失分",
+    "criterion_direct": "直接對賽",
+    "criterion_initial": "初始排名",
+    "simulation_title": "模擬",
+    "pool_round_n": "小組循環 {{n}}",
+    "scoring_standard": "標準 (1 劍 = 1 分)",
+    "scoring_zones": "自訂區域",
+    "zone_label": "區域",
+    "zone_points": "分數"
   }
 }


### PR DESCRIPTION
## Contexte
Les fichiers de langue **br** (breton), **ca** (catalan), **es** (espagnol) et **zh-HK** n'avaient pas la section `formula.*` ni les clés `weapons.custom` / `phases.logs` présentes dans `fr`/`en`/`de`. Résultat : textes non traduits (clés brutes affichées) dans le constructeur de formule et le menu de phases pour ces langues.

## Changement
- Ajout des **26 clés manquantes** par langue (24 `formula.*`, `weapons.custom`, `phases.logs`).
- Insertion chirurgicale (pas de reformatage du reste du fichier), **BOM UTF-8 préservé**.
- Parité atteinte : 0 clé manquante vs `fr` pour les 4 langues.

## Vérification
- `json.load` OK sur les 4 fichiers (JSON valide).
- Comparaison à plat vs `fr.json` : 0 clé manquante.

🤖 Généré avec Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFNATiSbd3G1nKdWuU7TA2)_