### PR TITLE
Tests unitaires : useAnalyticsStore (+ signalement incohérence useBracketStore)

### DIFF
--- a/src/features/analytics/hooks/useAnalyticsStore.test.tsx
+++ b/src/features/analytics/hooks/useAnalyticsStore.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+/**
+ * Tests unitaires - useAnalyticsStore
+ * BellePoule Modern
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useAnalyticsStore } from './useAnalyticsStore';
+
+const get = () => useAnalyticsStore.getState();
+
+beforeEach(() => {
+  useAnalyticsStore.setState({ fencerStats: [], competitionMetrics: null, isLoading: false, error: null } as any);
+});
+afterEach(() => { delete (window as any).electronAPI; });
+
+describe('loadFencerStats', () => {
+  it('charge les stats via le service', async () => {
+    (window as any).electronAPI = { db: { getCompetitionFencerStats: vi.fn(async () => [{ fencerId: 'f1' }]) } };
+    await get().loadFencerStats('c1');
+    expect(get().fencerStats).toHaveLength(1);
+    expect(get().isLoading).toBe(false);
+  });
+
+  it('retourne une liste vide sans API (pas d’erreur)', async () => {
+    await get().loadFencerStats('c1');
+    expect(get().fencerStats).toEqual([]);
+    expect(get().error).toBeNull();
+  });
+});
+
+describe('loadCompetitionMetrics', () => {
+  it('charge les métriques agrégées', async () => {
+    (window as any).electronAPI = {
+      db: {
+        getFencersByCompetition: vi.fn(async () => [{ id: 'a' }, { id: 'b' }]),
+        getPhasesByCompetition: vi.fn(async () => [{ id: 'ph' }]),
+        getPoolsByPhase: vi.fn(async () => [{ id: 'po' }]),
+        getMatchesByPool: vi.fn(async () => [{ status: 'finished' }, { status: 'not_started' }]),
+      },
+    };
+    await get().loadCompetitionMetrics('c1');
+    expect(get().competitionMetrics).toEqual({ totalFencers: 2, completedMatches: 1 });
+  });
+});
+
+describe('clearError', () => {
+  it('efface l’erreur', () => {
+    useAnalyticsStore.setState({ error: 'boom' } as any);
+    get().clearError();
+    expect(get().error).toBeNull();
+  });
+});


### PR DESCRIPTION
Tests unitaires sur `useAnalyticsStore` (env jsdom, `electronAPI.db` mocké via le service).

## Nouveau fichier
- `useAnalyticsStore.test.tsx` (4 tests) : `loadFencerStats` (succès / liste vide sans API), `loadCompetitionMetrics` (agrégation), `clearError`.

## Résultat
- **4 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

## ⚠️ Signalement (hors scope de cette PR)
`useBracketStore` appelle `service.updateMatch(...)` et `service.computeFinalResults(...)` qui **n'existent pas** sur `BracketService` (lequel expose `updateMatchResult` / `getProgression`). Ces actions du store finissent donc toujours en erreur (catchée). De plus `generateBracket` y est appelé avec une signature `(competitionId, ranking, config)` alors que le service attend `(competitionId, config)`. À corriger côté produit — je n'ai pas écrit de test figeant ce comportement cassé.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_