### PR TITLE
fix: saisie distante — tableau poule et TED non mis à jour après match

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1449,7 +1449,27 @@ export class RemoteScoreServer {
               break;
             }
           }
-          if (arenaToFinish) this.finishArenaMatch(arenaToFinish);
+          if (arenaToFinish) {
+            this.finishArenaMatch(arenaToFinish);
+          } else {
+            // Match non trouvé dans une arène active : notifier quand même le renderer
+            // (cas où l'arbitre soumet depuis referee.html mais l'arène a déjà changé)
+            const mainWin = (global as any).mainWindow;
+            if (mainWin) {
+              const isTableauMatch = !dbMatch.poolId;
+              mainWin.webContents.send('match:finished', {
+                matchId,
+                scoreA,
+                scoreB,
+                winner: winner as 'A' | 'B' | null,
+                poolId: dbMatch.poolId ?? null,
+                isTableau: isTableauMatch,
+              });
+              console.log(
+                `[RemoteScoreServer] Émission match:finished hors-arène pour ${matchId}: ${scoreA}-${scoreB}`
+              );
+            }
+          }
         } else {
           // Match en mémoire uniquement (poule non persistée)
           // Synchroniser les scores dans l'arène et déclencher l'IPC vers le renderer
@@ -1459,12 +1479,32 @@ export class RemoteScoreServer {
             status: MatchStatus.FINISHED,
           });
           // Mettre à jour les scores de l'arène puis terminer le match via l'IPC
+          let arenaFoundForInMemory = false;
           for (const [arenaId, arena] of this.arenas) {
             if (arena.currentMatch && arena.currentMatch.id === matchId) {
               arena.currentMatch.scoreA = scoreA;
               arena.currentMatch.scoreB = scoreB;
               this.finishArenaMatch(arenaId);
+              arenaFoundForInMemory = true;
               break;
+            }
+          }
+          if (!arenaFoundForInMemory) {
+            // Match en mémoire non trouvé dans une arène : notifier quand même le renderer
+            const mainWin = (global as any).mainWindow;
+            if (mainWin) {
+              const sm = this.sessionMatches.find((m: any) => m.id === matchId);
+              mainWin.webContents.send('match:finished', {
+                matchId,
+                scoreA,
+                scoreB,
+                winner: winner as 'A' | 'B' | null,
+                poolId: sm?.poolId ?? null,
+                isTableau: sm?.isTableau ?? false,
+              });
+              console.log(
+                `[RemoteScoreServer] Émission match:finished hors-arène (mémoire) pour ${matchId}: ${scoreA}-${scoreB}`
+              );
             }
           }
         }
@@ -3338,7 +3378,17 @@ export class RemoteScoreServer {
     try {
       const finalMatchId = finishedMatch.id;
       const dbMatch = this.db.getMatch(finalMatchId);
-      if (dbMatch && !finishedMatch.isTableau) {
+      // Pour les matchs TED, l'ID en base est "${competitionId}-${matchId}"
+      const compositeId = this.session?.competitionId
+        ? `${this.session.competitionId}-${finalMatchId}`
+        : null;
+      const dbTableauMatch = (!dbMatch && finishedMatch.isTableau && compositeId)
+        ? this.db.getMatch(compositeId)
+        : null;
+      const effectiveDbMatch = dbMatch ?? dbTableauMatch;
+      const effectiveDbId = dbMatch ? finalMatchId : compositeId;
+
+      if (effectiveDbMatch && effectiveDbId) {
         let winner: 'A' | 'B' | null =
           finishedMatch.scoreA > finishedMatch.scoreB ? 'A' :
           finishedMatch.scoreB > finishedMatch.scoreA ? 'B' : null;
@@ -3361,16 +3411,16 @@ export class RemoteScoreServer {
           isExclusion: false,
           isForfait: false,
         };
-        this.db.updateMatch(finalMatchId, {
+        this.db.updateMatch(effectiveDbId, {
           scoreA: scoreAObj,
           scoreB: scoreBObj,
           status: MatchStatus.FINISHED,
         });
         this.db.logScoreChange({
-          matchId: finalMatchId,
+          matchId: effectiveDbId,
           arenaId,
-          previousScoreA: dbMatch.scoreA ?? null,
-          previousScoreB: dbMatch.scoreB ?? null,
+          previousScoreA: effectiveDbMatch.scoreA ?? null,
+          previousScoreB: effectiveDbMatch.scoreB ?? null,
           newScoreA: scoreAObj,
           newScoreB: scoreBObj,
           changedBy: 'referee',


### PR DESCRIPTION
## Problème

En saisie distante, quand un match se termine, le tableau de poule et le TED (tableau d'élimination directe) ne se mettaient pas à jour automatiquement — l'utilisateur devait saisir les scores manuellement.

## Cause racine (deux bugs distincts)

### Bug 1 — IPC `match:finished` non émis (cas hors-arène)

Dans `POST /api/matches/:matchId/finish`, si le match n'était pas trouvé dans le `currentMatch` d'une arène active (`arenaToFinish === null`), l'IPC vers le renderer n'était **jamais** envoyé. La DB était mise à jour côté serveur, mais le renderer ignorait le résultat.

Cas déclencheur : l'arbitre soumet les scores via `referee.html` mais l'arène a entre-temps changé d'état (race condition, réassignation, état dérivé). Même chose pour les matchs uniquement en mémoire.

### Bug 2 — Matchs TED non persistés en DB depuis `finishArenaMatch`

La condition `if (dbMatch && !finishedMatch.isTableau)` ignorait systématiquement les matchs DE : `getMatch(plainUUID)` retourne `null` pour eux car ils sont stockés avec l'ID composite `${competitionId}-${matchId}` (via `upsertMultipleTableauMatches`). Résultat : les scores TED n'étaient jamais sauvegardés en DB par le serveur.

## Corrections

**`src/main/remoteScoreServer.ts`**

1. **`POST /api/matches/:matchId/finish`** — ajout d'un `else` sur les deux branches (match en DB, match en mémoire) : si aucune arène n'a ce match en `currentMatch`, on émet `match:finished` directement via `mainWindow.webContents.send`.

2. **`finishArenaMatch`** — remplacement de `if (dbMatch && !finishedMatch.isTableau)` par une logique qui tente l'ID composite pour les matchs TED quand `getMatch(plainUUID)` retourne `null`. Utilise `effectiveDbMatch` / `effectiveDbId` pour couvrir les deux cas (pool = plain UUID, TED = composite ID).

## Test plan

- [ ] Saisie distante poule via `referee.html` : score s'affiche dans le tableau poule après validation
- [ ] Saisie distante TED via `referee.html` : score s'affiche dans le bracket après validation
- [ ] Saisie directe poule via `pool.html` (inchangé) : toujours fonctionnel
- [ ] Carton noir via `referee.html` : combattant exclu et match terminé correctement
- [ ] Redémarrage de l'app après saisie distante : scores TED persistés en DB et restaurés au rechargement

https://claude.ai/code/session_017NTj89e52X92DZBnmcJZ1W

---
_Generated by [Claude Code](https://claude.ai/code/session_017NTj89e52X92DZBnmcJZ1W)_