### PR TITLE
fix: vider les assignations de pistes lors de la désactivation de l'auto-assign

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -234,6 +234,17 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
             onMatchArenaChange?.(m.id, orig.arena ?? null, m.arena ?? null);
           }
         });
+      } else if (!enabled) {
+        // Désactivation : vider les assignations des matchs non encore joués
+        const updated = matches.map(m =>
+          !m.winner ? ({ ...m, arena: null as number | null }) : m
+        );
+        onMatchesChange(updated);
+        matches.forEach(m => {
+          if (m.arena != null && !m.winner) {
+            onMatchArenaChange?.(m.id, m.arena, null);
+          }
+        });
       }
     },
     [arenaCount, distributeArenasRoundRobin, matches, onMatchesChange, onMatchArenaChange]


### PR DESCRIPTION
## Problème

Au passage du tableau finale, 3 matchs apparaissaient sur la piste 1 bien que l'assignation automatique soit désactivée et qu'aucun match n'ait été affecté manuellement.

## Cause

`remoteArenaCount` vaut 1 par défaut. Quand l'auto-assign était activé (même brièvement), `distributeArenasRoundRobin` assignait tous les matchs en attente à la piste 1 (`(n % 1) + 1 = 1`). La désactivation de l'auto-assign ne nettoyait pas ces assignations, qui persistaient dans le state React/session.

## Fix

`handleAutoAssignToggle(false)` vide maintenant les assignations de piste de tous les matchs non encore joués (sans winner). Les matchs terminés conservent leur assignation historique.

## Fichier modifié

- `src/renderer/components/TableauView.tsx` — branche `else if (!enabled)` dans `handleAutoAssignToggle`

https://claude.ai/code/session_011JSixCXWDSRawHNaKgVvAS

---
_Generated by [Claude Code](https://claude.ai/code/session_011JSixCXWDSRawHNaKgVvAS)_