### PR TITLE
fix(tableau): vainqueur routé vers le mauvais match en élimination directe

### DIFF
--- a/src/renderer/components/tableau/tableauTypes.test.ts
+++ b/src/renderer/components/tableau/tableauTypes.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { propagateWinners, TableauMatch } from './tableauTypes';
+
+const F = (id: string) => ({ id, firstName: id, lastName: id } as any);
+
+function mk(round: number, pos: number, a: any, b: any, o: Partial<TableauMatch> = {}): TableauMatch {
+  const isBye = o.isBye ?? (!a || !b);
+  return {
+    id: `${round}-${pos}`,
+    round,
+    position: pos,
+    fencerA: a,
+    fencerB: b,
+    scoreA: o.scoreA ?? null,
+    scoreB: o.scoreB ?? null,
+    winner: o.winner ?? (isBye ? a || b : null),
+    isBye,
+  };
+}
+
+describe('propagateWinners', () => {
+  // Régression : un vainqueur doit affronter son adversaire réel même quand
+  // matchList n'est pas ordonné par position (restauration DB / synchro tablette).
+  it('apparie les feeders par position même si matchList est désordonné', () => {
+    const dk = F('DK');
+    const toad = F('Toad');
+    const bowser = F('Bowser');
+
+    const matches: TableauMatch[] = [
+      mk(8, 1, toad, bowser),
+      mk(8, 3, F('z'), F('w')),
+      mk(8, 0, dk, null), // bye
+      mk(8, 2, F('x'), F('y')),
+      mk(4, 1, null, null, { isBye: false }),
+      mk(4, 0, null, null, { isBye: false }),
+      mk(2, 0, null, null, { isBye: false }),
+    ];
+
+    const m81 = matches.find(m => m.id === '8-1')!;
+    m81.scoreA = 0;
+    m81.scoreB = 15;
+    m81.winner = bowser;
+
+    propagateWinners(matches, 8);
+
+    const semi = matches.find(m => m.id === '4-0')!;
+    expect(semi.fencerA?.id).toBe('DK');
+    expect(semi.fencerB?.id).toBe('Bowser');
+  });
+});

--- a/src/renderer/components/tableau/tableauTypes.ts
+++ b/src/renderer/components/tableau/tableauTypes.ts
@@ -66,6 +66,11 @@ export function propagateWinners(matchList: TableauMatch[], size: number): void 
     if (bucket) bucket.push(m);
     else byRound.set(m.round, [m]);
   }
+  // L'appariement feeder→tour suivant se fait par index. L'ordre du tableau `matchList`
+  // n'est pas garanti (restauration DB, synchro tablette) : on trie chaque tour par
+  // `position` pour que index === position et éviter de router un vainqueur vers le
+  // mauvais match (ex. vainqueur isolé au lieu d'affronter son adversaire réel).
+  for (const bucket of byRound.values()) bucket.sort((a, b) => a.position - b.position);
   const emptyRound: TableauMatch[] = [];
 
   let currentRound = size;


### PR DESCRIPTION
## Beug

Bowser gagne son match mais n'affronte pas Donkey Kong au tour suivant : il apparaît isolé dans un autre match.

## Cause

`propagateWinners` apparie les feeders → tour suivant par **ordre d'insertion** dans `matchList`, pas par `position`. Quand l'ordre n'est pas garanti (restauration DB, synchro tablette), le vainqueur est routé vers le mauvais match.

## Fix

Tri de chaque tour par `position` avant l'appariement (`index === position`).

Test de régression ajouté : `tableauTypes.test.ts`.

https://claude.ai/code/session_01HkjmZNpKQG2oUTMCoCeCBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkjmZNpKQG2oUTMCoCeCBu)_