### PR TITLE
fix: splash screen — affichage minimum garanti sur Windows

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -37,6 +37,8 @@ let mainWindow: BrowserWindow | null = null;
 
 // Splash window shown during startup
 let splashWindow: BrowserWindow | null = null;
+let splashShownAt: number | null = null;
+const MIN_SPLASH_MS = 2500;
 
 function createSplashWindow(): void {
   splashWindow = new BrowserWindow({
@@ -72,20 +74,38 @@ function createSplashWindow(): void {
       channel,
     },
   });
-  splashWindow.once('ready-to-show', () => splashWindow?.show());
+  splashWindow.once('ready-to-show', () => {
+    splashWindow?.show();
+    splashShownAt = Date.now();
+  });
 }
 
-function closeSplash(): void {
-  if (!splashWindow || splashWindow.isDestroyed()) return;
-  splashWindow.webContents
-    .executeJavaScript('document.body.classList.add("fadeout"); true')
-    .catch(() => {});
+// onClosed est appelé après le fade-out, au moment d'afficher la fenêtre principale
+function closeSplash(onClosed?: () => void): void {
+  if (!splashWindow || splashWindow.isDestroyed()) {
+    onClosed?.();
+    return;
+  }
+  // Garantir un affichage minimum pour que l'animation soit visible
+  const elapsed = splashShownAt !== null ? Date.now() - splashShownAt : 0;
+  const remaining = Math.max(0, MIN_SPLASH_MS - elapsed);
+
   setTimeout(() => {
-    if (splashWindow && !splashWindow.isDestroyed()) {
-      splashWindow.close();
-      splashWindow = null;
+    if (!splashWindow || splashWindow.isDestroyed()) {
+      onClosed?.();
+      return;
     }
-  }, 420);
+    splashWindow.webContents
+      .executeJavaScript('document.body.classList.add("fadeout"); true')
+      .catch(() => {});
+    setTimeout(() => {
+      if (splashWindow && !splashWindow.isDestroyed()) {
+        splashWindow.close();
+        splashWindow = null;
+      }
+      onClosed?.();
+    }, 420);
+  }, remaining);
 }
 
 // Current UI language (kept in sync via IPC)
@@ -513,14 +533,12 @@ function createWindow(): void {
 
   const showFallback = setTimeout(() => {
     if (mainWindow && !mainWindow.isVisible()) {
-      closeSplash();
-      mainWindow.show();
+      closeSplash(() => mainWindow?.show());
     }
   }, 10000);
   mainWindow.once('ready-to-show', () => {
     clearTimeout(showFallback);
-    closeSplash();
-    setTimeout(() => mainWindow?.show(), 380);
+    closeSplash(() => mainWindow?.show());
   });
 
   // Allow camera access for webcam photo capture


### PR DESCRIPTION
## Problème

Sur Windows, le bundle Electron est souvent en cache, donc la fenêtre principale déclenchait `ready-to-show` quasi immédiatement → le splash disparaissait en un flash avant que l'animation ait le temps de jouer.

## Fix

- `MIN_SPLASH_MS = 2500` : temps d'affichage minimum garanti depuis l'apparition réelle du splash
- `closeSplash(onClosed?)` : callback appelé **après** le fade-out (420ms) — la fenêtre principale n'apparaît qu'à ce moment
- `splashShownAt` : timestamp de la première apparition du splash, pour calculer le temps restant

## Séquence corrigée

```
splash.ready-to-show  → splashShownAt = Date.now()
mainWindow.ready-to-show → closeSplash(() => mainWindow.show())
  └─ attend MAX(0, 2500 - elapsed)ms
  └─ fade-out 400ms
  └─ mainWindow.show()
```

https://claude.ai/code/session_01AQcykosK717NzjXSQkkJJC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQcykosK717NzjXSQkkJJC)_