### PR TITLE
fix: lancer le son de démarrage du splash (autoplay)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2108,6 +2108,9 @@ if (process.platform === 'linux') {
   app.commandLine.appendSwitch('use-gl', 'swiftshader');
 }
 
+// Autorise le son de démarrage du splash sans geste utilisateur (niveau Chromium)
+app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
+
 app.whenReady().then(async () => {
   // Afficher le splash immédiatement pendant que tout le reste charge
   createSplashWindow();


### PR DESCRIPTION
Le son du splash ne se lançait pas : Chromium bloquait l'autoplay malgré `webPreferences.autoplayPolicy`. Ajout du switch global `autoplay-policy=no-user-gesture-required` avant `app.whenReady()`.

https://claude.ai/code/session_01MPVbY1WDRvn7uGbuiCWpnU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPVbY1WDRvn7uGbuiCWpnU)_