### PR TITLE
Son de démarrage : épées + sabre laser sur le splash

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -54,6 +54,8 @@ function createSplashWindow(): void {
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
+      // Autorise le son de démarrage sans geste utilisateur
+      autoplayPolicy: 'no-user-gesture-required',
     },
   });
 

--- a/src/main/splash.html
+++ b/src/main/splash.html
@@ -289,6 +289,99 @@
       n = (n + 1) % 100;
     }, 80);
     setTimeout(function() { clearInterval(tick); }, 15000);
+
+    // ---- Son de démarrage : épées qui s'entrechoquent puis sabre laser ----
+    // Synthèse Web Audio (aucun fichier externe, compatible CSP).
+    (function () {
+      const muted = params.get('mute') === '1';
+      if (muted) return;
+      let ctx;
+      try {
+        ctx = new (window.AudioContext || window.webkitAudioContext)();
+      } catch (e) { return; }
+
+      // Bruit blanc réutilisable (clang métallique)
+      function noiseBuffer(dur) {
+        const len = Math.floor(ctx.sampleRate * dur);
+        const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+        const d = buf.getChannelData(0);
+        for (let i = 0; i < len; i++) d[i] = Math.random() * 2 - 1;
+        return buf;
+      }
+
+      // Un choc d'épée : burst de bruit filtré (bande métallique) + déclin rapide.
+      function clang(t0, freq, gainPeak) {
+        const src = ctx.createBufferSource();
+        src.buffer = noiseBuffer(0.35);
+        const bp = ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = freq;
+        bp.Q.value = 6;
+        const hp = ctx.createBiquadFilter();
+        hp.type = 'highpass';
+        hp.frequency.value = 2000;
+        const g = ctx.createGain();
+        g.gain.setValueAtTime(0.0001, t0);
+        g.gain.exponentialRampToValueAtTime(gainPeak, t0 + 0.004);
+        g.gain.exponentialRampToValueAtTime(0.0001, t0 + 0.3);
+        src.connect(bp); bp.connect(hp); hp.connect(g); g.connect(ctx.destination);
+        src.start(t0); src.stop(t0 + 0.35);
+
+        // Anneau résonant (tintement aigu)
+        const osc = ctx.createOscillator();
+        osc.type = 'triangle';
+        osc.frequency.value = freq * 1.6;
+        const og = ctx.createGain();
+        og.gain.setValueAtTime(0.0001, t0);
+        og.gain.exponentialRampToValueAtTime(gainPeak * 0.5, t0 + 0.006);
+        og.gain.exponentialRampToValueAtTime(0.0001, t0 + 0.45);
+        osc.connect(og); og.connect(ctx.destination);
+        osc.start(t0); osc.stop(t0 + 0.45);
+      }
+
+      // Sabre laser : bourdon (oscillateurs désaccordés) + vibrato + balayage filtre.
+      function lightsaber(t0, dur) {
+        const out = ctx.createGain();
+        out.gain.setValueAtTime(0.0001, t0);
+        out.gain.exponentialRampToValueAtTime(0.22, t0 + 0.12);
+        out.gain.setValueAtTime(0.22, t0 + dur - 0.25);
+        out.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+        const lp = ctx.createBiquadFilter();
+        lp.type = 'lowpass';
+        lp.frequency.setValueAtTime(400, t0);
+        lp.frequency.exponentialRampToValueAtTime(2200, t0 + 0.18);
+        lp.frequency.exponentialRampToValueAtTime(800, t0 + dur);
+        lp.connect(out); out.connect(ctx.destination);
+
+        // Vibrato (la respiration du sabre)
+        const lfo = ctx.createOscillator();
+        lfo.frequency.value = 22;
+        const lfoG = ctx.createGain();
+        lfoG.gain.value = 6;
+        lfo.connect(lfoG);
+        lfo.start(t0); lfo.stop(t0 + dur);
+
+        [110, 113, 165].forEach(function (f) {
+          const o = ctx.createOscillator();
+          o.type = 'sawtooth';
+          o.frequency.value = f;
+          lfoG.connect(o.frequency);
+          o.connect(lp);
+          o.start(t0); o.stop(t0 + dur);
+        });
+      }
+
+      function play() {
+        const t = ctx.currentTime + 0.15;
+        clang(t, 3200, 0.6);          // choc 1
+        clang(t + 0.32, 2600, 0.55);  // choc 2
+        clang(t + 0.62, 3800, 0.5);   // choc 3
+        lightsaber(t + 1.0, 2.4);     // sabre laser après les chocs
+      }
+
+      if (ctx.state === 'suspended') ctx.resume().then(play).catch(play);
+      else play();
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
Ajoute un son de démarrage synthétisé (Web Audio, aucun fichier externe, compatible CSP) sur le splash screen :
- 3 chocs d'épées métalliques
- puis bourdon de sabre laser

`autoplayPolicy: 'no-user-gesture-required'` ajouté à la fenêtre splash. Désactivable via `?mute=1`.

https://claude.ai/code/session_01MPVbY1WDRvn7uGbuiCWpnU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPVbY1WDRvn7uGbuiCWpnU)_