### PR TITLE
feat: inversion affichage public indépendante

### DIFF
--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -895,7 +895,11 @@
           const checkbox = document.getElementById('inversion-checkbox');
           checkbox.checked = this.inversionEnabled;
           checkbox.addEventListener('change', () => {
-            this.socket.emit('arena_control', { arenaId: this.arenaId, action: 'toggle_swap' });
+            this.inversionEnabled = checkbox.checked;
+            localStorage.setItem('publicInversionEnabled', this.inversionEnabled);
+            this.applyInversionColors();
+            if (this.currentMatch) this.updateMatchDisplay();
+            this.updateCardsDisplay();
           });
         }
 
@@ -1013,14 +1017,7 @@
             this.showPhotos = data.showPhotos;
           }
 
-          // Mise à jour état d'inversion (synchronisé avec le serveur)
-          if (data.swapped !== undefined) {
-            this.inversionEnabled = data.swapped;
-            const cb = document.getElementById('inversion-checkbox');
-            if (cb) cb.checked = data.swapped;
-            localStorage.setItem('publicInversionEnabled', data.swapped);
-            this.applyInversionColors();
-          }
+          // L'inversion public est locale — on ignore data.swapped
 
           if (data.status) {
             this.matchStatus = data.status;


### PR DESCRIPTION
## Résumé

- Le toggle d'inversion sur `public.html` ne propage plus `toggle_swap` au serveur (n'affecte plus l'arène ni l'arbitre)
- `data.swapped` reçu du serveur n'écrase plus l'état local de l'affichage public
- L'inversion est purement locale : stockée en `localStorage` (`publicInversionEnabled`), appliquée uniquement sur l'écran public

## Comportement

Avant : inverser le public inversait aussi l'arène et l'arbitre (et vice versa).  
Après : chaque écran a son inversion indépendante — l'écran public peut être placé n'importe où dans la salle sans perturber les autres affichages.

https://claude.ai/code/session_01Stg1fBwpdWnwjy2LJ7tQ8m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Stg1fBwpdWnwjy2LJ7tQ8m)_