### PR TITLE
Fix imports types cassés (usePenaltyStore) + tests

### DIFF
--- a/src/features/penalties/hooks/usePenaltyStore.test.tsx
+++ b/src/features/penalties/hooks/usePenaltyStore.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - usePenaltyStore (logique métier)
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePenaltyStore } from './usePenaltyStore';
+import { CardType, PenaltyReason, DEFAULT_PENALTY_CONFIG } from '../types/penalty.types';
+
+const reset = () =>
+  usePenaltyStore.setState({ penalties: [], config: DEFAULT_PENALTY_CONFIG, error: null });
+
+const add = (fencerId: string, cardType: CardType) =>
+  usePenaltyStore.getState().addPenalty({
+    fencerId, matchId: 'm1', cardType, reason: PenaltyReason.DELAY,
+  } as any);
+
+beforeEach(() => reset());
+
+describe('addPenalty / removePenalty', () => {
+  it('ajoute une pénalité avec scoreImpact issu de la config', () => {
+    const p = add('f1', CardType.RED);
+    expect(usePenaltyStore.getState().penalties).toHaveLength(1);
+    expect(p.scoreImpact).toBe(DEFAULT_PENALTY_CONFIG.redCardTouches);
+    expect(p.fencerId).toBe('f1');
+  });
+
+  it('supprime une pénalité par id', () => {
+    const p = add('f1', CardType.YELLOW);
+    usePenaltyStore.getState().removePenalty(p.id);
+    expect(usePenaltyStore.getState().penalties).toHaveLength(0);
+  });
+});
+
+describe('getFencerHistory', () => {
+  it('compte les cartons par type et déduit l’exclusion', () => {
+    add('f1', CardType.YELLOW);
+    add('f1', CardType.YELLOW);
+    const h = usePenaltyStore.getState().getFencerHistory('f1');
+    expect(h.yellowCards).toBe(2);
+    expect(h.isExcluded).toBe(true);
+  });
+
+  it('isole les pénalités par tireur', () => {
+    add('f1', CardType.YELLOW);
+    add('f2', CardType.RED);
+    expect(usePenaltyStore.getState().getFencerHistory('f2').redCards).toBe(1);
+    expect(usePenaltyStore.getState().getFencerHistory('f2').yellowCards).toBe(0);
+  });
+});
+
+describe('shouldExcludeFencer', () => {
+  it('exclut après 2 cartons jaunes', () => {
+    add('f1', CardType.YELLOW);
+    expect(usePenaltyStore.getState().shouldExcludeFencer('f1')).toBe(false);
+    add('f1', CardType.YELLOW);
+    expect(usePenaltyStore.getState().shouldExcludeFencer('f1')).toBe(true);
+  });
+
+  it('exclut immédiatement sur carton noir', () => {
+    add('f9', CardType.BLACK);
+    expect(usePenaltyStore.getState().shouldExcludeFencer('f9')).toBe(true);
+  });
+});
+
+describe('getNextCardType', () => {
+  it('jaune par défaut, rouge après le seuil de jaunes', () => {
+    expect(usePenaltyStore.getState().getNextCardType('f1')).toBe(CardType.YELLOW);
+    add('f1', CardType.YELLOW);
+    add('f1', CardType.YELLOW);
+    expect(usePenaltyStore.getState().getNextCardType('f1')).toBe(CardType.RED);
+  });
+});
+
+describe('calculateScoreImpact / updateConfig', () => {
+  it('reflète la config courante', () => {
+    const store = usePenaltyStore.getState();
+    expect(store.calculateScoreImpact({ cardType: CardType.RED } as any)).toBe(
+      DEFAULT_PENALTY_CONFIG.redCardTouches
+    );
+    store.updateConfig({ redCardTouches: 5 });
+    expect(usePenaltyStore.getState().calculateScoreImpact({ cardType: CardType.RED } as any)).toBe(5);
+  });
+});

