### PR TITLE
fix: matchs poule non joués après remplissage automatique et relance

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -707,22 +707,31 @@ export class DatabaseManager {
         .forEach(rRow => refereesById.set(rRow.id as string, this.rowToReferee(rRow)));
     }
 
-    return matchRows.map(row => ({
+    return matchRows.map(row => {
+      const scoreA = row.score_a ? JSON.parse(row.score_a as string) : null;
+      const scoreB = row.score_b ? JSON.parse(row.score_b as string) : null;
+      // Heal inconsistent DB state: scores present implies the match was played
+      const rawStatus = row.status as MatchStatus;
+      const status = (scoreA !== null && scoreB !== null && rawStatus !== MatchStatus.FINISHED)
+        ? MatchStatus.FINISHED
+        : rawStatus;
+      return {
       id: row.id as string,
       number: row.number as number,
       fencerA: row.fencer_a_id ? (fencersById.get(row.fencer_a_id as string) ?? null) : null,
       fencerB: row.fencer_b_id ? (fencersById.get(row.fencer_b_id as string) ?? null) : null,
-      scoreA: row.score_a ? JSON.parse(row.score_a as string) : null,
-      scoreB: row.score_b ? JSON.parse(row.score_b as string) : null,
+      scoreA,
+      scoreB,
       maxScore: row.max_score as number,
-      status: row.status as MatchStatus,
+      status,
       poolId: row.pool_id as string,
       tableId: row.table_id as string,
       round: row.round as number,
       referee: row.referee_id ? (refereesById.get(row.referee_id as string) ?? undefined) : undefined,
       createdAt: new Date(row.created_at as string),
       updatedAt: new Date(row.updated_at as string),
-    }));
+      };
+    });
   }
 
   public getCompetitionPools(competitionId: string): { id: string; name: string }[] {
@@ -874,14 +883,16 @@ export class DatabaseManager {
   public updateMatch(id: string, updates: Partial<Match> & { refereeId?: string }): void {
     if (!this.db) throw new Error('Database not open');
     const now = new Date().toISOString();
-    if (updates.scoreA !== undefined)
-      this.run('UPDATE matches SET score_a = ?, updated_at = ? WHERE id = ?', [JSON.stringify(updates.scoreA), now, id]);
-    if (updates.scoreB !== undefined)
-      this.run('UPDATE matches SET score_b = ?, updated_at = ? WHERE id = ?', [JSON.stringify(updates.scoreB), now, id]);
-    if (updates.status !== undefined)
-      this.run('UPDATE matches SET status = ?, updated_at = ? WHERE id = ?', [updates.status, now, id]);
-    if (updates.refereeId !== undefined)
-      this.run('UPDATE matches SET referee_id = ?, updated_at = ? WHERE id = ?', [updates.refereeId, now, id]);
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+    if (updates.scoreA !== undefined) { setClauses.push('score_a = ?'); params.push(JSON.stringify(updates.scoreA)); }
+    if (updates.scoreB !== undefined) { setClauses.push('score_b = ?'); params.push(JSON.stringify(updates.scoreB)); }
+    if (updates.status !== undefined) { setClauses.push('status = ?'); params.push(updates.status); }
+    if (updates.refereeId !== undefined) { setClauses.push('referee_id = ?'); params.push(updates.refereeId); }
+    if (setClauses.length === 0) return;
+    setClauses.push('updated_at = ?');
+    params.push(now, id);
+    this.run(`UPDATE matches SET ${setClauses.join(', ')} WHERE id = ?`, params);
   }
 
   public updatePool(pool: Pool): void {

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -280,9 +280,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     }
   }, [restoredState, isLoaded]);
 
-  // Fallback DB : si session state n'a pas de poules, essayer de les charger depuis la DB
+  // Fallback DB : si session state n'a pas de poules, essayer de les charger depuis la DB.
+  // Guard: ne pas déclencher si restoredState a déjà des poules (elles seront appliquées par
+  // l'effet [restoredState, isLoaded] dans le même cycle de rendu, évitant la race condition
+  // où l'IPC SQLite répond avant le prochain rendu React et écrase la session state).
   useEffect(() => {
     if (!isLoaded || pools.length > 0) return;
+    if (restoredState?.pools && restoredState.pools.length > 0) return;
     let cancelled = false;
     window.electronAPI.db.getPhasesByCompetition(competition.id)
       .then(phases => {
@@ -295,7 +299,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       })
       .catch((e: unknown) => logger.warn(LogCategory.DATABASE, 'DB pool fallback failed', e instanceof Error ? e : undefined));
     return () => { cancelled = true; };
-  }, [isLoaded, pools.length, competition.id]);
+  }, [isLoaded, pools.length, competition.id, restoredState]);
 
   // Rétablir isRemoteActive si une session est déjà en cours (ex: rechargement après phase poules)
   useEffect(() => {


### PR DESCRIPTION
## Problème

Après remplissage automatique des deux poules → sauvegarde → fermeture → relance, les deux premiers matchs de poule s'affichaient comme « non joués ». En cliquant sur la case, le score était bien présent ; terminer le match remettait tout en ordre.

## Causes racines

### 1. `updateMatch` non atomique (DB)
Trois `UPDATE` SQL séparés pour `score_a`, `score_b` et `status`. Si le process était interrompu entre le 2e et le 3e statement, la DB pouvait avoir des scores mais `status = not_started` — état incohérent chargé au redémarrage via le fallback DB.

**Fix :** un seul `UPDATE matches SET score_a=?, score_b=?, status=? WHERE id=?` dynamique — toutes les colonnes en une seule requête atomique.

### 2. Race condition fallback DB vs restauration session
L'effet fallback DB (`pools.length === 0`) et l'effet de restauration de session se déclenchent dans le **même cycle de rendu** (quand `isLoaded` devient `true`). L'IPC SQLite (synchrone, très rapide avec better-sqlite3) pouvait répondre **avant** que React ne traite le `setPools(restoredPools)` de l'effet de restauration, écrasant la bonne session state avec des données DB potentiellement incohérentes.

**Fix :** le fallback est bloqué si `restoredState` a déjà des poules — elles seront appliquées par l'effet dédié dans le même cycle.

### 3. Normalisation défensive dans `getMatchesByPool`
Si `scoreA` et `scoreB` sont présents en DB mais `status != finished`, force `status = finished`. Guérit tout état DB incohérent préexistant au chargement.

## Fichiers modifiés

- `src/database/index.ts` — `updateMatch` atomique + normalisation dans `getMatchesByPool`
- `src/renderer/components/CompetitionView.tsx` — guard sur le fallback DB load

https://claude.ai/code/session_01LJenFBPrgxvs5rcW97nLKD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJenFBPrgxvs5rcW97nLKD)_