### PR TITLE
fix: corrections issues #628 #629 #633 #728 #729 #730

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1862,8 +1862,8 @@ export class RemoteScoreServer {
             fencerB: m.fencerB
               ? { lastName: m.fencerB.lastName, firstName: m.fencerB.firstName, club: m.fencerB.club ?? '', id: m.fencerB.id }
               : null,
-            scoreA: live?.scoreA ?? m.scoreA ?? null,
-            scoreB: live?.scoreB ?? m.scoreB ?? null,
+            scoreA: (() => { const s = live?.scoreA ?? m.scoreA; return s != null ? ((s as any).value ?? s) : null; })(),
+            scoreB: (() => { const s = live?.scoreB ?? m.scoreB; return s != null ? ((s as any).value ?? s) : null; })(),
             winnerId: m.winner?.id ?? null,
             status: isFinished ? 'finished' : isLive ? 'live' : 'pending',
             isBye: !!m.isBye,

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -1785,18 +1785,52 @@
           return;
         }
 
+        // Build ranked list: top 4 from finale/petite finale, then losers of each earlier round
+        const ranked = [];
+
         const winner1 = finaleMatch.winnerId === finaleMatch.fencerA?.id ? finaleMatch.fencerA : finaleMatch.fencerB;
         const winner2 = finaleMatch.winnerId === finaleMatch.fencerA?.id ? finaleMatch.fencerB : finaleMatch.fencerA;
-        const winner3 = pfMatch?.winnerId
-          ? (pfMatch.winnerId === pfMatch.fencerA?.id ? pfMatch.fencerA : pfMatch.fencerB)
-          : null;
-        const winner4 = pfMatch?.winnerId
-          ? (pfMatch.winnerId === pfMatch.fencerA?.id ? pfMatch.fencerB : pfMatch.fencerA)
-          : null;
+        if (winner1) ranked.push({ rank: 1, fencer: winner1 });
+        if (winner2) ranked.push({ rank: 2, fencer: winner2 });
 
-        const medals = ['🥇', '🥈', '🥉', '4️⃣'];
-        const podium = [winner1, winner2, winner3, winner4].filter(Boolean);
-        document.getElementById('final-badge').textContent = podium.length + ' tireur' + (podium.length > 1 ? 's' : '');
+        if (pfMatch?.winnerId) {
+          const winner3 = pfMatch.winnerId === pfMatch.fencerA?.id ? pfMatch.fencerA : pfMatch.fencerB;
+          const winner4 = pfMatch.winnerId === pfMatch.fencerA?.id ? pfMatch.fencerB : pfMatch.fencerA;
+          if (winner3) ranked.push({ rank: 3, fencer: winner3 });
+          if (winner4) ranked.push({ rank: 4, fencer: winner4 });
+        } else {
+          // Petite finale not yet played: both semi-final losers share 3rd
+          const sfRound = data.rounds.find(r => r.round === 4);
+          if (sfRound) {
+            sfRound.matches.forEach(m => {
+              const loser = m.winnerId === m.fencerA?.id ? m.fencerB : (m.winnerId ? m.fencerA : null);
+              if (loser) ranked.push({ rank: 3, fencer: loser });
+            });
+          }
+        }
+
+        // Add losers from earlier rounds (round 4 and beyond)
+        const mainRounds = data.rounds
+          .filter(r => r.round !== 2 && r.round !== 3)
+          .sort((a, b) => a.round - b.round); // ascending: 4, 8, 16, ...
+
+        let currentRank = ranked.length > 0 ? Math.max(...ranked.map(r => r.rank)) + 1 : 5;
+        for (const round of mainRounds) {
+          const losers = [];
+          for (const m of round.matches) {
+            if (!m.isBye && m.winnerId) {
+              const loser = m.winnerId === m.fencerA?.id ? m.fencerB : m.fencerA;
+              if (loser) losers.push(loser);
+            }
+          }
+          if (losers.length > 0) {
+            losers.forEach(f => ranked.push({ rank: currentRank, fencer: f }));
+            currentRank += losers.length;
+          }
+        }
+
+        const rankLabel = r => r <= 4 ? ['🥇','🥈','🥉','4️⃣'][r-1] : r + 'e';
+        document.getElementById('final-badge').textContent = ranked.length + ' tireur' + (ranked.length > 1 ? 's' : '');
 
         el.innerHTML = `<div class="ranking-scroll-wrapper" style="flex:1">
           <table class="ranking-table">
@@ -1808,10 +1842,10 @@
               </tr>
             </thead>
             <tbody>
-              ${podium.map((f, i) => `<tr class="${i === 0 ? 'top-row' : ''}">
-                <td><span class="rank-medal">${medals[i]}</span></td>
-                <td style="font-weight:600;font-size:1.1rem">${escHtml(f.lastName + ' ' + (f.firstName || ''))}</td>
-                <td style="color:#64748b">${escHtml(f.club || '—')}</td>
+              ${ranked.map(({ rank, fencer }) => `<tr class="${rank === 1 ? 'top-row' : ''}">
+                <td><span class="rank-medal">${rankLabel(rank)}</span></td>
+                <td style="font-weight:600;font-size:1.1rem">${escHtml(fencer.lastName + ' ' + (fencer.firstName || ''))}</td>
+                <td style="color:#64748b">${escHtml(fencer.club || '—')}</td>
               </tr>`).join('')}
             </tbody>
           </table>

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -941,7 +941,7 @@
           lbl.className = 'section-label';
           lbl.textContent = `À jouer (${pending.length})`;
           view.appendChild(lbl);
