### PR TITLE
feat: identification et gestion des écrans kiosk depuis la télécommande

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1896,6 +1896,39 @@ ipcMain.handle('remote:broadcastCommand', async (_, competitionId: string, comma
   }
 });
 
+ipcMain.handle('remote:renameClient', async (_, competitionId: string, socketId: string, label: string) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: false, error: 'Serveur non démarré' };
+    entry.server.renameClient(socketId, label);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('remote:identifyClient', async (_, competitionId: string, socketId: string) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: false, error: 'Serveur non démarré' };
+    entry.server.identifyClient(socketId);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('remote:setClientKioskMode', async (_, competitionId: string, socketId: string, config: any) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: false, error: 'Serveur non démarré' };
+    entry.server.setClientKioskMode(socketId, config);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle('app:getLogo', async () => {
   const logoPath = path.join(app.getPath('userData'), 'logo.dat');
   try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -529,6 +529,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('remote:clientListUpdate', handler);
       return () => ipcRenderer.removeListener('remote:clientListUpdate', handler);
     },
+    renameClient: (competitionId: string, socketId: string, label: string) =>
+      ipcRenderer.invoke('remote:renameClient', competitionId, socketId, label),
+    identifyClient: (competitionId: string, socketId: string) =>
+      ipcRenderer.invoke('remote:identifyClient', competitionId, socketId),
+    setClientKioskMode: (competitionId: string, socketId: string, config: any) =>
+      ipcRenderer.invoke('remote:setClientKioskMode', competitionId, socketId, config),
   },
 
   // Remote event listeners (for real-time updates)

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -123,7 +123,11 @@ export class RemoteScoreServer {
     connectedAt: string;
     lastSeen: string;
     label?: string;
+    screenId?: string;
   }> = new Map();
+
+  // Labels persistants par screenId (survivent aux reconnexions)
+  private screenLabels: Map<string, string> = new Map();
 
   constructor(db: DatabaseManager, port: number = 8066, host: string = '0.0.0.0') {
     console.log('[RemoteScoreServer] Initialisation du serveur de saisie distante...');
@@ -2199,8 +2203,11 @@ export class RemoteScoreServer {
         clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard';
         arenaId?: string;
         userAgent?: string;
+        screenId?: string;
       }) => {
         const now = new Date().toISOString();
+        const screenId = data.screenId;
+        const label = screenId ? this.screenLabels.get(screenId) : undefined;
         this.connectedClients.set(socket.id, {
           socketId: socket.id,
           clientType: data.clientType ?? 'arena',
@@ -2209,6 +2216,8 @@ export class RemoteScoreServer {
           userAgent: data.userAgent ?? '',
           connectedAt: now,
           lastSeen: now,
+          label,
+          screenId,
         });
         this.broadcastClientList();
       });
