### PR TITLE
feat: bouton menu Outils + générateur QR Code WiFi

### DIFF
--- a/src/renderer/components/WifiQRModal.tsx
+++ b/src/renderer/components/WifiQRModal.tsx
@@ -1,0 +1,198 @@
+/**
+ * BellePoule Modern - WiFi QR Code Generator Modal
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useCallback, memo } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import { logger, LogCategory } from '@shared/services/logger';
+
+type SecurityType = 'WPA' | 'WEP' | 'nopass';
+
+interface WifiConfig {
+  ssid: string;
+  security: SecurityType;
+  password: string;
+  hidden: boolean;
+}
+
+interface WifiQRModalProps {
+  onClose: () => void;
+}
+
+const WifiQRModal_: React.FC<WifiQRModalProps> = ({ onClose }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
+  const [config, setConfig] = useState<WifiConfig>({
+    ssid: '',
+    security: 'WPA',
+    password: '',
+    hidden: false,
+  });
+  const [qrDataUrl, setQrDataUrl] = useState<string>('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string>('');
+
+  const buildWifiString = (cfg: WifiConfig): string => {
+    const escape = (s: string) => s.replace(/([\\;,":])/, '\\$1');
+    const parts: string[] = ['WIFI:'];
+    parts.push(`T:${cfg.security};`);
+    parts.push(`S:${escape(cfg.ssid)};`);
+    if (cfg.security !== 'nopass') {
+      parts.push(`P:${escape(cfg.password)};`);
+    }
+    if (cfg.hidden) parts.push('H:true;');
+    parts.push(';');
+    return parts.join('');
+  };
+
+  const generate = useCallback(async () => {
+    if (!config.ssid.trim()) {
+      setError('Le SSID est requis.');
+      return;
+    }
+    if (config.security !== 'nopass' && !config.password) {
+      setError('Le mot de passe est requis.');
+      return;
+    }
+    setError('');
+    setIsGenerating(true);
+    try {
+      const QRCode = (await import('qrcode')).default;
+      const url = await QRCode.toDataURL(buildWifiString(config), {
+        width: 280,
+        margin: 1,
+        errorCorrectionLevel: 'M',
+      });
+      setQrDataUrl(url);
+    } catch (err) {
+      logger.error(LogCategory.UI, 'Erreur génération QR WiFi', err as Error);
+      setError('Erreur lors de la génération du QR code.');
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [config]);
+
+  const download = () => {
+    if (!qrDataUrl) return;
+    const a = document.createElement('a');
+    a.href = qrDataUrl;
+    a.download = `wifi-qr-${config.ssid.replace(/\s+/g, '-')}.png`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  const handleChange = (field: keyof WifiConfig, value: string | boolean) => {
+    setConfig(prev => ({ ...prev, [field]: value }));
+    setQrDataUrl('');
+    setError('');
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        ref={modalRef}
+        className="modal modal--md"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="wifi-qr-title"
+      >
+        <div className="modal__header">
+          <h2 className="modal__title" id="wifi-qr-title">📶 Générateur QR Code WiFi</h2>
+          <button className="modal__close" onClick={onClose} aria-label="Fermer">×</button>
+        </div>
+
+        <div className="modal__body">
+          <p style={{ fontSize: '0.875rem', color: 'var(--text-muted, #6b7280)', marginBottom: '1rem' }}>
+            Les tablettes arbitres scannent ce QR code pour rejoindre le réseau WiFi.
+          </p>
+
+          <div className="form-group">
+            <label className="form-label" htmlFor="wifi-ssid">Nom du réseau (SSID)</label>
+            <input
+              id="wifi-ssid"
+              type="text"
+              className="form-control"
+              placeholder="Mon-Réseau-WiFi"
+              value={config.ssid}
+              onChange={e => handleChange('ssid', e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label" htmlFor="wifi-security">Type de sécurité</label>
+            <select
+              id="wifi-security"
+              className="form-control"
+              value={config.security}
+              onChange={e => handleChange('security', e.target.value as SecurityType)}
+            >
+              <option value="WPA">WPA / WPA2 / WPA3</option>
+              <option value="WEP">WEP</option>
+              <option value="nopass">Aucune (réseau ouvert)</option>
+            </select>
+          </div>
+
+          {config.security !== 'nopass' && (
+            <div className="form-group">
+              <label className="form-label" htmlFor="wifi-password">Mot de passe</label>
+              <input
+                id="wifi-password"
+                type="text"
+                className="form-control"
+                placeholder="Mot de passe WiFi"
+                value={config.password}
+                onChange={e => handleChange('password', e.target.value)}
+              />
+            </div>
+          )}
+
+          <div className="form-group" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              id="wifi-hidden"
+              type="checkbox"
+              checked={config.hidden}
+              onChange={e => handleChange('hidden', e.target.checked)}
+            />
+            <label htmlFor="wifi-hidden" className="form-label" style={{ marginBottom: 0, cursor: 'pointer' }}>
+              Réseau masqué (SSID caché)
+            </label>
+          </div>
+
+          {error && (
+            <div className="alert alert--error" style={{ marginTop: '0.5rem' }}>{error}</div>
+          )}
+
+          {qrDataUrl && (
+            <div style={{ textAlign: 'center', marginTop: '1.25rem' }}>
+              <img src={qrDataUrl} alt="QR Code WiFi" width={280} height={280} style={{ borderRadius: '8px' }} />
+              <p style={{ fontSize: '0.8rem', color: 'var(--text-muted, #6b7280)', marginTop: '0.5rem' }}>
+                Réseau : <strong>{config.ssid}</strong> · {config.security !== 'nopass' ? config.security : 'Ouvert'}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="modal__footer">
+          <button className="btn btn-secondary" onClick={onClose}>Fermer</button>
+          {qrDataUrl && (
+            <button className="btn btn-secondary" onClick={download}>
+              💾 Télécharger
+            </button>
+          )}
+          <button
+            className="btn btn-primary"
+            onClick={generate}
+            disabled={isGenerating || !config.ssid.trim()}
+          >
+            {isGenerating ? 'Génération...' : '📶 Générer le QR Code'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const WifiQRModal = memo(WifiQRModal_);

--- a/src/renderer/components/competition/CompetitionNav.tsx
+++ b/src/renderer/components/competition/CompetitionNav.tsx
@@ -3,10 +3,11 @@
  * Licensed under GPL-3.0
  */
 
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Competition, MatchStatus, QuestPhaseConfig, Fencer } from '../../../shared/types';
 import { Phase } from '../../hooks/useCompetitionSession';
 import CoachMark from '../CoachMark';
