### PR TITLE
Perf matrice + focus-trap modals (suite perf/UX)

### DIFF
--- a/src/renderer/components/AddFencerToPoolModal.tsx
+++ b/src/renderer/components/AddFencerToPoolModal.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Fencer, Pool } from '../../shared/types';
 import { useToast } from './Toast';
 import { useDebounce } from '../hooks/useDebounce';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface AddFencerToPoolModalProps {
   pool: Pool;
@@ -25,6 +26,7 @@ const AddFencerToPoolModalComponent: React.FC<AddFencerToPoolModalProps> = ({
   onClose,
 }) => {
   const { showToast } = useToast();
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [allFencers, setAllFencers] = useState<Fencer[]>([]);
   const [allPoolFencerIds, setAllPoolFencerIds] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
@@ -89,6 +91,7 @@ const AddFencerToPoolModalComponent: React.FC<AddFencerToPoolModalProps> = ({
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         onClick={e => e.stopPropagation()}
         style={{ maxWidth: '420px' }}

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useModalResize } from '../hooks/useModalResize';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Pool, Fencer, MatchStatus, Score, Weapon, FencerStatus, Referee } from '../../shared/types';
 import { Arena } from '../../shared/types/remote';
 import { logger, LogCategory } from '@shared/services/logger';
@@ -129,6 +130,9 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         .finally(() => setIsLoadingReferees(false));
     }
   }, [competitionId]);
+
+  const closeRefereeModal = useCallback(() => setShowRefereeModal(false), []);
+  const refereeModalRef = useFocusTrap<HTMLDivElement>(showRefereeModal, closeRefereeModal);
 
   const handleAssignReferee = useCallback((referee: Referee | null) => {
     window.electronAPI.db.updatePoolReferee(pool.id, referee?.id ?? null);
@@ -1563,6 +1567,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     {showRefereeModal && (
       <div className="modal-overlay" onClick={() => setShowRefereeModal(false)}>
         <div
+          ref={refereeModalRef}
           className="modal"
           onClick={e => e.stopPropagation()}
           style={{ maxWidth: '400px' }}

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -93,12 +93,29 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
   const calculateFencerStats = (fencer: Fencer): Stats =>
     statsMap.get(fencer.id) ?? { v: 0, d: 0, td: 0, tr: 0, index: 0, ratio: 0 };
 
+  // Données par ligne précalculées : sparkline + rang. Évite un filtre O(n·m) par rendu.
+  const rowDataMap = useMemo(() => {
+    const rankById = new Map(pool.ranking?.map(r => [r.fencer.id, r]) ?? []);
+    const sparkById = new Map<string, boolean[]>();
+    for (const f of fencers) sparkById.set(f.id, []);
+    for (const m of pool.matches) {
+      if (m.status !== MatchStatus.FINISHED) continue;
+      if (m.fencerA?.id && sparkById.has(m.fencerA.id)) {
+        sparkById.get(m.fencerA.id)!.push(!!m.scoreA?.isVictory);
+      }
+      if (m.fencerB?.id && sparkById.has(m.fencerB.id)) {
+        sparkById.get(m.fencerB.id)!.push(!!m.scoreB?.isVictory);
+      }
+    }
+    return { rankById, sparkById };
+  }, [pool.matches, pool.ranking, fencers]);
+
   return (
     <div className="pool-grid">
       <div className="pool-row">
         <div className="pool-cell pool-cell-header pool-cell-name"></div>
-        {fencers.map((_, i) => (
-          <div key={i} className="pool-cell pool-cell-header">
+        {fencers.map((f, i) => (
+          <div key={f.id} className="pool-cell pool-cell-header">
             {i + 1}
           </div>
         ))}
@@ -197,7 +214,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
 
       {fencers.map((rowFencer, rowIndex) => {
         const stats = calculateFencerStats(rowFencer);
-        const rankEntry = pool.ranking?.find(r => r.fencer.id === rowFencer.id);
+        const rankEntry = rowDataMap.rankById.get(rowFencer.id);
         const rankRatio = (rankEntry?.rank ?? fencers.length) / fencers.length;
         const rowBg =
           rankRatio <= 0.7
@@ -206,16 +223,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
               ? 'rgba(245,158,11,0.10)'
               : 'rgba(239,68,68,0.08)';
 
-        const fencerMatches = pool.matches.filter(
-          m =>
-            m.status === MatchStatus.FINISHED &&
-            (m.fencerA?.id === rowFencer.id || m.fencerB?.id === rowFencer.id)
-        );
-        const sparkBars = fencerMatches.map(m => {
-          const isA = m.fencerA?.id === rowFencer.id;
-          const won = isA ? m.scoreA?.isVictory : m.scoreB?.isVictory;
-          return won;
-        });
+        const sparkBars = rowDataMap.sparkById.get(rowFencer.id) ?? [];
 
         return (
           <div key={rowFencer.id} className="pool-row" style={{ backgroundColor: rowBg }}>
@@ -272,7 +280,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
 
             {fencers.map((colFencer, colIndex) => {
               if (rowIndex === colIndex) {
-                return <div key={colIndex} className="pool-cell pool-cell-diagonal"></div>;
+                return <div key={colFencer.id} className="pool-cell pool-cell-diagonal"></div>;
               }
 
               const rowFencerAbandoned =
@@ -287,7 +295,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
               if (rowFencerAbandoned || colFencerAbandoned) {
                 return (
                   <div
-                    key={colIndex}
+                    key={colFencer.id}
                     className="pool-cell pool-cell-forfeit"
                     style={{
                       cursor: 'not-allowed',
@@ -314,7 +322,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
 
               return (
                 <div
-                  key={colIndex}
+                  key={colFencer.id}
                   className={`pool-cell ${cellClass} ${isFlashing ? 'pool-cell-flash' : ''}`}
                   onClick={() => !isLocked && onCellClick(rowFencer, colFencer)}
                   onKeyDown={e => {

--- a/src/renderer/hooks/useFocusTrap.ts
+++ b/src/renderer/hooks/useFocusTrap.ts
@@ -1,0 +1,59 @@
+/**
+ * BellePoule Modern - useFocusTrap
+ * Piège le focus clavier dans une modal et restaure le focus à la fermeture.
+ * Ferme sur Échap via onClose.
+ * Licensed under GPL-3.0
+ */
+
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap<T extends HTMLElement>(
+  active: boolean,
+  onClose?: () => void
+) {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const container = ref.current;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    // Focus initial : élément marqué autofocus sinon premier focusable
+    const focusables = () =>
+      Array.from(container?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []).filter(
+        el => el.offsetParent !== null
+      );
+    const preferred = container?.querySelector<HTMLElement>('[autofocus], [data-autofocus]');
+    (preferred ?? focusables()[0])?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose?.();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    container?.addEventListener('keydown', handleKeyDown);
+    return () => {
+      container?.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, [active, onClose]);
+
+  return ref;
+}


### PR DESCRIPTION
Suite des améliorations perf + UX.

## Perf
- `PoolScoreMatrix` : sparklines + rangs précalculés dans un `useMemo` (`rowDataMap`) → fin du filtre O(n·m) et du `ranking.find` par ligne à chaque rendu.
- Clés React stables (`fencer.id`) à la place des index de boucle (en-têtes + cellules).

## UX / A11y
- Nouveau hook `useFocusTrap` : piège le focus clavier dans la modal, ferme sur Échap, restaure le focus à la fermeture. Focus initial sur l'élément `autoFocus`.
- Appliqué à `AddFencerToPoolModal` et à la modal d'assignation d'arbitre (`PoolView`).

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_