### PR TITLE
feat: modes vainqueurs de poule et compétition couplée

### DIFF
--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Competition, CustomFormulaConfig, Weapon, Gender, Category, CompetitionSettings, QuestPhaseConfig } from '../../shared/types';
+import { Competition, CustomFormulaConfig, Weapon, Gender, Category, CompetitionSettings, QuestPhaseConfig, PostPoolSplitCriteria } from '../../shared/types';
 import { useTranslation } from '../hooks/useTranslation';
 import { createDefaultCustomFormula } from '../../shared/utils/tournamentTemplates';
 import { FormulaBuilder } from './formula/FormulaBuilder';
@@ -56,6 +56,12 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
     competition.settings?.refereeFeatureEnabled ?? false
   );
   const [expertMode, setExpertMode] = useState(competition.settings?.expertMode ?? false);
+  const [poolWinnersOnly, setPoolWinnersOnly] = useState(
+    competition.settings?.poolWinnersOnly ?? false
+  );
+  const [postPoolSplitCriteria, setPostPoolSplitCriteria] = useState<PostPoolSplitCriteria | ''>(
+    competition.settings?.postPoolSplitCriteria ?? ''
+  );
   const [maxRefereesPerPool, setMaxRefereesPerPool] = useState(
     competition.settings?.maxRefereesPerPool ?? 1
   );
@@ -127,6 +133,8 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
       expertMode,
       ...(expertMode ? { maxRefereesPerPool, maxRefereesPerMatch } : {}),
       ...(weapon === Weapon.CUSTOM ? { customFormula } : {}),
+      poolWinnersOnly,
+      ...(postPoolSplitCriteria ? { postPoolSplitCriteria } : { postPoolSplitCriteria: undefined }),
     };
 
     onSave({
@@ -275,9 +283,42 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                   Les perdants de chaque tour forment un tableau de classement
                 </small>
               </div>
+              <div className="form-group">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={poolWinnersOnly}
+                    onChange={e => setPoolWinnersOnly(e.target.checked)}
+                    style={{ marginRight: '0.5rem' }}
+                  />
+                  Seuls les vainqueurs de poule accèdent au tableau
+                </label>
+                <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+                  Seul le 1er de chaque poule est qualifié pour le tableau d'élimination
+                </small>
+              </div>
             </>
           )}
         </div>
+        {(!questEnabled) && (
+          <div style={{ marginTop: '1rem' }}>
+            <div className="form-group">
+              <label htmlFor="postPoolSplitCriteria">Compétition couplée (séparation après poules)</label>
+              <select
+                id="postPoolSplitCriteria"
+                className="form-input form-select"
+                value={postPoolSplitCriteria}
+                onChange={e => setPostPoolSplitCriteria(e.target.value as PostPoolSplitCriteria | '')}
+              >
+                <option value="">Aucune — compétition standard</option>
+                <option value="gender">Par genre (H/F) — poules mixtes, tableaux séparés</option>
+              </select>
+              <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+                Utile quand H et F partagent les mêmes poules faute d'effectif suffisant
+              </small>
+            </div>
+          </div>
+        )}
       </React.Fragment>
     );
   }

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
-import { Competition, Fencer, FencerStatus, Match, MatchStatus, Weapon, QuestPhaseConfig, Referee } from '../../shared/types';
+import { Competition, Fencer, FencerStatus, Match, MatchStatus, Weapon, QuestPhaseConfig, Referee, Gender } from '../../shared/types';
 import { Arena } from '../../shared/types/remote';
 import { logger, LogCategory } from '@shared/services/logger';
 import { RankingImportResult } from '../../shared/utils/fileParser';
@@ -29,6 +29,7 @@ import {
   distributeFencersToPoolsSerpentine,
   generatePoolMatchOrder,
   generateInitialRanking,
+  filterPoolWinners,
 } from '../../shared/utils/poolCalculations';
 import { QRCodeShare } from './QRCodeShare';
 import { TouchOptimizedReferee } from './TouchOptimizedReferee';
@@ -98,6 +99,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const tableMaxScore = competition.settings?.defaultTableMaxScore ?? 0;
   const isLaserSabre = competition.weapon === Weapon.LASER;
   const expertMode = competition.settings?.expertMode ?? false;
