### PR TITLE
Tests composant : LanguageSelector

### DIFF
--- a/src/renderer/components/LanguageSelector.test.tsx
+++ b/src/renderer/components/LanguageSelector.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+/**
+ * Tests de composant - LanguageSelector
+ * BellePoule Modern
+ */
+
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const changeLanguage = vi.fn();
+const hookState = {
+  language: 'fr',
+  changeLanguage,
+  availableLanguages: [
+    { code: 'fr', name: 'Français', flag: '🇫🇷' },
+    { code: 'en', name: 'English', flag: '🇬🇧' },
+  ],
+  isLoading: false,
+};
+vi.mock('../hooks/useTranslation', () => ({ useTranslation: () => hookState }));
+
+import LanguageSelector from './LanguageSelector';
+
+beforeEach(() => {
+  changeLanguage.mockClear();
+  hookState.isLoading = false;
+});
+
+describe('LanguageSelector', () => {
+  it('rend les langues disponibles', () => {
+    render(<LanguageSelector />);
+    expect(screen.getByText(/Français/)).toBeInTheDocument();
+    expect(screen.getByText(/English/)).toBeInTheDocument();
+  });
+
+  it('applique directement le changement sans prop onLanguageChange', () => {
+    render(<LanguageSelector />);
+    fireEvent.change(screen.getByLabelText('Langue :'), { target: { value: 'en' } });
+    expect(changeLanguage).toHaveBeenCalledWith('en');
+  });
+
+  it('délègue à onLanguageChange si fourni (mode sélection)', () => {
+    const onLanguageChange = vi.fn();
+    render(<LanguageSelector onLanguageChange={onLanguageChange} />);
+    fireEvent.change(screen.getByLabelText('Langue :'), { target: { value: 'en' } });
+    expect(onLanguageChange).toHaveBeenCalledWith('en');
+    expect(changeLanguage).not.toHaveBeenCalled();
+  });
+
+  it('affiche un état de chargement', () => {
+    hookState.isLoading = true;
+    render(<LanguageSelector />);
+    expect(screen.getByText('Chargement...')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Tests de composant : `LanguageSelector` (env jsdom, `useTranslation` mocké).

## Nouveau fichier
- `LanguageSelector.test.tsx` (4 tests) : rend les langues disponibles, application directe (`changeLanguage`) sans prop, délégation à `onLanguageChange` en mode sélection, état de chargement.

## Résultat
- **4 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_