### PR TITLE
Fix build:ci — type du mock showToast dans useExport.test

### DIFF
--- a/src/renderer/hooks/useExport.test.tsx
+++ b/src/renderer/hooks/useExport.test.tsx
@@ -32,7 +32,10 @@ afterEach(() => {
   delete (window as any).electronAPI;
 });
 
-const setup = () => renderHook(() => useExport({ competition, showToast })).result.current;
+const setup = () =>
+  renderHook(() =>
+    useExport({ competition, showToast: showToast as unknown as (m: string, t?: any) => void })
+  ).result.current;
 
 describe('exportFencersList', () => {
   it('écrit un contenu FFF et notifie le succès', async () => {


### PR DESCRIPTION
🛠️ Corrige l'échec de `build:ci` introduit par #683.

## Problème
`build:ci` lance `tsc` sur tout le projet (tests inclus). Dans `useExport.test.tsx`, le mock `showToast` (`vi.fn()`) n'était pas assignable au type de prop attendu `(message: string, type?: ToastType) => void` :

```
src/renderer/hooks/useExport.test.tsx(35,63): error TS2322: Type 'Mock<...>' is not assignable to type '(message: string, type?: ToastType) => void'.
```

## Correctif
Cast explicite du mock à la signature attendue lors du passage à `useExport`. Aucun changement de comportement de test.

## Vérifs
- `tsc` (projet complet) : OK.
- `vitest run useExport.test.tsx` : 4/4 verts.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_