### PR TITLE
perf(bracket): bucketiser les matchs par tour dans propagateWinners

### DIFF
--- a/src/renderer/components/tableau/tableauTypes.ts
+++ b/src/renderer/components/tableau/tableauTypes.ts
@@ -40,12 +40,23 @@ export interface ConsolationBracket {
 }
 
 export function propagateWinners(matchList: TableauMatch[], size: number): void {
+  // Regroupe les matchs par tour une seule fois (O(n)) au lieu de filtrer à chaque
+  // itération (O(tours·n)). L'ordre d'insertion est préservé, donc l'appariement
+  // par index reste identique au comportement précédent.
+  const byRound = new Map<number, TableauMatch[]>();
+  for (const m of matchList) {
+    const bucket = byRound.get(m.round);
+    if (bucket) bucket.push(m);
+    else byRound.set(m.round, [m]);
+  }
+  const emptyRound: TableauMatch[] = [];
+
   let currentRound = size;
 
   while (currentRound > 2) {
     const nextRound = currentRound / 2;
-    const currentMatches = matchList.filter(m => m.round === currentRound);
-    const nextMatches = matchList.filter(m => m.round === nextRound);
+    const currentMatches = byRound.get(currentRound) ?? emptyRound;
+    const nextMatches = byRound.get(nextRound) ?? emptyRound;
 
     currentMatches.forEach((match, idx) => {
       if (match.winner) {
@@ -95,7 +106,7 @@ export function propagateWinners(matchList: TableauMatch[], size: number): void 
 
   const thirdPlaceMatchEntry = matchList.find(m => m.round === 3);
   if (thirdPlaceMatchEntry && size >= 4) {
-    const semiFinalMatches = matchList.filter(m => m.round === 4);
+    const semiFinalMatches = byRound.get(4) ?? emptyRound;
 
     if (semiFinalMatches.length === 2) {
       const losers: Fencer[] = [];


### PR DESCRIPTION
## Contexte
`propagateWinners()` (propagation des vainqueurs dans le tableau d'élimination directe) est appelée à chaque saisie de résultat. Elle refiltrait `matchList` deux fois par tour (`O(tours·n)` + allocations de tableaux à répétition).

## Changement
- Regroupement des matchs par tour **une seule fois** dans une `Map<round, matches[]>` (`O(n)`), réutilisée dans la boucle et pour le match de 3ᵉ place.
- L'ordre d'insertion est préservé par le regroupement → l'appariement par index (`idx/2`, `nextIdx*2`) reste **strictement identique**. Aucun changement de comportement.

## Impact
Sur un tableau de 128 (255 matchs), on passe de ~14 `filter()` full-scan à un seul passage `O(n)`. Gain le plus net sur les gros tableaux, propagation déclenchée à chaque score.

## Vérification
- `tsc --noEmit` ✅
- Tests unitaires non exécutés ici (`node_modules` absent de cet environnement) — refactor mécanique sans changement de logique.

🤖 Généré avec Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFNATiSbd3G1nKdWuU7TA2)_