### PR TITLE
Tests unitaires : customTouchSystem, fencerExport, tournamentTemplates

### DIFF
--- a/src/shared/utils/customTouchSystem.test.ts
+++ b/src/shared/utils/customTouchSystem.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests unitaires - Système de touches personnalisé (arme CUSTOM)
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  calculateMatchScoreCustom,
+  isMatchCompleteCustom,
+  getDefaultZones,
+  TouchRecord,
+} from './customTouchSystem';
+import { CustomTouchZone, CustomScoringConfig } from '../types';
+
+const zones: CustomTouchZone[] = [
+  { id: 'head', label: 'Tête', points: 3, color: '#EF4444' },
+  { id: 'torso', label: 'Tronc', points: 2, color: '#F59E0B' },
+  { id: 'arm', label: 'Bras', points: 1, color: '#10B981' },
+];
+
+describe('calculateMatchScoreCustom', () => {
+  it('retourne 0-0 sans touche', () => {
+    expect(calculateMatchScoreCustom([], zones)).toEqual({ scoreA: 0, scoreB: 0 });
+  });
+
+  it('additionne les points par zone et par tireur', () => {
+    const touches: TouchRecord[] = [
+      { zoneId: 'head', fencerId: 'A' }, // +3 A
+      { zoneId: 'arm', fencerId: 'A' }, // +1 A
+      { zoneId: 'torso', fencerId: 'B' }, // +2 B
+    ];
+    expect(calculateMatchScoreCustom(touches, zones)).toEqual({ scoreA: 4, scoreB: 2 });
+  });
+
+  it('attribue 1 point par défaut pour une zone inconnue', () => {
+    const touches: TouchRecord[] = [{ zoneId: 'inconnu', fencerId: 'A' }];
+    expect(calculateMatchScoreCustom(touches, zones)).toEqual({ scoreA: 1, scoreB: 0 });
+  });
+
+  it('traite tout fencerId non-A comme B', () => {
+    const touches: TouchRecord[] = [{ zoneId: 'head', fencerId: 'B' }];
+    expect(calculateMatchScoreCustom(touches, zones)).toEqual({ scoreA: 0, scoreB: 3 });
+  });
+});
+
+describe('isMatchCompleteCustom', () => {
+  const config: CustomScoringConfig = { maxScore: 15 } as CustomScoringConfig;
+
+  it('est complet quand A atteint le maxScore', () => {
+    expect(isMatchCompleteCustom(15, 8, config)).toBe(true);
+  });
+
+  it('est complet quand B atteint le maxScore', () => {
+    expect(isMatchCompleteCustom(3, 15, config)).toBe(true);
+  });
+
+  it('n’est pas complet en dessous du maxScore', () => {
+    expect(isMatchCompleteCustom(14, 14, config)).toBe(false);
+  });
+});
+
+describe('getDefaultZones', () => {
+  it('retourne 3 zones avec des points décroissants', () => {
+    const z = getDefaultZones();
+    expect(z).toHaveLength(3);
+    expect(z.map(x => x.points)).toEqual([3, 2, 1]);
+    expect(z.every(x => x.id && x.label && x.color)).toBe(true);
+  });
+});

