### PR TITLE
Extraction des styles répétés de CompetitionPropertiesModal

### DIFF
--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -5,6 +5,10 @@
 
 import React, { useState, useEffect } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import {
+  HINT, HINT_INDENT, CHECK_LABEL, CHECK_LABEL_SM, FIELD_LABEL,
+  MR, MB1, MB15, SM, GRID2, FLEX1,
+} from './competitionPropertiesModal.styles';
 import { Competition, CustomFormulaConfig, Weapon, Gender, Category, CompetitionSettings, QuestPhaseConfig, PostPoolSplitCriteria } from '../../shared/types';
 import { useTranslation } from '../hooks/useTranslation';
 import { createDefaultCustomFormula } from '../../shared/utils/tournamentTemplates';
@@ -158,7 +162,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
     if (isCustomWeapon) return null;
     return (
       <React.Fragment>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+        <div style={GRID2}>
           {(!questEnabled || questHasPools) && (
             <div className="form-group">
               <label htmlFor="poolRounds">Tours de poules</label>
@@ -173,7 +177,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 <option value="2">2 tours</option>
                 <option value="3">3 tours</option>
               </select>
-              <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+              <small style={HINT}>
                 {questEnabled && questHasPools
                   ? '1 tour imposé avant le Tour Quest'
                   : 'Nombre de phases de poules avant le tableau'}
@@ -191,7 +195,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
               <option value="true">Activée</option>
               <option value="false">Désactivée</option>
             </select>
-            <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+            <small style={HINT}>
               {hasDirectElimination ? 'Tableau après les poules' : 'Classement final sur les poules'}
             </small>
           </div>
@@ -208,7 +212,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
               min="1"
               placeholder="21"
             />
-            <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>Touches pour gagner un match de poule</small>
+            <small style={HINT}>Touches pour gagner un match de poule</small>
           </div>
           <div className="form-group">
             <label htmlFor="poolTimerSeconds">Chrono poules (secondes)</label>
@@ -221,7 +225,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
               min="1"
               placeholder="180"
             />
-            <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+            <small style={HINT}>
               {`${Math.floor(poolTimerSeconds / 60)}min ${poolTimerSeconds % 60}s par match de poule`}
             </small>
           </div>
@@ -238,7 +242,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                   min="0"
                   placeholder="21"
                 />
-                <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+                <small style={HINT}>
                   {tableMaxScore === 0 ? '0 = illimité (pas de limite)' : `${tableMaxScore} touches pour gagner`}
                 </small>
               </div>
@@ -253,7 +257,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                   min="1"
                   placeholder="180"
                 />
-                <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+                <small style={HINT}>
                   {`${Math.floor(tableTimerSeconds / 60)}min ${tableTimerSeconds % 60}s par match tableau`}
                 </small>
               </div>
@@ -263,11 +267,11 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                     type="checkbox"
                     checked={thirdPlaceMatch}
                     onChange={e => setThirdPlaceMatch(e.target.checked)}
-                    style={{ marginRight: '0.5rem' }}
+                    style={MR}
                   />
                   {t('competition.third_place_match_label')}
                 </label>
-                <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+                <small style={HINT_INDENT}>
                   {t('competition.third_place_match_description')}
                 </small>
               </div>
@@ -277,11 +281,11 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                     type="checkbox"
                     checked={playAllPositions}
                     onChange={e => setPlayAllPositions(e.target.checked)}
-                    style={{ marginRight: '0.5rem' }}
+                    style={MR}
                   />
                   Jouer toutes les places
                 </label>
-                <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+                <small style={HINT_INDENT}>
                   Les perdants de chaque tour forment un tableau de classement
                 </small>
               </div>
@@ -291,11 +295,11 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                     type="checkbox"
                     checked={poolWinnersOnly}
                     onChange={e => setPoolWinnersOnly(e.target.checked)}
-                    style={{ marginRight: '0.5rem' }}
+                    style={MR}
                   />
                   Seuls les vainqueurs de poule accèdent au tableau
                 </label>
-                <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+                <small style={HINT_INDENT}>
                   Seul le 1er de chaque poule est qualifié pour le tableau d'élimination
                 </small>
               </div>
@@ -315,7 +319,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 <option value="">Aucune — compétition standard</option>
                 <option value="gender">Par genre (H/F) — poules mixtes, tableaux séparés</option>
               </select>
-              <small style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+              <small style={HINT}>
                 Utile quand H et F partagent les mêmes poules faute d'effectif suffisant
               </small>
             </div>
@@ -344,7 +348,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
 
         <form onSubmit={handleSubmit} className="modal-body">
           {/* Informations générales */}
-          <div style={{ marginBottom: '1.5rem' }}>
+          <div style={MB15}>
             <h3
               style={{
                 fontSize: '0.875rem',
@@ -369,7 +373,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
               />
             </div>
 
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+            <div style={GRID2}>
               <div className="form-group">
                 <label htmlFor="date">Date</label>
                 <input
@@ -407,7 +411,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
           </div>
 
           {/* Configuration */}
-          <div style={{ marginBottom: '1.5rem' }}>
+          <div style={MB15}>
             <h3
               style={{
                 fontSize: '0.875rem',
@@ -479,7 +483,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
           </div>
 
           {/* Paramètres de formule */}
-          <div style={{ marginBottom: '1rem' }}>
+          <div style={MB1}>
             <h3
               style={{
                 fontSize: '0.875rem',
@@ -506,7 +510,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
 
           {/* Tour Quest — visible uniquement pour Sabre Laser */}
           {weapon === Weapon.LASER && (
-            <div style={{ marginBottom: '1rem' }}>
+            <div style={MB1}>
               <h3
                 style={{
                   fontSize: '0.875rem',
@@ -521,11 +525,11 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
 
               {/* Oui / Non */}
               <div className="form-group" style={{ marginBottom: '0.75rem' }}>
-                <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem' }}>
+                <label style={FIELD_LABEL}>
                   Tour Quest activé ?
                 </label>
-                <div style={{ display: 'flex', gap: '1rem' }}>
-                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer', fontSize: '0.875rem' }}>
+                <div style={FLEX1}>
+                  <label style={CHECK_LABEL}>
                     <input
                       type="radio"
                       name="questEnabled"
@@ -534,7 +538,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                     />
                     Non
                   </label>
-                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer', fontSize: '0.875rem' }}>
+                  <label style={CHECK_LABEL}>
                     <input
                       type="radio"
                       name="questEnabled"
@@ -560,11 +564,11 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 >
                   {/* Sans / Avec poules préliminaires */}
                   <div className="form-group">
-                    <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem' }}>
+                    <label style={FIELD_LABEL}>
                       Poules préliminaires ?
                     </label>
-                    <div style={{ display: 'flex', gap: '1rem' }}>
-                      <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer', fontSize: '0.875rem' }}>
+                    <div style={FLEX1}>
+                      <label style={CHECK_LABEL}>
                         <input
                           type="radio"
                           name="questHasPools"
@@ -573,7 +577,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                         />
                         Sans (Quest → Tableau)
                       </label>
-                      <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer', fontSize: '0.875rem' }}>
+                      <label style={CHECK_LABEL}>
                         <input
                           type="radio"
                           name="questHasPools"
@@ -588,7 +592,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                   {/* Nombre de qualifiés */}
                   {questHasPools && (
                     <div className="form-group">
-                      <label htmlFor="questQualifiers" style={{ fontSize: '0.875rem' }}>
+                      <label htmlFor="questQualifiers" style={SM}>
                         Nombre de qualifiés des poules vers le Tour Quest
                       </label>
                       <input
@@ -616,7 +620,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
           )}
 
           {/* Gestion des arbitres */}
-          <div style={{ marginBottom: '1rem' }}>
+          <div style={MB1}>
             <h3
               style={{
                 fontSize: '0.875rem',
@@ -629,7 +633,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
               Arbitrage
             </h3>
             <div className="form-group">
-              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+              <label style={CHECK_LABEL_SM}>
                 <input
                   type="checkbox"
                   checked={refereeFeatureEnabled}
@@ -637,12 +641,12 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 />
                 Activer la gestion des arbitres
               </label>
-              <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+              <small style={HINT_INDENT}>
                 Affiche le nom de l'arbitre sur l'arène et permet de le changer depuis la saisie distante
               </small>
             </div>
             <div className="form-group" style={{ marginTop: '0.75rem' }}>
-              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+              <label style={CHECK_LABEL_SM}>
                 <input
                   type="checkbox"
                   checked={expertMode}
@@ -650,7 +654,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 />
                 Mode expert
               </label>
-              <small style={{ color: '#6b7280', fontSize: '0.75rem', marginLeft: '1.5rem' }}>
+              <small style={HINT_INDENT}>
                 Active l'édition avancée des pistes et du nombre d'arbitres par poule / match
               </small>
             </div>
@@ -668,7 +672,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 }}
               >
                 <div className="form-group">
-                  <label htmlFor="maxRefereesPerPool" style={{ fontSize: '0.875rem' }}>
+                  <label htmlFor="maxRefereesPerPool" style={SM}>
                     Arbitres max par poule
                   </label>
                   <input
@@ -682,7 +686,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                   />
                 </div>
                 <div className="form-group">
-                  <label htmlFor="maxRefereesPerMatch" style={{ fontSize: '0.875rem' }}>
+                  <label htmlFor="maxRefereesPerMatch" style={SM}>
                     Arbitres max par match (tableau)
                   </label>
                   <input

--- a/src/renderer/components/competitionPropertiesModal.styles.ts
+++ b/src/renderer/components/competitionPropertiesModal.styles.ts
@@ -1,0 +1,42 @@
+/**
+ * BellePoule Modern - Styles statiques de CompetitionPropertiesModal
+ * Constantes au niveau module (références stables) pour les styles répétés.
+ * Licensed under GPL-3.0
+ */
+
+import type { CSSProperties } from 'react';
+
+export const HINT: CSSProperties = { color: '#6b7280', fontSize: '0.75rem' };
+export const HINT_INDENT: CSSProperties = {
+  color: '#6b7280',
+  fontSize: '0.75rem',
+  marginLeft: '1.5rem',
+};
+
+export const CHECK_LABEL: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.4rem',
+  cursor: 'pointer',
+  fontSize: '0.875rem',
+};
+
+export const CHECK_LABEL_SM: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  cursor: 'pointer',
+};
+
+export const FIELD_LABEL: CSSProperties = {
+  display: 'block',
+  marginBottom: '0.4rem',
+  fontSize: '0.875rem',
+};
+
+export const MR: CSSProperties = { marginRight: '0.5rem' };
+export const MB1: CSSProperties = { marginBottom: '1rem' };
+export const MB15: CSSProperties = { marginBottom: '1.5rem' };
+export const SM: CSSProperties = { fontSize: '0.875rem' };
+export const GRID2: CSSProperties = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' };
+export const FLEX1: CSSProperties = { display: 'flex', gap: '1rem' };


### PR DESCRIPTION
Même schéma d'extraction de styles appliqué à `CompetitionPropertiesModal`.

## Changements
- Nouveau module `competitionPropertiesModal.styles.ts`.
- Déduplication : `HINT` (×7), `HINT_INDENT` (×5), `CHECK_LABEL` (×4), `MR`/`MB1`/`SM` (×3), `MB15`/`GRID2`/`FLEX1`/`CHECK_LABEL_SM`/`FIELD_LABEL` (×2).

Rendu visuel inchangé.

## Résultat
- Styles inline : **50 → 15**.
- `tsc --noEmit` : OK.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_