+  const poolWinnersOnly = competition.settings?.poolWinnersOnly ?? false;
+  const postPoolSplitCriteria = competition.settings?.postPoolSplitCriteria;
 
   const auditLogEnabled = localStorage.getItem('bellepoule-audit-log-enabled') === 'true';
 
@@ -150,6 +153,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
   // Flag pour indiquer que la phase de poules est sautée (0 poules configurées)
   const [skipPoolPhase, setSkipPoolPhase] = useState(false);
+
+  // Mode compétition couplée : groupe actif ('M' | 'F' | null)
+  const [activeSplitGroup, setActiveSplitGroup] = useState<string | null>(null);
+  // État des tableaux par groupe (pour conserver les matchs quand on bascule)
+  const [splitTableauStates, setSplitTableauStates] = useState<
+    Record<string, { matches: TableauMatch[]; consolation: ConsolationBracket[]; results: FinalResult[] }>
+  >({});
 
   // Hooks personnalisés
   const {
@@ -670,10 +680,25 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     setCurrentPhase('ranking');
   };
 
-  const handleGoToTableau = () => {
+  const handleGoToTableau = (splitGroup?: string) => {
     setRankingValidated(true);
     // Ne pas recalculer : overallRanking est déjà à jour
-    // (calculé à l'entrée dans handleGoToRanking, mis à jour par onRankingChange si édité manuellement)
+
+    if (splitGroup && splitGroup !== activeSplitGroup) {
+      // Sauvegarder l'état du groupe courant avant de basculer
+      if (activeSplitGroup) {
+        setSplitTableauStates(prev => ({
+          ...prev,
+          [activeSplitGroup]: { matches: tableauMatches, consolation: consolationBrackets, results: finalResults },
+        }));
+      }
+      // Charger l'état sauvegardé du nouveau groupe (ou partir de zéro)
+      const saved = splitTableauStates[splitGroup];
+      setTableauMatches(saved?.matches ?? []);
+      setConsolationBrackets(saved?.consolation ?? []);
+      setFinalResults(saved?.results ?? []);
+      setActiveSplitGroup(splitGroup);
+    }
 
     // Si le classement a changé, réinitialiser les matches du tableau
     if (rankingChanged) {
@@ -684,6 +709,27 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     }
 
     setShowThirdPlaceDialog(true);
+  };
+
+  // Basculer vers un autre groupe dans un tableau déjà ouvert
+  const handleSwitchSplitGroup = (newGroup: string) => {
+    if (newGroup === activeSplitGroup) return;
+    // Sauvegarder l'état courant
+    if (activeSplitGroup) {
+      setSplitTableauStates(prev => ({
+        ...prev,
+        [activeSplitGroup]: { matches: tableauMatches, consolation: consolationBrackets, results: finalResults },
+      }));
+    }
+    const saved = splitTableauStates[newGroup];
+    setTableauMatches(saved?.matches ?? []);
+    setConsolationBrackets(saved?.consolation ?? []);
+    setFinalResults(saved?.results ?? []);
+    setActiveSplitGroup(newGroup);
+    // Revenir au classement si le groupe choisi n'a pas de résultats
+    if (!saved?.results?.length) {
+      setCurrentPhase('tableau');
+    }
   };
 
   const handleThirdPlaceDecision = (shouldHaveThirdPlace: boolean) => {
@@ -961,6 +1007,30 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     return () => document.removeEventListener('mousedown', handler);
   }, [showActionsMenu]);
 
+  // Groupes disponibles pour la séparation (pour les onglets du tableau)
+  const splitGroups = useMemo((): string[] => {
+    if (postPoolSplitCriteria !== 'gender') return [];
+    const genders = new Set<string>();
+    for (const r of overallRanking) {
+      if ((r.fencer.gender as string) !== Gender.MIXED) genders.add(r.fencer.gender as string);
+    }
+    return Array.from(genders).sort();
+  }, [postPoolSplitCriteria, overallRanking]);
+
+  // Classement effectif pour le tableau (filtré par vainqueurs de poule et/ou groupe actif)
+  const effectiveTableauRanking = useMemo(() => {
+    let ranking = overallRanking;
+    if (poolWinnersOnly && pools.length > 0) {
+      ranking = filterPoolWinners(pools, ranking);
+    }
+    if (postPoolSplitCriteria === 'gender' && activeSplitGroup) {
+      ranking = ranking
+        .filter(r => (r.fencer.gender as string) === activeSplitGroup)
+        .map((r, i) => ({ ...r, rank: i + 1 }));
+    }
+    return ranking;
+  }, [overallRanking, pools, poolWinnersOnly, postPoolSplitCriteria, activeSplitGroup]);
+
   // Calcul progression matchs
   const matchProgress = useMemo(() => {
     if (pools.length === 0 && tableauMatches.length === 0) return null;
@@ -1206,6 +1276,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               }
             }}
             onRankingChange={ranking => setOverallRanking(ranking)}
