### PR TITLE
Tests unitaires : useColumnVisibility

### DIFF
--- a/src/renderer/hooks/useColumnVisibility.test.tsx
+++ b/src/renderer/hooks/useColumnVisibility.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - useColumnVisibility
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useColumnVisibility } from './useColumnVisibility';
+
+describe('useColumnVisibility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    const { result } = renderHook(() => useColumnVisibility());
+    act(() => result.current.resetToDefaults());
+  });
+
+  it('expose les colonnes par défaut visibles', () => {
+    const { result } = renderHook(() => useColumnVisibility());
+    expect(result.current.isColumnVisible('pool', 'victories')).toBe(true);
+    expect(result.current.isColumnVisible('ranking', 'rank')).toBe(true);
+  });
+
+  it('toggleColumn masque puis réaffiche une colonne', () => {
+    const { result } = renderHook(() => useColumnVisibility());
+    act(() => result.current.toggleColumn('pool', 'victories'));
+    expect(result.current.isColumnVisible('pool', 'victories')).toBe(false);
+    act(() => result.current.toggleColumn('pool', 'victories'));
+    expect(result.current.isColumnVisible('pool', 'victories')).toBe(true);
+  });
+
+  it('setVisibleColumns remplace la liste', () => {
+    const { result } = renderHook(() => useColumnVisibility());
+    act(() => result.current.setVisibleColumns('ranking', ['rank', 'lastName']));
+    expect(result.current.getVisibleColumns('ranking')).toEqual(['rank', 'lastName']);
+    expect(result.current.isColumnVisible('ranking', 'club')).toBe(false);
+  });
+
+  it('réglage par poule indépendant du défaut global', () => {
+    const { result } = renderHook(() => useColumnVisibility());
+    act(() => result.current.toggleColumn('pool', 'td', 'poolX'));
+    // poolX : td masquée ; le défaut global reste inchangé
+    expect(result.current.isColumnVisible('pool', 'td', 'poolX')).toBe(false);
+    expect(result.current.isColumnVisible('pool', 'td')).toBe(true);
+    expect(result.current.isColumnVisible('pool', 'td', 'autrePool')).toBe(true);
+  });
+
+  it('setAllPoolColumns applique à tous et efface les réglages propres', () => {
+    const { result } = renderHook(() => useColumnVisibility());
+    act(() => result.current.toggleColumn('pool', 'td', 'poolX'));
+    act(() => result.current.setAllPoolColumns(['victories']));
+    expect(result.current.getVisibleColumns('pool', 'poolX')).toEqual(['victories']);
+    expect(result.current.getVisibleColumns('pool')).toEqual(['victories']);
+  });
+
+  it('persiste dans localStorage', () => {
+    const { result } = renderHook(() => useColumnVisibility());
+    act(() => result.current.setVisibleColumns('pool', ['rank']));
+    const stored = JSON.parse(localStorage.getItem('bellepoule_column_visibility')!);
+    expect(stored.pool).toEqual(['rank']);
+  });
+});


### PR DESCRIPTION
Tests unitaires sur `useColumnVisibility` (env jsdom, store externe + localStorage).

## Nouveau fichier
- `useColumnVisibility.test.tsx` (6 tests) : colonnes par défaut, `toggleColumn` (masquer/réafficher), `setVisibleColumns`, réglage par poule indépendant du défaut global, `setAllPoolColumns` (applique à tous + efface les réglages propres), persistance localStorage.

## Résultat
- **6 tests, tous verts**.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_