### PR TITLE
Fix: arène 1 affiche des matchs DE non assignés en saisie distante

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -4209,17 +4209,10 @@ export class RemoteScoreServer {
       const queuesByArena = new Map<string, ArenaMatch[]>();
       for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
 
-      let ssRrIdx = 0;
       for (const match of deMatches) {
-        let targetArenaId: string;
-        if (match.arena) {
-          targetArenaId = `arena${match.arena}`;
-          if (!queuesByArena.has(targetArenaId)) continue; // hors plage → ignorer
-        } else {
-          // Pas de piste assignée : round-robin automatique.
-          targetArenaId = `arena${(ssRrIdx % strips) + 1}`;
-          ssRrIdx++;
-        }
+        if (!match.arena) continue; // pas de piste assignée → ne pas distribuer
+        const targetArenaId = `arena${match.arena}`;
+        if (!queuesByArena.has(targetArenaId)) continue; // hors plage → ignorer
         queuesByArena.get(targetArenaId)!.push({
           id: match.id,
           fencerA: match.fencerA,
@@ -4567,20 +4560,13 @@ export class RemoteScoreServer {
     const queuesByArena = new Map<string, ArenaMatch[]>();
     for (let i = 1; i <= strips; i++) queuesByArena.set(`arena${i}`, []);
 
-    // Indice round-robin pour les matchs sans piste explicitement assignée
-    // (typiquement les SF/Finale dont les tireurs ne sont connus qu'après les QF).
-    let rrIdx = 0;
+    // N'assigner QUE les matchs ayant une piste explicitement définie (match.arena).
+    // Sans piste assignée → on ne charge rien sur une arène : sinon des matchs
+    // apparaissent sur l'arène 1 alors que l'assignation auto est désactivée.
     for (const match of pending) {
-      let targetArenaId: string;
-      if (match.arena) {
-        targetArenaId = `arena${match.arena}`;
-        if (!this.arenas.has(targetArenaId)) continue; // hors plage → ignorer
-      } else {
-        // Pas de piste assignée : distribution automatique round-robin pour que les
-        // arènes reçoivent les matchs des tours suivants sans intervention manuelle.
-        targetArenaId = `arena${(rrIdx % strips) + 1}`;
-        rrIdx++;
-      }
+      if (!match.arena) continue; // pas de piste assignée → ne pas distribuer
+      const targetArenaId = `arena${match.arena}`;
+      if (!this.arenas.has(targetArenaId)) continue; // hors plage → ignorer
       queuesByArena.get(targetArenaId)!.push({
         id: match.id,
         fencerA: match.fencerA,


### PR DESCRIPTION
## Problème

En tableau d'élimination finale, l'arène 1 affichait plusieurs matchs (≈3) en saisie distante alors que l'assignation auto était désactivée et qu'aucun match n'était associé à l'arène 1.

## Cause

`refreshDeMatches` et `startSession` distribuaient en round-robin les matchs DE sans piste explicite (`match.arena` absent) sur toutes les arènes → arène 1 chargée par défaut.

## Correctif

Ne distribuer que les matchs ayant une piste explicitement assignée. Les matchs sans piste restent hors file tant qu'ils ne sont pas assignés (manuellement ou via assignation auto).

https://claude.ai/code/session_015cGfff61P7iXdj8CVhr3tK

---
_Generated by [Claude Code](https://claude.ai/code/session_015cGfff61P7iXdj8CVhr3tK)_