+            poolWinnersOnly={poolWinnersOnly}
+            splitCriteria={postPoolSplitCriteria}
           />
         )}
 
@@ -1248,6 +1320,29 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
         {currentPhase === 'tableau' && (
           <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>Chargement tableau…</div>}>
+          {/* Sélecteur de groupe pour compétition couplée */}
+          {postPoolSplitCriteria && activeSplitGroup && splitGroups.length > 1 && (
+            <div style={{ display: 'flex', gap: '0.5rem', padding: '0.75rem 1rem', borderBottom: '1px solid #e5e7eb', background: '#f9fafb' }}>
+              {splitGroups.map(g => (
+                <button
+                  key={g}
+                  onClick={() => handleSwitchSplitGroup(g)}
+                  style={{
+                    padding: '0.375rem 0.875rem',
+                    borderRadius: '6px',
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontWeight: g === activeSplitGroup ? '700' : '400',
+                    background: g === activeSplitGroup ? '#2563eb' : '#e5e7eb',
+                    color: g === activeSplitGroup ? 'white' : '#374151',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  {g === Gender.MALE ? '♂ Hommes' : g === Gender.FEMALE ? '♀ Femmes' : g}
+                </button>
+              ))}
+            </div>
+          )}
           {finalResults.length > 0 && (
             <div style={{
               display: 'flex',
@@ -1285,7 +1380,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             </div>
           )}
           <TableauView
-            ranking={overallRanking}
+            ranking={effectiveTableauRanking}
             matches={tableauMatches}
             onMatchesChange={setTableauMatches}
             consolationBrackets={consolationBrackets}
@@ -1324,7 +1419,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         {currentPhase === 'results' && (
           <ResultsView
             competition={competition}
-            poolRanking={overallRanking}
+            poolRanking={effectiveTableauRanking}
             finalResults={finalResults}
             fencers={fencers}
             pools={[...poolHistory.flat(), ...pools]}

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
-import { PoolRanking, Pool, Weapon, FencerStatus } from '../../shared/types';
+import { PoolRanking, Pool, Weapon, FencerStatus, PostPoolSplitCriteria, Gender } from '../../shared/types';
 import { exportRankingToPDF } from '../../shared/utils/pdfExport';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import {
@@ -15,6 +15,8 @@ import {
   calculateOverallRanking,
   calculatePoolRanking,
   calculatePoolRankingQuest,
+  getPoolWinnerIds,
+  splitRankingByGender,
 } from '../../shared/utils/poolCalculations';
 import { useToast } from './Toast';
 import { useColumnVisibility, RANKING_COLUMNS, ColumnId } from '../hooks/useColumnVisibility';
@@ -24,12 +26,14 @@ interface PoolRankingViewProps {
   weapon?: Weapon;
   ranking?: PoolRanking[];
   isInitialRanking?: boolean;
-  onGoToTableau?: () => void;
+  onGoToTableau?: (splitGroup?: string) => void;
   onGoToResults?: () => void;
   hasDirectElimination?: boolean;
   onExport?: (format: 'csv' | 'xml' | 'pdf') => void;
   onPoolsChange?: (pools: Pool[], rankingChanged: boolean) => void;
   onRankingChange?: (ranking: PoolRanking[]) => void;
+  poolWinnersOnly?: boolean;
+  splitCriteria?: PostPoolSplitCriteria;
 }
 
 const PoolRankingView: React.FC<PoolRankingViewProps> = ({
@@ -43,6 +47,8 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   onExport,
   onPoolsChange,
   onRankingChange,
+  poolWinnersOnly = false,
+  splitCriteria,
 }) => {
   const { showToast } = useToast();
   const { isColumnVisible, toggleColumn, getVisibleColumns } = useColumnVisibility();
@@ -55,6 +61,25 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
   const [showColumnMenu, setShowColumnMenu] = useState(false);
   const columnMenuRef = useRef<HTMLDivElement>(null);
   const justSaved = useRef(false);
+  // Mode compétition couplée : onglet actif ('all' | 'M' | 'F')
+  const [splitTab, setSplitTab] = useState<'all' | string>('all');
+  const isInSplitGroupTab = splitCriteria != null && splitTab !== 'all';
+
+  // IDs des vainqueurs de poule (calculés une seule fois)
+  const poolWinnerIds = useMemo(
+    () => (poolWinnersOnly && pools.length > 0 ? getPoolWinnerIds(pools) : null),
+    [poolWinnersOnly, pools]
+  );
+
+  // Groupes disponibles pour la séparation par genre
+  const splitGroups = useMemo((): string[] => {
+    if (splitCriteria !== 'gender') return [];
+    const genders = new Set<string>();
+    for (const r of editedRanking) {
+      if (r.fencer.gender !== Gender.MIXED) genders.add(r.fencer.gender as string);
+    }
+    return Array.from(genders).sort();
+  }, [splitCriteria, editedRanking]);
 
   // Calculer le classement général selon le type d'arme
   const computedRanking = useMemo(() => {
@@ -65,6 +90,12 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
 
   // Utiliser le classement fourni par le parent s'il existe, sinon le calculé
   const overallRanking = externalRanking?.length ? externalRanking : computedRanking;
+
+  // Classement filtré pour l'onglet courant (split par genre)
+  const splitRankings = useMemo(
+    () => (splitCriteria === 'gender' ? splitRankingByGender(overallRanking) : null),
+    [splitCriteria, overallRanking]
+  );
 
   // Recalculer les classements de toutes les poules
   const handleRecalculate = useCallback(() => {
@@ -328,13 +359,15 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
           <button className="btn btn-secondary" onClick={handlePrint} title="Imprimer">
             🖨️ Imprimer
           </button>
-          <button
-            className="btn btn-secondary"
-            onClick={() => (isEditing ? saveChanges() : setIsEditing(true))}
-            title={isEditing ? 'Terminer la modification' : 'Modifier le classement'}
-          >
-            {isEditing ? '✓ Terminer' : '✏️ Modifier'}
-          </button>
+          {!isInSplitGroupTab && (
+            <button
+              className="btn btn-secondary"
+              onClick={() => (isEditing ? saveChanges() : setIsEditing(true))}
+              title={isEditing ? 'Terminer la modification' : 'Modifier le classement'}
+            >
+              {isEditing ? '✓ Terminer' : '✏️ Modifier'}
+            </button>
+          )}
           <div style={{ position: 'relative' }} ref={columnMenuRef}>
             <button
               onClick={() => setShowColumnMenu(!showColumnMenu)}
@@ -408,6 +441,29 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
         </div>
       </div>
 
+      {/* Onglets de séparation (compétition couplée) */}
+      {splitCriteria && splitGroups.length > 0 && (
+        <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+          <button
+            className={splitTab === 'all' ? 'btn btn-primary' : 'btn btn-secondary'}
+            style={{ fontSize: '0.8rem' }}
+            onClick={() => setSplitTab('all')}
+          >
+            🌐 Général
+          </button>
+          {splitGroups.map(g => (
+            <button
+              key={g}
+              className={splitTab === g ? 'btn btn-primary' : 'btn btn-secondary'}
+              style={{ fontSize: '0.8rem' }}
+              onClick={() => { if (isEditing) saveChanges(); setSplitTab(g); }}
+            >
+              {g === Gender.MALE ? '♂ Hommes' : g === Gender.FEMALE ? '♀ Femmes' : g}
+            </button>
+          ))}
+        </div>
+      )}
+
       <div className="card">
         <table className="table">
           <thead>
@@ -425,11 +481,22 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
                 <th style={{ width: '70px', color: '#7c3aed' }}>Quest</th>
               )}
               {isVisible('index') && <th style={{ width: '60px' }}>Indice</th>}
+              {poolWinnersOnly && <th style={{ width: '70px' }}>Qualif.</th>}
             </tr>
           </thead>
           <tbody>
-            {editedRanking.map((ranking, index) => (
-              <tr key={ranking.fencer.id}>
+            {(splitCriteria && splitTab !== 'all'
+              ? (splitRankings?.get(splitTab) ?? [])
+              : editedRanking
+            ).map((ranking, index) => (
+              <tr
+                key={ranking.fencer.id}
+                style={
+                  poolWinnersOnly && poolWinnerIds && !poolWinnerIds.has(ranking.fencer.id)
+                    ? { opacity: 0.45 }
+                    : undefined
+                }
+              >
                 {isVisible('rank') && (
                   <td style={{ fontWeight: '600' }}>
                     {isEditing ? (
@@ -561,6 +628,17 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
                     {formatIndex(ranking.index)}
                   </td>
                 )}
+                {poolWinnersOnly && (
+                  <td style={{ textAlign: 'center' }}>
+                    {poolWinnerIds?.has(ranking.fencer.id) ? (
+                      <span style={{ color: '#059669', fontWeight: '700', fontSize: '0.85rem' }}>
+                        ✓ Q
+                      </span>
+                    ) : (
+                      <span style={{ color: '#9ca3af', fontSize: '0.8rem' }}>—</span>
+                    )}
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>
@@ -585,9 +663,23 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
           {hasDirectElimination ? (
-            <button className="btn btn-primary" onClick={onGoToTableau}>
-              Passer au tableau →
-            </button>
+            splitCriteria && splitGroups.length > 1 ? (
+              splitGroups.map(g => (
+                <button
+                  key={g}
+                  className="btn btn-primary"
+                  onClick={() => onGoToTableau?.(g)}
+                >
+                  Tableau {g === Gender.MALE ? '♂ Hommes' : '♀ Femmes'} →
+                </button>
+              ))
+            ) : (
+              <button className="btn btn-primary" onClick={() => onGoToTableau?.()}>
+                {poolWinnersOnly
+                  ? `Tableau (${poolWinnerIds?.size ?? '?'} vainqueurs) →`
+                  : 'Passer au tableau →'}
+              </button>
+            )
           ) : (
             <button className="btn btn-primary" onClick={onGoToResults}>
               Voir les résultats →

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -399,7 +399,10 @@ export interface RankingCriterion {
   enabled: boolean;
 }
 
-export type AdvancementMode = 'all' | 'percentage' | 'fixed_count' | 'fixed_bracket';
+export type AdvancementMode = 'all' | 'percentage' | 'fixed_count' | 'fixed_bracket' | 'pool_winner';
+
+// Critère de séparation post-poules en deux tableaux distincts (compétition couplée)
+export type PostPoolSplitCriteria = 'gender';
 
 export interface AdvancementRule {
   mode: AdvancementMode;
@@ -577,6 +580,9 @@ export interface CompetitionSettings {
   expertMode?: boolean; // Mode expert : édition avancée des pistes et arbitres
   maxRefereesPerPool?: number; // Nombre max d'arbitres par poule (mode expert)
   maxRefereesPerMatch?: number; // Nombre max d'arbitres par match DE (mode expert)
+  // Modes spéciaux post-poules
+  poolWinnersOnly?: boolean; // Seuls les 1ers de chaque poule accèdent au tableau
+  postPoolSplitCriteria?: PostPoolSplitCriteria; // Séparation en deux tableaux après les poules
 }
 
 export interface Phase extends BaseEntity {

--- a/src/shared/utils/customRankingCalculator.ts
+++ b/src/shared/utils/customRankingCalculator.ts
@@ -202,6 +202,10 @@ export function resolveAdvancement(
       cutoff = sizes.filter(s => s <= target).pop() ?? 2;
       break;
     }
+    case 'pool_winner':
+      // Sans accès aux poules ici, utiliser count comme nombre de poules attendu
+      cutoff = rule.count ?? eligible.length;
+      break;
     default:
       cutoff = eligible.length;
   }
@@ -275,6 +279,8 @@ function calcAdvancingCount(
       if (nextDE?.bracketSize) return nextDE.bracketSize;
       return sizes.filter(s => s <= target).pop() ?? 2;
     }
+    case 'pool_winner':
+      return rule.count ?? eligible;
   }
 }
 

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -981,3 +981,44 @@ export function generateInitialRanking(fencers: Fencer[]): PoolRanking[] {
     questPoints: 0,
   }));
 }
+
+// ============================================================================
+// Mode vainqueurs de poule
+// ============================================================================
+
+/** Renvoie les IDs des tireurs classés 1er dans leur poule respective */
+export function getPoolWinnerIds(pools: Pool[]): Set<string> {
+  const ids = new Set<string>();
+  for (const pool of pools) {
+    const ranking = pool.ranking?.length ? pool.ranking : calculatePoolRanking(pool);
+    ranking.filter(r => r.rank === 1).forEach(r => ids.add(r.fencer.id));
+  }
+  return ids;
+}
+
+/** Filtre le classement général pour ne garder que les vainqueurs de poule */
+export function filterPoolWinners(pools: Pool[], overallRanking: PoolRanking[]): PoolRanking[] {
+  const winnerIds = getPoolWinnerIds(pools);
+  return overallRanking
+    .filter(r => winnerIds.has(r.fencer.id))
+    .map((r, i) => ({ ...r, rank: i + 1 }));
+}
+
+// ============================================================================
+// Mode compétition couplée (séparation par genre)
+// ============================================================================
+
+/** Répartit le classement général en sous-classements par genre */
+export function splitRankingByGender(overallRanking: PoolRanking[]): Map<string, PoolRanking[]> {
+  const groups = new Map<string, PoolRanking[]>();
+  for (const r of overallRanking) {
+    const key = r.fencer.gender as string;
+    const arr = groups.get(key) ?? [];
+    arr.push(r);
+    groups.set(key, arr);
+  }
+  for (const [key, rankings] of groups) {
+    groups.set(key, rankings.map((r, i) => ({ ...r, rank: i + 1 })));
+  }
+  return groups;
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Contexte

Deux nouveaux modes post-poules pour gérer des cas terrain courants :

---

## Feature 1 — Vainqueurs de poule (`poolWinnersOnly`)

**Activation** : Propriétés compétition → case "Seuls les vainqueurs de poule accèdent au tableau"

**Comportement** :
- Seul le 1er de chaque poule est qualifié pour le tableau d'élimination
- Le classement général affiche une colonne "Qualif." avec ✓ Q (vert) ou — (grisé)
- Les tireurs non-qualifiés apparaissent en transparence
- Le bouton "Passer au tableau" indique le nombre de vainqueurs

---

## Feature 2 — Compétition couplée (`postPoolSplitCriteria = 'gender'`)

**Activation** : Propriétés compétition → "Compétition couplée" → "Par genre (H/F)"

**Cas d'usage** : quand H et F partagent les mêmes poules faute d'effectif suffisant, puis ont des tableaux séparés.

**Comportement** :
- Classement post-poules affiche des onglets : 🌐 Général / ♂ Hommes / ♀ Femmes
- Deux boutons "Tableau ♂ Hommes →" et "Tableau ♀ Femmes →" séparés
- L'état de chaque tableau est conservé lors des bascules (aucune perte)
- Sélecteur de groupe ♂/♀ en haut du tableau d'élimination

---

## Fichiers modifiés

| Fichier | Rôle |
|---|---|
| `src/shared/types/index.ts` | `PostPoolSplitCriteria`, `pool_winner`, champs settings |
| `src/shared/utils/poolCalculations.ts` | `getPoolWinnerIds`, `filterPoolWinners`, `splitRankingByGender` |
| `src/shared/utils/customRankingCalculator.ts` | Cas `pool_winner` dans `resolveAdvancement` |
| `src/renderer/components/PoolRankingView.tsx` | UI onglets split + badges qualif. |
| `src/renderer/components/CompetitionView.tsx` | Logique état split, routing groupes |
| `src/renderer/components/CompetitionPropertiesModal.tsx` | Toggles dans les paramètres |

## Test plan

- [ ] Créer compétition MIXED, activer `poolWinnersOnly`, vérifier badges et filtre tableau
- [ ] Créer compétition MIXED, activer split genre, vérifier onglets H/F dans classement
- [ ] Valider poules → cliquer "Tableau ♂ Hommes →" puis "Tableau ♀ Femmes →" → vérifier deux brackets indépendants
- [ ] Basculer entre groupes dans la phase tableau → vérifier que les matchs sont préservés

https://claude.ai/code/session_01T5hVLLnKPJ458n8aq5PxJt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5hVLLnKPJ458n8aq5PxJt)_