### PR TITLE
Tests composant : AddFencerToPoolModal

### DIFF
--- a/src/renderer/components/AddFencerToPoolModal.test.tsx
+++ b/src/renderer/components/AddFencerToPoolModal.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+/**
+ * Tests de composant - AddFencerToPoolModal
+ * BellePoule Modern
+ */
+
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AddFencerToPoolModal from './AddFencerToPoolModal';
+import { Fencer, Pool, Gender, FencerStatus } from '../../shared/types';
+
+const fencer = (id: string, last: string): Fencer => ({
+  id, ref: Number(id), lastName: last, firstName: 'F',
+  gender: Gender.MALE, nationality: 'FRA', status: FencerStatus.CHECKED_IN,
+  createdAt: new Date(), updatedAt: new Date(),
+});
+
+const inPool = fencer('1', 'Dupont');
+const free = fencer('2', 'Martin');
+const pool: Pool = {
+  id: 'p1', number: 1, phaseId: 'ph', fencers: [inPool], matches: [], referees: [],
+  isComplete: false, hasError: false, ranking: [],
+  createdAt: new Date(), updatedAt: new Date(),
+};
+
+beforeEach(() => {
+  (window as any).electronAPI = {
+    db: {
+      getFencersByCompetition: vi.fn(async () => [inPool, free]),
+      getPhasesByCompetition: vi.fn(async () => []),
+      getPoolFencers: vi.fn(async () => []),
+      addFencerToPoolMidCompetition: vi.fn(async () => ({ ...pool, fencers: [inPool, free] })),
+    },
+  };
+});
+afterEach(() => { delete (window as any).electronAPI; });
+
+describe('AddFencerToPoolModal', () => {
+  it('affiche les tireurs disponibles (hors poule)', async () => {
+    render(<AddFencerToPoolModal pool={pool} competitionId="c1" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(await screen.findByText(/Martin/)).toBeInTheDocument();
+    // Dupont est déjà dans la poule → absent de la liste des disponibles
+    expect(screen.queryByText(/Dupont/)).not.toBeInTheDocument();
+  });
+
+  it('sélectionne un tireur et confirme l’ajout', async () => {
+    const onConfirm = vi.fn();
+    render(<AddFencerToPoolModal pool={pool} competitionId="c1" onConfirm={onConfirm} onClose={vi.fn()} />);
+    fireEvent.click(await screen.findByText(/Martin/));
+    fireEvent.click(screen.getByText('Ajouter le tireur'));
+    await waitFor(() =>
+      expect((window as any).electronAPI.db.addFencerToPoolMidCompetition).toHaveBeenCalledWith('p1', '2', 5)
+    );
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled());
+  });
+
+  it('le bouton ajouter est désactivé sans sélection', async () => {
+    render(<AddFencerToPoolModal pool={pool} competitionId="c1" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    await screen.findByText(/Martin/);
+    expect(screen.getByText('Ajouter le tireur')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Tests de composant : `AddFencerToPoolModal` (env jsdom, `electronAPI.db` mocké).

## Nouveau fichier
- `AddFencerToPoolModal.test.tsx` (3 tests) : affichage des tireurs disponibles (hors poule), sélection + confirmation → `addFencerToPoolMidCompetition(poolId, fencerId, maxScore)` + `onConfirm`, bouton « Ajouter » désactivé sans sélection.

## Résultat
- **3 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_