### PR TITLE
fix(tablet): corriger la boucle et l'absence de score en tableau DE

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -4144,10 +4144,17 @@ export class RemoteScoreServer {
       const queuesByArena = new Map<string, ArenaMatch[]>();
       for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
 
+      let ssRrIdx = 0;
       for (const match of deMatches) {
-        if (!match.arena) continue; // pas d'arène assignée → attente d'affectation manuelle
-        const targetArenaId = `arena${match.arena}`;
-        if (!queuesByArena.has(targetArenaId)) continue; // hors plage → ignorer
+        let targetArenaId: string;
+        if (match.arena) {
+          targetArenaId = `arena${match.arena}`;
+          if (!queuesByArena.has(targetArenaId)) continue; // hors plage → ignorer
+        } else {
+          // Pas de piste assignée : round-robin automatique.
+          targetArenaId = `arena${(ssRrIdx % strips) + 1}`;
+          ssRrIdx++;
+        }
         queuesByArena.get(targetArenaId)!.push({
           id: match.id,
           fencerA: match.fencerA,
@@ -4495,11 +4502,21 @@ export class RemoteScoreServer {
     const queuesByArena = new Map<string, ArenaMatch[]>();
     for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
 
+    // Indice round-robin pour les matchs sans piste explicitement assignée
+    // (typiquement les SF/Finale dont les tireurs ne sont connus qu'après les QF).
+    let rrIdx = 0;
     for (const match of pending) {
-      if (!match.arena) continue; // pas d'arène assignée → attente d'affectation manuelle
-      const preferred = `arena${match.arena}`;
-      if (!this.arenas.has(preferred)) continue; // hors plage → ignorer
-      queuesByArena.get(preferred)!.push({
+      let targetArenaId: string;
+      if (match.arena) {
+        targetArenaId = `arena${match.arena}`;
+        if (!this.arenas.has(targetArenaId)) continue; // hors plage → ignorer
+      } else {
+        // Pas de piste assignée : distribution automatique round-robin pour que les
+        // arènes reçoivent les matchs des tours suivants sans intervention manuelle.
+        targetArenaId = `arena${(rrIdx % strips) + 1}`;
+        rrIdx++;
+      }
+      queuesByArena.get(targetArenaId)!.push({
         id: match.id,
         fencerA: match.fencerA,
         fencerB: match.fencerB,
@@ -4522,12 +4539,20 @@ export class RemoteScoreServer {
       // alors que le match est terminé dans sessionMatches. On vérifie sessionMatches.
       let arenaEffectivelyFree = !arena.currentMatch;
       if (!arenaEffectivelyFree && arena.currentMatch) {
-        // Cas 1 : match tableau scoré manuellement depuis l'appli → il n'est plus dans deMatches
+        // Cas 1 : match tableau terminé (tablette ou appli) → il n'est plus dans deMatches
         if (arena.currentMatch.isTableau && !deMatches.some(m => m.id === arena.currentMatch!.id)) {
           arena.currentMatch = null;
-          arena.status = 'idle';
-          arenaEffectivelyFree = true;
-          this.updateArena(arenaId, { status: 'idle', currentMatch: null });
+          if (arena.status === 'finished') {
+            // Terminé via tablette : le timer loadNextMatch (3 s) est déjà programmé et
+            // lira la nouvelle file d'attente ; ne pas écraser 'finished' → ne pas bloquer
+            // le timer, et ne pas assigner immédiatement (firstPlayable restera undefined).
+            this.updateArena(arenaId, { currentMatch: null });
+          } else {
+            // Scoré manuellement depuis l'appli : libérer l'arène immédiatement.
+            arena.status = 'idle';
+            arenaEffectivelyFree = true;
+            this.updateArena(arenaId, { status: 'idle', currentMatch: null });
+          }
         } else {
           // Cas 2 : score remote ou fast-poule → vérifier le statut effectif
           const scoreUpdate = this.sessionMatchScores.get(arena.currentMatch.id);

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -170,20 +170,47 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     [arenaCount]
   );
 
+  // Nombre de matchs jouables (les deux tireurs connus) — utilisé comme signal de déclenchement
+  // pour l'auto-assign : augmente à chaque fois qu'un nouveau tour devient jouable après
+  // propagation des vainqueurs (QF → SF → Finale).
+  const playableMatchCount = matches.filter(m => m.fencerA && m.fencerB && !m.isBye).length;
+
   // Auto-assign arenas when matches are (re)generated and autoAssignArenas is on
   useEffect(() => {
     const playable = matches.filter(m => m.fencerA && m.fencerB && !m.isBye);
     const prev = prevMatchesLengthRef.current;
     prevMatchesLengthRef.current = playable.length;
     if (!autoAssignArenas || arenaCount <= 0 || playable.length === 0) return;
-    // Only auto-assign on initial generation (prev was 0) to avoid overriding manual changes.
     // Skip if a champion already exists: returning from results view would otherwise trigger
     // onMatchesChange → matches ref changes → safety-net effect fires → onComplete called
     // → forced redirect back to results.
+    const champion = matches.find(m => m.round === 2)?.winner;
+    if (champion) return;
+
     if (prev === 0 && playable.length > 0) {
-      const champion = matches.find(m => m.round === 2)?.winner;
-      if (!champion) {
-        const updated = distributeArenasRoundRobin(matches);
+      // Génération initiale : distribution complète.
+      const updated = distributeArenasRoundRobin(matches);
+      onMatchesChange(updated);
+      updated.forEach(m => {
+        const orig = matches.find(o => o.id === m.id);
+        if (orig && orig.arena !== m.arena) {
+          onMatchArenaChange?.(m.id, orig.arena ?? null, m.arena ?? null);
+        }
+      });
+    } else if (playable.length > prev) {
+      // Nouveau tour débloqué (ex. SF après QF) : assigner les pistes uniquement aux
+      // matchs qui n'en ont pas encore, sans écraser les affectations manuelles.
+      const unassigned = matches.filter(m => m.fencerA && m.fencerB && !m.isBye && !m.winner && !m.arena);
+      if (unassigned.length > 0) {
+        let arenaIdx = 0;
+        const updated = matches.map(m => {
+          if (m.fencerA && m.fencerB && !m.isBye && !m.winner && !m.arena) {
+            const arena = (arenaIdx % arenaCount) + 1;
+            arenaIdx++;
+            return { ...m, arena };
+          }
+          return m;
+        });
         onMatchesChange(updated);
         updated.forEach(m => {
           const orig = matches.find(o => o.id === m.id);
@@ -193,7 +220,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         });
       }
     }
-  }, [matches.length]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [playableMatchCount]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleAutoAssignToggle = useCallback(
     (enabled: boolean) => {


### PR DESCRIPTION
## Problème

Deux bugs liés lors de matchs DE sur tablette arbitre :
1. Le score ne remontait pas dans le tableau d'élimination directe
2. La tablette restait en boucle sur le dernier match assigné après les QF (affichage « Tous les matchs de cette arène sont terminés » sans jamais charger les SF/Finale)

## Cause racine

À la génération du bracket (8 fenceurs), les matchs SF/Finale sont créés **sans fenceurs** → `distributeArenasRoundRobin` les ignore → `arena = undefined`.

Quand les QF se terminent sur tablette :
- `propagateWinners` renseigne les fenceurs des SF
- `refreshDeMatches` envoie les SF au serveur
- Boucle serveur : `if (!match.arena) continue` → SF jamais mis en queue
- `refreshDeMatches` Cas 1 : réinitialise le statut arena à `'idle'`, écrasant `'finished'`
- Timer `loadNextMatch` (3s) : guard `a.status === 'finished'` échoue → match suivant jamais chargé

## Corrections (3 points)

### 1. `TableauView.tsx` — déclencheur `playableMatchCount`
- Ajout de `playableMatchCount` (nb de matchs avec 2 fenceurs connus)
- L'effet d'auto-assign utilise ce compteur comme dépendance au lieu de `matches.length`
- Nouvelle branche `else if (playable.length > prev)` : assigne les arènes aux matchs du nouveau tour (SF/Finale) en round-robin

### 2. `remoteScoreServer.ts` — distribution round-robin
- `refreshDeMatches` et `startSession` : remplace `if (!match.arena) continue` par une distribution round-robin sur les pistes disponibles pour les matchs sans arène assignée

### 3. `remoteScoreServer.ts` — préservation du statut `finished`
- `refreshDeMatches` Cas 1 : si `arena.status === 'finished'` (match terminé via tablette), ne pas écraser à `'idle'` — le timer `loadNextMatch` (3s) doit pouvoir se déclencher normalement

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUD2BobjpRVEnzCnQBzNQH)_