### PR TITLE
Fix: vainqueur non reconnu en tableau d'élimination directe

### DIFF
--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -26,10 +26,19 @@ const MatchCard: React.FC<MatchCardProps> = ({
 }) => {
   const canEdit = !readOnly && !!(match.fencerA && match.fencerB && !match.isBye) && !!onMatchClick;
   const hasScore = match.scoreA !== null && match.scoreB !== null;
-  const isMatchComplete = match.winner !== null;
 
-  const winnerA = match.winner?.id === match.fencerA?.id;
-  const winnerB = match.winner?.id === match.fencerB?.id;
+  // Filet d'affichage : déduit le vainqueur des scores s'il n'a pas été fixé
+  // (match restauré depuis la DB, saisie partielle). Ne mute pas l'objet source.
+  let winner = match.winner;
+  if (!winner && hasScore) {
+    if (match.scoreA! > match.scoreB!) winner = match.fencerA;
+    else if (match.scoreB! > match.scoreA!) winner = match.fencerB;
+  }
+
+  const isMatchComplete = winner !== null;
+
+  const winnerA = !!winner && winner.id === match.fencerA?.id;
+  const winnerB = !!winner && winner.id === match.fencerB?.id;
 
   const handleArenaClick = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/renderer/components/tableau/tableauTypes.ts
+++ b/src/renderer/components/tableau/tableauTypes.ts
@@ -39,7 +39,24 @@ export interface ConsolationBracket {
   parentBracketId: string;
 }
 
+/**
+ * Déduit le vainqueur d'un match à partir des scores quand il n'est pas déjà fixé.
+ * Couvre les chemins qui posent un score sans renseigner `winner`
+ * (restauration DB, statuts spéciaux, synchro partielle). En cas d'égalité,
+ * `winner` reste inchangé : seul un tirage au sort explicite peut le fixer.
+ */
+export function resolveWinnerFromScores(match: TableauMatch): void {
+  if (match.winner) return;
+  if (match.scoreA === null || match.scoreB === null) return;
+  if (match.scoreA > match.scoreB) match.winner = match.fencerA;
+  else if (match.scoreB > match.scoreA) match.winner = match.fencerB;
+}
+
 export function propagateWinners(matchList: TableauMatch[], size: number): void {
+  // Normalise les vainqueurs manquants avant toute propagation : un match dont
+  // les deux scores sont saisis a forcément un vainqueur (hors égalité).
+  for (const m of matchList) resolveWinnerFromScores(m);
+
   // Regroupe les matchs par tour une seule fois (O(n)) au lieu de filtrer à chaque
   // itération (O(tours·n)). L'ordre d'insertion est préservé, donc l'appariement
   // par index reste identique au comportement précédent.


### PR DESCRIPTION
## Problème
Match fini en tableau (ex: Mario 15 — Yoshi 0) mais vainqueur non reconnu : pas de couronne 🥇, pas de "V15", badges piste/arbitre encore affichés (match jugé non terminé).

Cause : certains chemins posent les deux scores sans renseigner `match.winner` (restauration DB, statut spécial, synchro partielle). Rien ne re-déduisait le vainqueur ensuite.

## Correctif
- `propagateWinners` normalise les vainqueurs manquants à partir des scores avant propagation
- `MatchCard` déduit le vainqueur à l'affichage (filet de sécurité, sans muter la source)
- Égalité préservée : seul un tirage au sort explicite fixe le vainqueur

https://claude.ai/code/session_01SwnK9seiXRUXxwYBYz8iCH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwnK9seiXRUXxwYBYz8iCH)_