### PR TITLE
Tests composant : Confetti

### DIFF
--- a/src/renderer/components/Confetti.test.tsx
+++ b/src/renderer/components/Confetti.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+/**
+ * Tests de composant - Confetti
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import Confetti from './Confetti';
+
+describe('Confetti', () => {
+  it('ne rend rien quand inactif', () => {
+    const { container } = render(<Confetti active={false} />);
+    expect(container.querySelector('canvas')).toBeNull();
+  });
+
+  it('rend un canvas plein écran quand actif', () => {
+    const { container } = render(<Confetti active={true} />);
+    const canvas = container.querySelector('canvas');
+    expect(canvas).not.toBeNull();
+    expect(canvas?.style.position).toBe('fixed');
+    expect(canvas?.style.pointerEvents).toBe('none');
+  });
+});


### PR DESCRIPTION
Tests de composant : `Confetti` (env jsdom).

## Nouveau fichier
- `Confetti.test.tsx` (2 tests) : ne rend rien quand `active=false`, rend un `<canvas>` plein écran (`position: fixed`, `pointerEvents: none`) quand `active=true`.

## Résultat
- **2 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_