### PR TITLE
fix: upgrade TypeScript 5.9 → 6.0.2 + ignoreDeprecations "6.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-dom": "^19.1.0",
         "socket.io": "^4.8.3",
         "sql.js": "^1.13.0",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.2",
         "uuid": "^11.1.0",
         "xml2js": "^0.6.2",
         "zustand": "^5.0.3"
@@ -13385,9 +13385,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "react-dom": "^19.1.0",
     "socket.io": "^4.8.3",
     "sql.js": "^1.13.0",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.2",
     "uuid": "^11.1.0",
     "xml2js": "^0.6.2",
     "zustand": "^5.0.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "baseUrl": ".",


### PR DESCRIPTION
## Problème

TypeScript 6.0 a transformé les options `moduleResolution: "node"` et `baseUrl` en **erreurs hard** (TS5107, TS5101) nécessitant `"ignoreDeprecations": "6.0"` pour les supprimer.

TypeScript <6.0 refuse `"6.0"` comme valeur valide pour `ignoreDeprecations` (seul `"5.0"` est accepté). La mise à jour simultanée du compilateur et de la config est donc nécessaire.

## Changements

- `tsconfig.json` : `"ignoreDeprecations": "5.0"` → `"6.0"`
- `package.json` : `"typescript": "^5.8.3"` → `"^6.0.2"`
- `package-lock.json` : TypeScript `5.9.3` → `6.0.2` (hash npm mis à jour)

## Notes

Les options `moduleResolution: "node"` et `baseUrl` restent fonctionnelles jusqu'à TypeScript 7.0 (suppression définitive prévue). Migration complète vers `moduleResolution: "bundler"` à planifier.

https://claude.ai/code/session_01DrRPB3PRaTgP7F9UwpAWVW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrRPB3PRaTgP7F9UwpAWVW)_