### PR TITLE
Tests unitaires : competitionUtils + teamCalculations

### DIFF
--- a/src/features/competition/utils/competitionUtils.test.ts
+++ b/src/features/competition/utils/competitionUtils.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests unitaires - competitionUtils
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateCompetition,
+  generateCompetitionId,
+  formatCompetitionDate,
+  generateCompetitionTitle,
+} from './competitionUtils';
+import { CreateCompetitionDTO } from '../types/competition.types';
+
+const base = (): CreateCompetitionDTO => ({
+  title: 'Open de Paris',
+  date: new Date('2026-05-01'),
+  weapon: 'E',
+  gender: 'M',
+  category: 'SENIOR',
+} as unknown as CreateCompetitionDTO);
+
+describe('validateCompetition', () => {
+  it('retourne null pour des données valides', () => {
+    expect(validateCompetition(base())).toBeNull();
+  });
+
+  it('exige un titre non vide', () => {
+    expect(validateCompetition({ ...base(), title: '   ' } as any)).toBe('Le titre est obligatoire');
+  });
+
+  it('exige date, arme, genre, catégorie', () => {
+    expect(validateCompetition({ ...base(), date: undefined } as any)).toMatch(/date/i);
+    expect(validateCompetition({ ...base(), weapon: undefined } as any)).toMatch(/arme/i);
+    expect(validateCompetition({ ...base(), gender: undefined } as any)).toMatch(/genre/i);
+    expect(validateCompetition({ ...base(), category: undefined } as any)).toMatch(/cat/i);
+  });
+});
+
+describe('generateCompetitionId', () => {
+  it('génère des UUID distincts', () => {
+    const a = generateCompetitionId();
+    const b = generateCompetitionId();
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+});
+
+describe('formatCompetitionDate', () => {
+  it('formate en français lisible', () => {
+    const out = formatCompetitionDate(new Date('2026-05-01'));
+    expect(out).toContain('2026');
+    expect(out).toContain('mai');
+  });
+});
+
+describe('generateCompetitionTitle', () => {
+  it('assemble arme/genre/catégorie/date', () => {
+    const out = generateCompetitionTitle('Épée', 'Hommes', 'Senior', new Date('2026-05-01'));
+    expect(out).toBe('Épée Hommes Senior - 01/05/2026');
+  });
+});

--- a/src/features/teams/utils/teamCalculations.test.ts
+++ b/src/features/teams/utils/teamCalculations.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests unitaires - teamCalculations
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateRelayBouts,
+  calculateTeamScore,
+  validateTeamComposition,
+  isTeamMatchComplete,
+  getTeamMatchWinner,
+} from './teamCalculations';
+import { Team, TeamFencer, TeamMatch, TeamBout } from '../types/team.types';
+
+const tf = (id: string, order: number, isReserve = false): TeamFencer =>
+  ({ id, lastName: id, firstName: id, teamOrder: order, isReserve } as unknown as TeamFencer);
+
+const team = (id: string, fencers: TeamFencer[], reserves: TeamFencer[] = []): Team => ({
+  id, name: id, club: 'C', fencers, reserveFencers: reserves, totalPoints: 0, ranking: 0,
+});
+
+const teamA = () => team('A', [tf('a1', 1), tf('a2', 2), tf('a3', 3)]);
+const teamB = () => team('B', [tf('b1', 1), tf('b2', 2), tf('b3', 3)]);
+
+describe('generateRelayBouts', () => {
+  it('génère 9 relais dans l’ordre standard', () => {
+    const bouts = generateRelayBouts(teamA(), teamB());
+    expect(bouts).toHaveLength(9);
+    expect(bouts[0].fencerA.id).toBe('a1');
+    expect(bouts[0].fencerB.id).toBe('b1');
+    expect(bouts[3].fencerA.id).toBe('a1'); // 1 vs 2
+    expect(bouts[3].fencerB.id).toBe('b2');
+    expect(bouts.map(b => b.order)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('ignore les réservistes et trie par teamOrder', () => {
+    const a = team('A', [tf('a3', 3), tf('a1', 1), tf('a2', 2), tf('aR', 4, true)]);
+    const bouts = generateRelayBouts(a, teamB());
+    expect(bouts[0].fencerA.id).toBe('a1');
+  });
+
+  it('lève une erreur si moins de 3 titulaires', () => {
+    const short = team('A', [tf('a1', 1), tf('a2', 2)]);
+    expect(() => generateRelayBouts(short, teamB())).toThrow();
+  });
+});
+
+describe('calculateTeamScore', () => {
+  it('compte uniquement les relais terminés avec vainqueur', () => {
+    const match: TeamMatch = {
+      id: 'm', teamA: teamA(), teamB: teamB(), bouts: [], scoreA: 0, scoreB: 0,
+      status: 'in_progress', currentBoutIndex: 0,
+    };
+    const bout = (winner: TeamFencer, fa: TeamFencer, fb: TeamFencer, status = 'finished'): TeamBout =>
+      ({ id: 'x', order: 1, fencerA: fa, fencerB: fb, scoreA: 0, scoreB: 0, maxScore: 5, status, winner } as TeamBout);
+    match.bouts = [
+      bout(tf('a1', 1), tf('a1', 1), tf('b1', 1)), // A
+      bout(tf('b2', 2), tf('a2', 2), tf('b2', 2)), // B
+      bout(tf('a3', 3), tf('a3', 3), tf('b3', 3), 'in_progress'), // ignoré
+    ];
+    expect(calculateTeamScore(match)).toEqual({ scoreA: 1, scoreB: 1 });
+  });
+});
+
+describe('validateTeamComposition', () => {
+  it('valide une équipe de 3 titulaires d’ordres 1,2,3', () => {
+    expect(validateTeamComposition(teamA())).toEqual({ valid: true, errors: [] });
+  });
+
+  it('refuse moins de 3 titulaires', () => {
+    const r = validateTeamComposition(team('A', [tf('a1', 1), tf('a2', 2)]));
+    expect(r.valid).toBe(false);
+  });
+
+  it('refuse plus d’un réserviste', () => {
+    const r = validateTeamComposition(
+      team('A', [tf('a1', 1), tf('a2', 2), tf('a3', 3)], [tf('r1', 4, true), tf('r2', 5, true)])
+    );
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => /reserve/i.test(e))).toBe(true);
+  });
+});
+
+describe('isTeamMatchComplete / getTeamMatchWinner', () => {
+  const finishedBout = (id: string, winner: TeamFencer, fa: TeamFencer, fb: TeamFencer): TeamBout =>
+    ({ id, order: 1, fencerA: fa, fencerB: fb, scoreA: 0, scoreB: 0, maxScore: 5, status: 'finished', winner } as TeamBout);
+
+  it('est complet après 9 relais terminés', () => {
+    const a = teamA(), b = teamB();
+    const bouts = Array.from({ length: 9 }, (_, i) => finishedBout(`x${i}`, tf('a1', 1), tf('a1', 1), tf('b1', 1)));
+    const match: TeamMatch = { id: 'm', teamA: a, teamB: b, bouts, scoreA: 0, scoreB: 0, status: 'finished', currentBoutIndex: 9 };
+    expect(isTeamMatchComplete(match)).toBe(true);
+    expect(getTeamMatchWinner(match)).toBe(a); // A gagne tous les relais
+  });
+
+  it('retourne null si le match n’est pas terminé', () => {
+    const match: TeamMatch = { id: 'm', teamA: teamA(), teamB: teamB(), bouts: [], scoreA: 0, scoreB: 0, status: 'in_progress', currentBoutIndex: 0 };
+    expect(isTeamMatchComplete(match)).toBe(false);
+    expect(getTeamMatchWinner(match)).toBeNull();
+  });
+});


### PR DESCRIPTION
Tests unitaires sur de la logique métier des features.

## Nouveaux fichiers
- `competition/utils/competitionUtils.test.ts` (6 tests) : `validateCompetition` (champs requis), `generateCompetitionId` (UUID uniques), `formatCompetitionDate`, `generateCompetitionTitle`.
- `teams/utils/teamCalculations.test.ts` (9 tests) : `generateRelayBouts` (ordre standard des 9 relais, tri/réservistes, erreur <3 titulaires), `calculateTeamScore`, `validateTeamComposition`, `isTeamMatchComplete`, `getTeamMatchWinner`.

## Résultat
- **15 tests, tous verts**.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_