### PR TITLE
ci: aligner toutes les actions sur checkout@v6 (fix build failures)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/track-downloads.yml
+++ b/.github/workflows/track-downloads.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "baseUrl": ".",


### PR DESCRIPTION
## Cause

Le commit [325049a](https://github.com/klinnex/bellepoule-modern/commit/325049acd3d7e53c81418492bc7343b0ba718bfa) (15 mai) avait mis à jour `build-dev.yml` et `build.yml` vers `checkout@v6` (Node.js 24 natif), mais avait **oublié** les trois autres workflows qui restaient sur des versions plus anciennes :

| Fichier | Avant | Après |
|---|---|---|
| `claude-code-review.yml` | `checkout@v5` (Node.js 20 déprécié) | `checkout@v6` |
| `claude.yml` | `checkout@v5` (Node.js 20 déprécié) | `checkout@v6` |
| `track-downloads.yml` | `checkout@v4` (Node.js 16 déprécié) | `checkout@v6` |
| `tsconfig.json` | `ignoreDeprecations: "5.0"` | `"6.0"` (TS 6.x) |

## Impact

- `claude-code-review.yml` échouait sur chaque PR ouverte
- `claude.yml` échouait sur chaque mention `@claude`
- `track-downloads.yml` échouait au cron quotidien (et déclenchait un build main en échec)

https://claude.ai/code/session_015Pomfa8yWyXYs1oJ5heSUW

---
_Generated by [Claude Code](https://claude.ai/code/session_015Pomfa8yWyXYs1oJ5heSUW)_