+import { WifiQRModal } from '../WifiQRModal';
 
 interface PhaseItem {
   id: string;
@@ -65,7 +66,23 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
   getCheckedInFencers,
   pools,
   tableauMatches,
-}) => (
+}) => {
+  const [showToolsMenu, setShowToolsMenu] = useState(false);
+  const [showWifiQR, setShowWifiQR] = useState(false);
+  const toolsMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showToolsMenu) return;
+    const handler = (e: MouseEvent) => {
+      if (toolsMenuRef.current && !toolsMenuRef.current.contains(e.target as Node)) {
+        setShowToolsMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showToolsMenu]);
+
+  return (
   <>
     {/* Breadcrumb */}
     <div style={{ padding: '0.25rem 1rem', fontSize: '0.75rem', color: 'var(--text-muted, #6b7280)', borderBottom: '1px solid var(--border-color, rgba(255,255,255,0.1))', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -124,6 +141,43 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
             {poolsNextAction.label}
           </button>
         )}
+
+        {/* Bouton menu outils */}
+        <div ref={toolsMenuRef} style={{ position: 'relative' }}>
+          <button
+            className="btn btn-secondary"
+            onClick={() => setShowToolsMenu(v => !v)}
+            title="Outils"
+            aria-haspopup="true"
+            aria-expanded={showToolsMenu}
+          >
+            🔧 Outils
+          </button>
+          {showToolsMenu && (
+            <div
+              style={{
+                position: 'absolute',
+                right: 0,
+                top: 'calc(100% + 4px)',
+                background: 'var(--bg-card, #1e293b)',
+                border: '1px solid var(--border-color, rgba(255,255,255,0.1))',
+                borderRadius: '8px',
+                boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+                minWidth: '200px',
+                zIndex: 200,
+                overflow: 'hidden',
+              }}
+            >
+              <button
+                className="comp-header-dropdown-item"
+                onClick={() => { setShowWifiQR(true); setShowToolsMenu(false); }}
+                style={{ width: '100%', textAlign: 'left' }}
+              >
+                📶 QR Code WiFi
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
 
@@ -165,8 +219,11 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
         )}
       </div>
     )}
+
+    {showWifiQR && <WifiQRModal onClose={() => setShowWifiQR(false)} />}
   </>
-);
+  );
+};
 
 const CompetitionNav = React.memo(CompetitionNavComponent);
 export default CompetitionNav;


### PR DESCRIPTION
## Résumé

- Nouveau bouton **🔧 Outils** dropdown dans la barre de navigation de compétition, à côté du bouton saisie distante
- Premier outil : **📶 QR Code WiFi** — génère un QR code scannable par les tablettes pour rejoindre le réseau

## Détails techniques

**`WifiQRModal.tsx`** (nouveau composant) :
- Champs : SSID, type de sécurité (WPA/WPA2/WPA3, WEP, Aucune), mot de passe, réseau masqué
- Format WiFi standard : `WIFI:T:WPA;S:<ssid>;P:<password>;;`
- Génération via `qrcode` (déjà en dépendance)
- Bouton téléchargement PNG

**`CompetitionNav.tsx`** :
- Ajout state local `showToolsMenu` + `showWifiQR`
- Click outside handler pour fermer le dropdown
- Bouton visible sur toutes les phases

## Plan de test

- [ ] Ouvrir une compétition → vérifier bouton "🔧 Outils" visible dans la nav
- [ ] Cliquer → dropdown avec "📶 QR Code WiFi"
- [ ] Remplir SSID + mot de passe + WPA → cliquer Générer → QR affiché
- [ ] Scanner avec un téléphone → connexion WiFi proposée
- [ ] Tester réseau ouvert (sans mot de passe)
- [ ] Tester réseau masqué (SSID caché)
- [ ] Bouton Télécharger → fichier PNG sauvegardé

https://claude.ai/code/session_01Y9c8yYEn9hc6r4UvfJYSDP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9c8yYEn9hc6r4UvfJYSDP)_