### PR TITLE
Tests unitaires : useLateFencerStore

### DIFF
--- a/src/features/latefencers/hooks/useLateFencerStore.test.tsx
+++ b/src/features/latefencers/hooks/useLateFencerStore.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - useLateFencerStore
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useLateFencerStore, DEFAULT_LATE_CONFIG } from './useLateFencerStore';
+import { Fencer, Gender, FencerStatus } from '../../../shared/types';
+
+const fencer = (id: string): Fencer => ({
+  id, ref: Number(id), lastName: 'L' + id, firstName: 'F',
+  gender: Gender.MALE, nationality: 'FRA', status: FencerStatus.CHECKED_IN,
+  createdAt: new Date(), updatedAt: new Date(),
+});
+
+const minutesAgo = (m: number) => new Date(Date.now() - m * 60000);
+const get = () => useLateFencerStore.getState();
+
+beforeEach(() => {
+  useLateFencerStore.setState({ lateFencers: [], config: { ...DEFAULT_LATE_CONFIG }, isMonitoring: false });
+});
+
+describe('registerFencer / markAsPresent', () => {
+  it('enregistre un tireur en attente', () => {
+    get().registerFencer(fencer('1'), minutesAgo(0));
+    expect(get().lateFencers).toHaveLength(1);
+    expect(get().lateFencers[0].status).toBe('waiting');
+  });
+
+  it('remplace l’entrée existante (pas de doublon)', () => {
+    get().registerFencer(fencer('1'), minutesAgo(0));
+    get().registerFencer(fencer('1'), minutesAgo(5));
+    expect(get().lateFencers).toHaveLength(1);
+  });
+
+  it('markAsPresent retire le tireur', () => {
+    get().registerFencer(fencer('1'), minutesAgo(0));
+    get().markAsPresent('1');
+    expect(get().lateFencers).toHaveLength(0);
+  });
+});
+
+describe('updateDelays - statuts selon les seuils', () => {
+  it('passe en "warned" au-delà du seuil d’avertissement', () => {
+    get().registerFencer(fencer('1'), minutesAgo(6));
+    get().updateDelays();
+    expect(get().lateFencers[0].status).toBe('warned');
+  });
+
+  it('passe en "critical" sans auto-forfait', () => {
+    useLateFencerStore.setState({ config: { ...DEFAULT_LATE_CONFIG, autoForfeit: false } });
+    get().registerFencer(fencer('1'), minutesAgo(16));
+    get().updateDelays();
+    expect(get().lateFencers[0].status).toBe('critical');
+  });
+
+  it('passe en "forfeit" avec auto-forfait au-delà du seuil', () => {
+    get().registerFencer(fencer('1'), minutesAgo(16));
+    get().updateDelays();
+    expect(get().lateFencers[0].status).toBe('forfeit');
+    expect(get().lateFencers[0].delayMinutes).toBeGreaterThanOrEqual(15);
+  });
+});
+
+describe('sélecteurs', () => {
+  it('getLateFencers / getCriticalFencers filtrent par délai', () => {
+    get().registerFencer(fencer('1'), minutesAgo(6));  // warned
+    get().registerFencer(fencer('2'), minutesAgo(12)); // critical
+    get().updateDelays();
+    expect(get().getLateFencers().length).toBe(2);      // >=5
+    expect(get().getCriticalFencers().length).toBe(1);  // >=10
+  });
+});
+
+describe('markAsForfeit / getLateStats', () => {
+  it('markAsForfeit force le statut forfeit', () => {
+    get().registerFencer(fencer('1'), minutesAgo(0));
+    get().markAsForfeit('1');
+    expect(get().getFencerStatus('1')?.status).toBe('forfeit');
+  });
+
+  it('getLateStats agrège les compteurs', () => {
+    get().registerFencer(fencer('1'), minutesAgo(6));
+    get().registerFencer(fencer('2'), minutesAgo(16));
+    get().updateDelays();
+    const stats = get().getLateStats();
+    expect(stats.totalLate).toBe(2);
+    expect(stats.forfeit).toBe(1);
+    expect(stats.averageDelay).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Tests unitaires sur `useLateFencerStore` (env jsdom).

## Nouveau fichier
- `useLateFencerStore.test.tsx` (9 tests) : `registerFencer` (ajout + remplacement sans doublon), `markAsPresent`, `updateDelays` (statuts warned/critical/forfeit selon les seuils + auto-forfait), sélecteurs `getLateFencers`/`getCriticalFencers`, `markAsForfeit`, `getLateStats`.

## Résultat
- **9 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_