### PR TITLE
Focus-trap + ARIA généralisés sur tous les modals + tests

### DIFF
--- a/src/renderer/components/AboutModal.tsx
+++ b/src/renderer/components/AboutModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import type { VersionInfo } from '../../shared/types/preload';
 
 interface Props {
@@ -206,6 +207,7 @@ const ANIM_ITER = '5';
 const ANIM_EASE = 'ease-in-out';
 
 const AboutModal: React.FC<Props> = ({ onClose }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
   const [easterActive, setEasterActive] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -241,7 +243,7 @@ const AboutModal: React.FC<Props> = ({ onClose }) => {
 
   return (
     <div style={styles.overlay} onClick={handleOverlayClick}>
-      <div style={styles.modal}>
+      <div ref={modalRef} style={styles.modal} role="dialog" aria-modal="true">
         <button style={styles.closeBtn} onClick={onClose} title="Fermer">✕</button>
 
         <div style={styles.title}>BellePoule Modern</div>

--- a/src/renderer/components/AnalyticsDashboard.tsx
+++ b/src/renderer/components/AnalyticsDashboard.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useEffect, useMemo , memo} from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Competition, Fencer, Pool, Match, MatchStatus } from '../../shared/types';
 import { FencerStatsTable } from '../../features/analytics/components/FencerStatsTable';
 
@@ -270,6 +271,7 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
   className = '',
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [activeTab, setActiveTab] = useState<'performance' | 'stats'>('performance');
   const [selectedTimeframe, setSelectedTimeframe] = useState<'live' | 'last30min' | 'all'>('live');
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -292,7 +294,7 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-    <div className={`modal modal--lg analytics-dashboard ${className}`} onClick={e => e.stopPropagation()}>
+    <div ref={modalRef} className={`modal modal--lg analytics-dashboard ${className}`} onClick={e => e.stopPropagation()} role="dialog" aria-modal="true">
       {/* Header */}
       <div className="flex justify-between items-center mb-4">
         <div>

--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Competition, CustomFormulaConfig, Weapon, Gender, Category, CompetitionSettings, QuestPhaseConfig, PostPoolSplitCriteria } from '../../shared/types';
 import { useTranslation } from '../hooks/useTranslation';
 import { createDefaultCustomFormula } from '../../shared/utils/tournamentTemplates';
@@ -20,6 +21,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
   onSave,
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const { t } = useTranslation();
   const [title, setTitle] = useState(competition.title);
   const [date, setDate] = useState(new Date(competition.date).toISOString().split('T')[0]);
@@ -326,9 +328,12 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         onClick={e => e.stopPropagation()}
         style={{ maxWidth: weapon === Weapon.CUSTOM ? '92vw' : '550px', width: weapon === Weapon.CUSTOM ? '1100px' : undefined }}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header">
           <h2>Propriétés de la compétition</h2>

--- a/src/renderer/components/FFEConnectModal.tsx
+++ b/src/renderer/components/FFEConnectModal.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Fencer } from '../../shared/types';
 import {
   FFEConnectService,
@@ -17,6 +18,7 @@ interface FFEConnectModalProps {
 }
 
 const FFEConnectModal: React.FC<FFEConnectModalProps> = ({ onImport, onClose }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [competitionCode, setCompetitionCode] = useState('');
   const [apiKey, setApiKey] = useState('');
   const [loading, setLoading] = useState(false);
@@ -81,9 +83,12 @@ const FFEConnectModal: React.FC<FFEConnectModalProps> = ({ onImport, onClose }) 
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         onClick={e => e.stopPropagation()}
         style={{ maxWidth: '860px', maxHeight: '85vh', display: 'flex', flexDirection: 'column' }}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header">
           <h2 className="modal-title">Importer depuis FFE Connect</h2>

--- a/src/renderer/components/FencerComparison.tsx
+++ b/src/renderer/components/FencerComparison.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useMemo , memo} from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Fencer, Pool } from '../../shared/types';
 import { TableauMatch } from './tableau/tableauTypes';
 import { FencerStatsCalculator } from '../../shared/utils/fencerStatsCalculator';
