### PR TITLE
feat: télécommande TV Xiaomi (menu Outils)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1865,6 +1865,37 @@ ipcMain.handle('remote:setRegistrationEnabled', async (_, competitionId: string,
   }
 });
 
+ipcMain.handle('remote:getConnectedClients', async (_, competitionId: string) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    return { success: true, clients: entry?.server.getConnectedClients() ?? [] };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue', clients: [] };
+  }
+});
+
+ipcMain.handle('remote:sendClientCommand', async (_, competitionId: string, socketId: string, command: any) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: false, error: 'Serveur non démarré' };
+    entry.server.sendClientCommand(socketId, command);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('remote:broadcastCommand', async (_, competitionId: string, command: any) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: false, error: 'Serveur non démarré' };
+    entry.server.broadcastCommand(command);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle('app:getLogo', async () => {
   const logoPath = path.join(app.getPath('userData'), 'logo.dat');
   try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -518,6 +518,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:resetPoolMatch', competitionId, matchId),
     setRegistrationEnabled: (competitionId: string, enabled: boolean) =>
       ipcRenderer.invoke('remote:setRegistrationEnabled', competitionId, enabled),
+    getConnectedClients: (competitionId: string) =>
+      ipcRenderer.invoke('remote:getConnectedClients', competitionId),
+    sendClientCommand: (competitionId: string, socketId: string, command: any) =>
+      ipcRenderer.invoke('remote:sendClientCommand', competitionId, socketId, command),
+    broadcastCommand: (competitionId: string, command: any) =>
+      ipcRenderer.invoke('remote:broadcastCommand', competitionId, command),
+    onClientListUpdate: (cb: (clients: any[]) => void) => {
+      const handler = (_: any, clients: any[]) => cb(clients);
+      ipcRenderer.on('remote:clientListUpdate', handler);
+      return () => ipcRenderer.removeListener('remote:clientListUpdate', handler);
+    },
   },
 
   // Remote event listeners (for real-time updates)

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -113,6 +113,18 @@ export class RemoteScoreServer {
   private readonly EVENT_BUFFER_MAX = 50;
   private readonly EVENT_BUFFER_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
+  // Registre des clients TV/affichage connectés (télécommande)
+  private connectedClients: Map<string, {
+    socketId: string;
+    clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard';
+    arenaId?: string;
+    ip: string;
+    userAgent: string;
+    connectedAt: string;
+    lastSeen: string;
+    label?: string;
+  }> = new Map();
+
   constructor(db: DatabaseManager, port: number = 8066, host: string = '0.0.0.0') {
     console.log('[RemoteScoreServer] Initialisation du serveur de saisie distante...');
     this.db = db;
@@ -2176,8 +2188,36 @@ export class RemoteScoreServer {
         }
       );
 
+      // Enregistrement client TV/affichage pour la télécommande
+      socket.on('client:register', (data: {
+        clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard';
+        arenaId?: string;
+        userAgent?: string;
+      }) => {
+        const now = new Date().toISOString();
+        this.connectedClients.set(socket.id, {
+          socketId: socket.id,
+          clientType: data.clientType ?? 'arena',
+          arenaId: data.arenaId,
+          ip: (socket.handshake.headers['x-forwarded-for'] as string) || socket.handshake.address || '',
+          userAgent: data.userAgent ?? '',
+          connectedAt: now,
+          lastSeen: now,
+        });
+        this.broadcastClientList();
+      });
+
+      socket.on('client:pong', () => {
+        const client = this.connectedClients.get(socket.id);
+        if (client) {
+          client.lastSeen = new Date().toISOString();
+        }
+      });
+
       socket.on('disconnect', () => {
         console.log('Client disconnected:', socket.id);
+        this.connectedClients.delete(socket.id);
+        this.broadcastClientList();
         this.handleDisconnect(socket);
       });
     });
