### PR TITLE
Tests unitaires : useKeyboardShortcuts

### DIFF
--- a/src/renderer/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/renderer/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - useKeyboardShortcuts
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useKeyboardShortcuts, KeyboardShortcut } from './useKeyboardShortcuts';
+
+const fireKey = (init: KeyboardEventInit & { target?: EventTarget }) => {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+  if (init.target) Object.defineProperty(event, 'target', { value: init.target });
+  window.dispatchEvent(event);
+  return event;
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('useKeyboardShortcuts', () => {
+  it('déclenche l’action sur la bonne touche + modificateur', () => {
+    const action = vi.fn();
+    const shortcuts: KeyboardShortcut[] = [
+      { key: 's', ctrl: true, description: 'Save', action },
+    ];
+    renderHook(() => useKeyboardShortcuts({ shortcuts }));
+    fireKey({ key: 's', ctrlKey: true });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('ne déclenche pas si les modificateurs ne correspondent pas', () => {
+    const action = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ shortcuts: [{ key: 's', ctrl: true, description: 'Save', action }] }));
+    fireKey({ key: 's' }); // sans ctrl
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('respecte enabled=false', () => {
+    const action = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ shortcuts: [{ key: 'a', description: 'A', action }], enabled: false }));
+    fireKey({ key: 'a' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('ignore les raccourcis dans un input (sauf Escape)', () => {
+    const action = vi.fn();
+    const esc = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      shortcuts: [
+        { key: 'a', description: 'A', action },
+        { key: 'Escape', description: 'Esc', action: esc },
+      ],
+    }));
+    const input = document.createElement('input');
+    fireKey({ key: 'a', target: input });
+    expect(action).not.toHaveBeenCalled();
+    fireKey({ key: 'Escape', target: input });
+    expect(esc).toHaveBeenCalledTimes(1);
+  });
+
+  it('appelle preventDefault par défaut', () => {
+    renderHook(() => useKeyboardShortcuts({ shortcuts: [{ key: 'x', description: 'X', action: () => {} }] }));
+    const evt = fireKey({ key: 'x' });
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it('respecte preventDefault=false', () => {
+    renderHook(() => useKeyboardShortcuts({
+      shortcuts: [{ key: 'y', description: 'Y', action: () => {}, preventDefault: false }],
+    }));
+    const evt = fireKey({ key: 'y' });
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  it('capture les erreurs de l’action sans planter', () => {
+    const action = vi.fn(() => { throw new Error('boom'); });
+    renderHook(() => useKeyboardShortcuts({ shortcuts: [{ key: 'z', description: 'Z', action }] }));
+    expect(() => fireKey({ key: 'z' })).not.toThrow();
+    expect(action).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Tests unitaires sur `useKeyboardShortcuts` (env jsdom).

## Nouveau fichier
- `useKeyboardShortcuts.test.tsx` (7 tests) : déclenchement sur touche + modificateur, non-déclenchement si modificateurs absents, `enabled:false`, ignore les inputs (sauf `Escape`), `preventDefault` par défaut / désactivé, capture des erreurs de l'action sans crash.

## Résultat
- **7 tests, tous verts**.
- `tsc` complet : OK (hors l'erreur `useExport.test` déjà corrigée par #685).
- Aucune modification de code de production.

⚠️ À merger après #685 pour que `build:ci` soit vert sur `dev`.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_