### PR TITLE
fix(splash): badge canal dev correct au démarrage

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -65,7 +65,8 @@ function createSplashWindow(): void {
 
   const iconPath = path.join(__dirname, '../../resources/icons/256x256.png');
   const versionInfo = getVersionInfo();
-  const channel = process.env.NODE_ENV === 'development' ? 'dev' : 'main';
+  const channel =
+    process.env.NODE_ENV === 'development' || !app.isPackaged ? 'dev' : 'main';
   splashWindow.loadFile(splashPath, {
     query: {
       icon: iconPath,


### PR DESCRIPTION
Splash affichait "main" en mode dev. Détection canal via `app.isPackaged`.

https://claude.ai/code/session_01RFZCnZ9z1koMyqtoqRcWkm

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFZCnZ9z1koMyqtoqRcWkm)_