### PR TITLE
Focus-trap + ARIA modals, memo CommandPalette, lazy PDF, tests hooks

### DIFF
--- a/src/renderer/components/AddFencerModal.tsx
+++ b/src/renderer/components/AddFencerModal.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Fencer, Gender, FencerStatus } from '../../shared/types';
 import { useToast } from './Toast';
 import FencerPhoto from './FencerPhoto';
@@ -15,6 +16,7 @@ interface AddFencerModalProps {
 }
 
 const AddFencerModalComponent: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const { showToast } = useToast();
   const { t } = useTranslation();
   const [lastName, setLastName] = useState('');
@@ -52,7 +54,7 @@ const AddFencerModalComponent: React.FC<AddFencerModalProps> = ({ onClose, onAdd
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
+      <div ref={modalRef} className="modal" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true">
         <div className="modal-header">
           <h2 className="modal-title">{t('fencer.add')}</h2>
           <button

--- a/src/renderer/components/ChangePoolModal.tsx
+++ b/src/renderer/components/ChangePoolModal.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useRef } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Fencer, Pool, MatchStatus } from '../../shared/types';
 
 interface ChangePoolModalProps {
@@ -22,6 +23,7 @@ const ChangePoolModalComponent: React.FC<ChangePoolModalProps> = ({
   onMove,
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [selectedPoolIndex, setSelectedPoolIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const dragRef = useRef<boolean>(false);
@@ -47,7 +49,7 @@ const ChangePoolModalComponent: React.FC<ChangePoolModalProps> = ({
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '450px' }}>
+      <div ref={modalRef} className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '450px' }} role="dialog" aria-modal="true">
         <div className="modal-header">
           <h2>Changer de poule</h2>
           <button className="btn-close" onClick={onClose}>

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -37,33 +37,34 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  const staticCommands: Command[] = [
-    {
-      id: 'new-competition',
-      label: t('menu.new_competition'),
-      icon: '➕',
-      action: () => { onClose(); onNewCompetition(); },
-      keywords: ['new', 'nouveau', 'creer', 'create'],
-    },
-    {
-      id: 'settings',
-      label: t('settings.title'),
-      icon: '⚙️',
-      action: () => { onClose(); onOpenSettings(); },
-      keywords: ['settings', 'parametres', 'config', 'theme', 'langue'],
-    },
-  ];
-
-  const competitionCommands: Command[] = competitions.map(c => ({
-    id: `comp-${c.id}`,
-    label: c.title,
-    description: `${c.weapon} · ${c.category} · ${c.fencers.length} tireurs`,
-    icon: '🏆',
-    action: () => { onClose(); onSelectCompetition(c.id); },
-    keywords: [c.title.toLowerCase(), c.weapon, c.category],
-  }));
-
-  const allCommands = [...staticCommands, ...competitionCommands];
+  // Liste des commandes mémoïsée : ne se reconstruit que si les entrées changent
+  const allCommands = useMemo<Command[]>(() => {
+    const staticCommands: Command[] = [
+      {
+        id: 'new-competition',
+        label: t('menu.new_competition'),
+        icon: '➕',
+        action: () => { onClose(); onNewCompetition(); },
+        keywords: ['new', 'nouveau', 'creer', 'create'],
+      },
+      {
+        id: 'settings',
+        label: t('settings.title'),
+        icon: '⚙️',
+        action: () => { onClose(); onOpenSettings(); },
+        keywords: ['settings', 'parametres', 'config', 'theme', 'langue'],
+      },
+    ];
+    const competitionCommands: Command[] = competitions.map(c => ({
+      id: `comp-${c.id}`,
+      label: c.title,
+      description: `${c.weapon} · ${c.category} · ${c.fencers.length} tireurs`,
+      icon: '🏆',
+      action: () => { onClose(); onSelectCompetition(c.id); },
+      keywords: [c.title.toLowerCase(), c.weapon, c.category],
+    }));
+    return [...staticCommands, ...competitionCommands];
+  }, [competitions, t, onClose, onNewCompetition, onOpenSettings, onSelectCompetition]);
 
   // Mémoïsé pour éviter le recalcul à chaque changement de selectedIndex
   const filtered = useMemo(() => {
@@ -75,7 +76,6 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
         cmd.description?.toLowerCase().includes(q) ||
         cmd.keywords?.some(k => k.includes(q))
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, allCommands]);
 
   useEffect(() => {

--- a/src/renderer/components/ConfirmDialog.tsx
+++ b/src/renderer/components/ConfirmDialog.tsx
@@ -84,9 +84,16 @@ export const ConfirmProvider: React.FC<{ children: React.ReactNode }> = ({ child
           onKeyDown={handleKeyDown}
           style={{ zIndex: 11000 }}
         >
-          <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '420px' }}>
+          <div
+            className="modal"
+            onClick={e => e.stopPropagation()}
+            style={{ maxWidth: '420px' }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="confirm-dialog-title"
+          >
             <div className="modal-header">
-              <h2 className="modal-title">Confirmation</h2>
+              <h2 className="modal-title" id="confirm-dialog-title">Confirmation</h2>
             </div>
             <div className="modal-body">
               <p style={{ whiteSpace: 'pre-line', margin: 0 }}>{pending.message}</p>

--- a/src/renderer/components/EditFencerModal.tsx
+++ b/src/renderer/components/EditFencerModal.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Fencer, Gender, FencerStatus } from '../../shared/types';
 import FencerPhoto from './FencerPhoto';
 
@@ -14,6 +15,7 @@ interface EditFencerModalProps {
 }
 
 const EditFencerModal: React.FC<EditFencerModalProps> = ({ fencer, onSave, onClose }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [lastName, setLastName] = useState(fencer.lastName);
   const [firstName, setFirstName] = useState(fencer.firstName);
   const [gender, setGender] = useState<Gender>(fencer.gender);
@@ -46,7 +48,7 @@ const EditFencerModal: React.FC<EditFencerModalProps> = ({ fencer, onSave, onClo
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }}>
+      <div ref={modalRef} className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }} role="dialog" aria-modal="true">
         <div className="modal-header">
           <h2>Modifier le tireur</h2>
           <button className="btn-close" onClick={onClose}>

--- a/src/renderer/components/ImportModal.tsx
+++ b/src/renderer/components/ImportModal.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Fencer } from '../../shared/types';
 import {
   parseFFEFile,
@@ -33,6 +34,7 @@ const ImportModal: React.FC<ImportModalProps> = ({
   onImportRanking,
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [result, setResult] = useState<ImportResult | null>(null);
   const [rankingResult, setRankingResult] = useState<RankingImportResult | null>(null);
   const [selectedFencers, setSelectedFencers] = useState<Set<number>>(new Set());
@@ -98,9 +100,12 @@ const ImportModal: React.FC<ImportModalProps> = ({
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         onClick={e => e.stopPropagation()}
         style={{ maxWidth: '800px', maxHeight: '80vh', display: 'flex', flexDirection: 'column' }}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header">
           <h2>{isRankingImport ? 'Importer un classement' : 'Importer des tireurs'}</h2>

--- a/src/renderer/components/NewCompetitionModal.tsx
+++ b/src/renderer/components/NewCompetitionModal.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Competition, CustomFormulaConfig, Weapon, Gender, Category } from '../../shared/types';
 import { useTranslation } from '../hooks/useTranslation';
 import {
@@ -17,6 +18,7 @@ interface NewCompetitionModalProps {
 }
 
 const NewCompetitionModal: React.FC<NewCompetitionModalProps> = ({ onClose, onCreate }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const { t } = useTranslation();
   const [title, setTitle] = useState('');
   const [date, setDate] = useState(new Date().toISOString().split('T')[0]);
@@ -79,9 +81,12 @@ const NewCompetitionModal: React.FC<NewCompetitionModalProps> = ({ onClose, onCr
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         style={isCustom ? { maxWidth: '92vw', width: '1100px' } : undefined}
         onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header">
           <h2 className="modal-title">{t('competition.new')}</h2>

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -5,9 +5,11 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from '../hooks/useTranslation';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import type { Language } from '../contexts/TranslationContext';
 import LanguageSelector from './LanguageSelector';
-import PdfTemplateModal from './PdfTemplateModal';
+// Chargé à la demande : embarque jsPDF, lourd pour le bundle initial
+const PdfTemplateModal = React.lazy(() => import('./PdfTemplateModal'));
 import { logger, LogCategory } from '@shared/services/logger';
 
 const LOGO_STORAGE_KEY = 'bellepoule-logo';
@@ -67,6 +69,7 @@ interface SettingsModalProps {
 }
 
 const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const { t, language, theme, changeLanguage, changeTheme } = useTranslation();
   const [showPdfEditor, setShowPdfEditor] = useState(false);
   const [settings, setSettings] = useState({
@@ -218,7 +221,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
   return (
     <>
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }}>
+      <div ref={modalRef} className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }} role="dialog" aria-modal="true">
         <div className="modal-header">
           <h2 className="modal-title">{t('settings.title')}</h2>
         </div>
@@ -387,7 +390,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
         </div>
       </div>
     </div>
-    {showPdfEditor && <PdfTemplateModal onClose={() => setShowPdfEditor(false)} />}
+    {showPdfEditor && (
+      <React.Suspense fallback={null}>
+        <PdfTemplateModal onClose={() => setShowPdfEditor(false)} />
+      </React.Suspense>
+    )}
     </>
   );
 };

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -72,6 +72,9 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
       {/* Toast Container */}
       <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="false"
         style={{
           position: 'fixed',
           top: '1rem',

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -260,6 +260,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                     onFencerChangePool(rowFencer);
                   }}
                   title="Changer de poule"
+                  aria-label={`Changer ${rowFencer.lastName} de poule`}
                   style={{
                     padding: '0.125rem 0.25rem',
                     fontSize: '0.625rem',
@@ -351,6 +352,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                             onMatchReset(rowFencer, colFencer);
                           }}
                           title="Annuler ce résultat"
+                          aria-label="Annuler ce résultat"
                           className="pool-cell-reset-btn"
                           style={{
                             position: 'absolute',

--- a/src/renderer/components/tableau/TableauScoreModal.tsx
+++ b/src/renderer/components/tableau/TableauScoreModal.tsx
@@ -69,6 +69,8 @@ const TableauScoreModalComponent: React.FC<TableauScoreModalProps> = ({
           minHeight: '400px',
         }}
         onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header" style={{ cursor: 'move' }}>
           <h3 className="modal-title">{getRoundName(match.round)} - Saisie rapide</h3>

--- a/src/renderer/hooks/useDebounce.test.tsx
+++ b/src/renderer/hooks/useDebounce.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from './useDebounce';
+
+describe('useDebounce', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('retourne la valeur initiale immédiatement', () => {
+    const { result } = renderHook(() => useDebounce('a', 300));
+    expect(result.current).toBe('a');
+  });
+
+  it('ne met à jour la valeur qu’après le délai', () => {
+    const { result, rerender } = renderHook(({ v }) => useDebounce(v, 300), {
+      initialProps: { v: 'a' },
+    });
+
+    rerender({ v: 'b' });
+    expect(result.current).toBe('a'); // pas encore
+
+    act(() => vi.advanceTimersByTime(299));
+    expect(result.current).toBe('a');
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe('b');
+  });
+
+  it('réinitialise le minuteur à chaque changement rapide', () => {
+    const { result, rerender } = renderHook(({ v }) => useDebounce(v, 300), {
+      initialProps: { v: 'a' },
+    });
+
+    rerender({ v: 'b' });
+    act(() => vi.advanceTimersByTime(200));
+    rerender({ v: 'c' });
+    act(() => vi.advanceTimersByTime(200));
+    expect(result.current).toBe('a'); // toujours pas, timer relancé
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(result.current).toBe('c');
+  });
+});

--- a/src/renderer/hooks/useFocusTrap.test.tsx
+++ b/src/renderer/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { useFocusTrap } from './useFocusTrap';
+
+const Modal: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+  const ref = useFocusTrap<HTMLDivElement>(true, onClose);
+  return (
+    <div ref={ref} data-testid="modal">
+      <button>premier</button>
+      <button>dernier</button>
+    </div>
+  );
+};
+
+describe('useFocusTrap', () => {
+  it('place le focus sur le premier élément focusable', () => {
+    const { getByText } = render(<Modal onClose={() => {}} />);
+    expect(document.activeElement).toBe(getByText('premier'));
+  });
+
+  it('appelle onClose sur Échap', () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(<Modal onClose={onClose} />);
+    fireEvent.keyDown(getByTestId('modal'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('boucle du dernier au premier avec Tab', () => {
+    const { getByText, getByTestId } = render(<Modal onClose={() => {}} />);
+    const last = getByText('dernier');
+    last.focus();
+    fireEvent.keyDown(getByTestId('modal'), { key: 'Tab' });
+    expect(document.activeElement).toBe(getByText('premier'));
+  });
+});

--- a/src/renderer/hooks/useFocusTrap.ts
+++ b/src/renderer/hooks/useFocusTrap.ts
@@ -24,7 +24,7 @@ export function useFocusTrap<T extends HTMLElement>(
     // Focus initial : élément marqué autofocus sinon premier focusable
     const focusables = () =>
       Array.from(container?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []).filter(
-        el => el.offsetParent !== null
+        el => !el.hasAttribute('hidden') && el.getAttribute('aria-hidden') !== 'true'
       );
     const preferred = container?.querySelector<HTMLElement>('[autofocus], [data-autofocus]');
     (preferred ?? focusables()[0])?.focus();


### PR DESCRIPTION
Troisième lot perf + UX.

## UX / A11y
- Focus-trap (`useFocusTrap`) + `role="dialog"`/`aria-modal` sur : `EditFencerModal`, `AddFencerModal`, `NewCompetitionModal`, `ChangePoolModal`, `ImportModal`, `SettingsModal`.
- ARIA seul (ref resize/focus déjà géré) sur `TableauScoreModal` et `ConfirmDialog`.
- Hook `useFocusTrap` : filtre visibilité compatible jsdom (plus de dépendance à `offsetParent`).
- `aria-label` sur boutons emoji de la matrice (changer de poule ↔, annuler résultat ↺).
- `role="status"` + `aria-live="polite"` sur le conteneur de toasts.

## Perf
- `CommandPalette` : `allCommands` désormais mémoïsé (`useMemo`) → la liste filtrée ne se reconstruit plus à chaque frappe/navigation.
- `PdfTemplateModal` (embarque jsPDF) en `React.lazy` + `Suspense` dans `SettingsModal` → bundle initial allégé.

## Tests
- `useDebounce.test.tsx` : valeur initiale, délai, réinitialisation du minuteur.
- `useFocusTrap.test.tsx` : focus initial, fermeture Échap, bouclage Tab.

## Non inclus (gros chantiers, à discuter)
- Web Worker pour ordonnancement/ranking sur grosses compétitions.
- Extraction des inline styles massifs vers CSS.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_