### PR TITLE
Lazy-load pdfExport dans TableauView + extraction pdfConstants

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -11,7 +11,8 @@ import { TableauMatch, FinalResult, ConsolationBracket, propagateWinners } from 
 import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
 import Bracket from './Bracket';
-import { exportTableauToPDF, printTableauHTML, MAX_MATCHES_PER_PAGE_TABLEAU, exportBracketTreeToPDF } from '../../shared/utils/pdfExport';
+// pdfExport (jsPDF) chargé à la demande ; seule la constante reste en import statique léger
+import { MAX_MATCHES_PER_PAGE_TABLEAU } from '../../shared/utils/pdfConstants';
 import { usePdfTemplateStore } from '../../features/pdfTemplates/hooks/usePdfTemplateStore';
 import MatchCard from './tableau/MatchCard';
 import SeedingTable from './tableau/SeedingTable';
@@ -931,6 +932,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const title = `Tableau de ${tableauSize}${roundLabel ? ` — ${roundLabel}` : ''}`;
     const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
     try {
+      const { printTableauHTML, exportTableauToPDF } = await import('../../shared/utils/pdfExport');
       if (pdfMode === 'print') {
         await printTableauHTML(filteredMatches, perPage, title, logo, tableauTemplate);
       } else {
@@ -946,6 +948,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const title = `Arbre — Tableau de ${tableauSize}`;
     const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
     try {
+      const { exportBracketTreeToPDF } = await import('../../shared/utils/pdfExport');
       await exportBracketTreeToPDF(matches, title, logo, tableauTemplate);
     } catch (e) {
       showToast((e as Error).message, 'error');

--- a/src/shared/utils/pdfConstants.ts
+++ b/src/shared/utils/pdfConstants.ts
@@ -1,0 +1,9 @@
+/**
+ * BellePoule Modern - Constantes PDF légères
+ * Séparées de pdfExport (jsPDF) afin de pouvoir être importées sans embarquer
+ * la dépendance lourde jsPDF dans le bundle initial.
+ * Licensed under GPL-3.0
+ */
+
+/** Nombre maximum de matchs par page lors de l'export PDF d'un tableau. */
+export const MAX_MATCHES_PER_PAGE_TABLEAU = 5;

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -540,7 +540,8 @@ export interface TableauMatchForPDF {
   arena?: number | null;
 }
 
-export const MAX_MATCHES_PER_PAGE_TABLEAU = 5;
+export { MAX_MATCHES_PER_PAGE_TABLEAU } from './pdfConstants';
+import { MAX_MATCHES_PER_PAGE_TABLEAU } from './pdfConstants';
 
 function getTableauRoundName(round: number): string {
   const names: Record<number, string> = {


### PR DESCRIPTION
Finalisation du lazy-loading de `pdfExport` (jsPDF) côté tableau.

## Changements
- Nouveau module léger `shared/utils/pdfConstants.ts` contenant `MAX_MATCHES_PER_PAGE_TABLEAU` (sortie de `pdfExport.ts` qui embarque jsPDF).
- `pdfExport.ts` ré-exporte la constante depuis `pdfConstants` (compat préservée).
- `TableauView` : import statique réduit à la constante (module léger) ; `exportTableauToPDF`, `printTableauHTML`, `exportBracketTreeToPDF` chargés via `import()` dynamique dans leurs handlers.

→ jsPDF n'est plus dans le bundle initial de `TableauView`.

## Vérifs
- `tsc --noEmit` : OK.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_