@@ -2185,6 +2225,25 @@ export class RemoteScoreServer {
 
   private handleDisconnect(socket: any): void {
     console.log(`Client ${socket.id} disconnected`);
+  }
+
+  private broadcastClientList(): void {
+    const mainWin = (global as any).mainWindow;
+    if (mainWin) {
+      mainWin.webContents.send('remote:clientListUpdate', this.getConnectedClients());
+    }
+  }
+
+  getConnectedClients() {
+    return Array.from(this.connectedClients.values());
+  }
+
+  sendClientCommand(socketId: string, command: { type: string; url?: string; text?: string; duration?: number }): void {
+    this.io.to(socketId).emit('server:command', command);
+  }
+
+  broadcastCommand(command: { type: string; url?: string; text?: string; duration?: number }): void {
+    this.io.emit('server:command', command);
   }
 
   // Stockage des cartons par arène

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1431,7 +1431,17 @@
           this.socket.on('connect', () => {
             this.updateConnectionStatus(true);
             this.socket.emit('join_arena', { arenaId: this.arenaId, role: 'display' });
+            this.socket.emit('client:register', { clientType: 'arena', arenaId: this.arenaId, userAgent: navigator.userAgent });
           });
+
+          this.socket.on('server:command', cmd => {
+            if (cmd.type === 'refresh') { location.reload(); return; }
+            if (cmd.type === 'navigate' && cmd.url) { location.href = cmd.url; return; }
+            if (cmd.type === 'ping') { this.socket.emit('client:pong'); return; }
+            if (cmd.type === 'message' && cmd.text) { this.showRemoteMessage(cmd.text, cmd.duration ?? 5000); }
+          });
+
+          setInterval(() => { if (this.socket.connected) this.socket.emit('client:pong'); }, 30000);
 
           this.socket.on('disconnect', () => {
             this.updateConnectionStatus(false);
@@ -1461,6 +1471,20 @@
             .then(res => res.json())
             .then(data => { if (data.wallpaper) this.applyWallpaper(data.wallpaper); })
             .catch(() => {});
+        }
+
+        showRemoteMessage(text, duration) {
+          let banner = document.getElementById('remote-msg-banner');
+          if (!banner) {
+            banner = document.createElement('div');
+            banner.id = 'remote-msg-banner';
+            banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:rgba(0,0,0,0.82);color:#fff;font-size:1.3rem;padding:0.7rem 1.2rem;text-align:center;z-index:9999;pointer-events:none;transition:opacity 0.4s;';
+            document.body.appendChild(banner);
+          }
+          banner.textContent = text;
+          banner.style.opacity = '1';
+          clearTimeout(banner._hideTimer);
+          banner._hideTimer = setTimeout(() => { banner.style.opacity = '0'; }, duration);
         }
 
         applyWallpaper(wallpaper) {

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -2565,6 +2565,21 @@
         try {
           const socket = io({ reconnection: true, reconnectionDelay: 200, reconnectionDelayMax: 5000, randomizationFactor: 0.5 });
           socket.on('bracket:update', fetchBracket);
+          socket.on('connect', () => {
+            socket.emit('client:register', { clientType: 'kiosk', userAgent: navigator.userAgent });
+          });
+          socket.on('server:command', cmd => {
+            if (cmd.type === 'refresh') { location.reload(); return; }
+            if (cmd.type === 'navigate' && cmd.url) { location.href = cmd.url; return; }
+            if (cmd.type === 'ping') { socket.emit('client:pong'); return; }
+            if (cmd.type === 'message' && cmd.text) {
+              let b = document.getElementById('remote-msg-banner');
+              if (!b) { b = document.createElement('div'); b.id = 'remote-msg-banner'; b.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:rgba(0,0,0,0.82);color:#fff;font-size:1.3rem;padding:0.7rem 1.2rem;text-align:center;z-index:9999;pointer-events:none;transition:opacity 0.4s;'; document.body.appendChild(b); }
+              b.textContent = cmd.text; b.style.opacity = '1';
+              clearTimeout(b._t); b._t = setTimeout(() => { b.style.opacity = '0'; }, cmd.duration ?? 5000);
+            }
+          });
+          setInterval(() => { if (socket.connected) socket.emit('client:pong'); }, 30000);
         } catch { /* Socket.IO optionnel */ }
 
         // Plein écran automatique au premier clic seulement

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -907,7 +907,22 @@
           this.socket.on('connect', () => {
             this.updateConnectionStatus(true);
             this.socket.emit('join_arena', { arenaId: this.arenaId, role: 'public' });
+            this.socket.emit('client:register', { clientType: 'public', arenaId: this.arenaId, userAgent: navigator.userAgent });
           });
+
+          this.socket.on('server:command', cmd => {
+            if (cmd.type === 'refresh') { location.reload(); return; }
+            if (cmd.type === 'navigate' && cmd.url) { location.href = cmd.url; return; }
+            if (cmd.type === 'ping') { this.socket.emit('client:pong'); return; }
+            if (cmd.type === 'message' && cmd.text) {
+              let b = document.getElementById('remote-msg-banner');
+              if (!b) { b = document.createElement('div'); b.id = 'remote-msg-banner'; b.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:rgba(0,0,0,0.82);color:#fff;font-size:1.3rem;padding:0.7rem 1.2rem;text-align:center;z-index:9999;pointer-events:none;transition:opacity 0.4s;'; document.body.appendChild(b); }
+              b.textContent = cmd.text; b.style.opacity = '1';
+              clearTimeout(b._t); b._t = setTimeout(() => { b.style.opacity = '0'; }, cmd.duration ?? 5000);
+            }
+          });
+
+          setInterval(() => { if (this.socket.connected) this.socket.emit('client:pong'); }, 30000);
 
           this.socket.on('disconnect', () => {
             this.updateConnectionStatus(false);

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1087,6 +1087,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         getCheckedInFencers={getCheckedInFencers}
         pools={pools}
         tableauMatches={tableauMatches}
+        remoteServerUrl={remoteServerUrl ?? undefined}
+        remoteArenaCount={remoteArenaCount}
       />
 
       {/* Content — keyed pour animation de transition */}

--- a/src/renderer/components/XiaomiRemotePanel.tsx
+++ b/src/renderer/components/XiaomiRemotePanel.tsx
@@ -1,0 +1,250 @@
+/**
+ * BellePoule Modern - Xiaomi TV Remote Control Panel
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import type { ConnectedClient, TVCommand } from '@shared/types/preload';
+
+interface XiaomiRemotePanelProps {
+  competitionId: string;
+  serverUrl: string;
+  arenaCount: number;
+  onClose: () => void;
+}
+
+const CLIENT_TYPE_LABELS: Record<string, string> = {
+  arena: 'Arène',
+  kiosk: 'Kiosk',
+  public: 'Public',
+  pool: 'Poules',
+  dashboard: 'Dashboard',
+};
+
+function getOnlineStatus(lastSeen: string): 'online' | 'warn' | 'offline' {
+  const diff = Date.now() - new Date(lastSeen).getTime();
+  if (diff < 35000) return 'online';
+  if (diff < 120000) return 'warn';
+  return 'offline';
+}
+
+function formatLastSeen(lastSeen: string): string {
+  const diff = Math.floor((Date.now() - new Date(lastSeen).getTime()) / 1000);
+  if (diff < 10) return 'à l\'instant';
+  if (diff < 60) return `il y a ${diff}s`;
+  const m = Math.floor(diff / 60);
+  return `il y a ${m}m`;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  online: '#22c55e',
+  warn: '#f59e0b',
+  offline: '#6b7280',
+};
+
+const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
+  competitionId,
+  serverUrl,
+  arenaCount,
+  onClose,
+}) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
+  const [clients, setClients] = useState<ConnectedClient[]>([]);
+  const [message, setMessage] = useState('');
+  const [msgDuration, setMsgDuration] = useState(5);
+  const [openNav, setOpenNav] = useState<string | null>(null);
+  const navRef = useRef<HTMLDivElement>(null);
+
+  const navTargets = buildNavTargets(serverUrl, arenaCount);
+
+  const fetchClients = useCallback(async () => {
+    const res = await window.electronAPI.remote.getConnectedClients(competitionId);
+    if (res.success) setClients(res.clients);
+  }, [competitionId]);
+
+  useEffect(() => {
+    fetchClients();
+    const interval = setInterval(fetchClients, 5000);
+    const unsub = window.electronAPI.remote.onClientListUpdate((updated) => setClients(updated));
+    return () => { clearInterval(interval); unsub(); };
+  }, [fetchClients]);
+
+  useEffect(() => {
+    if (!openNav) return;
+    const handler = (e: MouseEvent) => {
+      if (navRef.current && !navRef.current.contains(e.target as Node)) {
+        setOpenNav(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [openNav]);
+
+  const sendCmd = useCallback((socketId: string, cmd: TVCommand) => {
+    window.electronAPI.remote.sendClientCommand(competitionId, socketId, cmd);
+  }, [competitionId]);
+
+  const broadcastCmd = useCallback((cmd: TVCommand) => {
+    window.electronAPI.remote.broadcastCommand(competitionId, cmd);
+  }, [competitionId]);
+
+  const sendMessage = () => {
+    if (!message.trim()) return;
+    broadcastCmd({ type: 'message', text: message.trim(), duration: msgDuration * 1000 });
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        ref={modalRef}
+        style={{
+          background: 'var(--bg-card, #1e293b)',
+          border: '1px solid var(--border-color, rgba(255,255,255,0.1))',
+          borderRadius: '12px',
+          width: '560px',
+          maxWidth: '95vw',
+          maxHeight: '85vh',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div style={{ padding: '1rem 1.25rem', borderBottom: '1px solid var(--border-color, rgba(255,255,255,0.1))', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <span style={{ fontSize: '1.25rem' }}>📺</span>
+          <span style={{ fontWeight: 600, fontSize: '1rem', flex: 1 }}>Télécommande TV</span>
+          <button className="btn btn-secondary" onClick={fetchClients} style={{ padding: '0.25rem 0.6rem', fontSize: '0.8rem' }}>↻</button>
+          <button className="btn btn-primary" onClick={() => broadcastCmd({ type: 'refresh' })} style={{ padding: '0.25rem 0.6rem', fontSize: '0.8rem' }}>Tout rafraîchir</button>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted, #6b7280)', fontSize: '1.2rem', padding: '0 0.25rem' }}>×</button>
+        </div>
+
+        {/* Client list */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '0.75rem 1.25rem' }}>
+          {clients.length === 0 ? (
+            <div style={{ color: 'var(--text-muted, #6b7280)', textAlign: 'center', padding: '2rem', fontSize: '0.9rem' }}>
+              Aucun écran connecté.<br />
+              <span style={{ fontSize: '0.8rem' }}>Les TV apparaissent ici dès qu'elles ouvrent une page arena ou kiosk.</span>
+            </div>
+          ) : (
+            clients.map((client) => {
+              const status = getOnlineStatus(client.lastSeen);
+              return (
+                <div
+                  key={client.socketId}
+                  style={{
+                    background: 'var(--bg-secondary, rgba(255,255,255,0.04))',
+                    border: '1px solid var(--border-color, rgba(255,255,255,0.08))',
+                    borderRadius: '8px',
+                    padding: '0.6rem 0.85rem',
+                    marginBottom: '0.5rem',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.75rem',
+                  }}
+                >
+                  <span style={{ width: 10, height: 10, borderRadius: '50%', background: STATUS_COLORS[status], flexShrink: 0 }} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontWeight: 500, fontSize: '0.88rem' }}>
+                      {CLIENT_TYPE_LABELS[client.clientType] ?? client.clientType}
+                      {client.arenaId ? ` — ${client.arenaId}` : ''}
+                    </div>
+                    <div style={{ fontSize: '0.75rem', color: 'var(--text-muted, #6b7280)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {client.ip} · {formatLastSeen(client.lastSeen)}
+                    </div>
+                  </div>
+                  <button
+                    className="btn btn-secondary"
+                    style={{ padding: '0.2rem 0.5rem', fontSize: '0.75rem' }}
+                    onClick={() => sendCmd(client.socketId, { type: 'refresh' })}
+                  >
+                    ↻
+                  </button>
+                  <div ref={openNav === client.socketId ? navRef : null} style={{ position: 'relative' }}>
+                    <button
+                      className="btn btn-secondary"
+                      style={{ padding: '0.2rem 0.5rem', fontSize: '0.75rem' }}
+                      onClick={() => setOpenNav(openNav === client.socketId ? null : client.socketId)}
+                    >
+                      Naviguer ▾
+                    </button>
+                    {openNav === client.socketId && (
+                      <div style={{ position: 'absolute', right: 0, top: 'calc(100% + 4px)', background: 'var(--bg-card, #1e293b)', border: '1px solid var(--border-color, rgba(255,255,255,0.15))', borderRadius: '8px', boxShadow: '0 8px 24px rgba(0,0,0,0.4)', minWidth: '180px', zIndex: 300, overflow: 'hidden' }}>
+                        {navTargets.map(t => (
+                          <button
+                            key={t.url}
+                            className="comp-header-dropdown-item"
+                            style={{ width: '100%', textAlign: 'left', fontSize: '0.82rem' }}
+                            onClick={() => { sendCmd(client.socketId, { type: 'navigate', url: t.url }); setOpenNav(null); }}
+                          >
+                            {t.label}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    className="btn btn-secondary"
+                    style={{ padding: '0.2rem 0.5rem', fontSize: '0.75rem' }}
+                    onClick={() => sendCmd(client.socketId, { type: 'ping' })}
+                    title="Ping"
+                  >
+                    Ping
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Message global */}
+        <div style={{ padding: '0.75rem 1.25rem', borderTop: '1px solid var(--border-color, rgba(255,255,255,0.1))' }}>
+          <div style={{ fontSize: '0.78rem', color: 'var(--text-muted, #6b7280)', marginBottom: '0.4rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Message global</div>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            <input
+              type="text"
+              value={message}
+              onChange={e => setMessage(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') sendMessage(); }}
+              placeholder="Texte affiché en bas de tous les écrans…"
+              style={{ flex: 1, padding: '0.4rem 0.6rem', fontSize: '0.85rem', background: 'var(--bg-secondary, rgba(255,255,255,0.06))', border: '1px solid var(--border-color, rgba(255,255,255,0.15))', borderRadius: '6px', color: 'inherit' }}
+            />
+            <select
+              value={msgDuration}
+              onChange={e => setMsgDuration(Number(e.target.value))}
+              style={{ padding: '0.4rem 0.4rem', fontSize: '0.82rem', background: 'var(--bg-secondary, rgba(255,255,255,0.06))', border: '1px solid var(--border-color, rgba(255,255,255,0.15))', borderRadius: '6px', color: 'inherit' }}
+            >
+              <option value={3}>3s</option>
+              <option value={5}>5s</option>
+              <option value={10}>10s</option>
+              <option value={30}>30s</option>
+              <option value={60}>60s</option>
+            </select>
+            <button className="btn btn-primary" style={{ padding: '0.4rem 0.75rem', fontSize: '0.85rem' }} onClick={sendMessage}>
+              Envoyer
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function buildNavTargets(serverUrl: string, arenaCount: number) {
+  const base = serverUrl.replace(/\/$/, '');
+  const targets: { label: string; url: string }[] = [];
+  for (let i = 1; i <= arenaCount; i++) {
+    targets.push({ label: `Arène ${i}`, url: `${base}/arene${i}` });
+  }
+  targets.push({ label: 'Kiosk public', url: `${base}/kiosk` });
+  targets.push({ label: 'Classement', url: `${base}/` });
+  return targets;
+}
+
+export const XiaomiRemotePanel = React.memo(XiaomiRemotePanelComponent);

--- a/src/renderer/components/competition/CompetitionNav.tsx
+++ b/src/renderer/components/competition/CompetitionNav.tsx
@@ -8,6 +8,7 @@ import { Competition, MatchStatus, QuestPhaseConfig, Fencer } from '../../../sha
 import { Phase } from '../../hooks/useCompetitionSession';
 import CoachMark from '../CoachMark';
 import { WifiQRModal } from '../WifiQRModal';
+import { XiaomiRemotePanel } from '../XiaomiRemotePanel';
 
 interface PhaseItem {
   id: string;
@@ -49,6 +50,8 @@ interface CompetitionNavProps {
   getCheckedInFencers: () => Fencer[];
   pools: PoolItem[];
   tableauMatches: TableauMatchItem[];
+  remoteServerUrl?: string;
+  remoteArenaCount?: number;
 }
 
 const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
@@ -66,9 +69,12 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
   getCheckedInFencers,
   pools,
   tableauMatches,
+  remoteServerUrl,
+  remoteArenaCount = 4,
 }) => {
   const [showToolsMenu, setShowToolsMenu] = useState(false);
   const [showWifiQR, setShowWifiQR] = useState(false);
+  const [showTVRemote, setShowTVRemote] = useState(false);
   const toolsMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -175,6 +181,13 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
               >
                 📶 QR Code WiFi
               </button>
+              <button
+                className="comp-header-dropdown-item"
+                onClick={() => { setShowTVRemote(true); setShowToolsMenu(false); }}
+                style={{ width: '100%', textAlign: 'left' }}
+              >
+                📺 Télécommande TV
+              </button>
             </div>
           )}
         </div>
@@ -221,6 +234,14 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
     )}
 
     {showWifiQR && <WifiQRModal onClose={() => setShowWifiQR(false)} />}
+    {showTVRemote && (
+      <XiaomiRemotePanel
+        competitionId={competition.id}
+        serverUrl={remoteServerUrl ?? ''}
+        arenaCount={remoteArenaCount}
+        onClose={() => setShowTVRemote(false)}
+      />
+    )}
   </>
   );
 };

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -335,6 +335,24 @@ export interface RemoteServerInfo {
   port: number;
 }
 
+export interface ConnectedClient {
+  socketId: string;
+  clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard';
+  arenaId?: string;
+  ip: string;
+  userAgent: string;
+  connectedAt: string;
+  lastSeen: string;
+  label?: string;
+}
+
+export interface TVCommand {
+  type: 'refresh' | 'navigate' | 'message' | 'ping';
+  url?: string;
+  text?: string;
+  duration?: number;
+}
+
 export interface RemoteServerAPI {
   getNetworkInterfaces: () => Promise<{
     success: boolean;
@@ -424,6 +442,10 @@ export interface RemoteServerAPI {
     competitionId: string,
     enabled: boolean
   ) => Promise<{ success: boolean; error?: string }>;
+  getConnectedClients: (competitionId: string) => Promise<{ success: boolean; clients: ConnectedClient[]; error?: string }>;
+  sendClientCommand: (competitionId: string, socketId: string, command: TVCommand) => Promise<{ success: boolean; error?: string }>;
+  broadcastCommand: (competitionId: string, command: TVCommand) => Promise<{ success: boolean; error?: string }>;
+  onClientListUpdate: (cb: (clients: ConnectedClient[]) => void) => () => void;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Résumé

- Nouveau panneau **📺 Télécommande TV** dans le menu Outils (CompetitionNav)
- Pilotage en temps réel de tous les écrans TV connectés au serveur remote (arène, kiosk, public) depuis le PC organisateur
- Aucune dépendance externe — fonctionne via le serveur Socket.IO déjà existant (port 8066)

## Fonctionnalités

- **Liste des écrans connectés** avec indicateur de statut (vert < 35s / orange < 2m / gris hors ligne), IP et type (Arène / Kiosk / Public)
- **Par écran** : Rafraîchir, Naviguer vers (dropdown : arènes, kiosk, classement), Ping
- **Global** : Tout rafraîchir d'un clic
- **Message global** : texte diffusé en bandeau bas sur tous les écrans, durée configurable (3/5/10/30/60s)
- **Mise à jour en temps réel** : push via IPC + polling 5s de secours

## Fichiers modifiés

| Fichier | Rôle |
|---|---|
| `src/main/remoteScoreServer.ts` | Registre ConnectedClient, handlers `client:register`/`pong`, méthodes `getConnectedClients`/`sendClientCommand`/`broadcastCommand` |
| `src/main/main.ts` | 3 handlers IPC : `remote:getConnectedClients`, `remote:sendClientCommand`, `remote:broadcastCommand` |
| `src/shared/types/preload.ts` | Types `ConnectedClient`, `TVCommand`, méthodes dans `RemoteServerAPI` |
| `src/main/preload.ts` | Exposition IPC + listener `onClientListUpdate` |
| `src/remote/arena.html` | `client:register` au connect, listener `server:command`, heartbeat 30s, `showRemoteMessage()` |
| `src/remote/kiosk.html` | Idem |
| `src/remote/public.html` | Idem |
| `src/renderer/components/XiaomiRemotePanel.tsx` | Nouveau composant React |
| `src/renderer/components/competition/CompetitionNav.tsx` | Bouton menu + props `remoteServerUrl`/`remoteArenaCount` |
| `src/renderer/components/CompetitionView.tsx` | Transmission des nouvelles props à CompetitionNav |

## Test plan

- [ ] Démarrer le serveur remote depuis l'onglet Remote
- [ ] Ouvrir `http://<ip>:8066/arene1` dans un navigateur (ou TV)
- [ ] Ouvrir **Outils → 📺 Télécommande TV** → l'écran apparaît dans la liste en vert
- [ ] Cliquer **↻** sur l'écran → la page se recharge
- [ ] **Naviguer vers → Kiosk** → la TV navigue vers `/kiosk`
- [ ] Envoyer un message → bandeau translucide apparaît en bas de l'écran TV
- [ ] **Tout rafraîchir** → tous les écrans connectés rechargent
- [ ] Fermer l'onglet TV → l'écran passe gris dans le panel en < 35s

https://claude.ai/code/session_012huQkLL9cLStMGnkexU8Ri

---
_Generated by [Claude Code](https://claude.ai/code/session_012huQkLL9cLStMGnkexU8Ri)_