### PR TITLE
feat: heatmap touches, overlay OBS JSON, minuteur vocal, rotation arbitres

### DIFF
--- a/src/features/analytics/components/FencerDetailModal.tsx
+++ b/src/features/analytics/components/FencerDetailModal.tsx
@@ -8,6 +8,7 @@ import { Competition, FencerCompetitionStats } from '../../../shared/types';
 import { FencerMatchRecord } from '../../../shared/types/preload';
 import { useTranslation } from '../../../renderer/contexts/TranslationContext';
 import { exportFencerDetailPDF } from '../../../shared/utils/fencerDetailPdfExport';
+import { TouchZoneHeatmap } from '../../../renderer/components/analytics/TouchZoneHeatmap';
 
 interface Props {
   fencer: FencerCompetitionStats;
@@ -159,14 +160,34 @@ export const FencerDetailModal: React.FC<Props> = ({ fencer, competition, onClos
               <div className="text-xs text-gray-500 mt-0.5">Points touches</div>
               <div className="text-xs text-gray-400">A:{fencer.touchesZoneA} B:{fencer.touchesZoneB} C:{fencer.touchesZoneC}</div>
             </div>
-          ) : (
-            <div className="text-center">
+          ) : null}
+        </div>
+
+        {/* Heatmap Laser Sabre */}
+        {isLaser && (
+          <div className="px-5 py-3 bg-blue-50 border-b border-gray-200 flex-shrink-0">
+            <div className="text-xs font-semibold text-gray-600 mb-2">Répartition des touches</div>
+            <div className="flex justify-center">
+              <TouchZoneHeatmap
+                zoneA={fencer.touchesZoneA}
+                zoneB={fencer.touchesZoneB}
+                zoneC={fencer.touchesZoneC}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Sorties piste (armes classiques) */}
+        {!isLaser && (
+          <div className="grid grid-cols-4 gap-3 px-5 py-0 bg-gray-50 border-b border-gray-200 flex-shrink-0">
+            <div></div><div></div><div></div>
+            <div className="text-center py-2">
               <div className="text-2xl font-bold text-blue-700">{fencer.arenaExits || '0'}</div>
               <div className="text-xs text-gray-500 mt-0.5">{t('stats.arena_exits')}</div>
               <div className="text-xs text-gray-400">&nbsp;</div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Match list */}
         <div className="flex-1 overflow-y-auto px-5 py-4 space-y-3">

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -486,6 +486,92 @@ export class RemoteScoreServer {
       res.json(arena);
     });
 
+    // Rapport de rotation des arbitres
+    this.app.get('/api/referees/rotation-report', (req, res) => {
+      if (!this.session) return res.status(404).json({ error: 'Pas de session active' });
+
+      const competitionId = this.session.competitionId;
+      const referees = this.db.getRefereesByCompetition(competitionId);
+      const allMatches = this.db.getMatchesWithReferees(competitionId);
+
+      const MAX_CONSECUTIVE = 3;
+      const MIN_REST_MINUTES = 15;
+
+      const report = referees.map(ref => {
+        const refMatches = allMatches.filter(m => m.refereeId === ref.id && m.status === 'finished');
+        const total = refMatches.length;
+
+        // Approximer matchs consécutifs sur les derniers matchs (ordre du tableau)
+        let consecutive = 0;
+        for (let i = refMatches.length - 1; i >= 0; i--) {
+          consecutive++;
+          if (consecutive >= MAX_CONSECUTIVE) break;
+          // Sans timestamp précis, on compte les derniers matchs du tableau
+        }
+
+        // Vérifier si l'arbitre est actuellement sur une piste
+        const isActive = Array.from(this.arenas.values()).some(a =>
+          a.status === 'in_progress' && a.currentMatch?.referee?.id === ref.id
+        );
+
+        const fatigueScore = Math.min(100, Math.round((consecutive / MAX_CONSECUTIVE) * 100));
+
+        return {
+          refereeId: ref.id,
+          refereeName: `${ref.firstName ?? ''} ${ref.lastName ?? ''}`.trim(),
+          matchesTotal: total,
+          consecutiveEstimate: consecutive,
+          fatigueScore,
+          isActive,
+          needsRest: consecutive >= MAX_CONSECUTIVE || fatigueScore >= 80,
+          category: (ref as any).category ?? null,
+        };
+      });
+
+      // Trier par score de fatigue décroissant
+      report.sort((a, b) => b.fatigueScore - a.fatigueScore);
+      res.json({ config: { maxConsecutive: MAX_CONSECUTIVE, minRestMinutes: MIN_REST_MINUTES }, report });
+    });
+
+    // Endpoint JSON structuré pour OBS Browser Source / intégrations externes
+    this.app.get('/api/arenas/:arenaId/obs-json', (req, res) => {
+      const { arenaId } = req.params;
+      const arena = this.getArena(arenaId);
+      if (!arena) return res.status(404).json({ error: 'Arène non trouvée' });
+
+      const touches = this.arenaTouches.get(arenaId) || { touchesA: [], touchesB: [] };
+      const cards   = this.arenaCards.get(arenaId)   || { cardsA: [], cardsB: [] };
+
+      const countZones = (zones: string[]) => ({
+        A: zones.filter(z => z === 'A').length,
+        B: zones.filter(z => z === 'B').length,
+        C: zones.filter(z => z === 'C').length,
+      });
+
+      res.json({
+        arenaId,
+        status: arena.status,
+        weapon: this.sessionWeapon ?? null,
+        match: arena.currentMatch ? {
+          id:       arena.currentMatch.id,
+          fencerA:  arena.currentMatch.fencerA,
+          fencerB:  arena.currentMatch.fencerB,
+          scoreA:   arena.currentMatch.scoreA,
+          scoreB:   arena.currentMatch.scoreB,
+          referee:  arena.currentMatch.referee,
+        } : null,
+        cards: { A: cards.cardsA, B: cards.cardsB },
+        touches: {
+          A: { raw: touches.touchesA, zones: countZones(touches.touchesA) },
+          B: { raw: touches.touchesB, zones: countZones(touches.touchesB) },
+        },
+        suddenDeath:     this.arenaSuddenDeath.get(arenaId) ?? false,
+        waitingOvertime: this.arenaWaitingOvertime.get(arenaId) ?? false,
+        swapped:         arena.swapped ?? false,
+        timestamp:       new Date().toISOString(),
+      });
+    });
+
     this.app.post('/api/arenas/:arenaId/assign', (req, res) => {
       const { match } = req.body;
       try {
@@ -2421,6 +2507,12 @@ export class RemoteScoreServer {
           if (data.cardsA !== undefined) currentCards.cardsA = data.cardsA;
           if (data.cardsB !== undefined) currentCards.cardsB = data.cardsB;
           this.arenaCards.set(data.arenaId, currentCards);
+          // Mettre à jour les touches par zone si fournies
+          const currentTouches = this.arenaTouches.get(data.arenaId) || { touchesA: [], touchesB: [] };
+          if (data.touchesA !== undefined) currentTouches.touchesA = data.touchesA;
+          if (data.touchesB !== undefined) currentTouches.touchesB = data.touchesB;
+          this.arenaTouches.set(data.arenaId, currentTouches);
+
           this.broadcastArenaUpdate(data.arenaId, {
             arenaId: data.arenaId,
             match: arena.currentMatch,
@@ -2428,18 +2520,13 @@ export class RemoteScoreServer {
             scoreB: data.scoreB ?? arena.currentMatch?.scoreB,
             cardsA: currentCards.cardsA,
             cardsB: currentCards.cardsB,
+            touchesA: currentTouches.touchesA,
+            touchesB: currentTouches.touchesB,
             suddenDeath: this.arenaSuddenDeath.get(data.arenaId) ?? false,
             overtimeType: this.arenaOvertimeType.get(data.arenaId) ?? null,
             waitingOvertime: this.arenaWaitingOvertime.get(data.arenaId) ?? false,
             status: arena.status,
           });
-        }
-        // Mettre à jour les touches par zone si fournies
-        if (data.touchesA !== undefined || data.touchesB !== undefined) {
-          const currentTouches = this.arenaTouches.get(data.arenaId) || { touchesA: [], touchesB: [] };
-          if (data.touchesA !== undefined) currentTouches.touchesA = data.touchesA;
-          if (data.touchesB !== undefined) currentTouches.touchesB = data.touchesB;
-          this.arenaTouches.set(data.arenaId, currentTouches);
         }
         break;
       }

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1250,6 +1250,14 @@
           <div class="timer-hint" data-i18n="referee.timer_hint">
             Tapez pour démarrer/pause - Appui long pour reset
           </div>
+          <div style="display:flex;justify-content:center;margin-top:0.4rem;">
+            <button
+              id="btn-tts-toggle"
+              onclick="refereeApp.toggleTTS()"
+              title="Minuteur vocal"
+              style="background:none;border:1px solid rgba(255,255,255,0.3);border-radius:0.5rem;color:rgba(255,255,255,0.7);font-size:0.8rem;padding:0.2rem 0.6rem;cursor:pointer;"
+            >🔇 Voix</button>
+          </div>
         </div>
 
         <!-- Boutons de contrôle -->
@@ -1590,6 +1598,8 @@
           this.swapped = false;
           this.pausedForModal = false;
           this.offlineQueue = new OfflineQueueInline();
+          this.ttsEnabled = false;
+          this._ttsAnnouncedSeconds = new Set();
 
           this.init();
         }
@@ -2653,11 +2663,13 @@
           this.updateTimerDisplay();
           this.broadcastTimerUpdate();
 
+          this._ttsAnnouncedSeconds = new Set();
           this.timerInterval = setInterval(() => {
             if (this.timerSeconds > 0) {
               this.timerSeconds--;
               this.updateTimerDisplay();
               this.broadcastTimerUpdate();
+              this.ttsCheckAnnounce();
 
               if (this.timerSeconds === 0) {
                 this.stopTimer();
@@ -2698,11 +2710,50 @@
           this.waitingOvertimeStart = false;
           this.overtimeType = null;
           this.timerSeconds = this.defaultTimerSeconds;
+          this._ttsAnnouncedSeconds = new Set();
           this.updateTimerDisplay();
           this.broadcastTimerUpdate();
           this.updateSuddenDeathUI();
           this.updateControlButtons();
           this.showNotification('🔄 Chronomètre réinitialisé');
+        }
+
+        toggleTTS() {
+          this.ttsEnabled = !this.ttsEnabled;
+          const btn = document.getElementById('btn-tts-toggle');
+          if (btn) btn.textContent = this.ttsEnabled ? '🔊 Voix' : '🔇 Voix';
+          if (this.ttsEnabled) this.ttsSpeak('Minuteur vocal activé');
+        }
+
+        ttsSpeak(text) {
+          if (!this.ttsEnabled || !window.speechSynthesis) return;
+          window.speechSynthesis.cancel();
+          const utt = new SpeechSynthesisUtterance(text);
+          const lang = (document.documentElement.lang || 'fr').toLowerCase();
+          utt.lang = lang.startsWith('de') ? 'de-DE' : lang.startsWith('en') ? 'en-GB' : 'fr-FR';
+          utt.rate = 1.1;
+          utt.volume = 1.0;
+          window.speechSynthesis.speak(utt);
+        }
+
+        ttsCheckAnnounce() {
+          if (!this.ttsEnabled) return;
+          const s = this.timerSeconds;
+          if (this._ttsAnnouncedSeconds.has(s)) return;
+          const lang = (document.documentElement.lang || 'fr').toLowerCase();
+          const isFr = !lang.startsWith('de') && !lang.startsWith('en');
+          const isEn = lang.startsWith('en');
+          const THRESHOLDS = {
+            60: isFr ? 'Une minute' : isEn ? 'One minute' : 'Eine Minute',
+            30: isFr ? 'Trente secondes' : isEn ? 'Thirty seconds' : 'Dreißig Sekunden',
+            10: isFr ? 'Dix secondes' : isEn ? 'Ten seconds' : 'Zehn Sekunden',
+            5:  '5', 4: '4', 3: '3', 2: '2', 1: '1',
+            0:  isFr ? 'Halte !' : isEn ? 'Stop!' : 'Halt!',
+          };
+          if (s in THRESHOLDS) {
+            this._ttsAnnouncedSeconds.add(s);
+            this.ttsSpeak(THRESHOLDS[s]);
+          }
         }
 
         prepareSuddenDeath() {

--- a/src/renderer/components/RefereeManager.tsx
+++ b/src/renderer/components/RefereeManager.tsx
@@ -112,7 +112,7 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
   };
 
   const rotationReport = useMemo(() => {
-    return manager.generateRotationReport();
+    return manager.generateRotationReportDetailed();
   }, [manager, assignments]);
 
   const getConflictWarning = (match: Match, referee: Referee): string | null => {
@@ -504,69 +504,38 @@ export const RefereeManagerComponent: React.FC<RefereeManagerProps> = ({
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
               <tr style={{ background: '#dcfce7' }}>
-                <th
-                  style={{
-                    padding: '0.5rem',
-                    textAlign: 'left',
-                    borderBottom: '2px solid #86efac',
-                  }}
-                >
-                  Arbitre
-                </th>
-                <th
-                  style={{
-                    padding: '0.5rem',
-                    textAlign: 'center',
-                    borderBottom: '2px solid #86efac',
-                  }}
-                >
-                  Matchs
-                </th>
-                <th
-                  style={{
-                    padding: '0.5rem',
-                    textAlign: 'center',
-                    borderBottom: '2px solid #86efac',
-                  }}
-                >
-                  Violations Repos
-                </th>
-                <th
-                  style={{
-                    padding: '0.5rem',
-                    textAlign: 'center',
-                    borderBottom: '2px solid #86efac',
-                  }}
-                >
-                  Conflits
-                </th>
+                {['Arbitre', 'Matchs', 'Consécutifs', 'Fatigue', 'Violations', 'Conflits'].map(h => (
+                  <th key={h} style={{ padding: '0.5rem', textAlign: h === 'Arbitre' ? 'left' : 'center', borderBottom: '2px solid #86efac' }}>
+                    {h}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>
-              {rotationReport.map((row, idx) => (
-                <tr key={idx} style={{ borderBottom: '1px solid #bbf7d0' }}>
-                  <td style={{ padding: '0.5rem' }}>{row.refereeName}</td>
-                  <td style={{ padding: '0.5rem', textAlign: 'center' }}>{row.matchesAssigned}</td>
-                  <td
-                    style={{
-                      padding: '0.5rem',
-                      textAlign: 'center',
-                      color: row.restViolations > 0 ? '#dc2626' : '#166534',
-                    }}
-                  >
-                    {row.restViolations}
-                  </td>
-                  <td
-                    style={{
-                      padding: '0.5rem',
-                      textAlign: 'center',
-                      color: row.conflicts > 0 ? '#dc2626' : '#166534',
-                    }}
-                  >
-                    {row.conflicts}
-                  </td>
-                </tr>
-              ))}
+              {rotationReport.map((row, idx) => {
+                const fatigueColor = row.fatigueScore >= 80 ? '#dc2626' : row.fatigueScore >= 50 ? '#d97706' : '#166534';
+                return (
+                  <tr key={idx} style={{ borderBottom: '1px solid #bbf7d0', background: row.needsRest ? '#fef9c3' : undefined }}>
+                    <td style={{ padding: '0.5rem' }}>
+                      {row.needsRest && <span title="Repos recommandé">⚠️ </span>}
+                      {row.refereeName}
+                    </td>
+                    <td style={{ padding: '0.5rem', textAlign: 'center' }}>{row.matchesAssigned}</td>
+                    <td style={{ padding: '0.5rem', textAlign: 'center' }}>{row.consecutiveMatches}</td>
+                    <td style={{ padding: '0.5rem', textAlign: 'center' }}>
+                      <span style={{ color: fatigueColor, fontWeight: row.fatigueScore >= 80 ? 700 : 400 }}>
+                        {row.fatigueScore}%
+                      </span>
+                    </td>
+                    <td style={{ padding: '0.5rem', textAlign: 'center', color: row.restViolations > 0 ? '#dc2626' : '#166534' }}>
+                      {row.restViolations}
+                    </td>
+                    <td style={{ padding: '0.5rem', textAlign: 'center', color: row.conflicts > 0 ? '#dc2626' : '#166534' }}>
+                      {row.conflicts}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/src/renderer/components/analytics/TouchZoneHeatmap.tsx
+++ b/src/renderer/components/analytics/TouchZoneHeatmap.tsx
@@ -1,0 +1,92 @@
+/**
+ * BellePoule Modern - Heatmap des zones de touche (Laser Sabre)
+ * Licensed under GPL-3.0
+ */
+
+import React from 'react';
+
+interface Props {
+  zoneA: number;
+  zoneB: number;
+  zoneC: number;
+  label?: string;
+}
+
+function intensity(count: number, max: number): string {
+  if (max === 0 || count === 0) return 'rgba(59,130,246,0.08)';
+  const ratio = count / max;
+  const alpha = 0.15 + ratio * 0.75;
+  return `rgba(59,130,246,${alpha.toFixed(2)})`;
+}
+
+function stroke(count: number, max: number): string {
+  if (max === 0 || count === 0) return '#93c5fd';
+  const ratio = count / max;
+  if (ratio > 0.6) return '#1d4ed8';
+  if (ratio > 0.3) return '#3b82f6';
+  return '#93c5fd';
+}
+
+export const TouchZoneHeatmap: React.FC<Props> = ({ zoneA, zoneB, zoneC, label }) => {
+  const max = Math.max(zoneA, zoneB, zoneC, 1);
+  const total = zoneA + zoneB + zoneC;
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      {label && <div className="text-xs font-medium text-gray-600 text-center">{label}</div>}
+      <svg
+        viewBox="0 0 60 120"
+        width="60"
+        height="120"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-label={`Heatmap: Zone A=${zoneA} B=${zoneB} C=${zoneC}`}
+      >
+        {/* Tête */}
+        <ellipse cx="30" cy="10" rx="9" ry="9" fill="#e5e7eb" stroke="#9ca3af" strokeWidth="1" />
+
+        {/* Zone C — jambes (5 pts) */}
+        <rect
+          x="18" y="80" width="11" height="36" rx="4"
+          fill={intensity(zoneC, max)} stroke={stroke(zoneC, max)} strokeWidth="1.5"
+        />
+        <rect
+          x="31" y="80" width="11" height="36" rx="4"
+          fill={intensity(zoneC, max)} stroke={stroke(zoneC, max)} strokeWidth="1.5"
+        />
+
+        {/* Zone B — bras (3 pts) */}
+        <rect
+          x="6" y="30" width="10" height="30" rx="4"
+          fill={intensity(zoneB, max)} stroke={stroke(zoneB, max)} strokeWidth="1.5"
+        />
+        <rect
+          x="44" y="30" width="10" height="30" rx="4"
+          fill={intensity(zoneB, max)} stroke={stroke(zoneB, max)} strokeWidth="1.5"
+        />
+
+        {/* Zone A — torse (1 pt) */}
+        <rect
+          x="18" y="22" width="24" height="56" rx="4"
+          fill={intensity(zoneA, max)} stroke={stroke(zoneA, max)} strokeWidth="1.5"
+        />
+      </svg>
+
+      {/* Légende */}
+      <div className="grid grid-cols-3 gap-1 w-full text-center">
+        {[
+          { zone: 'A', count: zoneA, pts: '1pt', color: 'bg-blue-100 text-blue-800' },
+          { zone: 'B', count: zoneB, pts: '3pts', color: 'bg-blue-200 text-blue-900' },
+          { zone: 'C', count: zoneC, pts: '5pts', color: 'bg-blue-400 text-white' },
+        ].map(({ zone, count, pts, color }) => (
+          <div key={zone} className={`rounded px-1 py-0.5 ${color}`}>
+            <div className="text-xs font-bold">{count}</div>
+            <div className="text-[10px] leading-tight">{zone} · {pts}</div>
+          </div>
+        ))}
+      </div>
+      {total > 0 && (
+        <div className="text-[10px] text-gray-400">{total} touche{total > 1 ? 's' : ''}</div>
+      )}
+    </div>
+  );
+};

--- a/src/shared/services/refereeManager.ts
+++ b/src/shared/services/refereeManager.ts
@@ -27,6 +27,8 @@ export class RefereeManager {
   private assignments: Map<string, RefereeAssignment[]> = new Map();
   private config: RefereeRotationConfig;
   private currentMatches: Match[] = [];
+  // Matchs consécutifs en cours (sans pause entre deux) par arbitre
+  private consecutiveCount: Map<string, number> = new Map();
 
   constructor(referees: Referee[], config: Partial<RefereeRotationConfig> = {}) {
     this.referees = referees.filter(r => r.status !== 'unavailable');
@@ -186,6 +188,10 @@ export class RefereeManager {
       if (referee.assignedMatches >= referee.maxMatchesPerDay) return false;
     }
 
+    // Enforce maxConsecutiveMatches
+    const consecutive = this.consecutiveCount.get(referee.id) ?? 0;
+    if (consecutive >= this.config.maxConsecutiveMatches) return false;
+
     return true;
   }
 
@@ -220,10 +226,80 @@ export class RefereeManager {
     existing.push(assignment);
     this.assignments.set(referee.id, existing);
 
+    // Mise à jour compteur consécutif : reset si temps de repos suffisant
+    const prev = existing[existing.length - 2];
+    if (prev) {
+      const minutesSinceLast = (assignment.assignmentTime.getTime() - prev.assignmentTime.getTime()) / 60000;
+      if (minutesSinceLast >= this.config.minRestTimeMinutes) {
+        this.consecutiveCount.set(referee.id, 1);
+      } else {
+        this.consecutiveCount.set(referee.id, (this.consecutiveCount.get(referee.id) ?? 0) + 1);
+      }
+    } else {
+      this.consecutiveCount.set(referee.id, 1);
+    }
+
     // Update referee stats
     referee.assignedMatches = (referee.assignedMatches || 0) + 1;
     referee.lastAssignmentTime = new Date();
     referee.status = 'assigned';
+  }
+
+  /**
+   * Score de fatigue [0–100] pour l'affichage UI (100 = épuisé)
+   */
+  getFatigueScore(refereeId: string): number {
+    const consecutive = this.consecutiveCount.get(refereeId) ?? 0;
+    const assignments = this.assignments.get(refereeId) || [];
+    const last = assignments[assignments.length - 1];
+    const minutesSinceLast = last
+      ? (Date.now() - last.assignmentTime.getTime()) / 60000
+      : Infinity;
+
+    const consecutiveScore = Math.min(100, (consecutive / this.config.maxConsecutiveMatches) * 70);
+    const restScore = minutesSinceLast < this.config.minRestTimeMinutes
+      ? ((this.config.minRestTimeMinutes - minutesSinceLast) / this.config.minRestTimeMinutes) * 30
+      : 0;
+
+    return Math.round(consecutiveScore + restScore);
+  }
+
+  /**
+   * Rapport enrichi avec score de fatigue
+   */
+  generateRotationReportDetailed(): {
+    refereeId: string;
+    refereeName: string;
+    matchesAssigned: number;
+    consecutiveMatches: number;
+    fatigueScore: number;
+    restViolations: number;
+    conflicts: number;
+    needsRest: boolean;
+  }[] {
+    return this.referees.map(referee => {
+      const assignments = this.assignments.get(referee.id) || [];
+      const conflicts = assignments.filter(a => a.conflictWarning).length;
+      const consecutive = this.consecutiveCount.get(referee.id) ?? 0;
+      const fatigueScore = this.getFatigueScore(referee.id);
+
+      let restViolations = 0;
+      for (let i = 1; i < assignments.length; i++) {
+        const diff = (assignments[i].assignmentTime.getTime() - assignments[i - 1].assignmentTime.getTime()) / 60000;
+        if (diff < this.config.minRestTimeMinutes) restViolations++;
+      }
+
+      return {
+        refereeId: referee.id,
+        refereeName: `${referee.firstName} ${referee.lastName}`,
+        matchesAssigned: assignments.length,
+        consecutiveMatches: consecutive,
+        fatigueScore,
+        restViolations,
+        conflicts,
+        needsRest: consecutive >= this.config.maxConsecutiveMatches || fatigueScore >= 80,
+      };
+    });
   }
 
   /**

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -167,6 +167,8 @@ export interface ArenaUpdate {
   poolComplete?: boolean; // vrai quand tous les matchs de la poule sont terminés
   completedPoolId?: string; // id de la poule terminée
   refereeSelected?: boolean; // vrai quand l'arbitre a explicitement sélectionné le match
+  touchesA?: string[]; // zones touchées par le tireur A ('A'|'B'|'C') — Laser Sabre
+  touchesB?: string[]; // zones touchées par le tireur B ('A'|'B'|'C') — Laser Sabre
 }
 
 export interface RefereeControl {


### PR DESCRIPTION
## Résumé

- **Heatmap touches** — composant SVG `TouchZoneHeatmap` avec intensité couleur proportionnelle au nb de touches par zone (A/B/C) ; affiché dans `FencerDetailModal` pour les compétitions Laser Sabre
- **Overlay OBS natif** — endpoint `GET /api/arenas/:id/obs-json` retournant scores, touches par zone, cartons, statut mort subite/overtime en JSON propre pour OBS Browser Source ou tout webhook externe ; les `touchesA`/`touchesB` sont maintenant incluses dans chaque `broadcastArenaUpdate` (event `update_score`)
- **Minuteur vocal** — Web Speech API dans `referee.html`, toggle 🔇/🔊 dans l'interface arbitre, annonces à 60 s, 30 s, 10 s, 5→1 s et « Halte ! » à 0 ; multilingue fr/en/de selon `lang` de la page
- **Rotation arbitres** — `maxConsecutiveMatches` désormais vérifié dans `isRefereeAvailable`, compteur consécutif remis à zéro après `minRestTimeMinutes`, nouveau `getFatigueScore` [0–100] et `generateRotationReportDetailed` avec flag `needsRest` ; endpoint REST `GET /api/referees/rotation-report` ; UI `RefereeManager` enrichie avec colonnes Consécutifs / Fatigue% / ⚠️

## Plan de test

- [ ] Ouvrir une compétition Laser Sabre → `FencerDetailModal` → vérifier heatmap SVG avec couleurs proportionnelles
- [ ] Démarrer serveur distant → `GET /api/arenas/arena1/obs-json` → vérifier JSON avec `touches.A.zones` et `touches.B.zones`
- [ ] Tablet arbitre → bouton 🔇 Voix → activer → lancer chrono → vérifier annonces à 30 s, 10 s, 1 s, « Halte »
- [ ] Onglet Arbitres → assigner 3+ matchs consécutifs à un arbitre → vérifier ⚠️ dans rapport de rotation et colonne Fatigue%

https://claude.ai/code/session_01Bn6TFDuDEMgs5BFWXb3kB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bn6TFDuDEMgs5BFWXb3kB3)_