### PR TITLE
fix: synchronisation score tableau DE via saisie distante

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1348,6 +1348,7 @@ export class RemoteScoreServer {
               scoreA: m.scoreA ?? 0,
               scoreB: m.scoreB ?? 0,
               status: m.status,
+              isTableau: m.isTableau ?? false,
             }));
           return res.json({ matches: queueMatches, poolId: null, poolName: null });
         }
@@ -2459,8 +2460,11 @@ export class RemoteScoreServer {
         // Sélection d'un match par l'arbitre (depuis sa tablette)
         if (data.match) {
           const m = data.match;
+          // Restaurer isTableau depuis sessionMatches car la tablette ne le transmet pas
+          const sessionMatch = this.sessionMatches.find(sm => sm.id === m.id);
           this.assignMatchToArena(data.arenaId, {
             ...m,
+            isTableau: m.isTableau ?? sessionMatch?.isTableau ?? false,
             scoreA:
               typeof (m.scoreA as unknown) === 'object'
                 ? ((m.scoreA as unknown as { value?: number })?.value ?? 0)
@@ -3382,7 +3386,7 @@ export class RemoteScoreServer {
       const compositeId = this.session?.competitionId
         ? `${this.session.competitionId}-${finalMatchId}`
         : null;
-      const dbTableauMatch = (!dbMatch && finishedMatch.isTableau && compositeId)
+      const dbTableauMatch = (!dbMatch && !finishedMatch.poolId && compositeId)
         ? this.db.getMatch(compositeId)
         : null;
       const effectiveDbMatch = dbMatch ?? dbTableauMatch;

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -395,21 +395,34 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       updateMatchFromRemote(matchId, scoreA, scoreB, MatchStatus.FINISHED, winnerOverride);
 
       // Mise à jour du tableau d'élimination directe si c'est un match DE
+      const resolveWinner = (match: TableauMatch) =>
+        scoreA > scoreB ? match.fencerA :
+        scoreB > scoreA ? match.fencerB :
+        winnerOverride === 'A' ? match.fencerA :
+        winnerOverride === 'B' ? match.fencerB :
+        null;
+
       setTableauMatches(prev => {
         const idx = prev.findIndex(m => m.id === matchId);
         if (idx === -1) return prev;
-        const match = prev[idx];
-        const winner =
-          scoreA > scoreB ? match.fencerA :
-          scoreB > scoreA ? match.fencerB :
-          winnerOverride === 'A' ? match.fencerA :
-          winnerOverride === 'B' ? match.fencerB :
-          null;
-        const updated = prev.map((m, i) => (i === idx ? { ...m, scoreA, scoreB, winner } : m));
+        const updated = prev.map((m, i) => (i === idx ? { ...m, scoreA, scoreB, winner: resolveWinner(m) } : m));
         const size = prev.length > 0 ? Math.max(...prev.map(m => m.round)) : 0;
         propagateWinners(updated, size);
         return [...updated];
       });
+
+      setConsolationBrackets(prev =>
+        prev.map(bracket => {
+          const idx = bracket.matches.findIndex(m => m.id === matchId);
+          if (idx === -1) return bracket;
+          const updated = bracket.matches.map((m, i) =>
+            i === idx ? { ...m, scoreA, scoreB, winner: resolveWinner(m) } : m
+          );
+          const size = updated.length > 0 ? Math.max(...updated.map(m => m.round)) : 0;
+          propagateWinners(updated, size);
+          return { ...bracket, matches: updated };
+        })
+      );
     };
 
     const offMatchFinished = window.electronAPI.onRemoteMatchFinished(handleMatchFinished);

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -256,10 +256,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     [tableauMatches, consolationBrackets]
   );
   useEffect(() => {
+    if (!isRemoteActive || !session || pendingDeMatches.length === 0) return;
     const key = pendingDeMatches.map(m => m.id).join(',');
     if (key === prevDeMatchesKeyRef.current) return;
     prevDeMatchesKeyRef.current = key;
-    if (!isRemoteActive || !session || pendingDeMatches.length === 0) return;
     window.electronAPI.remote.refreshDeMatches(competition.id, pendingDeMatches).catch((err: unknown) => {
       logger.warn(LogCategory.NETWORK, 'Échec refreshDeMatches', err instanceof Error ? err : undefined);
     });


### PR DESCRIPTION
## Problème

En fin de match DE (tableau d'élimination directe) via tablette arbitre, le score ne remontait pas dans l'application. Le match restait en statut non-terminé.

## Causes identifiées et corrections

**Bug A — `RemoteScoreManager.tsx`**
`prevDeMatchesKeyRef.current` était mis à jour AVANT la vérification `session === null`. Si la session chargeait de manière asynchrone, la clé était enregistrée mais `refreshDeMatches` jamais appelé. Au second déclenchement (session prête), la clé correspondait → early return → le serveur ne recevait jamais les matchs DE.
→ Déplacer l'affectation du ref APRÈS les conditions.

**Bug B — `CompetitionView.tsx`**
`handleMatchFinished` ne mettait à jour que `tableauMatches`. Les matchs de consolation (`consolationBrackets`) n'étaient jamais trouvés (`findIndex` retournait -1).
→ Ajouter `setConsolationBrackets` avec la même logique de propagation.

**Bug C — `remoteScoreServer.ts` / `select_match`**
Quand l'arbitre sélectionne manuellement un match depuis sa tablette, le champ `isTableau` n'est pas transmis. `arena.currentMatch.isTableau` restait `undefined` → `finishArenaMatch` ratait la mise à jour DB.
→ Restaurer `isTableau` depuis `sessionMatches` dans le handler `select_match`.

**Bug D — `remoteScoreServer.ts` / `finishArenaMatch`**
La garde `finishedMatch.isTableau && compositeId` empêchait la recherche DB si `isTableau` était falsy.
→ Utiliser `!finishedMatch.poolId` (plus robuste, indépendant du champ `isTableau`).

## Test plan
- [ ] Lancer un tourneau avec phase tableau DE
- [ ] Activer la saisie distante, assigner un match à une arène
- [ ] Saisir et terminer le match depuis la tablette arbitre
- [ ] Vérifier que le score remonte dans l'application et que le vainqueur est propagé
- [ ] Tester aussi avec un match de consolation (repêchage)
- [ ] Tester la sélection manuelle de match depuis la tablette (select_match)

https://claude.ai/code/session_018HnnwZsceGvaHkioam3J5T

---
_Generated by [Claude Code](https://claude.ai/code/session_018HnnwZsceGvaHkioam3J5T)_