### PR TITLE
Fix build:ci — type du mock onUpdate (useFencerManagement.test)

### DIFF
--- a/src/renderer/hooks/useFencerManagement.test.tsx
+++ b/src/renderer/hooks/useFencerManagement.test.tsx
@@ -33,7 +33,10 @@ beforeEach(() => {
 
 afterEach(() => { delete (window as any).electronAPI; });
 
-const setup = () => renderHook(() => useFencerManagement({ competition, onUpdate })).result;
+const setup = () =>
+  renderHook(() =>
+    useFencerManagement({ competition, onUpdate: onUpdate as unknown as (c: Competition) => void })
+  ).result;
 
 describe('addFencer', () => {
   it('ajoute le tireur et notifie le parent', async () => {


### PR DESCRIPTION
🛠️ Corrige `build:ci` cassé par #689.

## Problème
Même classe d'erreur que #685 : dans `useFencerManagement.test.tsx`, le mock `onUpdate` (`vi.fn()`) n'était pas assignable à la prop typée `(competition: Competition) => void` sous `tsc` (lancé par `build:ci`).

```
useFencerManagement.test.tsx(36,73): error TS2322: Type 'Mock<...>' is not assignable to type '(competition: Competition) => void'.
```

## Correctif
Cast explicite du mock à la signature attendue. Aucun changement de comportement.

## Vérifs
- `tsc` (projet complet) : OK.
- `vitest run useFencerManagement.test.tsx` : 5/5 verts.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_