### PR TITLE
fix: 2ème carton jaune réévalué en rouge (saisie distante)

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2168,7 +2168,15 @@
           if (this.cardAnnounceEnabled) {
             this.openReasonSelector(ef, cardType);
           } else {
-            this.addCard(ef, cardType);
+            if (cardType === 'yellow') {
+              const history = ef === 'A' ? this.faultHistoryA : this.faultHistoryB;
+              const g2count = history[2] || 0;
+              if (g2count >= 1) cardType = 'red';
+              this.addCard(ef, cardType);
+              history[2] = g2count + 1; // après pushHistory dans addCard
+            } else {
+              this.addCard(ef, cardType);
+            }
           }
         }
 


### PR DESCRIPTION
## Problème

Dans l'interface d'arbitrage distante, quand le sélecteur de raison est désactivé (`cardAnnounceEnabled = false`, valeur par défaut), appuyer deux fois sur le bouton jaune ajoutait deux cartons jaunes au lieu de convertir le 2ème en rouge (règle Groupe 2 : Jaune → Rouge).

## Cause

`handleCardButtonPress` appelait `addCard(ef, 'yellow')` directement, sans consulter `faultHistory[2]`. La réévaluation Groupe 2 n'avait lieu que via `confirmReasonSelector` (chemin avec sélecteur de raison activé).

## Fix

Dans `handleCardButtonPress`, branche `else` (sans sélecteur) :
- Lit `faultHistory[2]` avant d'appeler `addCard`
- Si `count ≥ 1` → convertit `cardType` en `'red'`
- Incrémente `faultHistory[2]` **après** `addCard` pour ne pas polluer le snapshot `pushHistory` (undo bouton)

## Compatibilité

- Undo bouton : snapshot pris avant l'incrément → restauration correcte ✓
- Long-press undo : `removeLastCard` décrémente `history[2]` pour un rouge → correct ✓
- Chemin avec sélecteur de raison : inchangé (`confirmReasonSelector` gère toujours `faultHistory`) ✓
- Conversion blanc→jaune (Groupe 1) : non affectée (passe par `cardType='white'`, pas `'yellow'`) ✓

https://claude.ai/code/session_013aAKgL2RUyjpsxFR4BrHg4

---
_Generated by [Claude Code](https://claude.ai/code/session_013aAKgL2RUyjpsxFR4BrHg4)_