--- a/src/shared/utils/fencerExport.test.ts
+++ b/src/shared/utils/fencerExport.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests unitaires - Export des tireurs (TXT / FFF)
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import { exportFencersToFFF, exportFencersToTXT } from './fencerExport';
+import { Fencer, Gender, FencerStatus } from '../types';
+
+const makeFencer = (over: Partial<Fencer> = {}): Fencer => ({
+  id: '1',
+  ref: 1,
+  lastName: 'Dupont',
+  firstName: 'Jean',
+  gender: Gender.MALE,
+  nationality: 'FRA',
+  status: FencerStatus.CHECKED_IN,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...over,
+});
+
+describe('exportFencersToFFF', () => {
+  it('commence par l’en-tête FFF standard', () => {
+    const out = exportFencersToFFF([]);
+    expect(out.split('\n')[0]).toBe('FFF;WIN;competition;;individuel');
+  });
+
+  it('met le nom en majuscules et convertit le genre', () => {
+    const out = exportFencersToFFF([makeFencer({ lastName: 'Martin', gender: Gender.FEMALE })]);
+    const line = out.split('\n')[1];
+    expect(line.startsWith('MARTIN,Jean,')).toBe(true);
+    expect(line).toContain(',F,FRA');
+  });
+
+  it('formate la date de naissance en DD/MM/YYYY', () => {
+    const out = exportFencersToFFF([makeFencer({ birthDate: new Date('1990-03-05') })]);
+    expect(out.split('\n')[1]).toContain(',05/03/1990,');
+  });
+
+  it('incrémente la position pour chaque tireur', () => {
+    const out = exportFencersToFFF([
+      makeFencer({ id: '1' }),
+      makeFencer({ id: '2', lastName: 'Martin' }),
+    ]);
+    const lines = out.split('\n');
+    expect(lines[1].endsWith(';1,t')).toBe(true);
+    expect(lines[2].endsWith(';2,t')).toBe(true);
+  });
+
+  it('laisse la date vide si absente', () => {
+    const out = exportFencersToFFF([makeFencer({ birthDate: undefined })]);
+    // section0 : NOM,Prénom,,Sexe,Nation
+    expect(out.split('\n')[1]).toContain('DUPONT,Jean,,M,FRA');
+  });
+});
+
+describe('exportFencersToTXT', () => {
+  it('inclut le titre souligné quand fourni', () => {
+    const out = exportFencersToTXT([makeFencer()], 'Liste');
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('Liste');
+    expect(lines[1]).toBe('=====');
+  });
+
+  it('indique le nombre de tireurs', () => {
+    const out = exportFencersToTXT([makeFencer(), makeFencer({ id: '2' })]);
+    expect(out).toContain('Nombre de tireurs : 2');
+  });
+
+  it('gère la liste vide', () => {
+    const out = exportFencersToTXT([]);
+    expect(out).toContain('Nombre de tireurs : 0');
+    expect(out).toContain('Aucun tireur.');
+  });
+
+  it('affiche le nom en majuscules et l’année de naissance', () => {
+    const out = exportFencersToTXT([makeFencer({ lastName: 'Bernard', birthDate: new Date('2001-07-09') })]);
+    expect(out).toContain('BERNARD');
+    expect(out).toContain('2001');
+  });
+
+  it('affiche le classement préfixé de # ou un tiret', () => {
+    const withRank = exportFencersToTXT([makeFencer({ ranking: 12 })]);
+    expect(withRank).toContain('#12');
+    const withoutRank = exportFencersToTXT([makeFencer({ ranking: undefined })]);
+    expect(withoutRank).toContain(' - ');
+  });
+
+  it('clôt la liste par une ligne de fin', () => {
+    const out = exportFencersToTXT([makeFencer()]);
+    expect(out).toContain('--- Fin de la liste (1 tireurs) ---');
+  });
+});

--- a/src/shared/utils/tournamentTemplates.test.ts
+++ b/src/shared/utils/tournamentTemplates.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests unitaires - Modèles de tournoi (templates)
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  OFFICIAL_TEMPLATES,
+  getOfficialTemplates,
+  getTemplateById,
+  applyTemplate,
+} from './tournamentTemplates';
+
+describe('OFFICIAL_TEMPLATES', () => {
+  it('contient au moins un modèle officiel', () => {
+    expect(OFFICIAL_TEMPLATES.length).toBeGreaterThan(0);
+  });
+
+  it('a des ids uniques', () => {
+    const ids = OFFICIAL_TEMPLATES.map(t => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('expose une catégorie valide pour chaque modèle', () => {
+    expect(OFFICIAL_TEMPLATES.every(t => t.category === 'official' || t.category === 'custom')).toBe(true);
+  });
+
+  it('getOfficialTemplates retourne la même liste', () => {
+    expect(getOfficialTemplates()).toEqual(OFFICIAL_TEMPLATES);
+  });
+});
+
+describe('getTemplateById', () => {
+  it('retrouve un modèle officiel existant', () => {
+    const first = OFFICIAL_TEMPLATES[0];
+    expect(getTemplateById(first.id)).toEqual(first);
+  });
+
+  it('retourne null pour un id inconnu', () => {
+    expect(getTemplateById('id-inexistant')).toBeNull();
+  });
+});
+
+describe('applyTemplate', () => {
+  it('reporte arme, genre, catégorie, couleur et settings', () => {
+    const tpl = OFFICIAL_TEMPLATES[0];
+    const result = applyTemplate(tpl);
+    expect(result.weapon).toBe(tpl.weapon);
+    expect(result.gender).toBe(tpl.gender);
+    expect(result.category).toBe(tpl.category_age);
+    expect(result.color).toBe(tpl.color);
+    expect(result.settings).toEqual(tpl.settings);
+  });
+
+  it('utilise le nom du modèle comme titre par défaut', () => {
+    const tpl = OFFICIAL_TEMPLATES[0];
+    expect(applyTemplate(tpl).title).toBe(tpl.name);
+  });
+
+  it('utilise le titre fourni s’il est présent', () => {
+    const tpl = OFFICIAL_TEMPLATES[0];
+    expect(applyTemplate(tpl, 'Mon Tournoi').title).toBe('Mon Tournoi');
+  });
+});


### PR DESCRIPTION
Ajout de tests unitaires sur de la logique métier non couverte.

## Nouveaux fichiers de test
- `customTouchSystem.test.ts` (8 tests) : calcul de score par zones, complétude de match, zones par défaut.
- `fencerExport.test.ts` (11 tests) : export FFF (en-tête, majuscules, date DD/MM/YYYY, positions) et TXT (titre, comptage, liste vide, classement).
- `tournamentTemplates.test.ts` (9 tests) : intégrité des modèles officiels, `getTemplateById`, `applyTemplate`.

## Résultat
- **28 tests, tous verts** (`vitest run` sur les 3 fichiers).
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_