### PR TITLE
Tests composant : AddFencerModal

### DIFF
--- a/src/renderer/components/AddFencerModal.test.tsx
+++ b/src/renderer/components/AddFencerModal.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+/**
+ * Tests de composant - AddFencerModal
+ * BellePoule Modern
+ */
+
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('../contexts/TranslationContext', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+import AddFencerModal from './AddFencerModal';
+
+const setup = () => {
+  const onAdd = vi.fn();
+  const onClose = vi.fn();
+  const { container } = render(<AddFencerModal onAdd={onAdd} onClose={onClose} />);
+  return { onAdd, onClose, container };
+};
+
+describe('AddFencerModal', () => {
+  it('ajoute un tireur avec nom en majuscules puis ferme', () => {
+    const { onAdd, onClose, container } = setup();
+    fireEvent.change(screen.getByPlaceholderText('DUPONT'), { target: { value: 'dupont' } });
+    fireEvent.change(screen.getByPlaceholderText('Jean'), { target: { value: 'Jean' } });
+    fireEvent.submit(container.querySelector('form')!);
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onAdd.mock.calls[0][0].lastName).toBe('DUPONT');
+    expect(onAdd.mock.calls[0][0].firstName).toBe('Jean');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('ne soumet pas sans nom/prénom', () => {
+    const { onAdd, container } = setup();
+    fireEvent.submit(container.querySelector('form')!);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('le bouton annuler ferme la modale', () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByText('actions.cancel'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Tests de composant : `AddFencerModal` (env jsdom, `TranslationContext` mocké).

## Nouveau fichier
- `AddFencerModal.test.tsx` (3 tests) : ajout d'un tireur (nom mis en majuscules + `onClose`), validation (pas de soumission sans nom/prénom), bouton annuler → `onClose`.

## Résultat
- **3 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_