### PR TITLE
Tests composant : TableauScoreModal

### DIFF
--- a/src/renderer/components/tableau/TableauScoreModal.test.tsx
+++ b/src/renderer/components/tableau/TableauScoreModal.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+/**
+ * Tests de composant - TableauScoreModal
+ * BellePoule Modern
+ */
+
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TableauScoreModal from './TableauScoreModal';
+
+const match = {
+  id: 'm1', round: 8,
+  fencerA: { id: 'a', lastName: 'Dupont', firstName: 'Jean' },
+  fencerB: { id: 'b', lastName: 'Martin', firstName: 'Marie' },
+} as any;
+
+const setup = (over: Partial<Record<string, any>> = {}) => {
+  const props = {
+    match,
+    editScoreA: '',
+    setEditScoreA: vi.fn(),
+    editScoreB: '',
+    setEditScoreB: vi.fn(),
+    maxScore: 15,
+    isUnlimitedScore: false,
+    modalRef: React.createRef<HTMLDivElement>(),
+    onClose: vi.fn(),
+    onSubmit: vi.fn(),
+    onSpecialStatus: vi.fn(),
+    getRoundName: (r: number) => `Tour ${r}`,
+    ...over,
+  };
+  const utils = render(<TableauScoreModal {...(props as any)} />);
+  return { props, utils };
+};
+
+describe('TableauScoreModal', () => {
+  it('affiche le nom du tour et les tireurs', () => {
+    setup();
+    expect(screen.getByText('Tour 8 - Saisie rapide')).toBeInTheDocument();
+    expect(screen.getByText(/Dupont/)).toBeInTheDocument();
+    expect(screen.getByText(/Martin/)).toBeInTheDocument();
+  });
+
+  it('saisir un score appelle setEditScoreA', () => {
+    const { props, utils } = setup();
+    const inputs = utils.container.querySelectorAll('input[type="number"]');
+    fireEvent.change(inputs[0], { target: { value: '15' } });
+    expect(props.setEditScoreA).toHaveBeenCalledWith('15');
+  });
+
+  it('Valider déclenche onSubmit', () => {
+    const { props } = setup();
+    fireEvent.click(screen.getByText('Valider'));
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Tests de composant : `TableauScoreModal` (env jsdom).

## Nouveau fichier
- `TableauScoreModal.test.tsx` (3 tests) : affichage du nom de tour + tireurs, saisie de score → `setEditScoreA`, bouton « Valider » → `onSubmit`.

## Résultat
- **3 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_