### PR TITLE
fix: mise à jour automatique des scores poule en saisie distante

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -544,7 +544,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('arena:update', handler);
   },
   onRemoteMatchFinished: (callback: (data: any) => void) => {
-    ipcRenderer.on('match:finished', (_, data) => callback(data));
+    const handler = (_: any, data: any) => callback(data);
+    ipcRenderer.on('match:finished', handler);
+    return () => ipcRenderer.removeListener('match:finished', handler);
   },
   onRemoteFencerExcluded: (callback: (data: { fencerId: string; matchId: string }) => void) => {
     const handler = (_: any, data: any) => callback(data);

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -360,10 +360,19 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
           };
           return updated;
         });
+
+        // Propager le score live vers la vue poule (scores intermédiaires pendant le match)
+        const matchId = data.update?.match?.id;
+        const scoreA = data.update?.scoreA ?? data.update?.match?.scoreA;
+        const scoreB = data.update?.scoreB ?? data.update?.match?.scoreB;
+        if (matchId !== undefined && scoreA !== undefined && scoreB !== undefined
+            && data.update?.status !== 'finished') {
+          updateMatchFromRemote(matchId, scoreA as number, scoreB as number, MatchStatus.IN_PROGRESS);
+        }
       });
     }
     return () => unlisten?.();
-  }, [isRemoteActive, competition.id]);
+  }, [isRemoteActive, competition.id, updateMatchFromRemote]);
 
   // Écouter les mises à jour des matches distants
   // Note: pas de garde sur currentPhase car la phase 'remote' affiche le panel de saisie distante
@@ -403,7 +412,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       });
     };
 
-    window.electronAPI.onRemoteMatchFinished(handleMatchFinished);
+    const offMatchFinished = window.electronAPI.onRemoteMatchFinished(handleMatchFinished);
 
     // Carton noir distant : exclure le combattant fautif dans le store
     const offExcluded = window.electronAPI.onRemoteFencerExcluded?.(({ fencerId }) => {
@@ -412,7 +421,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     });
 
     return () => {
-      window.electronAPI.removeAllListeners?.('match:finished');
+      offMatchFinished?.();
       offExcluded?.();
     };
   }, [updateMatchFromRemote, updateFencer]);

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -764,7 +764,7 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   crypto: CryptoAPI;
   remote: RemoteServerAPI;
   onRemoteArenaUpdate: (callback: (data: any) => void) => () => void;
-  onRemoteMatchFinished: (callback: (data: any) => void) => void;
+  onRemoteMatchFinished: (callback: (data: any) => void) => () => void;
   onRemoteFencerExcluded: (callback: (data: { fencerId: string; matchId: string }) => void) => (() => void);
   onKioskNoteUpdate: (
     callback: (note: import('../types/remote').OrgNote | null) => void


### PR DESCRIPTION
## Problème

Les scores en mode poule ne se mettaient pas à jour automatiquement après une saisie distante — obligation de rafraîchir ou changer d'onglet.

## Causes identifiées

**Cause 1 — Listener `match:finished` sans cleanup propre (`preload.ts`)**

`onRemoteMatchFinished` créait un handler anonyme sans le stocker, donc impossible de le supprimer par référence. Le cleanup dans `CompetitionView` utilisait `removeAllListeners('match:finished')` — méthode brutale. Si un re-run du `useEffect` survenait au moment exact où un IPC arrivait, le message était perdu.

**Cause 2 — `arena:update` ne propageait pas les scores vers les pools (`CompetitionView`)**

En mode arène, l'arbitre envoie des `arena:update` pendant le match (scores intermédiaires) et un `match:finished` uniquement à la fin. Le handler `onRemoteArenaUpdate` ne mettait à jour que `arenaStates` (panneau arène) — jamais l'état `pools`. Résultat : aucun rafraîchissement visuel pendant le match, et risque de perte du `match:finished` final (cause 1).

## Corrections

- **`src/main/preload.ts`** — `onRemoteMatchFinished` stocke le handler et retourne une cleanup, comme tous les autres listeners IPC
- **`src/shared/types/preload.ts`** — type mis à jour : `() => void` en retour
- **`src/renderer/components/CompetitionView.tsx`** :
  - Utilise la cleanup retournée (`offMatchFinished?.()`) au lieu de `removeAllListeners`
  - `onRemoteArenaUpdate` propage les scores live vers `updateMatchFromRemote` (`MatchStatus.IN_PROGRESS`) pour affichage en temps réel dans la vue poule pendant le match

https://claude.ai/code/session_0144hPzrVqP1VrkBcqi92xJx

---
_Generated by [Claude Code](https://claude.ai/code/session_0144hPzrVqP1VrkBcqi92xJx)_