### PR TITLE
Lazy-load pdfExport dans PoolRankingView et ResultsView

### DIFF
--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -6,7 +6,7 @@
 
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { PoolRanking, Pool, Weapon, FencerStatus, PostPoolSplitCriteria, Gender } from '../../shared/types';
-import { exportRankingToPDF } from '../../shared/utils/pdfExport';
+// pdfExport (jsPDF) chargé à la demande pour alléger le bundle initial
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import { CENTER, W40, W50, W60, SM, FLEX_GAP } from './poolRankingView.styles';
 import {
@@ -205,6 +205,7 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     try {
       const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
       const cols = getVisibleColumns('ranking').filter(col => col !== 'quest' || isLaserSabre);
+      const { exportRankingToPDF } = await import('../../shared/utils/pdfExport');
       await exportRankingToPDF(overallRanking, 'Classement Général', weapon, cols, logo, rankingTemplate);
     } catch (e) {
       showToast((e as Error).message, 'error');

--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -9,7 +9,7 @@ import { Fencer, PoolRanking, Competition, FencerStatus } from '../../shared/typ
 import type { Pool } from '../../shared/types';
 import { useToast } from './Toast';
 import { exportResultsXMLFFE } from '../../shared/utils/multiFormatExport';
-import { exportResultsToPDF, exportFullCompetitionPDF } from '../../shared/utils/pdfExport';
+// pdfExport (jsPDF) chargé à la demande pour alléger le bundle initial
 import type { TableauMatchForPDF, FinalResultForPDF } from '../../shared/utils/pdfExport';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import type { ConsolationBracket } from './tableau/tableauTypes';
@@ -166,6 +166,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({
   const exportPDF = async () => {
     try {
       const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+      const { exportResultsToPDF } = await import('../../shared/utils/pdfExport');
       await exportResultsToPDF(
         resultsToDisplay,
         `Résultats — ${competition.title}`,
@@ -231,6 +232,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({
         }, 'poules', []);
       }
 
+      const { exportFullCompetitionPDF } = await import('../../shared/utils/pdfExport');
       await exportFullCompetitionPDF({
         fencers: effectiveFencers,
         appelVisibleColumns,


### PR DESCRIPTION
Poursuite du lazy-loading de `pdfExport` (jsPDF) — gain sur le bundle initial.

## Changements
- `PoolRankingView` : `exportRankingToPDF` chargé via `import()` dynamique dans le handler d'export.
- `ResultsView` : `exportResultsToPDF` et `exportFullCompetitionPDF` idem.

jsPDF n'est désormais téléchargé qu'au moment d'un export, comme déjà fait pour `PoolView` et `FencerList`.

## Vérifs
- `tsc --noEmit` : OK.

## Restant
- `TableauView` importe aussi `MAX_MATCHES_PER_PAGE_TABLEAU` (constante utilisée hors handler) → lazy-load partiel plus délicat, non traité ici.
- `PdfPreview` génère le HTML de façon synchrone (useMemo) → non lazy-able simplement.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_