### PR TITLE
fix(nav): menu Outils coupé sous l'affichage

### DIFF
--- a/src/renderer/components/competition/CompetitionNav.tsx
+++ b/src/renderer/components/competition/CompetitionNav.tsx
@@ -76,9 +76,15 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
   const [showWifiQR, setShowWifiQR] = useState(false);
   const [showTVRemote, setShowTVRemote] = useState(false);
   const toolsMenuRef = useRef<HTMLDivElement>(null);
+  const toolsBtnRef = useRef<HTMLButtonElement>(null);
+  const [toolsMenuPos, setToolsMenuPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
 
   useEffect(() => {
     if (!showToolsMenu) return;
+    const rect = toolsBtnRef.current?.getBoundingClientRect();
+    if (rect) {
+      setToolsMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+    }
     const handler = (e: MouseEvent) => {
       if (toolsMenuRef.current && !toolsMenuRef.current.contains(e.target as Node)) {
         setShowToolsMenu(false);
@@ -151,6 +157,7 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
         {/* Bouton menu outils */}
         <div ref={toolsMenuRef} style={{ position: 'relative' }}>
           <button
+            ref={toolsBtnRef}
             className="btn btn-secondary"
             onClick={() => setShowToolsMenu(v => !v)}
             title="Outils"
@@ -162,9 +169,9 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
           {showToolsMenu && (
             <div
               style={{
-                position: 'absolute',
-                right: 0,
-                top: 'calc(100% + 4px)',
+                position: 'fixed',
+                right: toolsMenuPos.right,
+                top: toolsMenuPos.top,
                 background: 'var(--bg-card, #1e293b)',
                 border: '1px solid var(--border-color, rgba(255,255,255,0.1))',
                 borderRadius: '8px',


### PR DESCRIPTION
## Problème
Menu "Outils" invisible. Dropdown `position: absolute` clippé par `.phase-nav { overflow-x: auto }` (overflow vertical devient clip).

## Fix
Dropdown en `position: fixed`, coords calculées depuis le rect du bouton à l'ouverture. Plus de clip.

https://claude.ai/code/session_011u2N2YR7sJ1oFjaC4UQMu4

---
_Generated by [Claude Code](https://claude.ai/code/session_011u2N2YR7sJ1oFjaC4UQMu4)_