### PR TITLE
fix: issues 628-633 — 6 bugs/features poule, arbitre, tableau

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2196,6 +2196,8 @@ export class RemoteScoreServer {
   private arenaSuddenDeath: Map<string, boolean> = new Map();
   private arenaOvertimeType: Map<string, string | null> = new Map();
   private arenaWaitingOvertime: Map<string, boolean> = new Map();
+  // Vrai quand l'arbitre a explicitement sélectionné le match depuis sa tablette
+  private arenaRefereeSelected: Map<string, boolean> = new Map();
   // Debounce par socket pour update_score : clé = socketId:arenaId, valeur = timestamp dernier envoi
   private scoreUpdateDebounce: Map<string, number> = new Map();
   private readonly SCORE_UPDATE_DEBOUNCE_MS = 200;
@@ -2240,7 +2242,7 @@ export class RemoteScoreServer {
 
     switch (data.action) {
       case 'select_match':
-        // Sélection d'un match par l'arbitre
+        // Sélection d'un match par l'arbitre (depuis sa tablette)
         if (data.match) {
           const m = data.match;
           this.assignMatchToArena(data.arenaId, {
@@ -2253,7 +2255,7 @@ export class RemoteScoreServer {
               typeof (m.scoreB as unknown) === 'object'
                 ? ((m.scoreB as unknown as { value?: number })?.value ?? 0)
                 : (m.scoreB ?? 0),
-          });
+          }, true);
           this.arenaCards.set(data.arenaId, { cardsA: [], cardsB: [] });
           this.arenaTouches.set(data.arenaId, { touchesA: [], touchesB: [] });
           this.arenaExits.set(data.arenaId, []);
@@ -2768,15 +2770,18 @@ export class RemoteScoreServer {
     });
   }
 
-  public assignMatchToArena(arenaId: string, match: ArenaMatch): void {
+  public assignMatchToArena(arenaId: string, match: ArenaMatch, fromReferee = false): void {
     console.log(
-      `[RemoteScoreServer] assignMatchToArena called: arenaId=${arenaId}, matchId=${match.id}`
+      `[RemoteScoreServer] assignMatchToArena called: arenaId=${arenaId}, matchId=${match.id}, fromReferee=${fromReferee}`
     );
     const arena = this.arenas.get(arenaId);
     if (!arena) {
       console.error(`[RemoteScoreServer] ERREUR: Arène ${arenaId} n'existe pas!`);
       return;
     }
+
+    // Mettre à jour le flag de sélection arbitre avant le broadcast
+    this.arenaRefereeSelected.set(arenaId, fromReferee);
 
     arena.currentMatch = match;
     arena.status = 'ready';
@@ -3025,6 +3030,9 @@ export class RemoteScoreServer {
     if (!arena || !arena.currentMatch) return;
     // Éviter le double-déclenchement (REST + Socket.IO)
     if (arena.status === 'finished') return;
+
+    // Réinitialiser le flag de sélection arbitre (match terminé)
+    this.arenaRefereeSelected.set(arenaId, false);
 
     const finishedMatch = { ...arena.currentMatch };
 
@@ -3513,6 +3521,7 @@ export class RemoteScoreServer {
       refereeFeatureEnabled: this.sessionRefereeFeatureEnabled,
       referees: this.session?.referees ?? [],
       timerDuration: isPoolMatch ? this.sessionPoolTimerSeconds : this.sessionTableTimerSeconds,
+      refereeSelected: this.arenaRefereeSelected.get(arenaId) ?? false,
     };
 
     // Stocker dans le buffer de replay (TTL + max size)

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -1027,7 +1027,7 @@
             this.updateStatusBadge();
           }
 
-          if (data.match) {
+          if (data.match && (data.refereeSelected || data.status === 'in_progress' || data.status === 'finished')) {
             this.currentMatch = data.match;
             this.updateMatchDisplay();
             if (this.matchStatus === 'ready' && this.showPhotos) {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1122,6 +1122,13 @@
     <div class="main-container">
       <!-- Match actif -->
       <div class="active-match" id="active-match">
+        <div style="display:flex;justify-content:flex-end;margin-bottom:0.5rem;">
+          <button
+            onclick="window.location.reload()"
+            style="background:rgba(0,0,0,0.12);border:none;border-radius:0.5rem;color:#374151;padding:0.35rem 0.85rem;font-size:0.85rem;cursor:pointer;"
+            title="Retour à la liste des matchs"
+          >← Retour</button>
+        </div>
         <div class="fencers-container">
           <!-- Tireur A (Rouge) -->
           <div class="fencer-box red-side" id="fencer-a-box">
@@ -3295,9 +3302,9 @@
           };
           container.innerHTML = matches
             .map(match => {
-              const poolNum = match.poolId ? match.poolId.replace(/\D/g, '') || '?' : '';
-              const poolLabel = match.poolId
-                ? `<span style="opacity:0.5;font-size:0.72rem;">Poule ${escHtml(poolNum)}</span>`
+              const poolNum = match.poolNumber ?? (match.poolId ? match.poolId.replace(/\D/g, '') || '?' : '');
+              const poolLabel = (match.poolNumber !== undefined || match.poolId)
+                ? `<span style="opacity:0.5;font-size:0.72rem;">Poule ${escHtml(String(poolNum))}</span>`
                 : '';
               const safeId = escHtml(match.id);
               const clubLine =

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -219,7 +219,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     }
     if (fingerprint === sessionMatchesFingerprintRef.current) return;
     sessionMatchesFingerprintRef.current = fingerprint;
-    const poolsData = pools.map(pool => ({ poolId: pool.id, matches: pool.matches ?? [] }));
+    const poolsData = pools.map(pool => ({
+      poolId: pool.id,
+      matches: (pool.matches ?? []).map((m: any) => ({ ...m, poolNumber: pool.number })),
+    }));
     window.electronAPI.remote.syncPoolMatches(competition.id, poolsData).catch((err: unknown) => {
       logger.warn(
         LogCategory.NETWORK,

--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -62,27 +62,30 @@ const MatchCard: React.FC<MatchCardProps> = ({
       style={posStyle}
       onClick={() => canEdit && onMatchClick && onMatchClick(match)}
     >
-      {/* Arena badge */}
-      {canEdit && !isMatchComplete && onArenaClick && (
-        <button
-          className={`match-arena-btn ${match.arena ? 'match-arena-btn-active' : ''}`}
-          onClick={handleArenaClick}
-          title={match.arena ? `Piste ${match.arena}` : 'Assigner une piste'}
-        >
-          {match.arena ? `P${match.arena}` : '+P'}
-        </button>
-      )}
-
-      {/* Referee badge */}
-      {canEdit && !isMatchComplete && onRefereeClick && (
-        <button
-          className={`match-arena-btn ${match.referee ? 'match-arena-btn-active' : ''}`}
-          onClick={handleRefereeClick}
-          title={match.referee ? `Arbitre : ${match.referee.lastName} ${match.referee.firstName}` : 'Assigner un arbitre'}
-          style={{ marginLeft: onArenaClick ? '0.25rem' : undefined }}
-        >
-          {match.referee ? `A:${match.referee.lastName.charAt(0)}${match.referee.firstName.charAt(0)}` : '+A'}
-        </button>
+      {/* Arena + Referee badges */}
+      {canEdit && !isMatchComplete && (onArenaClick || onRefereeClick) && (
+        <div style={{ position: 'absolute', top: '4px', right: '4px', display: 'flex', gap: '0.2rem' }}>
+          {onArenaClick && (
+            <button
+              className={`match-arena-btn ${match.arena ? 'match-arena-btn-active' : ''}`}
+              style={{ position: 'static' }}
+              onClick={handleArenaClick}
+              title={match.arena ? `Piste ${match.arena}` : 'Assigner une piste'}
+            >
+              {match.arena ? `P${match.arena}` : '+P'}
+            </button>
+          )}
+          {onRefereeClick && (
+            <button
+              className={`match-arena-btn ${match.referee ? 'match-arena-btn-active' : ''}`}
+              style={{ position: 'static' }}
+              onClick={handleRefereeClick}
+              title={match.referee ? `Arbitre : ${match.referee.lastName} ${match.referee.firstName}` : 'Assigner un arbitre'}
+            >
+              {match.referee ? `A:${match.referee.lastName.charAt(0)}${match.referee.firstName.charAt(0)}` : '+A'}
+            </button>
+          )}
+        </div>
       )}
 
       {/* Fencer A */}

--- a/src/renderer/components/tableau/TableauScoreModal.tsx
+++ b/src/renderer/components/tableau/TableauScoreModal.tsx
@@ -6,7 +6,6 @@
 
 import React, { useState } from 'react';
 import { TableauMatch } from './tableauTypes';
-import NumericKeypad from '../common/NumericKeypad';
 
 interface TableauScoreModalProps {
   match: TableauMatch;
@@ -55,8 +54,6 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
   const [pendingStatus, setPendingStatus] = useState<
     'abandon' | 'forfait' | 'exclusion' | null
   >(null);
-  // Champ ciblé par le pavé numérique tactile (saisie sur tablette)
-  const [keypadField, setKeypadField] = useState<'A' | 'B'>('A');
 
   const fencerName = (f: TableauMatch['fencerA']) =>
     f ? `${f.lastName} ${f.firstName}`.trim() : '';
@@ -125,7 +122,6 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
               }}
               value={editScoreA}
               onChange={e => setEditScoreA(e.target.value)}
-              onFocus={() => setKeypadField('A')}
               min="0"
               max={isUnlimitedScore ? undefined : maxScore}
               autoFocus
@@ -171,7 +167,6 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
               }}
               value={editScoreB}
               onChange={e => setEditScoreB(e.target.value)}
-              onFocus={() => setKeypadField('B')}
               min="0"
               max={isUnlimitedScore ? undefined : maxScore}
               onKeyDown={e => {
@@ -221,27 +216,6 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
               💡 Score maximum : {maxScore} touches
             </p>
           )}
-
-          {/* Pavé numérique tactile (tablette) — cible le champ actif */}
-          <div style={{ maxWidth: '280px', margin: '0 auto 1rem' }}>
-            <div
-              style={{
-                textAlign: 'center',
-                fontSize: '0.8rem',
-                color: '#6b7280',
-                marginBottom: '0.5rem',
-              }}
-            >
-              Saisie tactile → tireur {keypadField === 'A' ? 'A' : 'B'}
-            </div>
-            <NumericKeypad
-              value={keypadField === 'A' ? editScoreA : editScoreB}
-              onChange={v => (keypadField === 'A' ? setEditScoreA(v) : setEditScoreB(v))}
-              maxValue={isUnlimitedScore ? undefined : maxScore}
-              maxDigits={3}
-              onConfirm={onSubmit}
-            />
-          </div>
 
           {/* Boutons spéciaux sur une ligne */}
           {!pendingStatus ? (

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -179,7 +179,8 @@ export const usePoolManagement = ({
         match.status = MatchStatus.FINISHED;
         match.updatedAt = new Date();
 
-        // Mettre à jour le pool
+        // Mettre à jour le pool (nouveau tableau pour invalider le useMemo)
+        pool.matches = [...pool.matches];
         pool.matches[matchIndex] = match;
         pool.updatedAt = new Date();
 

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -166,6 +166,7 @@ export interface ArenaUpdate {
   timerDuration?: number; // durée du chrono en secondes pour ce match
   poolComplete?: boolean; // vrai quand tous les matchs de la poule sont terminés
   completedPoolId?: string; // id de la poule terminée
+  refereeSelected?: boolean; // vrai quand l'arbitre a explicitement sélectionné le match
 }
 
 export interface RefereeControl {


### PR DESCRIPTION
$(cat <<'EOF'
## Issues traitées

### #628 — Scores poule n'apparaissent pas sans changer d'onglet
`usePoolManagement.ts` → `updateScore` mutait `pool.matches[i]` en place sans créer un nouveau tableau, donc `useMemo([pool.matches])` dans `PoolScoreMatrix` ne se recalculait pas. Fix : `pool.matches = [...pool.matches]` avant l'assignation (même pattern que `cancelMatch`).

### #629 — Numéros de poule n-1 dans l'affichage arbitre
`match.poolId` est un UUID ; le regex `/\D/g` extrait des chiffres aléatoires. Fix : enrichir chaque match avec `poolNumber: pool.number` dans `RemoteScoreManager.syncPoolMatches`, et utiliser `match.poolNumber` dans `referee.html → renderNextMatchesList`.

### #630 — Bouton Retour sur un match sélectionné
Ajout d'un bouton `← Retour` en haut du panneau `.active-match` dans `referee.html` ; `onclick="window.location.reload()"` (comportement F5 demandé).

### #631 — Bouton piste tableau disparu depuis l'ajout des arbitres
Les deux boutons `+P` et `+A` utilisaient `.match-arena-btn` (`position:absolute; top:4px; right:4px`) et se superposaient. Fix : wrapper dans un `div` flex absolu positionné `top:4px right:4px`; les boutons passent en `position:static`.

### #632 — Saisie score tableau différente des poules
`TableauScoreModal` avait un `NumericKeypad` tactile absent des poules. Suppression du pavé virtuel — les deux modales utilisent maintenant les mêmes `<input type="number">` natifs (supportent clavier, numpad, spinner +/-).

### #633 — Vue publique affiche le match dès l'attribution de piste
Ajout de `arenaRefereeSelected: Map<string, boolean>` dans `remoteScoreServer`. Ce flag est `true` uniquement quand l'arbitre sélectionne explicitement le match via `arena_control: select_match` (tablette). La vue `public.html` n'affiche les détails du match que si `refereeSelected === true || status === 'in_progress' || status === 'finished'`.

## Fichiers modifiés
- `src/renderer/hooks/usePoolManagement.ts`
- `src/renderer/components/RemoteScoreManager.tsx`
- `src/remote/referee.html`
- `src/renderer/components/tableau/MatchCard.tsx`
- `src/renderer/components/tableau/TableauScoreModal.tsx`
- `src/shared/types/remote.ts`
- `src/main/remoteScoreServer.ts`
- `src/remote/public.html`

https://claude.ai/code/session_01TLVArgmtNdt86bk2mPYz34
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLVArgmtNdt86bk2mPYz34)_