### PR TITLE
Lazy-load de la librairie qrcode

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { useVirtualList } from '../../shared/services/performanceService';
-import QRCode from 'qrcode';
+// qrcode chargé à la demande (génération du QR uniquement à l'affichage)
 import { Fencer, FencerStatus } from '../../shared/types';
 import EditFencerModal from './EditFencerModal';
 import { useTranslation } from '../hooks/useTranslation';
@@ -124,7 +124,8 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   // Générer le QR code quand l'URL d'inscription change
   useEffect(() => {
     if (!registerUrl) { setRegisterQRDataUrl(null); return; }
-    QRCode.toDataURL(registerUrl, { width: 220, margin: 1 })
+    import('qrcode')
+      .then(m => m.default.toDataURL(registerUrl, { width: 220, margin: 1 }))
       .then(setRegisterQRDataUrl)
       .catch(() => setRegisterQRDataUrl(null));
   }, [registerUrl]);

--- a/src/renderer/components/QRCodeShare.tsx
+++ b/src/renderer/components/QRCodeShare.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect , memo} from 'react';
-import QRCode from 'qrcode';
+// qrcode chargé à la demande (génération du QR uniquement à l'affichage)
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { logger, LogCategory } from '@shared/services/logger';
 import { Competition } from '../../shared/types';
@@ -51,6 +51,7 @@ const QRCodeShare_: React.FC<QRCodeShareProps> = ({ competition, onClose, mode: 
       const url = `${info.serverInfo.url}${path}`;
       setShareUrl(url);
 
+      const QRCode = (await import('qrcode')).default;
       const dataUrl = await QRCode.toDataURL(url, { width: 300, margin: 1 });
       setQrCodeUrl(dataUrl);
     } catch (err) {

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import QRCode from 'qrcode';
+// qrcode chargé à la demande (génération du QR uniquement à l'affichage)
 import { Competition, Pool } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { TableauMatch, ConsolationBracket } from './tableau/tableauTypes';
@@ -164,7 +164,8 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       setQrDataUrl(null);
       return;
     }
-    QRCode.toDataURL(activeQR.url, { width: 220, margin: 1 })
+    import('qrcode')
+      .then(m => m.default.toDataURL(activeQR.url, { width: 220, margin: 1 }))
       .then(setQrDataUrl)
       .catch(() => setQrDataUrl(null));
   }, [activeQR]);


### PR DESCRIPTION
Lazy-loading de la librairie `qrcode` (chargée seulement quand un QR est généré).

## Changements
- `RemoteScoreManager`, `FencerList` : `import('qrcode')` dynamique dans l'effet de génération.
- `QRCodeShare` : `const QRCode = (await import('qrcode')).default;` dans le handler async.

→ `qrcode` n'est plus dans le bundle initial de ces composants.

## Vérifs
- `tsc --noEmit` : OK.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_