### PR TITLE
Tests unitaires : usePdfTemplateStore

### DIFF
--- a/src/features/pdfTemplates/hooks/usePdfTemplateStore.test.tsx
+++ b/src/features/pdfTemplates/hooks/usePdfTemplateStore.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - usePdfTemplateStore
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePdfTemplateStore } from './usePdfTemplateStore';
+import type { PdfTemplate } from '../../../shared/types/pdfTemplate.types';
+
+const get = () => usePdfTemplateStore.getState();
+
+beforeEach(() => {
+  // restaure les modèles par défaut
+  get().resetTemplate('pool');
+  get().resetTemplate('tableau');
+  get().resetTemplate('ranking');
+});
+
+const custom = (docType: PdfTemplate['docType']): PdfTemplate =>
+  ({ docType, customTitle: 'PERSO', elements: [], colors: {}, fonts: {} } as unknown as PdfTemplate);
+
+describe('usePdfTemplateStore', () => {
+  it('fournit des modèles par défaut pour les 3 types', () => {
+    expect(get().templates.pool.docType).toBe('pool');
+    expect(get().templates.tableau.docType).toBe('tableau');
+    expect(get().templates.ranking.docType).toBe('ranking');
+    expect(get().templates.pool.elements.length).toBeGreaterThan(0);
+  });
+
+  it('setTemplate remplace le modèle d’un type', () => {
+    get().setTemplate('pool', custom('pool'));
+    expect(get().templates.pool.customTitle).toBe('PERSO');
+    // les autres types restent inchangés
+    expect(get().templates.tableau.customTitle).not.toBe('PERSO');
+  });
+
+  it('resetTemplate restaure le modèle par défaut', () => {
+    get().setTemplate('ranking', custom('ranking'));
+    expect(get().templates.ranking.elements).toHaveLength(0);
+    get().resetTemplate('ranking');
+    expect(get().templates.ranking.elements.length).toBeGreaterThan(0);
+  });
+
+  it('importTemplate cible le bon type via docType', () => {
+    get().importTemplate(custom('tableau'));
+    expect(get().templates.tableau.customTitle).toBe('PERSO');
+    expect(get().templates.pool.customTitle).not.toBe('PERSO');
+  });
+});


### PR DESCRIPTION
Tests unitaires sur `usePdfTemplateStore` (env jsdom).

## Nouveau fichier
- `usePdfTemplateStore.test.tsx` (4 tests) : modèles par défaut pour pool/tableau/ranking, `setTemplate` (remplacement ciblé), `resetTemplate` (restauration défaut), `importTemplate` (ciblage via `docType`).

## Résultat
- **4 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_