### PR TITLE
fix(kiosk): corrige le build TS (vue 'final' manquante dans RemoteScoreManager)

### DIFF
--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -158,7 +158,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   // kioskModal : socketId de l'écran pour lequel on configure le mode kiosk
   const [kioskModal, setKioskModal] = useState<string | null>(null);
   const [kioskModalConfig, setKioskModalConfig] = useState<KioskScreenConfig>({
-    poules: true, classement: true, direct: true, suivants: true, tableau: true, rotationSec: 15,
+    poules: true, classement: true, final: false, direct: true, suivants: true, tableau: true, rotationSec: 15,
   });
 
   useEffect(() => {
@@ -1227,7 +1227,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                     title="Configurer et envoyer en mode kiosk"
                     onClick={() => {
                       setKioskModal(client.socketId);
-                      setKioskModalConfig({ poules: true, classement: true, direct: true, suivants: true, tableau: true, rotationSec: 15 });
+                      setKioskModalConfig({ poules: true, classement: true, final: false, direct: true, suivants: true, tableau: true, rotationSec: 15 });
                     }}
                   >
                     🖥️ Mode kiosk
@@ -1261,6 +1261,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               {([
                 { key: 'poules', label: 'Poules' },
                 { key: 'classement', label: 'Classement' },
+                { key: 'final', label: 'Classement final' },
                 { key: 'direct', label: 'Matchs en direct' },
                 { key: 'suivants', label: 'Matchs suivants' },
                 { key: 'tableau', label: 'Tableau DE' },


### PR DESCRIPTION
`build:ci` échouait après #745 : `KioskScreenConfig` requiert maintenant `final`, mais deux littéraux de `RemoteScoreManager.tsx` ne l'avaient pas.

- Ajout de `final: false` aux deux configs `kioskModalConfig`.
- Ajout de l'option « Classement final » dans la modale kiosk par client.
- Les listes `kioskViews` de session (type sans `final`) restent inchangées.

https://claude.ai/code/session_01Tqn2vWdUQ9JFtfWaTvNWa3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tqn2vWdUQ9JFtfWaTvNWa3)_