@@ -60,6 +61,7 @@ const FencerComparison_: React.FC<FencerComparisonProps> = ({
   tableauMatches,
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [fencer1Id, setFencer1Id] = useState<string>('');
   const [fencer2Id, setFencer2Id] = useState<string>('');
 
@@ -185,7 +187,7 @@ const FencerComparison_: React.FC<FencerComparisonProps> = ({
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal modal--lg" onClick={e => e.stopPropagation()}>
+      <div ref={modalRef} className="modal modal--lg" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true">
         <div className="modal__header">
           <h2 className="modal__title">⚔️ Comparaison Head-to-Head</h2>
           <button className="modal__close" onClick={onClose}>

--- a/src/renderer/components/HistoricalStats.tsx
+++ b/src/renderer/components/HistoricalStats.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { logger, LogCategory } from '@shared/services/logger';
 
 interface CompetitionResult {
@@ -30,6 +31,7 @@ export const HistoricalStats: React.FC<HistoricalStatsProps> = ({
   fencerName,
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [results, setResults] = useState<CompetitionResult[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -66,9 +68,12 @@ export const HistoricalStats: React.FC<HistoricalStatsProps> = ({
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         onClick={e => e.stopPropagation()}
         style={{ maxWidth: '750px', maxHeight: '85vh', display: 'flex', flexDirection: 'column' }}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header" style={{ flexShrink: 0 }}>
           <h2 style={{ margin: 0 }}>Historique — {fencerName}</h2>

--- a/src/renderer/components/LiveInterPoolRanking.tsx
+++ b/src/renderer/components/LiveInterPoolRanking.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Pool, PoolRanking, Weapon, MatchStatus } from '../../shared/types';
 import { calculateOverallRanking, calculateOverallRankingQuest } from '../../shared/utils/poolCalculations';
 import { formatRatio, formatIndex } from '../../shared/utils/poolCalculations';
@@ -26,6 +27,7 @@ export const LiveInterPoolRanking: React.FC<LiveInterPoolRankingProps> = ({
   isLaserSabre,
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [ranking, setRanking] = useState<RankedEntry[]>([]);
   const [lastUpdate, setLastUpdate] = useState(new Date());
 
@@ -66,9 +68,12 @@ export const LiveInterPoolRanking: React.FC<LiveInterPoolRankingProps> = ({
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         onClick={e => e.stopPropagation()}
         style={{ maxWidth: '900px', maxHeight: '90vh', display: 'flex', flexDirection: 'column' }}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header" style={{ flexShrink: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>

--- a/src/renderer/components/MultiStripManager.tsx
+++ b/src/renderer/components/MultiStripManager.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useMemo } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Pool, Match, MatchStatus } from '../../shared/types';
 
 interface StripState {
@@ -27,6 +28,7 @@ export const MultiStripManager: React.FC<MultiStripManagerProps> = ({
   onMatchAssigned,
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [strips, setStrips] = useState<StripState[]>(() =>
     Array.from({ length: stripCount }, (_, i) => ({
       id: i + 1,
@@ -95,9 +97,12 @@ export const MultiStripManager: React.FC<MultiStripManagerProps> = ({
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         onClick={e => e.stopPropagation()}
         style={{ maxWidth: '800px', maxHeight: '90vh', display: 'flex', flexDirection: 'column' }}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header" style={{ flexShrink: 0 }}>
           <h2 style={{ margin: 0 }}>Gestion multi-pistes ({stripCount} pistes)</h2>

--- a/src/renderer/components/PdfTemplateModal.tsx
+++ b/src/renderer/components/PdfTemplateModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useTranslation } from '../hooks/useTranslation';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import PdfTemplateEditor from './PdfTemplateEditor';
@@ -12,6 +13,7 @@ interface Props {
 const DOC_TYPES: PdfDocType[] = ['pool', 'tableau', 'ranking'];
 
 const PdfTemplateModal: React.FC<Props> = ({ onClose }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const { t } = useTranslation();
   const [activeType, setActiveType] = useState<PdfDocType>('pool');
   const { templates, setTemplate, resetTemplate } = usePdfTemplateStore();
@@ -24,9 +26,12 @@ const PdfTemplateModal: React.FC<Props> = ({ onClose }) => {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
+        ref={modalRef}
         className="modal"
         onClick={e => e.stopPropagation()}
         style={{ maxWidth: '1350px', width: '98%', maxHeight: '92vh', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        role="dialog"
+        aria-modal="true"
       >
         <div className="modal-header" style={{ flexShrink: 0 }}>
           <h2 className="modal-title">{t('pdfTemplate.modalTitle')}</h2>

--- a/src/renderer/components/QRCodeShare.tsx
+++ b/src/renderer/components/QRCodeShare.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect , memo} from 'react';
 import QRCode from 'qrcode';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { logger, LogCategory } from '@shared/services/logger';
 import { Competition } from '../../shared/types';
 
@@ -17,6 +18,7 @@ interface QRCodeShareProps {
 }
 
 const QRCodeShare_: React.FC<QRCodeShareProps> = ({ competition, onClose, mode: initialMode = 'results' }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [activeMode, setActiveMode] = useState<QRMode>(initialMode);
   const [qrCodeUrl, setQrCodeUrl] = useState<string>('');
   const [isGenerating, setIsGenerating] = useState(true);
@@ -93,7 +95,7 @@ const QRCodeShare_: React.FC<QRCodeShareProps> = ({ competition, onClose, mode: 
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal modal--md" onClick={e => e.stopPropagation()}>
+      <div ref={modalRef} className="modal modal--md" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true">
         <div className="modal__header">
           <h2 className="modal__title">📱 {cfg.title}</h2>
           <button className="modal__close" onClick={onClose}>×</button>

--- a/src/renderer/components/ReportIssueModal.tsx
+++ b/src/renderer/components/ReportIssueModal.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useToast } from './Toast';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface ReportIssueModalProps {
   onClose: () => void;
@@ -18,6 +19,7 @@ interface VersionInfo {
 }
 
 const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ onClose }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const { showToast } = useToast();
   const [issueType, setIssueType] = useState<'bug' | 'feature'>('bug');
   const [title, setTitle] = useState('');
@@ -111,7 +113,7 @@ _Issue créée automatiquement depuis BellePoule Modern_`;
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }}>
+      <div ref={modalRef} className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }} role="dialog" aria-modal="true">
         <div className="modal-header">
           <h2>📝 Signaler un bug / Suggestion</h2>
           <button className="btn-close" onClick={onClose}>

--- a/src/renderer/components/formula/FormulaTemplateModal.tsx
+++ b/src/renderer/components/formula/FormulaTemplateModal.tsx
@@ -3,6 +3,7 @@
  */
 
 import React, { useRef, useState , memo} from 'react';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { CustomFormulaConfig } from '../../../shared/types';
 import {
   deleteCustomFormulaTemplate,
@@ -25,6 +26,7 @@ const FormulaTemplateModal_: React.FC<Props> = ({
   onLoad,
   onClose,
 }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const [name, setName] = useState('');
   const [templates, setTemplates] = useState(() => getCustomFormulaTemplates());
   const [error, setError] = useState('');
@@ -79,7 +81,7 @@ const FormulaTemplateModal_: React.FC<Props> = ({
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
+      <div ref={modalRef} className="modal" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true">
         <div className="modal-header">
           <h2 className="modal-title">
             {mode === 'save' ? 'Enregistrer la formule' : 'Charger une formule'}

--- a/src/renderer/hooks/useDebounce.test.tsx
+++ b/src/renderer/hooks/useDebounce.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useDebounce } from './useDebounce';

--- a/src/renderer/hooks/useFocusTrap.test.tsx
+++ b/src/renderer/hooks/useFocusTrap.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
@@ -33,5 +34,13 @@ describe('useFocusTrap', () => {
     last.focus();
     fireEvent.keyDown(getByTestId('modal'), { key: 'Tab' });
     expect(document.activeElement).toBe(getByText('premier'));
+  });
+
+  it('boucle du premier au dernier avec Shift+Tab', () => {
+    const { getByText, getByTestId } = render(<Modal onClose={() => {}} />);
+    const first = getByText('premier');
+    first.focus();
+    fireEvent.keyDown(getByTestId('modal'), { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(getByText('dernier'));
   });
 });


### PR DESCRIPTION
Quatrième lot UX/A11y — généralisation du focus-trap.

## Focus-trap + ARIA (`role="dialog"` / `aria-modal`)
Appliqué à tous les modals restants :
`CompetitionPropertiesModal`, `FFEConnectModal`, `MultiStripManager`, `ReportIssueModal`, `FormulaTemplateModal`, `PdfTemplateModal`, `QRCodeShare`, `FencerComparison`, `HistoricalStats`, `LiveInterPoolRanking`, `AnalyticsDashboard`, `AboutModal`.

→ Échap ferme, Tab/Shift+Tab bouclent dans la modal, focus restauré à la fermeture.

## Tests
- `useFocusTrap` : ajout du cas Shift+Tab.
- Docblock `@vitest-environment jsdom` explicite sur les tests de hooks (le `environmentMatchGlobs` ne s'appliquait pas en exécution ciblée).

## Vérifs locales
- `tsc --noEmit` : OK (hors fichiers de test préexistants).
- `vitest run` sur les hooks : 7/7 verts.

## Restant (gros, à valider)
- Web Worker ordonnancement/ranking.
- Extraction inline styles → CSS.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_