### PR TITLE
fix: voyant orange tablette après auto-fill de poule

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1676,6 +1676,17 @@ ipcMain.handle('remote:resetPoolMatch', async (_, competitionId: string, matchId
   }
 });
 
+ipcMain.handle('remote:finishPoolMatch', async (_, competitionId: string, matchId: string, scoreA: number, scoreB: number) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: true };
+    entry.server.finishPoolMatch(matchId, scoreA, scoreB);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+  }
+});
+
 ipcMain.handle('remote:stopSession', async (_event, competitionId: string) => {
   try {
     const entry = remoteServers.get(competitionId);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -517,6 +517,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:acknowledgeDTCall', competitionId, arenaId),
     resetPoolMatch: (competitionId: string, matchId: string) =>
       ipcRenderer.invoke('remote:resetPoolMatch', competitionId, matchId),
+    finishPoolMatch: (competitionId: string, matchId: string, scoreA: number, scoreB: number) =>
+      ipcRenderer.invoke('remote:finishPoolMatch', competitionId, matchId, scoreA, scoreB),
     setRegistrationEnabled: (competitionId: string, enabled: boolean) =>
       ipcRenderer.invoke('remote:setRegistrationEnabled', competitionId, enabled),
     getConnectedClients: (competitionId: string) =>

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2944,6 +2944,67 @@ export class RemoteScoreServer {
     }
   }
 
+  // Marque un match de poule comme terminé depuis l'UI principale (ex: auto-fill).
+  // Met à jour sessionMatchScores + sessionMatches, libère l'arène si nécessaire,
+  // puis diffuse la mise à jour à la tablette.
+  public finishPoolMatch(matchId: string, scoreA: number, scoreB: number): void {
+    this.sessionMatchScores.set(matchId, {
+      scoreA: { value: scoreA, isVictory: scoreA > scoreB },
+      scoreB: { value: scoreB, isVictory: scoreB > scoreA },
+      status: MatchStatus.FINISHED,
+    });
+
+    const matchIdx = (this.sessionMatches as any[]).findIndex((m: any) => m.id === matchId);
+    if (matchIdx >= 0) {
+      (this.sessionMatches as any[])[matchIdx].status = MatchStatus.FINISHED;
+    }
+
+    // Si le match est actif sur une arène, la marquer terminée
+    for (const [arenaId, arena] of this.arenas) {
+      if (arena.currentMatch?.id === matchId && arena.status !== 'finished') {
+        arena.status = 'finished';
+        arena.currentMatch.status = 'finished';
+        this.broadcastArenaUpdate(arenaId, {
+          arenaId,
+          status: 'finished',
+          match: arena.currentMatch,
+          scoreA: arena.currentMatch.scoreA,
+          scoreB: arena.currentMatch.scoreB,
+          fencerA: arena.currentMatch.fencerA,
+          fencerB: arena.currentMatch.fencerB,
+        });
+        break;
+      }
+    }
+
+    this.io.emit('match:finished', { matchId });
+
+    const match = matchIdx >= 0 ? (this.sessionMatches as any[])[matchIdx] : null;
+    const poolId = match?.poolId ?? match?.pool?.id;
+    if (!poolId) return;
+
+    const fencers = this.poolFencersCache.get(poolId) ?? this.db.getPoolFencers(poolId);
+    const poolMatches = (this.sessionMatches as any[])
+      .filter((m: any) => !m.isTableau && (m.poolId ?? m.pool?.id) === poolId)
+      .sort((a: any, b: any) => (a.number || 0) - (b.number || 0))
+      .map((m: any) => {
+        const u = this.sessionMatchScores.get(m.id);
+        return u ? { ...m, ...u } : m;
+      });
+    const isComplete =
+      poolMatches.length > 0 &&
+      poolMatches.every(
+        (m: any) => m.status === MatchStatus.FINISHED || m.status === 'finished'
+      );
+    for (const [aId, arena] of this.arenas) {
+      if ((arena.currentMatch?.poolId ?? arena.activePoolId) === poolId) {
+        this.io
+          .to(`pool:${aId}`)
+          .emit(`pool:${aId}:update`, { poolId, fencers, matches: poolMatches, isComplete });
+      }
+    }
+  }
+
   public setLanguage(lang: string): void {
     this.currentLang = lang;
   }

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1212,9 +1212,17 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                         competitionName={competition.title}
                         maxScore={poolMaxScore}
                         competitionId={competition.id}
-                        onScoreUpdate={(matchIndex, scoreA, scoreB, winner, specialStatus) =>
-                          updateScore(poolIndex, matchIndex, scoreA, scoreB, winner, specialStatus)
-                        }
+                        onScoreUpdate={(matchIndex, scoreA, scoreB, winner, specialStatus) => {
+                          updateScore(poolIndex, matchIndex, scoreA, scoreB, winner, specialStatus);
+                          if (isRemoteActive && competition?.id) {
+                            const match = pool.matches[matchIndex];
+                            if (match) {
+                              window.electronAPI.remote.finishPoolMatch(
+                                competition.id, match.id, scoreA, scoreB
+                              ).catch(() => {});
+                            }
+                          }
+                        }}
                         onMatchReset={(matchIndex) => {
                           const match = pool.matches[matchIndex];
                           if (!match) return;

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -452,6 +452,12 @@ export interface RemoteServerAPI {
     competitionId: string,
     matchId: string
   ) => Promise<{ success: boolean; error?: string }>;
+  finishPoolMatch: (
+    competitionId: string,
+    matchId: string,
+    scoreA: number,
+    scoreB: number
+  ) => Promise<{ success: boolean; error?: string }>;
   setRegistrationEnabled: (
     competitionId: string,
     enabled: boolean


### PR DESCRIPTION
## Problème

Après auto-fill des scores de poule (bouton 🎲 Auto), le premier match restait visible sur la tablette arbitre avec un voyant orange (`in_progress`).

## Cause racine

`sessionMatchScores` du serveur remote n'était jamais mis à jour quand un score était saisi depuis l'UI principale (auto-fill ou saisie manuelle). La tablette interroge `/api/arenas/:id/matches` qui filtre sur `sessionMatchScores.status ?? sessionMatches.status` — sans mise à jour, le match passait toujours le filtre et apparaissait disponible.

## Fix

- **`RemoteScoreServer.finishPoolMatch(matchId, scoreA, scoreB)`** : met à jour `sessionMatchScores` + `sessionMatches`, libère l'arène si le match y était actif (`in_progress`), diffuse `pool:update` à la tablette via Socket.IO
- **IPC `remote:finishPoolMatch`** dans `main.ts`
- **Pont preload** + type dans `preload.ts` / `preload.types.ts`
- **`CompetitionView`** : appel `finishPoolMatch` après chaque `updateScore` quand le remote est actif (couvre auto-fill ET saisie manuelle)

https://claude.ai/code/session_01HhunK6iobocyan6uTUzHTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhunK6iobocyan6uTUzHTK)_