@@ -2250,6 +2259,31 @@ export class RemoteScoreServer {
 
   broadcastCommand(command: { type: string; url?: string; text?: string; duration?: number }): void {
     this.io.emit('server:command', command);
+  }
+
+  renameClient(socketId: string, label: string): void {
+    const client = this.connectedClients.get(socketId);
+    if (client) {
+      client.label = label;
+      if (client.screenId) this.screenLabels.set(client.screenId, label);
+      this.broadcastClientList();
+      // Notifier l'écran de son nouveau nom
+      this.io.to(socketId).emit('server:command', { type: 'identify', screenLabel: label, duration: 3000 });
+    }
+  }
+
+  identifyClient(socketId: string): void {
+    const client = this.connectedClients.get(socketId);
+    const label = client?.label ?? client?.screenId ?? socketId.slice(0, 8);
+    this.io.to(socketId).emit('server:command', { type: 'identify', screenLabel: label, duration: 5000 });
+  }
+
+  setClientKioskMode(socketId: string, config: {
+    poules: boolean; classement: boolean; direct: boolean;
+    suivants: boolean; tableau: boolean; rotationSec: number;
+  }): void {
+    this.io.to(socketId).emit('server:command', { type: 'kiosk:config', kioskConfig: config });
+    this.io.to(socketId).emit('server:command', { type: 'navigate', url: '/kiosk' });
   }
 
   // Stockage des cartons par arène

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -2595,17 +2595,65 @@
         setInterval(fetchBracket, 15000);
         startRotation();
 
+        // Identifiant persistant de cet écran (survit aux rechargements)
+        let _screenId = localStorage.getItem('bp_screen_id');
+        if (!_screenId) {
+          _screenId = 'scr_' + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+          localStorage.setItem('bp_screen_id', _screenId);
+        }
+
+        function _showIdentifyOverlay(label, durationMs) {
+          let ov = document.getElementById('bp-identify-overlay');
+          if (!ov) {
+            ov = document.createElement('div');
+            ov.id = 'bp-identify-overlay';
+            ov.style.cssText = [
+              'position:fixed;inset:0;z-index:99999;display:flex;flex-direction:column;',
+              'align-items:center;justify-content:center;pointer-events:none;',
+              'animation:bp-identify-blink 0.5s ease-in-out infinite alternate;',
+            ].join('');
+            const style = document.createElement('style');
+            style.textContent = '@keyframes bp-identify-blink{from{background:rgba(59,130,246,0.55)}to{background:rgba(139,92,246,0.65)}}';
+            document.head.appendChild(style);
+            document.body.appendChild(ov);
+          }
+          ov.innerHTML = '<div style="background:rgba(0,0,0,0.85);border:3px solid #3b82f6;border-radius:1.5rem;padding:2rem 4rem;text-align:center;max-width:80vw;">'
+            + '<div style="font-size:2.5rem;font-weight:900;color:#fff;margin-bottom:0.5rem;">📺 ' + escHtml(label) + '</div>'
+            + '<div style="font-size:1rem;color:#94a3b8;">Identification écran</div>'
+            + '</div>';
+          ov.style.display = 'flex';
+          clearTimeout(ov._t);
+          ov._t = setTimeout(() => { ov.style.display = 'none'; }, durationMs ?? 5000);
+        }
+
         // Socket.IO : mise à jour temps réel du bracket
         try {
           const socket = io({ reconnection: true, reconnectionDelay: 200, reconnectionDelayMax: 5000, randomizationFactor: 0.5 });
           socket.on('bracket:update', fetchBracket);
           socket.on('connect', () => {
-            socket.emit('client:register', { clientType: 'kiosk', userAgent: navigator.userAgent });
+            socket.emit('client:register', { clientType: 'kiosk', userAgent: navigator.userAgent, screenId: _screenId });
           });
           socket.on('server:command', cmd => {
             if (cmd.type === 'refresh') { location.reload(); return; }
             if (cmd.type === 'navigate' && cmd.url) { location.href = cmd.url; return; }
             if (cmd.type === 'ping') { socket.emit('client:pong'); return; }
+            if (cmd.type === 'identify') {
+              const lbl = cmd.screenLabel || localStorage.getItem('bp_screen_label') || _screenId;
+              if (cmd.screenLabel) localStorage.setItem('bp_screen_label', cmd.screenLabel);
+              _showIdentifyOverlay(lbl, cmd.duration ?? 5000);
+              return;
+            }
+            if (cmd.type === 'kiosk:config' && cmd.kioskConfig) {
+              const cfg = cmd.kioskConfig;
+              if (cfg.rotationSec != null) localStorage.setItem('kioskRotationSec', String(Math.max(3, cfg.rotationSec)));
+              const viewKeys = ['poules','classement','direct','suivants','tableau'];
+              const cur = JSON.parse(localStorage.getItem('kioskViewsLocal') || '{}');
+              viewKeys.forEach(k => { if (k in cfg) cur[k] = cfg[k]; });
+              localStorage.setItem('kioskViewsLocal', JSON.stringify(cur));
+              // Recharger pour appliquer la nouvelle config
+              location.reload();
+              return;
+            }
             if (cmd.type === 'message' && cmd.text) {
               let b = document.getElementById('remote-msg-banner');
               if (!b) { b = document.createElement('div'); b.id = 'remote-msg-banner'; b.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:rgba(0,0,0,0.82);color:#fff;font-size:1.3rem;padding:0.7rem 1.2rem;text-align:center;z-index:9999;pointer-events:none;transition:opacity 0.4s;'; document.body.appendChild(b); }

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -12,6 +12,7 @@ import { TableauMatch, ConsolationBracket } from './tableau/tableauTypes';
 import { useToast } from './Toast';
 import ThemeEditor from './ThemeEditor';
 import { CustomTheme, DisplayTheme } from '../../shared/types/remote';
+import { ConnectedClient, KioskScreenConfig } from '../../shared/types/preload';
 
 interface RemoteScoreManagerProps {
   competition: Competition;
@@ -151,6 +152,15 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     return localStorage.getItem(key) === 'true';
   });
 
+  // Écrans connectés
+  const [connectedClients, setConnectedClients] = useState<ConnectedClient[]>([]);
+  const [renameValues, setRenameValues] = useState<Record<string, string>>({});
+  // kioskModal : socketId de l'écran pour lequel on configure le mode kiosk
+  const [kioskModal, setKioskModal] = useState<string | null>(null);
+  const [kioskModalConfig, setKioskModalConfig] = useState<KioskScreenConfig>({
+    poules: true, classement: true, direct: true, suivants: true, tableau: true, rotationSec: 15,
+  });
+
   useEffect(() => {
     window.electronAPI.remote.getNetworkInterfaces().then((res: any) => {
       if (res?.success && res.interfaces?.length) {
@@ -254,6 +264,17 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       logger.warn(LogCategory.NETWORK, 'Échec refreshDeMatches', err instanceof Error ? err : undefined);
     });
   }, [pendingDeMatches, isRemoteActive, session]);
+
+  // Abonnement aux mises à jour de la liste des clients connectés
+  useEffect(() => {
+    if (!isRemoteActive) return;
+    window.electronAPI.remote.getConnectedClients(competition.id).then((res: any) => {
+      if (res.success) setConnectedClients(res.clients ?? []);
+    });
+    return window.electronAPI.remote.onClientListUpdate((clients: ConnectedClient[]) => {
+      setConnectedClients(clients);
+    });
+  }, [isRemoteActive, competition.id]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -1144,6 +1165,80 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         </div>
       </div>
 
+      {/* ── Section : Écrans connectés ── */}
+      {connectedClients.length > 0 && (
+        <div className="arena-url-card" style={{ marginTop: '1rem' }}>
+          <div className="arena-url-header">
+            <strong>📺 Écrans connectés ({connectedClients.length})</strong>
+          </div>
+          {connectedClients.map(client => {
+            const clientLabel = client.label || client.screenId?.slice(0, 8) || client.socketId.slice(0, 8);
+            const typeLabel: Record<string, string> = {
+              kiosk: 'Kiosk', arena: 'Arène', public: 'Public', pool: 'Poule', dashboard: 'Dashboard', lobby: 'Lobby',
+            };
+            return (
+              <div key={client.socketId} style={{
+                display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.5rem',
+                padding: '0.5rem 0', borderBottom: '1px solid #1e293b',
+              }}>
+                <span style={{ fontSize: '0.75rem', padding: '0.15rem 0.4rem', borderRadius: '0.3rem', background: '#1e3a5f', color: '#7dd3fc', whiteSpace: 'nowrap' }}>
+                  {typeLabel[client.clientType] ?? client.clientType}
+                </span>
+                <span style={{ fontSize: '0.85rem', fontWeight: 600, color: '#e2e8f0', minWidth: '6rem' }}>
+                  {clientLabel}
+                </span>
+                <span style={{ fontSize: '0.75rem', color: '#64748b' }}>{client.ip}</span>
+                <div style={{ display: 'flex', gap: '0.35rem', marginLeft: 'auto', flexWrap: 'wrap' }}>
+                  <button
+                    className="btn-secondary"
+                    style={{ fontSize: '0.75rem', padding: '0.2rem 0.5rem' }}
+                    title="Faire clignoter cet écran pour l'identifier"
+                    onClick={() => window.electronAPI.remote.identifyClient(competition.id, client.socketId)}
+                  >
+                    🔦 Identifier
+                  </button>
+                  <input
+                    type="text"
+                    placeholder="Renommer…"
+                    value={renameValues[client.socketId] ?? ''}
+                    onChange={e => setRenameValues(v => ({ ...v, [client.socketId]: e.target.value }))}
+                    onKeyDown={async e => {
+                      if (e.key === 'Enter') {
+                        const lbl = renameValues[client.socketId]?.trim();
+                        if (lbl) await window.electronAPI.remote.renameClient(competition.id, client.socketId, lbl);
+                      }
+                    }}
+                    style={{ width: '8rem', fontSize: '0.75rem', padding: '0.2rem 0.4rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#0f172a', color: '#e2e8f0' }}
+                  />
+                  <button
+                    className="btn-secondary"
+                    style={{ fontSize: '0.75rem', padding: '0.2rem 0.5rem' }}
+                    title="Renommer"
+                    onClick={async () => {
+                      const lbl = renameValues[client.socketId]?.trim();
+                      if (lbl) await window.electronAPI.remote.renameClient(competition.id, client.socketId, lbl);
+                    }}
+                  >
+                    ✓
+                  </button>
+                  <button
+                    className="btn-primary"
+                    style={{ fontSize: '0.75rem', padding: '0.2rem 0.5rem' }}
+                    title="Configurer et envoyer en mode kiosk"
+                    onClick={() => {
+                      setKioskModal(client.socketId);
+                      setKioskModalConfig({ poules: true, classement: true, direct: true, suivants: true, tableau: true, rotationSec: 15 });
+                    }}
+                  >
+                    🖥️ Mode kiosk
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
       <div className="remote-instructions">
         <h5>Instructions pour les arbitres</h5>
         <ol>
@@ -1155,6 +1250,61 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           <li>Cliquer sur "Match suivant" pour passer au match suivant</li>
         </ol>
       </div>
+
+      {/* ── Modal kiosk config ── */}
+      {kioskModal && (
+        <div className="qr-popup-overlay" onClick={() => setKioskModal(null)}>
+          <div className="qr-popup" onClick={e => e.stopPropagation()} style={{ minWidth: '20rem', maxWidth: '26rem' }}>
+            <strong style={{ fontSize: '1rem' }}>🖥️ Configurer le mode kiosk</strong>
+            <div style={{ margin: '0.75rem 0', textAlign: 'left' }}>
+              <div style={{ fontSize: '0.85rem', color: '#94a3b8', marginBottom: '0.5rem' }}>Vues à afficher :</div>
+              {([
+                { key: 'poules', label: 'Poules' },
+                { key: 'classement', label: 'Classement' },
+                { key: 'direct', label: 'Matchs en direct' },
+                { key: 'suivants', label: 'Matchs suivants' },
+                { key: 'tableau', label: 'Tableau DE' },
+              ] as const).map(({ key, label }) => (
+                <label key={key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.3rem 0', cursor: 'pointer', color: '#e2e8f0' }}>
+                  <input
+                    type="checkbox"
+                    checked={kioskModalConfig[key]}
+                    onChange={e => setKioskModalConfig(c => ({ ...c, [key]: e.target.checked }))}
+                  />
+                  {label}
+                </label>
+              ))}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.75rem' }}>
+                <label style={{ fontSize: '0.85rem', color: '#94a3b8', whiteSpace: 'nowrap' }}>Rotation (s) :</label>
+                <input
+                  type="number"
+                  min={3}
+                  max={300}
+                  value={kioskModalConfig.rotationSec}
+                  onChange={e => setKioskModalConfig(c => ({ ...c, rotationSec: Math.max(3, parseInt(e.target.value) || 15) }))}
+                  style={{ width: '5rem', padding: '0.3rem 0.5rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#0f172a', color: '#e2e8f0' }}
+                />
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+              <button
+                className="btn btn-primary"
+                style={{ flex: 1 }}
+                onClick={async () => {
+                  await window.electronAPI.remote.setClientKioskMode(competition.id, kioskModal, kioskModalConfig);
+                  setKioskModal(null);
+                  showToast('Écran basculé en mode kiosk', 'success');
+                }}
+              >
+                Envoyer en kiosk
+              </button>
+              <button className="btn btn-secondary" onClick={() => setKioskModal(null)}>
+                Annuler
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {themeEditorTarget && (
         <ThemeEditor

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -344,13 +344,25 @@ export interface ConnectedClient {
   connectedAt: string;
   lastSeen: string;
   label?: string;
+  screenId?: string;
+}
+
+export interface KioskScreenConfig {
+  poules: boolean;
+  classement: boolean;
+  direct: boolean;
+  suivants: boolean;
+  tableau: boolean;
+  rotationSec: number;
 }
 
 export interface TVCommand {
-  type: 'refresh' | 'navigate' | 'message' | 'ping';
+  type: 'refresh' | 'navigate' | 'message' | 'ping' | 'identify' | 'kiosk:config';
   url?: string;
   text?: string;
   duration?: number;
+  kioskConfig?: Partial<KioskScreenConfig>;
+  screenLabel?: string;
 }
 
 export interface RemoteServerAPI {
@@ -446,6 +458,9 @@ export interface RemoteServerAPI {
   sendClientCommand: (competitionId: string, socketId: string, command: TVCommand) => Promise<{ success: boolean; error?: string }>;
   broadcastCommand: (competitionId: string, command: TVCommand) => Promise<{ success: boolean; error?: string }>;
   onClientListUpdate: (cb: (clients: ConnectedClient[]) => void) => () => void;
+  renameClient: (competitionId: string, socketId: string, label: string) => Promise<{ success: boolean; error?: string }>;
+  identifyClient: (competitionId: string, socketId: string) => Promise<{ success: boolean; error?: string }>;
+  setClientKioskMode: (competitionId: string, socketId: string, config: KioskScreenConfig) => Promise<{ success: boolean; error?: string }>;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Résumé

- Chaque écran kiosk génère un `screenId` persistant (localStorage) — survit aux rechargements et reconnexions Socket.IO
- Les labels d'écran sont mémorisés côté serveur par `screenId` (pas perdus à la déconnexion)
- Nouvelle commande Socket.IO `identify` : overlay animé bleu/violet clignotant affiché sur l'écran ciblé pendant N secondes
- Nouvelle commande `kiosk:config` : envoie la config vues + rotation à un écran, qui applique et recharge
- Section **"Écrans connectés"** dans `RemoteScoreManager` : liste tous les clients avec IP, type, label, boutons Identifier / Renommer / Mode kiosk
- Modal **"Mode kiosk"** : cocher les vues (poules, classement, direct, suivants, tableau) + régler la durée de rotation, puis envoyer d'un clic

## Fichiers modifiés

| Fichier | Changement |
|---|---|
| `src/shared/types/preload.ts` | `KioskScreenConfig`, `screenId` dans `ConnectedClient`, `identify`/`kiosk:config` dans `TVCommand`, 3 nouvelles méthodes API |
| `src/main/remoteScoreServer.ts` | `screenLabels` Map, `renameClient`, `identifyClient`, `setClientKioskMode`, `screenId` dans `client:register` |
| `src/main/main.ts` | IPC handlers `remote:renameClient`, `remote:identifyClient`, `remote:setClientKioskMode` |
| `src/main/preload.ts` | Expose les 3 nouvelles méthodes via `ipcRenderer` |
| `src/remote/kiosk.html` | Génération/persistance `screenId`, handler `identify` (overlay flash), handler `kiosk:config` (apply + reload) |
| `src/renderer/components/RemoteScoreManager.tsx` | Section "Écrans connectés" + modal config kiosk par écran |

Travail terminé — valider et clore si OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5zgFmQmnS7VpdCvFkQPoy)_