### PR TITLE
Tests unitaires : useMatchAuditStore

### DIFF
--- a/src/features/matchAuditLog/hooks/useMatchAuditStore.test.tsx
+++ b/src/features/matchAuditLog/hooks/useMatchAuditStore.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - useMatchAuditStore
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useMatchAuditStore } from './useMatchAuditStore';
+
+const get = () => useMatchAuditStore.getState();
+
+beforeEach(() => {
+  get().reset();
+});
+afterEach(() => { delete (window as any).electronAPI; });
+
+describe('loadMatchTimeline', () => {
+  it('charge les entrées et positionne activeMatchId', async () => {
+    (window as any).electronAPI = { db: { getMatchTimeline: vi.fn(async () => [{ id: 'e1' }]) } };
+    await get().loadMatchTimeline('m1');
+    expect(get().entries).toEqual([{ id: 'e1' }]);
+    expect(get().isLoading).toBe(false);
+    expect(get().activeMatchId).toBe('m1');
+    expect(get().activeCompetitionId).toBeNull();
+  });
+
+  it('positionne une erreur en cas d’échec', async () => {
+    (window as any).electronAPI = { db: { getMatchTimeline: vi.fn(async () => { throw new Error('boom'); }) } };
+    await get().loadMatchTimeline('m1');
+    expect(get().error).toBe('boom');
+    expect(get().isLoading).toBe(false);
+  });
+});
+
+describe('loadCompetitionTimeline', () => {
+  it('charge les entrées et positionne activeCompetitionId', async () => {
+    (window as any).electronAPI = { db: { getCompetitionTimeline: vi.fn(async () => [{ id: 'c-e' }]) } };
+    await get().loadCompetitionTimeline('c1');
+    expect(get().entries).toEqual([{ id: 'c-e' }]);
+    expect(get().activeCompetitionId).toBe('c1');
+    expect(get().activeMatchId).toBeNull();
+  });
+});
+
+describe('setFilterTypes / clearError / reset', () => {
+  it('met à jour les filtres', () => {
+    get().setFilterTypes(['SCORE' as any]);
+    expect(get().filterTypes).toEqual(['SCORE']);
+  });
+
+  it('clearError remet l’erreur à null', () => {
+    useMatchAuditStore.setState({ error: 'x' });
+    get().clearError();
+    expect(get().error).toBeNull();
+  });
+
+  it('reset réinitialise tout', () => {
+    useMatchAuditStore.setState({ entries: [{ id: 'e' } as any], activeMatchId: 'm', isLoading: true });
+    get().reset();
+    expect(get().entries).toEqual([]);
+    expect(get().activeMatchId).toBeNull();
+    expect(get().isLoading).toBe(false);
+  });
+});


### PR DESCRIPTION
Tests unitaires sur `useMatchAuditStore` (env jsdom, `electronAPI.db` mocké).

## Nouveau fichier
- `useMatchAuditStore.test.tsx` (6 tests) : `loadMatchTimeline` (succès + `activeMatchId`, erreur), `loadCompetitionTimeline` (`activeCompetitionId`), `setFilterTypes`, `clearError`, `reset`.

## Résultat
- **6 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_