-          pending.forEach((m, i) => view.appendChild(buildMatchItem(m, fencers, i + 1, false, locked)));
+          pending.forEach(m => view.appendChild(buildMatchItem(m, fencers, m.number, false, locked)));
         }
 
         if (finished.length > 0) {
@@ -949,7 +949,7 @@
           lbl.className = 'section-label';
           lbl.textContent = `Terminés (${finished.length})`;
           view.appendChild(lbl);
-          finished.forEach((m, i) => view.appendChild(buildMatchItem(m, fencers, i + 1, true, locked)));
+          finished.forEach(m => view.appendChild(buildMatchItem(m, fencers, m.number, true, locked)));
         }
 
         if (matches.length === 0) {

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -867,6 +867,7 @@
           this.cardsB = [];
           this.isSuddenDeath = false;
           this.overtimeType = null;
+          this.refereeSelected = false;
           // Clé localStorage indépendante des autres écrans
           this.inversionEnabled = localStorage.getItem('publicInversionEnabled') === 'true';
           this.showPhotos = false;
@@ -1039,7 +1040,17 @@
             this.updateStatusBadge();
           }
 
-          if (data.match && (data.refereeSelected || data.status === 'in_progress' || data.status === 'finished')) {
+          if (data.refereeSelected !== undefined) {
+            this.refereeSelected = data.refereeSelected;
+          }
+          if (data.status === 'in_progress' || data.status === 'finished') {
+            this.refereeSelected = true;
+          }
+          if (data.status === 'idle') {
+            this.refereeSelected = false;
+          }
+
+          if (data.match && (this.refereeSelected || data.status === 'in_progress' || data.status === 'finished')) {
             this.currentMatch = data.match;
             this.updateMatchDisplay();
             if (this.matchStatus === 'ready' && this.showPhotos) {
@@ -1209,7 +1220,8 @@
           const matchDisplay = document.getElementById('match-display');
           const photoIntro = document.getElementById('photo-intro');
 
-          if (this.matchStatus === 'idle' || this.matchStatus === 'not_started') {
+          if (this.matchStatus === 'idle' || this.matchStatus === 'not_started' ||
+              (this.matchStatus === 'ready' && !this.refereeSelected)) {
             waitingScreen.classList.remove('hidden');
             matchDisplay.classList.remove('active');
             photoIntro.classList.add('hidden');

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1124,7 +1124,8 @@
       <div class="active-match" id="active-match">
         <div style="display:flex;justify-content:flex-end;margin-bottom:0.5rem;">
           <button
-            onclick="window.location.reload()"
+            id="btn-back-to-list"
+            onclick="if(!refereeApp.timerRunning) window.location.reload();"
             style="background:rgba(0,0,0,0.12);border:none;border-radius:0.5rem;color:#374151;padding:0.35rem 0.85rem;font-size:0.85rem;cursor:pointer;"
             title="Retour à la liste des matchs"
           >← Retour</button>
@@ -2628,10 +2629,27 @@
           }
         }
 
+        updateBackButton() {
+          const btn = document.getElementById('btn-back-to-list');
+          if (!btn) return;
+          if (this.timerRunning) {
+            btn.disabled = true;
+            btn.style.opacity = '0.4';
+            btn.style.cursor = 'not-allowed';
+            btn.title = 'Retour désactivé pendant le chrono';
+          } else {
+            btn.disabled = false;
+            btn.style.opacity = '1';
+            btn.style.cursor = 'pointer';
+            btn.title = 'Retour à la liste des matchs';
+          }
+        },
+
         startTimer() {
           if (this.timerRunning) return;
 
           this.timerRunning = true;
+          this.updateBackButton();
           this.updateTimerDisplay();
           this.broadcastTimerUpdate();
 
@@ -2671,6 +2689,7 @@
             this.timerInterval = null;
           }
           this.timerRunning = false;
+          this.updateBackButton();
         }
 
         resetTimer() {

--- a/src/renderer/components/competition/CompetitionNav.tsx
+++ b/src/renderer/components/competition/CompetitionNav.tsx
@@ -170,7 +170,7 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
                 borderRadius: '8px',
                 boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
                 minWidth: '200px',
-                zIndex: 200,
+                zIndex: 1100,
                 overflow: 'hidden',
               }}
             >

--- a/src/renderer/hooks/usePoolManagement.ts
+++ b/src/renderer/hooks/usePoolManagement.ts
@@ -602,7 +602,9 @@ export const usePoolManagement = ({
                 scoreB > scoreA ? 'B' :
                 (winnerOverride ?? null);
 
-              pool.matches[matchIdx] = {
+              const updatedPool = { ...pool };
+              const updatedMatches = [...pool.matches];
+              updatedMatches[matchIdx] = {
                 ...match,
                 scoreA: {
                   value: scoreA,
@@ -621,11 +623,10 @@ export const usePoolManagement = ({
                 status,
                 updatedAt: new Date(),
               };
-
-              // Recalculer le classement de la pool
-              pool.updatedAt = new Date();
-              pool.ranking = computePoolRanking(pool);
-              updatedPools[poolIdx] = pool;
+              updatedPool.matches = updatedMatches;
+              updatedPool.updatedAt = new Date();
+              updatedPool.ranking = computePoolRanking(updatedPool);
+              updatedPools[poolIdx] = updatedPool;
               break;
             }
           }


### PR DESCRIPTION
## Corrections

- **#628** `usePoolManagement.ts` — mutation React state dans `updateMatchFromRemote` : crée maintenant de nouveaux objets pool/matches au lieu de muter en place (fix re-render React.memo)
- **#629** `pool.html` — numérotation matchs : utilise `m.number` au lieu de `i+1` (index du tableau filtré)
- **#633** `public.html` — affichage public : match ne s'affiche plus avant que l'arbitre ait sélectionné son match (`this.refereeSelected` persistant dans l'état du composant)
- **#728** `CompetitionNav.tsx` — z-index dropdown outils : 200 → 1100 (au-dessus des modales à 1000)
- **#729** `remoteScoreServer.ts` — `/api/bracket` : extraction de `.value` depuis les objets `Score` stockés dans `sessionMatchScores`
- **#730** `kiosk.html` — classement final : affiche tous les participants du tableau, pas seulement le top 4

https://claude.ai/code/session_015bgc4tEgq2UNawvCBLssvW

---
_Generated by [Claude Code](https://claude.ai/code/session_015bgc4tEgq2UNawvCBLssvW)_