### PR TITLE
fix: TS2882 CSS imports — css.d.ts ambient séparé

### DIFF
--- a/src/renderer/css.d.ts
+++ b/src/renderer/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css' {}

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -11,6 +11,4 @@ declare global {
   }
 }
 
-declare module '*.css' {}
-
 export {};


### PR DESCRIPTION
## Problème

`declare module '*.css' {}` placé dans `types.d.ts` était **inopérant** : ce fichier contient des `import`/`export`, ce qui en fait un **module TypeScript**. Dans un module, `declare module '*.css'` est une augmentation de module ciblée, pas une déclaration ambiante wildcard.

Résultat : TS2882 persistait après PR #641.

## Fix

Nouveau fichier `src/renderer/css.d.ts` (script pur, sans import ni export) :
```ts
declare module '*.css' {}
```

TypeScript le ramasse automatiquement via `\"include\": [\"src/renderer/**/*\"]` dans tsconfig.json.

https://claude.ai/code/session_01DrRPB3PRaTgP7F9UwpAWVW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrRPB3PRaTgP7F9UwpAWVW)_