### PR TITLE
Tests composant : ImportModal

### DIFF
--- a/src/renderer/components/ImportModal.test.tsx
+++ b/src/renderer/components/ImportModal.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+/**
+ * Tests de composant - ImportModal
+ * BellePoule Modern
+ */
+
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ImportModal from './ImportModal';
+
+const setup = (over: Partial<Record<string, any>> = {}) => {
+  const onImport = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <ImportModal
+      format="txt"
+      filepath="/chemin/tireurs.txt"
+      content={'DUPONT;Jean\nMARTIN;Marie'}
+      fencers={[]}
+      onImport={onImport}
+      onClose={onClose}
+      {...(over as any)}
+    />
+  );
+  return { onImport, onClose };
+};
+
+describe('ImportModal', () => {
+  it('affiche le fichier et la liste des tireurs parsés', () => {
+    setup();
+    expect(screen.getByText(/tireurs\.txt/)).toBeInTheDocument();
+    expect(screen.getByText('DUPONT')).toBeInTheDocument();
+    expect(screen.getByText('MARTIN')).toBeInTheDocument();
+  });
+
+  it('importe les tireurs sélectionnés (tous par défaut) puis ferme', () => {
+    const { onImport, onClose } = setup();
+    fireEvent.click(screen.getByText(/Importer 2 tireurs/));
+    expect(onImport).toHaveBeenCalledTimes(1);
+    expect(onImport.mock.calls[0][0]).toHaveLength(2);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('le bouton fermer déclenche onClose', () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByText('×'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Tests de composant : `ImportModal` (env jsdom, format TXT).

## Nouveau fichier
- `ImportModal.test.tsx` (3 tests) : affichage du fichier + liste des tireurs parsés (DUPONT/MARTIN), import des tireurs sélectionnés (tous par défaut) → `onImport(2)` + `onClose`, bouton fermer → `onClose`.

## Résultat
- **3 tests, tous verts**.
- `tsc` complet : OK.
- Aucune modification de code de production.

https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHYFPGiUJPLonTmXZ2mFii)_