### PR TITLE
feat: vibrations haptiques complètes sur interface arbitre distant

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2328,6 +2328,7 @@
         callDT() {
           const btn = document.getElementById('btn-dt-icon');
           if (!btn || btn.classList.contains('dt-active') || btn.classList.contains('dt-ack')) return;
+          if (navigator.vibrate) navigator.vibrate([50, 30, 50]);
           btn.classList.add('dt-active');
           this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'dt_call' });
           this.showNotification(window.T('referee.dt_called'));
@@ -2349,6 +2350,7 @@
 
         undoLastAction() {
           if (this.actionHistory.length === 0) return;
+          if (navigator.vibrate) navigator.vibrate([40, 30, 40]);
           const prev = this.actionHistory.pop();
           this.scoreA = prev.scoreA;
           this.scoreB = prev.scoreB;
@@ -2410,6 +2412,7 @@
           if (this.matchStatus === 'finished') return;
 
           this.pushHistory('arena_exit');
+          if (navigator.vibrate) navigator.vibrate([80, 40, 80]);
           const ef = this._effectiveFencer(fencer);
           const points = 3;
           if (ef === 'A') {
@@ -2448,6 +2451,7 @@
           if (this.matchStatus === 'not_started') return;
           if (this.matchStatus === 'finished') return;
 
+          if (navigator.vibrate) navigator.vibrate(30);
           const ef = this._effectiveFencer(fencer);
           const zone = points === 1 ? 'A' : points === 3 ? 'B' : 'C';
           if (ef === 'A') {
@@ -2496,6 +2500,7 @@
             return;
           }
 
+          if (navigator.vibrate) navigator.vibrate(30);
           const lastCard = cards.pop();
 
           // Restituer les points accordés à l'adversaire
@@ -2631,6 +2636,7 @@
 
               if (this.timerSeconds === 0) {
                 this.stopTimer();
+                if (navigator.vibrate) navigator.vibrate([300, 100, 300]);
                 if (this.scoreA === this.scoreB &&
                     (!this.isSuddenDeath || this.overtimeType === 'challenger')) {
                   // Égalité : attente manuelle de l'arbitre pour lancer les 30s
@@ -2897,6 +2903,7 @@
         startMatch() {
           if (!this.currentMatch) return;
 
+          if (navigator.vibrate) navigator.vibrate([30, 20, 30, 20, 80]);
           this.matchStatus = 'in_progress';
           this.startTimer();
           this.updateScores();
@@ -3058,10 +3065,12 @@
 
           if (this.timerRunning) {
             this.pauseTimer();
+            if (navigator.vibrate) navigator.vibrate(30);
             this.updateControlButtons();
             this.showNotification(window.T('referee.match_paused'));
           } else {
             this.startTimer();
+            if (navigator.vibrate) navigator.vibrate(30);
             this.updateControlButtons();
             this.showNotification(window.T('referee.match_resumed'));
           }


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Ajout des retours vibratoires manquants sur `referee.html`
- Démarrage match : `[30,20,30,20,80]`
- Pause / reprise chrono : `30ms`
- Fin du temps : `[300,100,300]`
- Undo (action globale) : `[40,30,40]`
- Retrait de touche (appui long score) : `30ms`
- Retrait de carton (appui long carton) : `30ms`
- Appel DT : `[50,30,50]`
- Sortie d'arène (+3 pts) : `[80,40,80]`

Vibrations déjà présentes conservées : score (+1/+3/+5), cartes (blanc/jaune/rouge), mort subite challenger, temps supplémentaire, modal fin de match.

## Plan de test

- [ ] Ouvrir interface arbitre sur tablette Android (Chrome)
- [ ] Vérifier vibration au démarrage match
- [ ] Vérifier vibration pause/reprise chrono
- [ ] Laisser le temps s'écouler → vibration fin de temps
- [ ] Appui court score → vibration proportionnelle aux points
- [ ] Appui long score → vibration courte retrait
- [ ] Appui court carton → vibration selon couleur
- [ ] Appui long carton → vibration courte retrait
- [ ] Bouton DT → double vibration
- [ ] Bouton sortie arène → double vibration
- [ ] Bouton undo → double vibration
- [ ] Mort subite 10-10 (Laser Sabre) → vibration longue
- [ ] Fin 30s supplémentaires → vibration longue

https://claude.ai/code/session_01XUeLLVqGerfuQopEgswTBv
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUeLLVqGerfuQopEgswTBv)_