### PR TITLE
feat(ui): activer l'overlay d'aide des raccourcis clavier

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,6 +16,7 @@ const AboutModal = React.lazy(() => import('./components/AboutModal'));
 const SettingsModal = React.lazy(() => import('./components/SettingsModal'));
 const DTCallNotification = React.lazy(() => import('./components/DTCallNotification'));
 const UpdateNotification = React.lazy(() => import('./components/UpdateNotification'));
+const KeyboardShortcutsHelp = React.lazy(() => import('./components/KeyboardShortcutsHelp'));
 import { ToastProvider, useToast } from './components/Toast';
 import { ConfirmProvider, useConfirm } from './components/ConfirmDialog';
 import { TranslationProvider, useTranslation, Theme } from './contexts/TranslationContext';
@@ -618,6 +619,11 @@ const AppContent: React.FC = () => {
             />
           </Suspense>
         )}
+
+        {/* Overlay d'aide raccourcis clavier (autonome : touche « ? », Échap pour fermer) */}
+        <Suspense fallback={null}>
+          <KeyboardShortcutsHelp />
+        </Suspense>
       </div>
     </>
   );

--- a/src/renderer/components/KeyboardShortcutsHelp.tsx
+++ b/src/renderer/components/KeyboardShortcutsHelp.tsx
@@ -45,9 +45,17 @@ export const KeyboardShortcutsHelp: React.FC = () => {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === '?' && !e.ctrlKey && !e.metaKey) {
+      // Ne pas intercepter « ? » pendant une saisie texte
+      const target = e.target as HTMLElement | null;
+      const isTyping =
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable);
+      if (e.key === '?' && !e.ctrlKey && !e.metaKey && !isTyping) {
         e.preventDefault();
-        setIsOpen(true);
+        setIsOpen(prev => !prev);
       }
       if (e.key === 'Escape') {
         setIsOpen(false);


### PR DESCRIPTION
## Contexte
Le composant `KeyboardShortcutsHelp` (overlay listant les raccourcis, déclenché par `?`) existait et était entièrement traduit, mais n'était **monté nulle part** — donc inaccessible.

## Changement
- Montage de `KeyboardShortcutsHelp` dans `App.tsx` (lazy + `Suspense`), rendu en permanence (le composant gère lui-même son ouverture via `?` et sa fermeture via `Échap`).
- Durcissement du listener : `?` n'ouvre plus l'aide pendant une saisie (`INPUT`/`TEXTAREA`/`SELECT`/contentEditable) ; `?` bascule désormais l'overlay (toggle).

## Vérification
- `tsc --noEmit` ✅.
- Clés i18n `shortcuts.*` déjà présentes (fr/en/de).

🤖 Généré avec Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFNATiSbd3G1nKdWuU7TA2)_