### PR TITLE
feat(ui): pavé numérique tactile pour la saisie de score

### DIFF
--- a/src/renderer/components/common/NumericKeypad.tsx
+++ b/src/renderer/components/common/NumericKeypad.tsx
@@ -1,0 +1,116 @@
+/**
+ * BellePoule Modern - Pavé numérique tactile réutilisable
+ * Conçu pour la saisie de score sur tablette (grandes cibles tactiles).
+ * Licensed under GPL-3.0
+ */
+
+import React from 'react';
+
+interface NumericKeypadProps {
+  /** Valeur courante (chaîne de chiffres, '' si vide). */
+  value: string;
+  /** Appelé avec la nouvelle valeur après chaque appui. */
+  onChange: (value: string) => void;
+  /** Valeur maximale autorisée ; les saisies au-delà sont ignorées. */
+  maxValue?: number;
+  /** Nombre maximal de chiffres (défaut 2). */
+  maxDigits?: number;
+  /** Appelé sur la touche de validation (✓), si fournie. */
+  onConfirm?: () => void;
+  /** Désactive la touche de validation. */
+  confirmDisabled?: boolean;
+}
+
+const KEY_STYLE: React.CSSProperties = {
+  minHeight: '56px',
+  fontSize: '1.5rem',
+  fontWeight: 600,
+  border: '1px solid #d1d5db',
+  borderRadius: '8px',
+  background: '#f9fafb',
+  cursor: 'pointer',
+  touchAction: 'manipulation',
+  userSelect: 'none',
+};
+
+const NumericKeypad: React.FC<NumericKeypadProps> = ({
+  value,
+  onChange,
+  maxValue,
+  maxDigits = 2,
+  onConfirm,
+  confirmDisabled = false,
+}) => {
+  const appendDigit = (d: string) => {
+    if (value.length >= maxDigits) return;
+    // Évite les zéros de tête non significatifs ('0' + '5' -> '5')
+    const next = value === '0' ? d : value + d;
+    if (maxValue !== undefined && parseInt(next, 10) > maxValue) return;
+    onChange(next);
+  };
+
+  const backspace = () => onChange(value.slice(0, -1));
+  const clear = () => onChange('');
+
+  const digitKey = (d: string) => (
+    <button
+      key={d}
+      type="button"
+      onClick={() => appendDigit(d)}
+      aria-label={d}
+      style={KEY_STYLE}
+    >
+      {d}
+    </button>
+  );
+
+  return (
+    <div
+      role="group"
+      aria-label="Pavé numérique"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: '0.5rem',
+      }}
+    >
+      {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map(digitKey)}
+      <button
+        type="button"
+        onClick={clear}
+        aria-label="Effacer"
+        style={{ ...KEY_STYLE, fontSize: '1rem', color: '#dc2626' }}
+      >
+        C
+      </button>
+      {digitKey('0')}
+      <button
+        type="button"
+        onClick={backspace}
+        aria-label="Retour arrière"
+        style={{ ...KEY_STYLE, fontSize: '1.25rem' }}
+      >
+        ⌫
+      </button>
+      {onConfirm && (
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={confirmDisabled}
+          aria-label="Valider"
+          style={{
+            ...KEY_STYLE,
+            gridColumn: '1 / -1',
+            background: confirmDisabled ? '#e5e7eb' : '#10b981',
+            color: confirmDisabled ? '#9ca3af' : 'white',
+            cursor: confirmDisabled ? 'not-allowed' : 'pointer',
+          }}
+        >
+          ✓
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default NumericKeypad;

--- a/src/renderer/components/tableau/TableauScoreModal.tsx
+++ b/src/renderer/components/tableau/TableauScoreModal.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState } from 'react';
 import { TableauMatch } from './tableauTypes';
+import NumericKeypad from '../common/NumericKeypad';
 
 interface TableauScoreModalProps {
   match: TableauMatch;
@@ -54,6 +55,8 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
   const [pendingStatus, setPendingStatus] = useState<
     'abandon' | 'forfait' | 'exclusion' | null
   >(null);
+  // Champ ciblé par le pavé numérique tactile (saisie sur tablette)
+  const [keypadField, setKeypadField] = useState<'A' | 'B'>('A');
 
   const fencerName = (f: TableauMatch['fencerA']) =>
     f ? `${f.lastName} ${f.firstName}`.trim() : '';
@@ -122,6 +125,7 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
               }}
               value={editScoreA}
               onChange={e => setEditScoreA(e.target.value)}
+              onFocus={() => setKeypadField('A')}
               min="0"
               max={isUnlimitedScore ? undefined : maxScore}
               autoFocus
@@ -167,6 +171,7 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
               }}
               value={editScoreB}
               onChange={e => setEditScoreB(e.target.value)}
+              onFocus={() => setKeypadField('B')}
               min="0"
               max={isUnlimitedScore ? undefined : maxScore}
               onKeyDown={e => {
@@ -216,6 +221,27 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
               💡 Score maximum : {maxScore} touches
             </p>
           )}
+
+          {/* Pavé numérique tactile (tablette) — cible le champ actif */}
+          <div style={{ maxWidth: '280px', margin: '0 auto 1rem' }}>
+            <div
+              style={{
+                textAlign: 'center',
+                fontSize: '0.8rem',
+                color: '#6b7280',
+                marginBottom: '0.5rem',
+              }}
+            >
+              Saisie tactile → tireur {keypadField === 'A' ? 'A' : 'B'}
+            </div>
+            <NumericKeypad
+              value={keypadField === 'A' ? editScoreA : editScoreB}
+              onChange={v => (keypadField === 'A' ? setEditScoreA(v) : setEditScoreB(v))}
+              maxValue={isUnlimitedScore ? undefined : maxScore}
+              maxDigits={3}
+              onConfirm={onSubmit}
+            />
+          </div>
 
           {/* Boutons spéciaux sur une ligne */}
           {!pendingStatus ? (


### PR DESCRIPTION
## Contexte
La saisie de score sur tablette reposait uniquement sur des `<input type="number">`, peu pratiques au doigt (clavier système qui masque l'écran, cibles petites).

## Changement
- Nouveau composant réutilisable `src/renderer/components/common/NumericKeypad.tsx` : pavé 0–9, C (effacer), ⌫ (retour), ✓ (valider). Grandes cibles (≥56px), `touch-action: manipulation`, `aria-label` par touche.
- Intégré dans `TableauScoreModal` : le pavé cible le champ actif (A/B, suivi via `onFocus`), respecte `maxValue` (score max) et `maxDigits`.
- Validation et flux de soumission existants inchangés (`onSubmit`).

## Vérification
- `tsc --noEmit` ✅ (aucune erreur sur les fichiers modifiés).

🤖 Généré avec Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFNATiSbd3G1nKdWuU7TA2)_