### PR TITLE
fix(kiosk): mémoriser les options et corriger l'affichage du classement final

### DIFF
--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -1608,19 +1608,21 @@
           renderOrgNote(state.session.orgNote || null);
 
           // Appliquer les vues kiosk : localStorage en priorité, sinon config serveur
+          // 'final' (classement final) désactivé par défaut s'il n'est pas explicitement présent
+          const viewDefault = (src, v) => (v === 'final' ? src[v] === true : src[v] !== false);
           const localViews = loadLocalViews();
           if (localViews) {
             // Restaurer l'état des checkboxes depuis localStorage
             ALL_VIEWS.forEach(v => {
               const cb = document.getElementById('cb-' + v);
-              if (cb) cb.checked = localViews[v] !== false;
+              if (cb) cb.checked = viewDefault(localViews, v);
             });
           } else if (state.session.kioskViews) {
             // Initialiser les checkboxes depuis la config serveur (premier chargement)
             const kv = state.session.kioskViews;
             ALL_VIEWS.forEach(v => {
               const cb = document.getElementById('cb-' + v);
-              if (cb) cb.checked = kv[v] !== false;
+              if (cb) cb.checked = viewDefault(kv, v);
             });
           }
           applyLocalViews();
@@ -2646,7 +2648,7 @@
             if (cmd.type === 'kiosk:config' && cmd.kioskConfig) {
               const cfg = cmd.kioskConfig;
               if (cfg.rotationSec != null) localStorage.setItem('kioskRotationSec', String(Math.max(3, cfg.rotationSec)));
-              const viewKeys = ['poules','classement','direct','suivants','tableau'];
+              const viewKeys = ['poules','classement','final','direct','suivants','tableau'];
               const cur = JSON.parse(localStorage.getItem('kioskViewsLocal') || '{}');
               viewKeys.forEach(k => { if (k in cfg) cur[k] = cfg[k]; });
               localStorage.setItem('kioskViewsLocal', JSON.stringify(cur));

--- a/src/renderer/components/XiaomiRemotePanel.tsx
+++ b/src/renderer/components/XiaomiRemotePanel.tsx
@@ -60,12 +60,23 @@ function clientLabel(client: ConnectedClient): string {
 }
 
 const DEFAULT_KIOSK_CONFIG: KioskScreenConfig = {
-  poules: true, classement: true, direct: true, suivants: true, tableau: true, rotationSec: 15,
+  poules: true, classement: true, final: false, direct: true, suivants: true, tableau: true, rotationSec: 15,
 };
+
+const KIOSK_CONFIG_STORAGE_KEY = 'bp_kiosk_config';
+
+function loadKioskConfig(): KioskScreenConfig {
+  try {
+    const stored = localStorage.getItem(KIOSK_CONFIG_STORAGE_KEY);
+    if (stored) return { ...DEFAULT_KIOSK_CONFIG, ...JSON.parse(stored) };
+  } catch { /* ignore */ }
+  return DEFAULT_KIOSK_CONFIG;
+}
 
 const KIOSK_VIEWS: { key: keyof KioskScreenConfig; label: string }[] = [
   { key: 'poules', label: 'Poules' },
   { key: 'classement', label: 'Classement' },
+  { key: 'final', label: 'Classement final' },
   { key: 'direct', label: 'Matchs en direct' },
   { key: 'suivants', label: 'Matchs suivants' },
   { key: 'tableau', label: 'Tableau DE' },
@@ -87,7 +98,7 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [kioskTarget, setKioskTarget] = useState<string | null>(null);
-  const [kioskConfig, setKioskConfig] = useState<KioskScreenConfig>(DEFAULT_KIOSK_CONFIG);
+  const [kioskConfig, setKioskConfig] = useState<KioskScreenConfig>(loadKioskConfig);
   const [locked, setLocked] = useState<boolean>(() => localStorage.getItem('bp_remote_locked') === '1');
 
   const toggleLock = () => {
@@ -165,6 +176,7 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
 
   const sendKiosk = () => {
     if (!kioskTarget) return;
+    try { localStorage.setItem(KIOSK_CONFIG_STORAGE_KEY, JSON.stringify(kioskConfig)); } catch { /* ignore */ }
     window.electronAPI.remote.setClientKioskMode(competitionId, kioskTarget, kioskConfig);
     setKioskTarget(null);
   };
@@ -287,7 +299,7 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
                   <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => { setRenameTarget(client.socketId); setRenameValue(client.label ?? ''); }} title="Renommer cet écran">✏️</button>
 
                   {/* Mode kiosk */}
-                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => { setKioskTarget(client.socketId); setKioskConfig(DEFAULT_KIOSK_CONFIG); }} title="Configurer et envoyer en mode kiosk">🖥️</button>
+                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => { setKioskTarget(client.socketId); setKioskConfig(loadKioskConfig()); }} title="Configurer et envoyer en mode kiosk">🖥️</button>
 
                   {/* Rafraîchir */}
                   <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => sendCmd(client.socketId, { type: 'refresh' })} title="Rafraîchir">↻</button>

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -350,6 +350,7 @@ export interface ConnectedClient {
 export interface KioskScreenConfig {
   poules: boolean;
   classement: boolean;
+  final: boolean;
   direct: boolean;
   suivants: boolean;
   tableau: boolean;


### PR DESCRIPTION
## Problème
Mode kiosk depuis la télécommande :
1. Options choisies non gardées en mémoire (reset à chaque ouverture).
2. Classement final affiché alors qu'il n'est pas dans les choix.

## Cause
- `XiaomiRemotePanel` réinitialisait `kioskConfig` à `DEFAULT_KIOSK_CONFIG` à chaque clic.
- `final` absent de `KioskScreenConfig`/`viewKeys` → côté kiosk `kv['final'] !== false` = `true` → toujours affiché.

## Correctifs
- Config kiosk persistée dans `localStorage` (`bp_kiosk_config`), restaurée à l'ouverture et à l'envoi.
- `final` ajouté comme option configurable (« Classement final »), désactivé par défaut.
- `viewKeys` du merge kiosk inclut `final`.
- Côté kiosk : `final` off par défaut s'il n'est pas explicitement activé.

https://claude.ai/code/session_01Tqn2vWdUQ9JFtfWaTvNWa3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tqn2vWdUQ9JFtfWaTvNWa3)_