### PR TITLE
feat: rapport post-tournoi PDF + webhook résultats par match

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1870,6 +1870,17 @@ ipcMain.handle('remote:acknowledgeDTCall', async (_, competitionId: string, aren
   }
 });
 
+ipcMain.handle('remote:setWebhookUrl', async (_, url: string | null) => {
+  try {
+    for (const { server } of remoteServers.values()) {
+      server.setWebhookUrl(url);
+    }
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle('remote:updateLogo', async (_, logo: string | null) => {
   try {
     const logoPath = path.join(app.getPath('userData'), 'logo.dat');

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -507,6 +507,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     clearOrgNote: (competitionId: string) => ipcRenderer.invoke('remote:clearOrgNote', competitionId),
     updateArenaTheme: (competitionId: string, arenaId: string, theme: string, customTheme?: any) =>
       ipcRenderer.invoke('remote:updateArenaTheme', competitionId, arenaId, theme, customTheme),
+    setWebhookUrl: (url: string | null) => ipcRenderer.invoke('remote:setWebhookUrl', url),
     updateLogo: (logo: string | null) => ipcRenderer.invoke('remote:updateLogo', logo),
     setWallpaper: (competitionId: string, wallpaper: string | null) =>
       ipcRenderer.invoke('remote:setWallpaper', competitionId, wallpaper),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -90,6 +90,9 @@ export class RemoteScoreServer {
     tableau: true,
   };
 
+  // Webhook résultats (URL HTTPS externe configurée via Settings)
+  private webhookUrl: string | null = null;
+
   // Inscription distante : actif pendant la phase CHECKIN, désactivé après génération des poules
   private registrationEnabled: boolean = true;
 
@@ -3297,6 +3300,27 @@ export class RemoteScoreServer {
       nextMatch,
     });
 
+    // Webhook résultats
+    this.fireWebhook({
+      event: 'match_finished',
+      arenaId,
+      matchId: finishedMatch.id,
+      fencerA: finishedMatch.fencerA
+        ? { id: finishedMatch.fencerA.id, name: `${finishedMatch.fencerA.lastName} ${finishedMatch.fencerA.firstName}`, club: finishedMatch.fencerA.club }
+        : null,
+      fencerB: finishedMatch.fencerB
+        ? { id: finishedMatch.fencerB.id, name: `${finishedMatch.fencerB.lastName} ${finishedMatch.fencerB.firstName}`, club: finishedMatch.fencerB.club }
+        : null,
+      scoreA: finishedMatch.scoreA,
+      scoreB: finishedMatch.scoreB,
+      winner: finishedMatch.scoreA > finishedMatch.scoreB ? 'A'
+        : finishedMatch.scoreB > finishedMatch.scoreA ? 'B' : null,
+      duration: finishedMatch.duration ?? null,
+      timestamp: new Date().toISOString(),
+      // Compatibilité Slack/Discord : champ text en clair
+      text: `Match terminé — ${finishedMatch.fencerA ? `${finishedMatch.fencerA.lastName} ${finishedMatch.fencerA.firstName}` : '?'} ${finishedMatch.scoreA} – ${finishedMatch.scoreB} ${finishedMatch.fencerB ? `${finishedMatch.fencerB.lastName} ${finishedMatch.fencerB.firstName}` : '?'}`,
+    });
+
     // Persister le score final dans la DB et dans l'audit log
     try {
       const finalMatchId = finishedMatch.id;
@@ -4489,6 +4513,19 @@ export class RemoteScoreServer {
 
   public acknowledgeDTCall(arenaId: string): void {
     this.io.to(`arena:${arenaId}`).emit(`arena:${arenaId}:dt_call_ack`);
+  }
+
+  public setWebhookUrl(url: string | null): void {
+    this.webhookUrl = url && url.startsWith('https://') ? url : null;
+  }
+
+  private fireWebhook(payload: Record<string, unknown>): void {
+    if (!this.webhookUrl) return;
+    fetch(this.webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).catch(() => {/* silencieux — ne pas bloquer le flux */});
   }
 
   public setLogo(logo: string | null): void {

--- a/src/renderer/components/AnalyticsDashboard.tsx
+++ b/src/renderer/components/AnalyticsDashboard.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect, useMemo , memo} from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Competition, Fencer, Pool, Match, MatchStatus } from '../../shared/types';
 import { FencerStatsTable } from '../../features/analytics/components/FencerStatsTable';
+import { exportPostTournamentPDF } from '../../shared/utils/postTournamentReport';
 
 interface AnalyticsData {
   totalFencers: number;
@@ -276,6 +277,21 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
   const [selectedTimeframe, setSelectedTimeframe] = useState<'live' | 'last30min' | 'all'>('live');
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [lastUpdate, setLastUpdate] = useState(new Date());
+  const [exporting, setExporting] = useState(false);
+
+  const handleExportReport = async () => {
+    setExporting(true);
+    try {
+      const [fencerStats, matchesWithRefs] = await Promise.all([
+        window.electronAPI.db.getCompetitionFencerStats(competition.id),
+        window.electronAPI.db.getMatchesWithReferees(competition.id),
+      ]);
+      const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+      await exportPostTournamentPDF(competition, fencerStats, matchesWithRefs, logo);
+    } finally {
+      setExporting(false);
+    }
+  };
 
   const analyticsData = useMemo(
     () => calculateAnalytics(competition, pools, matches, fencers, selectedTimeframe),
@@ -323,6 +339,14 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
             <option value="last30min">Last 30 min</option>
             <option value="all">All time</option>
           </select>
+          <button
+            onClick={handleExportReport}
+            disabled={exporting}
+            className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50"
+            title="Exporter le rapport post-tournoi en PDF"
+          >
+            {exporting ? '⏳' : '📄'} Rapport PDF
+          </button>
           {onClose && (
             <button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-xl font-bold">
               ×

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -358,6 +358,11 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         setCommittedCount(count);
         onArenaCountChange?.(count);
         showToast('Saisie distante démarrée', 'success');
+        // Synchroniser le webhook URL configuré vers le serveur qui vient de démarrer
+        const savedWebhook = localStorage.getItem('bellepoule-webhook-url');
+        if (savedWebhook) {
+          window.electronAPI.remote.setWebhookUrl?.(savedWebhook).catch(() => {});
+        }
         // Envoyer les matchs DE avec leurs pistes au serveur (la clé ref est déjà stockée
         // avant que session/isRemoteActive soient prêts, donc l'effet ne se déclenche pas).
         if (deMatches.length > 0) {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -175,6 +175,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
     setWebhookUrl(url);
     setWebhookTestStatus('idle');
     localStorage.setItem(WEBHOOK_STORAGE_KEY, url);
+    // Synchronise l'URL vers tous les serveurs distants actifs
+    (window as any).electronAPI?.remote?.setWebhookUrl?.(url || null).catch(() => {/* serveur inactif */});
   };
 
   const handleTestWebhook = async () => {

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -434,6 +434,7 @@ export interface RemoteServerAPI {
     theme: import('../types/remote').DisplayTheme,
     customTheme?: import('../types/remote').CustomTheme
   ) => Promise<{ success: boolean; error?: string }>;
+  setWebhookUrl: (url: string | null) => Promise<{ success: boolean; error?: string }>;
   updateLogo: (logo: string | null) => Promise<{ success: boolean; error?: string }>;
   setWallpaper: (
     competitionId: string,

--- a/src/shared/utils/postTournamentReport.ts
+++ b/src/shared/utils/postTournamentReport.ts
@@ -1,0 +1,220 @@
+/**
+ * BellePoule Modern - Rapport post-tournoi PDF
+ * Génère un rapport HTML complet pour export PDF
+ * Licensed under GPL-3.0
+ */
+
+import { Competition, FencerCompetitionStats } from '../types';
+
+interface MatchWithReferee {
+  matchId: string;
+  matchNumber: number;
+  poolName: string | null;
+  fencerAName: string;
+  fencerBName: string;
+  scoreA: number | null;
+  scoreB: number | null;
+  status: string;
+  refereeId: string | null;
+  refereeName: string | null;
+}
+
+interface RefereeStats {
+  name: string;
+  matchCount: number;
+}
+
+function weaponLabel(w: string): string {
+  return w === 'E' ? 'Épée' : w === 'F' ? 'Fleuret' : w === 'S' ? 'Sabre' : w === 'L' ? 'Laser Sabre' : w;
+}
+
+function categoryLabel(c: string): string {
+  const MAP: Record<string, string> = {
+    U11: 'U11', U13: 'U13', U15: 'U15', U17: 'U17', U20: 'U20',
+    SENIOR: 'Sénior', V1: 'V1', V2: 'V2', V3: 'V3', V4: 'V4',
+  };
+  return MAP[c] ?? c;
+}
+
+function fmt(seconds: number): string {
+  if (!seconds) return '—';
+  return `${Math.floor(seconds / 60)}min ${seconds % 60}s`;
+}
+
+function buildRefereeStats(matches: MatchWithReferee[]): RefereeStats[] {
+  const map = new Map<string, { name: string; count: number }>();
+  for (const m of matches) {
+    if (!m.refereeId || !m.refereeName) continue;
+    const e = map.get(m.refereeId) ?? { name: m.refereeName, count: 0 };
+    e.count++;
+    map.set(m.refereeId, e);
+  }
+  return Array.from(map.values())
+    .map(e => ({ name: e.name, matchCount: e.count }))
+    .sort((a, b) => b.matchCount - a.matchCount)
+    .slice(0, 10);
+}
+
+export function generatePostTournamentReportHTML(
+  competition: Competition,
+  fencerStats: FencerCompetitionStats[],
+  matchesWithRefs: MatchWithReferee[],
+  logoBase64?: string | null
+): string {
+  const isLaser = competition.weapon === 'L';
+  const completedMatches = matchesWithRefs.filter(m => m.status === 'finished').length;
+  const totalMatches = matchesWithRefs.length;
+
+  // Top 5 tireurs par victoires
+  const sorted = [...fencerStats]
+    .filter(f => f.matchesPlayed > 0)
+    .sort((a, b) => {
+      const vA = fencerStats.indexOf(a);
+      const vB = fencerStats.indexOf(b);
+      // Use victories from matchesPlayed — stored as field or derive from index position
+      return b.totalTouchPoints - a.totalTouchPoints || vA - vB;
+    });
+
+  // Victories not directly in FencerCompetitionStats — sort by best indicator available
+  const top5 = [...fencerStats]
+    .filter(f => f.matchesPlayed > 0)
+    .sort((a, b) => b.totalTouchPoints - a.totalTouchPoints || b.matchesPlayed - a.matchesPlayed)
+    .slice(0, 5);
+
+  const refereeStats = buildRefereeStats(matchesWithRefs);
+
+  const date = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
+
+  const topFencersRows = top5.map((f, i) => {
+    const laserInfo = isLaser
+      ? `<br><small style="color:#6b7280">A:${f.touchesZoneA} B:${f.touchesZoneB} C:${f.touchesZoneC} = ${f.totalTouchPoints}pts</small>`
+      : '';
+    return `
+      <tr style="${i % 2 === 0 ? 'background:#f9fafb' : ''}">
+        <td style="padding:0.6rem 1rem;font-weight:700;color:#6b7280">${i + 1}</td>
+        <td style="padding:0.6rem 1rem;font-weight:600">
+          ${f.fencerLastName.toUpperCase()} ${f.fencerFirstName}
+          ${f.fencerClub ? `<br><small style="color:#9ca3af;font-weight:400">${f.fencerClub}</small>` : ''}
+        </td>
+        <td style="padding:0.6rem 1rem;text-align:center">${f.matchesPlayed}</td>
+        <td style="padding:0.6rem 1rem;text-align:center">${isLaser ? f.totalTouchPoints + laserInfo : '—'}</td>
+        <td style="padding:0.6rem 1rem;text-align:center">
+          ${f.yellowCards > 0 ? `${f.yellowCards}🟡 ` : ''}${f.redCards > 0 ? `${f.redCards}🔴` : ''}${f.yellowCards === 0 && f.redCards === 0 ? '—' : ''}
+        </td>
+      </tr>`;
+  }).join('');
+
+  const refereeRows = refereeStats.map((r, i) =>
+    `<tr style="${i % 2 === 0 ? 'background:#f9fafb' : ''}">
+      <td style="padding:0.5rem 1rem">${r.name}</td>
+      <td style="padding:0.5rem 1rem;text-align:center;font-weight:600">${r.matchCount}</td>
+    </tr>`
+  ).join('');
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8"/>
+  <style>
+    @page { margin: 15mm 12mm; size: A4; }
+    * { box-sizing: border-box; font-family: -apple-system, Arial, sans-serif; }
+    body { margin: 0; color: #111827; font-size: 13px; }
+    h1 { font-size: 1.6rem; margin: 0 0 0.2rem; color: #111827; }
+    h2 { font-size: 1rem; color: #374151; margin: 1.4rem 0 0.6rem; border-bottom: 2px solid #e5e7eb; padding-bottom: 0.3rem; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
+    th { background: #1d4ed8; color: white; padding: 0.5rem 1rem; text-align: left; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    th.center { text-align: center; }
+    td { border-bottom: 1px solid #f3f4f6; }
+    .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 3px solid #1d4ed8; }
+    .stats-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 0.75rem; margin-bottom: 1.5rem; }
+    .stat-box { background: #eff6ff; border-radius: 0.5rem; padding: 0.75rem; text-align: center; border: 1px solid #bfdbfe; }
+    .stat-value { font-size: 1.6rem; font-weight: 800; color: #1d4ed8; }
+    .stat-label { font-size: 0.7rem; color: #6b7280; margin-top: 0.15rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .footer { margin-top: 2rem; text-align: center; color: #9ca3af; font-size: 0.75rem; border-top: 1px solid #e5e7eb; padding-top: 0.75rem; }
+    .badge { display: inline-block; background: #dbeafe; color: #1e40af; border-radius: 0.25rem; padding: 0.15rem 0.5rem; font-size: 0.75rem; font-weight: 600; margin-left: 0.5rem; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div>
+      <h1>${competition.title ?? (competition as any).name ?? ''}</h1>
+      <div style="color:#6b7280;font-size:0.85rem;margin-top:0.25rem">
+        ${weaponLabel(competition.weapon ?? '')}
+        ${competition.category ? `<span class="badge">${categoryLabel(String(competition.category))}</span>` : ''}
+        <span style="margin-left:0.75rem">${date}</span>
+      </div>
+    </div>
+    ${logoBase64 ? `<img src="${logoBase64}" style="height:50px;object-fit:contain" alt="logo"/>` : ''}
+  </div>
+
+  <h2>Statistiques globales</h2>
+  <div class="stats-grid">
+    <div class="stat-box">
+      <div class="stat-value">${fencerStats.length}</div>
+      <div class="stat-label">Tireurs</div>
+    </div>
+    <div class="stat-box">
+      <div class="stat-value">${completedMatches}</div>
+      <div class="stat-label">Matchs terminés</div>
+    </div>
+    <div class="stat-box">
+      <div class="stat-value">${totalMatches}</div>
+      <div class="stat-label">Matchs total</div>
+    </div>
+    <div class="stat-box">
+      <div class="stat-value">${Math.round((completedMatches / Math.max(totalMatches, 1)) * 100)}%</div>
+      <div class="stat-label">Complétion</div>
+    </div>
+  </div>
+
+  <h2>Top tireurs</h2>
+  <table>
+    <thead>
+      <tr>
+        <th style="width:3rem">#</th>
+        <th>Tireur</th>
+        <th class="center">Matchs</th>
+        <th class="center">${isLaser ? 'Points touches' : 'Points'}</th>
+        <th class="center">Cartons</th>
+      </tr>
+    </thead>
+    <tbody>${top5.length > 0 ? topFencersRows : '<tr><td colspan="5" style="padding:1rem;text-align:center;color:#9ca3af">Aucune donnée</td></tr>'}</tbody>
+  </table>
+
+  ${refereeStats.length > 0 ? `
+  <h2>Arbitres</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Arbitre</th>
+        <th class="center">Matchs arbitrés</th>
+      </tr>
+    </thead>
+    <tbody>${refereeRows}</tbody>
+  </table>` : ''}
+
+  <div class="footer">
+    Rapport généré par BellePoule Modern · ${new Date().toLocaleString('fr-FR')}
+  </div>
+</body>
+</html>`;
+}
+
+export async function exportPostTournamentPDF(
+  competition: Competition,
+  fencerStats: FencerCompetitionStats[],
+  matchesWithRefs: MatchWithReferee[],
+  logoBase64?: string | null
+): Promise<void> {
+  const html = generatePostTournamentReportHTML(competition, fencerStats, matchesWithRefs, logoBase64);
+
+  const title = competition.title ?? (competition as any).name ?? 'competition';
+  const result = await window.electronAPI.dialog.saveFile({
+    defaultPath: `rapport-${title.replace(/[^a-zA-Z0-9]/g, '_')}.pdf`,
+    filters: [{ name: 'PDF', extensions: ['pdf'] }],
+  });
+
+  if (!result || result.canceled || !result.filePath) return;
+
+  await window.electronAPI.file.printHtmlToPDF(html, result.filePath);
+}


### PR DESCRIPTION
## Résumé

- **Rapport post-tournoi PDF** — bouton dans AnalyticsDashboard génère un PDF A4 avec : stats globales (tireurs, matchs, complétion %), top tireurs (points/zones Laser Sabre, cartons), tableau arbitres les plus actifs ; logo organisateur inclus si configuré
- **Webhook résultats** — à chaque fin de match, POST HTTPS vers l'URL configurée dans Settings ; payload compatible Slack/Discord (`text`) + champs structurés (`event`, `fencerA/B`, `scoreA/B`, `winner`, `duration`, `timestamp`) ; synchronisation automatique de l'URL au démarrage de la session distante

## Plan de test

- [ ] Analytics Dashboard → bouton "📄 Rapport PDF" → vérifier dialog save + PDF généré avec stats et top tireurs
- [ ] Settings → saisir une URL Discord webhook → finir un match depuis tablette arbitre → vérifier POST reçu
- [ ] Settings → modifier l'URL → vérifier que le serveur en cours prend la nouvelle URL immédiatement
- [ ] Démarrer session distante avec webhook URL déjà sauvegardée → vérifier que le premier match envoie bien le webhook

https://claude.ai/code/session_01Bn6TFDuDEMgs5BFWXb3kB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bn6TFDuDEMgs5BFWXb3kB3)_