### PR TITLE
Tests unitaires : hooks useHistory + usePagination

### DIFF
--- a/src/renderer/hooks/useHistory.test.tsx
+++ b/src/renderer/hooks/useHistory.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - useHistory (undo/redo)
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useHistory } from './useHistory';
+
+const makeAction = (undo = vi.fn(), redo = vi.fn()) => ({
+  type: 'UPDATE_SCORE' as const,
+  description: 'test',
+  undo,
+  redo,
+});
+
+describe('useHistory', () => {
+  it('démarre vide, sans undo/redo possible', () => {
+    const { result } = renderHook(() => useHistory());
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+    expect(result.current.history).toHaveLength(0);
+  });
+
+  it('addAction rend l’annulation possible', () => {
+    const { result } = renderHook(() => useHistory());
+    act(() => result.current.addAction(makeAction()));
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+    expect(result.current.history).toHaveLength(1);
+  });
+
+  it('undo invoque action.undo et redo invoque action.redo', () => {
+    const undo = vi.fn();
+    const redo = vi.fn();
+    const { result } = renderHook(() => useHistory());
+    act(() => result.current.addAction(makeAction(undo, redo)));
+
+    act(() => result.current.undo());
+    expect(undo).toHaveBeenCalledTimes(1);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => result.current.redo());
+    expect(redo).toHaveBeenCalledTimes(1);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it('une nouvelle action après undo écrase le futur (pas de redo)', () => {
+    const { result } = renderHook(() => useHistory());
+    act(() => result.current.addAction(makeAction()));
+    act(() => result.current.undo());
+    act(() => result.current.addAction(makeAction()));
+    expect(result.current.canRedo).toBe(false);
+    expect(result.current.history).toHaveLength(1);
+  });
+
+  it('getHistoryInfo reflète les compteurs undo/redo', () => {
+    const { result } = renderHook(() => useHistory());
+    act(() => result.current.addAction(makeAction()));
+    act(() => result.current.addAction(makeAction()));
+    act(() => result.current.undo());
+    expect(result.current.getHistoryInfo()).toEqual({ undoCount: 1, redoCount: 1 });
+  });
+
+  it('clear réinitialise tout', () => {
+    const { result } = renderHook(() => useHistory());
+    act(() => result.current.addAction(makeAction()));
+    act(() => result.current.clear());
+    expect(result.current.history).toHaveLength(0);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it('appelle les callbacks onUndo / onRedo', () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    const { result } = renderHook(() => useHistory({ onUndo, onRedo }));
+    act(() => result.current.addAction(makeAction()));
+    act(() => result.current.undo());
+    act(() => result.current.redo());
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/hooks/usePagination.test.tsx
+++ b/src/renderer/hooks/usePagination.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - usePagination
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePagination } from './usePagination';
+
+const data = Array.from({ length: 45 }, (_, i) => i);
+
+describe('usePagination', () => {
+  it('calcule pages et tranche initiale', () => {
+    const { result } = renderHook(() => usePagination(data, { defaultPageSize: 20 }));
+    expect(result.current.totalItems).toBe(45);
+    expect(result.current.totalPages).toBe(3);
+    expect(result.current.items).toHaveLength(20);
+    expect(result.current.items[0]).toBe(0);
+    expect(result.current.hasPrev).toBe(false);
+    expect(result.current.hasNext).toBe(true);
+  });
+
+  it('navigue next/prev/first/last', () => {
+    const { result } = renderHook(() => usePagination(data, { defaultPageSize: 20 }));
+    act(() => result.current.goToNext());
+    expect(result.current.page).toBe(1);
+    expect(result.current.items[0]).toBe(20);
+
+    act(() => result.current.goToLast());
+    expect(result.current.page).toBe(2);
+    expect(result.current.items).toHaveLength(5); // 45 - 40
+    expect(result.current.hasNext).toBe(false);
+
+    act(() => result.current.goToPrev());
+    expect(result.current.page).toBe(1);
+
+    act(() => result.current.goToFirst());
+    expect(result.current.page).toBe(0);
+  });
+
+  it('borne setPage dans [0, totalPages-1]', () => {
+    const { result } = renderHook(() => usePagination(data, { defaultPageSize: 20 }));
+    act(() => result.current.setPage(99));
+    expect(result.current.page).toBe(2);
+    act(() => result.current.setPage(-5));
+    expect(result.current.page).toBe(0);
+  });
+
+  it('setPageSize remet à la première page et recalcule', () => {
+    const { result } = renderHook(() => usePagination(data, { defaultPageSize: 20 }));
+    act(() => result.current.goToLast());
+    act(() => result.current.setPageSize(10));
+    expect(result.current.page).toBe(0);
+    expect(result.current.totalPages).toBe(5);
+    expect(result.current.items).toHaveLength(10);
+  });
+
+  it('gère une liste vide (au moins 1 page)', () => {
+    const { result } = renderHook(() => usePagination([], {}));
+    expect(result.current.totalPages).toBe(1);
+    expect(result.current.items).toHaveLength(0);
+    expect(result.current.hasNext).toBe(false);
+  });
+
+  it('startIndex / endIndex cohérents', () => {
+    const { result } = renderHook(() => usePagination(data, { defaultPageSize: 20 }));
+    act(() => result.current.goToNext());
+    expect(result.current.startIndex).toBe(20);
+    expect(result.current.endIndex).toBe(40);
+  });
+});


### PR DESCRIPTION
Tests unitaires sur deux hooks renderer (env jsdom, `@testing-library/react`).

## Nouveaux fichiers
- `useHistory.test.tsx` (7 tests) : état initial, `addAction`, `undo`/`redo` (invocation des callbacks d'action), écrasement du futur après undo, `getHistoryInfo`, `clear`, callbacks `onUndo`/`onRedo`.
- `usePagination.test.tsx` (6 tests) : calcul pages/tranche, navigation next/prev/first/last, bornage de `setPage`, `setPageSize` (retour page 0 + recalcul), liste vide, cohérence `startIndex`/`endIndex`.

## Résultat
- **13 tests, tous verts**.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_