### PR TITLE
Tests unitaires : OfflineStorageManager (fake-indexeddb)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.1005",
+  "version": "1.0.3-build.1062",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.1005",
+      "version": "1.0.3-build.1062",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",
@@ -51,6 +51,7 @@
         "eslint-plugin-prettier": "^5.1.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.5.0",
         "html-webpack-plugin": "^5.6.3",
         "jsdom": "^25.0.0",
@@ -7076,6 +7077,16 @@
         "node >=0.6.0"
       ],
       "optional": true
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "eslint-plugin-prettier": "^5.1.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.5.0",
     "html-webpack-plugin": "^5.6.3",
     "jsdom": "^25.0.0",

--- a/src/renderer/services/offlineStorage.test.ts
+++ b/src/renderer/services/offlineStorage.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - OfflineStorageManager (IndexedDB via fake-indexeddb)
+ * BellePoule Modern
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { OfflineStorageManager } from './offlineStorage';
+import type { Competition } from '../../shared/types';
+
+let store: OfflineStorageManager;
+
+beforeEach(async () => {
+  // base fraîche pour chaque test
+  await new Promise<void>(resolve => {
+    const req = indexedDB.deleteDatabase('BellePouleOffline');
+    req.onsuccess = req.onerror = req.onblocked = () => resolve();
+  });
+  store = new OfflineStorageManager();
+});
+
+afterEach(() => {
+  // ferme la connexion pour ne pas bloquer le deleteDatabase suivant
+  (store as any).db?.close?.();
+});
+
+describe('cache compétition', () => {
+  it('met en cache et relit une compétition', async () => {
+    const comp = { id: 'c1', title: 'Open' } as unknown as Competition;
+    await store.cacheCompetition(comp);
+    const got = await store.getCachedCompetition('c1');
+    expect(got?.id).toBe('c1');
+  });
+
+  it('retourne null/undefined pour une compétition absente', async () => {
+    const got = await store.getCachedCompetition('inconnu');
+    expect(got ?? null).toBeNull();
+  });
+});
+
+describe('pending actions', () => {
+  it('ajoute, liste (triées par timestamp) et supprime', async () => {
+    const id1 = await store.addPendingAction({ type: 'UPDATE_MATCH', data: { matchId: 'm1' } } as any);
+    await store.addPendingAction({ type: 'UPDATE_FENCER', data: { fencerId: 'f1' } } as any);
+
+    let actions = await store.getPendingActions();
+    expect(actions).toHaveLength(2);
+    expect(actions[0].timestamp).toBeLessThanOrEqual(actions[1].timestamp);
+
+    await store.removePendingAction(id1);
+    actions = await store.getPendingActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('UPDATE_FENCER');
+  });
+
+  it('incrémente le compteur de tentatives', async () => {
+    const id = await store.addPendingAction({ type: 'UPDATE_MATCH', data: {} } as any);
+    await store.incrementRetryCount(id);
+    await store.incrementRetryCount(id);
+    const actions = await store.getPendingActions();
+    expect(actions[0].retryCount).toBe(2);
+  });
+});
+
+describe('conflits', () => {
+  it('ajoute, liste (non résolus) et résout', async () => {
+    const id = await store.addConflict({
+      entityType: 'match', entityId: 'm1', localVersion: {}, remoteVersion: {},
+    } as any);
+    expect(await store.getConflicts()).toHaveLength(1);
+    await store.resolveConflict(id, 'local');
+    expect(await store.getConflicts()).toHaveLength(0); // les résolus sont filtrés
+  });
+});
+
+describe('getSyncStatus', () => {
+  it('agrège les compteurs en attente et conflits', async () => {
+    await store.addPendingAction({ type: 'UPDATE_MATCH', data: {} } as any);
+    await store.addConflict({ entityType: 'match', entityId: 'm', localVersion: {}, remoteVersion: {} } as any);
+    const status = await store.getSyncStatus();
+    expect(status.pendingActions).toBe(1);
+    expect(status.conflicts).toBe(1);
+  });
+});


### PR DESCRIPTION
Tests unitaires sur `OfflineStorageManager` (IndexedDB).

## Changements
- Ajout de la devDependency **`fake-indexeddb`** pour polyfiller `indexedDB` en environnement de test.
- `offlineStorage.test.ts` (6 tests) : cache compétition (round-trip + absence), pending actions (ajout/tri par timestamp/suppression, `incrementRetryCount`), conflits (ajout/liste non-résolus/résolution), `getSyncStatus` (agrégation).
- Isolation par test : `deleteDatabase` + fermeture de connexion en `afterEach`.

## Résultat
- **6 tests, tous verts**.
- `tsc` complet : OK.
- Code de production inchangé (seul `package.json` gagne une devDependency).

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_