### PR TITLE
fix: erreurs TS6 — pool_winner exhaustif + déclaration CSS

### DIFF
--- a/src/renderer/components/formula/AdvancementRuleEditor.tsx
+++ b/src/renderer/components/formula/AdvancementRuleEditor.tsx
@@ -25,6 +25,8 @@ function computeAdvancing(fencers: number, rule: AdvancementRule): number {
       const target = rule.count ?? fencers;
       return sizes.filter(s => s <= target).pop() ?? 2;
     }
+    case 'pool_winner':
+      return 1;
   }
 }
 
@@ -33,6 +35,7 @@ const MODE_LABELS: Record<AdvancementMode, string> = {
   percentage: 'Top %',
   fixed_count: 'Nombre fixe',
   fixed_bracket: 'Tableau suivant',
+  pool_winner: 'Vainqueur de poule',
 };
 
 const AdvancementRuleEditor_: React.FC<Props> = ({
@@ -49,6 +52,7 @@ const AdvancementRuleEditor_: React.FC<Props> = ({
       percentage: { percentage: 80 },
       fixed_count: { count: 16 },
       fixed_bracket: { count: 16 },
+      pool_winner: {},
     };
     onChange({ mode, ...defaults[mode] });
   };

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -11,4 +11,6 @@ declare global {
   }
 }
 
+declare module '*.css' {}
+
 export {};


### PR DESCRIPTION
## Erreurs révélées par le build CI après upgrade TypeScript 6.0

### AdvancementRuleEditor.tsx (TS2741, TS2366)
`pool_winner` ajouté à `AdvancementMode` dans PR #639 mais pas propagé dans ce composant :
- `computeAdvancing` : cas `pool_winner` manquant (return 1)
- `MODE_LABELS` : label `'Vainqueur de poule'` ajouté
- `defaults` : entrée `pool_winner: {}` ajoutée

### types.d.ts (TS2882)
TypeScript 6.0 exige une déclaration de module pour les imports CSS side-effect :
- Ajout de `declare module '*.css' {}`

https://claude.ai/code/session_01DrRPB3PRaTgP7F9UwpAWVW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrRPB3PRaTgP7F9UwpAWVW)_