### PR TITLE
fix: corriger ignoreDeprecations TS invalide (6.0 → 5.0)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "baseUrl": ".",


### PR DESCRIPTION
## Résumé

- `tsconfig.json` avait `"ignoreDeprecations": "6.0"` — valeur rejetée par TypeScript 5.x
- Erreur `TS5103: Invalid value for '--ignoreDeprecations'` bloquait le build CI depuis 3 runs
- Corrigé en `"5.0"` (seule valeur valide pour TS 5.x)
- Build vérifié localement : `webpack compiled successfully`

## Plan de test

- [ ] Merger vers `dev` et vérifier que le workflow `build-dev.yml` passe

https://claude.ai/code/session_013yfi16LTme6EC2PWdWgaVz

---
_Generated by [Claude Code](https://claude.ai/code/session_013yfi16LTme6EC2PWdWgaVz)_