### PR TITLE
fix: 3ème carton jaune reste rouge (pas noir) en saisie distante

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2099,7 +2099,7 @@
           this.saveScore();
         }
 
-        addCard(fencer, cardType) {
+        addCard(fencer, cardType, noBlackEscalation = false) {
           if (!this.currentMatch) return;
           if (this.matchStatus === 'not_started') {
             this.showNotification('⏱ Démarrez le match pour saisir des touches');
@@ -2123,7 +2123,8 @@
           }
 
           // 2ème rouge (hors escrime moderne) = carton noir → confirmation
-          if (cardType === 'red' && !this.isModernFencing) {
+          // noBlackEscalation = true quand le rouge vient d'un jaune escaladé (3ème jaune → rouge, pas noir)
+          if (cardType === 'red' && !this.isModernFencing && !noBlackEscalation) {
             const redCount = cards.filter(c => c === 'red').length;
             if (redCount >= 1) {
               this._pendingBlackCardFencer = ef;
@@ -2171,8 +2172,9 @@
             if (cardType === 'yellow') {
               const history = ef === 'A' ? this.faultHistoryA : this.faultHistoryB;
               const g2count = history[2] || 0;
-              if (g2count >= 1) cardType = 'red';
-              this.addCard(ef, cardType);
+              const escalatedToRed = g2count >= 1;
+              if (escalatedToRed) cardType = 'red';
+              this.addCard(ef, cardType, escalatedToRed);
               history[2] = g2count + 1; // après pushHistory dans addCard
             } else {
               this.addCard(ef, cardType);


### PR DESCRIPTION
## Problème

En saisie distante (bouton jaune sans sélecteur de raison) :
- Jaune 1 → jaune ✓
- Jaune 2 → rouge ✓
- Jaune 3 → déclenchait la modale carton noir ✗

## Cause

`handleCardButtonPress` convertissait le 3ème jaune en rouge, puis `addCard` voyait déjà un rouge dans `cards[]` et ouvrait la confirmation carton noir.

## Fix

Ajout d'un flag `noBlackEscalation` sur `addCard`. Quand un jaune est escaladé en rouge (groupe 2), le flag empêche le déclenchement de la modale carton noir.

```
jaune 1 → yellow           (g2count=0 → noBlackEscalation=false)
jaune 2 → red              (g2count=1 → noBlackEscalation=true)
jaune 3+ → red             (g2count=2+ → noBlackEscalation=true)
```

Le carton noir reste réservé aux rouges directs (bouton rouge pressé deux fois).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHFQE9mvsArkstW6GXnRjr)_