### PR TITLE
fix: onglet Tableau reste grisé après restauration de session

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -870,7 +870,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const isResultsLocked = hasDirectElimination && finalResults.length === 0;
   // En mode quest-sans-poules, le tableau se débloque par la complétion de la quête (rankingValidated)
   // Le tableau reste accessible en lecture seule si les résultats finaux existent déjà
-  const isTableauUnlocked = finalResults.length > 0 || (questNoPool
+  // ou si des matchs de tableau ont déjà été générés (session restaurée même sans poules chargées)
+  const isTableauUnlocked = finalResults.length > 0 || tableauMatches.length > 0 || (questNoPool
     ? rankingValidated
     : canAdvanceFromPools && rankingValidated);
 


### PR DESCRIPTION
## Problème

Quand une session est restaurée avec des matchs de tableau existants mais `canAdvanceFromPools = false` (poules non chargées ou incomplètes en mémoire), l'onglet **Tableau** restait grisé (`disabled`). L'utilisateur ne pouvait pas cliquer dessus pour y revenir, même en étant en phase tableau.

Même symptôme après navigation onglet→tableau→ranking : l'effet qui remet `rankingValidated = false` (quand `canAdvanceFromPools` est faux) rendait `isTableauUnlocked = false`, bloquant le retour au tableau.

## Cause racine

`isTableauUnlocked` ne vérifiait pas `tableauMatches.length > 0` :

```ts
// AVANT
const isTableauUnlocked = finalResults.length > 0 || (questNoPool ? ... : canAdvanceFromPools && rankingValidated);
```

Si `tableauMatches` existent (session restaurée) mais `canAdvanceFromPools = false` et `finalResults = []`, le tab était désactivé à tort.

## Fix

```ts
// APRÈS
const isTableauUnlocked = finalResults.length > 0 || tableauMatches.length > 0 || (questNoPool ? ... : canAdvanceFromPools && rankingValidated);
```

Si des matchs de tableau ont déjà été générés, le tab est toujours accessible — indépendamment de l'état des poules en mémoire.

https://claude.ai/code/session_014Ufy9cgD8LDQgpywQ91XWc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ufy9cgD8LDQgpywQ91XWc)_