### PR TITLE
Fix compilation error — npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.1062",
+  "version": "1.0.3-build.1092",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.1062",
+      "version": "1.0.3-build.1092",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/express": "^5.0.6",


### PR DESCRIPTION
## Résumé

- `node_modules` absent → erreurs TS (react, vitest, uuid, jspdf, @types/node…)
- `npm install` résout tout — `package-lock.json` mis à jour

## Test

```bash
npm install
npm run build:main  # 0 erreur
```

https://claude.ai/code/session_01C7WARFgyDBJ6yW72kXgpoG

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7WARFgyDBJ6yW72kXgpoG)_