### PR TITLE
fix: sync score tablette → tableau élimination directe

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -141,6 +141,12 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const isUnlimitedScore = maxScore === 999;
   const prevMatchesLengthRef = useRef(0);
   const mountMatchesRef = useRef(matches);
+  const matchesRef = useRef(matches);
+  matchesRef.current = matches;
+  const tableauSizeRef = useRef(tableauSize);
+  tableauSizeRef.current = tableauSize;
+  const onMatchesChangeRef = useRef(onMatchesChange);
+  onMatchesChangeRef.current = onMatchesChange;
   const consolationBrackets = consolationBracketsprop;
   const setConsolationBrackets = (updater: ConsolationBracket[] | ((prev: ConsolationBracket[]) => ConsolationBracket[])) => {
     const next = typeof updater === 'function' ? updater(consolationBrackets) : updater;
@@ -299,6 +305,31 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     // calculateFinalResults et onComplete sont stables pendant la phase tableau
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [matches, readOnly]);
+
+  // Synchronisation temps réel depuis la tablette d'arbitrage (élimination directe)
+  useEffect(() => {
+    if (readOnly) return;
+    const unsub = window.electronAPI?.onRemoteMatchFinished?.((data: {
+      matchId: string;
+      scoreA: number;
+      scoreB: number;
+      winner: 'A' | 'B' | null;
+      isTableau: boolean;
+    }) => {
+      if (!data.isTableau) return;
+      const currentMatches = matchesRef.current;
+      const match = currentMatches.find(m => m.id === data.matchId);
+      if (!match) return;
+      const winner = data.winner === 'A' ? match.fencerA : data.winner === 'B' ? match.fencerB : null;
+      const updatedMatches = currentMatches.map(m =>
+        m.id === data.matchId ? { ...m, scoreA: data.scoreA, scoreB: data.scoreB, winner } : m
+      );
+      propagateWinners(updatedMatches, tableauSizeRef.current);
+      onMatchesChangeRef.current(updatedMatches.map(m => ({ ...m })));
+    });
+    return () => { unsub?.(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [readOnly]);
 
   // playAllPositions : déclencher onComplete quand le tableau principal ET tous les brackets de consolation sont terminés
   useEffect(() => {


### PR DESCRIPTION
## Problème

Quand un match finit sur la tablette d'arbitrage, le vainqueur et le score ne remontaient pas dans le tableau d'élimination directe du logiciel. Le bracket ne progressait pas.

## Cause

Le serveur émettait bien l'événement IPC `match:finished` (avec `isTableau: true`) vers le renderer, mais `TableauView` n'avait aucun écouteur pour cet événement. Seule la saisie manuelle via la modale déclenchait `propagateWinners()` et la mise à jour du bracket.

## Fix

`src/renderer/components/TableauView.tsx` — ajout d'un `useEffect` qui :
1. S'abonne à `window.electronAPI.onRemoteMatchFinished`
2. Filtre sur `isTableau: true`
3. Met à jour le match (`scoreA`, `scoreB`, `winner`) dans l'état local
4. Appelle `propagateWinners()` pour avancer le bracket
5. Appelle `onMatchesChange()` pour persister et forcer le re-render

Des refs (`matchesRef`, `tableauSizeRef`, `onMatchesChangeRef`) sont synchronisées à chaque render pour éviter les closures périmées dans le callback IPC.

https://claude.ai/code/session_018xLyMKYCamCQGiTgCVkCfe

---
_Generated by [Claude Code](https://claude.ai/code/session_018xLyMKYCamCQGiTgCVkCfe)_