### PR TITLE
Fix import penaltyUtils + tests unitaires

### DIFF
--- a/src/features/penalties/utils/penaltyUtils.test.ts
+++ b/src/features/penalties/utils/penaltyUtils.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests unitaires - penaltyUtils
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getPenaltyDescription,
+  getPenaltyColor,
+  validatePenalty,
+  getCardTypeLabel,
+  getImpactDescription,
+} from './penaltyUtils';
+import { CardType, PenaltyReason } from '../types/penalty.types';
+
+describe('getPenaltyDescription', () => {
+  it('traduit chaque motif connu', () => {
+    expect(getPenaltyDescription(PenaltyReason.VIOLENCE)).toBe('Violence');
+    expect(getPenaltyDescription(PenaltyReason.DELAY)).toBe('Retard au match');
+  });
+});
+
+describe('getPenaltyColor', () => {
+  it('retourne une couleur par type de carton', () => {
+    expect(getPenaltyColor(CardType.YELLOW)).toBe('#fbbf24');
+    expect(getPenaltyColor(CardType.RED)).toBe('#ef4444');
+    expect(getPenaltyColor(CardType.BLACK)).toBe('#000000');
+    expect(getPenaltyColor(CardType.WHITE)).toBe('#ffffff');
+  });
+});
+
+describe('getCardTypeLabel', () => {
+  it('libellé français par type', () => {
+    expect(getCardTypeLabel(CardType.YELLOW)).toBe('Carton Jaune');
+    expect(getCardTypeLabel(CardType.BLACK)).toBe('Carton Noir');
+  });
+});
+
+describe('validatePenalty', () => {
+  const valid = {
+    fencerId: 'f1',
+    matchId: 'm1',
+    cardType: CardType.YELLOW,
+    reason: PenaltyReason.DELAY,
+  };
+
+  it('valide une pénalité complète', () => {
+    expect(validatePenalty(valid)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('liste les champs requis manquants', () => {
+    const r = validatePenalty({});
+    expect(r.valid).toBe(false);
+    expect(r.errors).toEqual(
+      expect.arrayContaining([
+        'Fencer ID is required',
+        'Match ID is required',
+        'Card type is required',
+        'Reason is required',
+      ])
+    );
+  });
+
+  it('exige fencerId', () => {
+    expect(validatePenalty({ ...valid, fencerId: undefined }).valid).toBe(false);
+  });
+});
+
+describe('getImpactDescription', () => {
+  it('jaune = avertissement, noir = exclusion', () => {
+    expect(getImpactDescription(CardType.YELLOW, 0)).toBe('Avertissement');
+    expect(getImpactDescription(CardType.BLACK, 0)).toBe('Exclusion du match');
+  });
+
+  it('rouge = retrait de touches avec accord pluriel', () => {
+    expect(getImpactDescription(CardType.RED, 1)).toBe('-1 touche');
+    expect(getImpactDescription(CardType.RED, 3)).toBe('-3 touches');
+  });
+});

--- a/src/features/penalties/utils/penaltyUtils.ts
+++ b/src/features/penalties/utils/penaltyUtils.ts
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import { CardType, PenaltyReason, Penalty } from './types/penalty.types';
+import { CardType, PenaltyReason, Penalty } from '../types/penalty.types';
 
 export function getPenaltyDescription(reason: PenaltyReason): string {
   const descriptions: Record<PenaltyReason, string> = {


### PR DESCRIPTION
Tests unitaires `penaltyUtils` — **et correction d'un bug d'import au passage**.

## Bug corrigé
`penaltyUtils.ts` importait `./types/penalty.types` (chemin inexistant depuis `utils/`) au lieu de `../types/penalty.types`. Le module ne pouvait pas se charger → cela cassait aussi le test existant `penalties.test.ts`. Import corrigé.

## Nouveau fichier
- `penaltyUtils.test.ts` (8 tests) : `getPenaltyDescription`, `getPenaltyColor`, `getCardTypeLabel`, `validatePenalty` (cas valide + champs requis manquants), `getImpactDescription` (accord singulier/pluriel des touches).

## Résultat
- `penaltyUtils.test.ts` (8) + `penalties.test.ts` (20) = **28 tests verts**.
- `tsc --noEmit` : OK.

Note : `PenaltyReason.OTHER` est référencé dans `validatePenalty` mais n'existe pas dans l'enum (vaut `undefined`) — latent, hors scope de cette PR.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_