### PR TITLE
Fix splash dev : badge de canal affiche « dev »

### DIFF
--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -54,6 +54,14 @@ module.exports = (env = {}) => ({
     open: false,
     historyApiFallback: true,
     allowedHosts: 'auto',
+    // En dev, webpack serve garde les assets en mémoire. Le splash (chargé par
+    // Electron via loadFile depuis dist/) doit être écrit sur disque, sinon
+    // Electron lit un fichier obsolète et le badge de canal reste figé sur « main ».
+    devMiddleware: {
+      writeToDisk: (filePath) =>
+        /[\\/]dist[\\/]main[\\/]splash\.html$/.test(filePath) ||
+        /[\\/]dist[\\/]remote[\\/]/.test(filePath),
+    },
     static: {
       directory: path.join(__dirname, 'dist/renderer'),
       publicPath: '/',


### PR DESCRIPTION
## Problème

Au démarrage en dev, le splash affichait le badge de canal « MAIN » au lieu de « DEV ».

## Cause

`webpack serve` garde les assets de `CopyWebpackPlugin` en mémoire. Electron charge `dist/main/splash.html` via `loadFile` depuis le disque → fichier obsolète sans lecture du paramètre `channel`.

## Fix

`devServer.devMiddleware.writeToDisk` écrit `splash.html` (et `dist/remote/*`) sur disque en dev.

https://claude.ai/code/session_019Y6psuUapegchZ2xqE3UeR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Y6psuUapegchZ2xqE3UeR)_