--- a/src/features/penalties/hooks/usePenaltyStore.ts
+++ b/src/features/penalties/hooks/usePenaltyStore.ts
@@ -17,7 +17,7 @@ import {
   CreatePenaltyDTO,
   DEFAULT_PENALTY_CONFIG,
   PenaltyConfig,
-} from './types/penalty.types';
+} from '../types/penalty.types';
 
 interface PenaltyState {
   penalties: Penalty[];

--- a/src/features/teams/hooks/useTeamStore.test.tsx
+++ b/src/features/teams/hooks/useTeamStore.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - useTeamStore (logique métier)
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTeamStore } from './useTeamStore';
+import type { Team, TeamMatch, TeamBout } from '../types/team.types';
+
+const reset = () =>
+  useTeamStore.setState({ teams: [], matches: [], pools: [], currentMatch: null, error: null });
+
+const get = () => useTeamStore.getState();
+
+beforeEach(() => reset());
+
+describe('addTeam / updateTeam / removeTeam', () => {
+  it('ajoute une équipe', () => {
+    get().addTeam({ name: 'Les Bleus', club: 'CEP', fencerIds: [] } as any);
+    expect(get().teams).toHaveLength(1);
+    expect(get().teams[0].name).toBe('Les Bleus');
+  });
+
+  it('met à jour puis supprime une équipe', () => {
+    get().addTeam({ name: 'A', club: 'C', fencerIds: [] } as any);
+    const id = get().teams[0].id;
+    get().updateTeam(id, { name: 'B' });
+    expect(get().teams[0].name).toBe('B');
+    get().removeTeam(id);
+    expect(get().teams).toHaveLength(0);
+  });
+});
+
+describe('createMatch', () => {
+  it('crée un match entre deux équipes existantes', () => {
+    useTeamStore.setState({
+      teams: [{ id: 'tA' } as Team, { id: 'tB' } as Team],
+    });
+    const match = get().createMatch('tA', 'tB');
+    expect(match.teamA.id).toBe('tA');
+    expect(match.status).toBe('not_started');
+    expect(get().matches).toHaveLength(1);
+  });
+
+  it('lève une erreur si une équipe est introuvable', () => {
+    expect(() => get().createMatch('x', 'y')).toThrow('Teams not found');
+  });
+});
+
+describe('updateBoutScore', () => {
+  it('désigne le vainqueur et incrémente le score d’équipe', () => {
+    const bout: TeamBout = {
+      id: 'b1', order: 1,
+      fencerA: { id: 'fa', teamOrder: 1 } as any,
+      fencerB: { id: 'fb', teamOrder: 1 } as any,
+      scoreA: 0, scoreB: 0, maxScore: 5, status: 'in_progress',
+    };
+    const match: TeamMatch = {
+      id: 'm1', teamA: { id: 'tA' } as Team, teamB: { id: 'tB' } as Team,
+      bouts: [bout], scoreA: 0, scoreB: 0, status: 'in_progress', currentBoutIndex: 0,
+    };
+    useTeamStore.setState({ matches: [match] });
+
+    get().updateBoutScore('m1', { boutId: 'b1', scoreA: 5, scoreB: 3, status: 'finished' });
+    const m = get().matches[0];
+    expect(m.bouts[0].winner?.id).toBe('fa');
+    expect(m.scoreA).toBe(1);
+    expect(m.scoreB).toBe(0);
+  });
+});
+
+describe('finishMatch', () => {
+  it('marque le match terminé et le vainqueur', () => {
+    const match: TeamMatch = {
+      id: 'm1', teamA: { id: 'tA' } as Team, teamB: { id: 'tB' } as Team,
+      bouts: [], scoreA: 0, scoreB: 0, status: 'in_progress', currentBoutIndex: 0,
+    };
+    useTeamStore.setState({ matches: [match] });
+    get().finishMatch('m1', 'tB');
+    expect(get().matches[0].status).toBe('finished');
+    expect(get().matches[0].winner?.id).toBe('tB');
+  });
+});
+
+describe('generatePools', () => {
+  it('répartit les équipes en poules selon la taille', () => {
+    useTeamStore.setState({
+      teams: ['1', '2', '3', '4', '5'].map(id => ({ id } as Team)),
+    });
+    get().generatePools(['1', '2', '3', '4', '5'], 2);
+    expect(get().pools).toHaveLength(3); // ceil(5/2)
+    expect(get().pools[0].teams).toHaveLength(2);
+    expect(get().pools[2].teams).toHaveLength(1);
+  });
+});

--- a/src/features/teams/hooks/useTeamStore.ts
+++ b/src/features/teams/hooks/useTeamStore.ts
@@ -15,7 +15,7 @@ import {
   CreateTeamDTO,
   UpdateTeamBoutScoreDTO,
   TeamStats,
-} from './types/team.types';
+} from '../types/team.types';
 
 interface TeamState {
   teams: Team[];

--- a/src/features/teams/utils/teamCalculations.ts
+++ b/src/features/teams/utils/teamCalculations.ts
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import { Team, TeamFencer, TeamBout, TeamMatch } from './types/team.types';
+import { Team, TeamFencer, TeamBout, TeamMatch } from '../types/team.types';
 
 /**
  * Generate relay bouts for a team match


### PR DESCRIPTION
Tests de `usePenaltyStore` + correction d'imports cassés (suite du bug d'import de #672).

## Bugs corrigés
Trois fichiers importaient `./types/...` au lieu de `../types/...` (le dossier `types` est au niveau de la feature, pas dans `hooks/`/`utils/`) :
- **`usePenaltyStore.ts`** : importait des **valeurs runtime** (`CardType`, `PenaltyReason`, `DEFAULT_PENALTY_CONFIG`) → vrai bug (le module ne se charge pas sous un bundler strict / vite).
- `useTeamStore.ts` et `teamCalculations.ts` : imports de **types** uniquement (élidés à la compilation, donc inoffensifs au runtime), corrigés par cohérence.

`tsc`/webpack toléraient ces chemins ; vite/vitest non — d'où leur détection via les tests.

## Nouveau fichier
- `usePenaltyStore.test.tsx` (8 tests) : `addPenalty`/`removePenalty`, `getFencerHistory` (comptage cartons + exclusion), `shouldExcludeFencer` (2 jaunes / carton noir), `getNextCardType`, `calculateScoreImpact` + `updateConfig`.

## Résultat
- 8 (store) + 9 (teamCalculations) + 20 (penalties) = **37 tests verts**.
- `tsc` complet : OK (hors `useExport` corrigé par #685).

⚠️ À merger après #685.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_