### PR TITLE
fix(tableau): transfert du vainqueur même si taille du tableau périmée

### DIFF
--- a/src/renderer/components/tableau/tableauTypes.test.ts
+++ b/src/renderer/components/tableau/tableauTypes.test.ts
@@ -48,3 +48,38 @@ describe('propagateWinners', () => {
     expect(semi.fencerB?.id).toBe('Bowser');
   });
 });
+
+describe('propagateWinners - taille périmée/invalide', () => {
+  const mk16 = (): TableauMatch[] => {
+    const m: TableauMatch[] = [];
+    for (let p = 0; p < 8; p++) m.push(mk(16, p, F('a' + p), F('b' + p)));
+    for (let p = 0; p < 4; p++) m.push(mk(8, p, null, null, { isBye: false }));
+    for (let p = 0; p < 2; p++) m.push(mk(4, p, null, null, { isBye: false }));
+    m.push(mk(2, 0, null, null, { isBye: false }));
+    return m;
+  };
+
+  // Régression : un score saisi alors que tableauSize n'est pas encore recalculé
+  // (restauration de session) passait size=0 → propagation no-op → vainqueur perdu.
+  it('propage même si size vaut 0', () => {
+    const matches = mk16();
+    const m0 = matches.find(x => x.id === '16-0')!;
+    m0.scoreA = 15; m0.scoreB = 3; m0.winner = m0.fencerA;
+    const m1 = matches.find(x => x.id === '16-1')!;
+    m1.scoreA = 3; m1.scoreB = 15; m1.winner = m1.fencerB;
+
+    propagateWinners(matches, 0);
+
+    const qf0 = matches.find(x => x.id === '8-0')!;
+    expect(qf0.fencerA?.id).toBe('a0');
+    expect(qf0.fencerB?.id).toBe('b1');
+  });
+
+  it('propage le vainqueur des 8es vers les quarts (size correct)', () => {
+    const matches = mk16();
+    const m1 = matches.find(x => x.id === '16-1')!;
+    m1.scoreA = 3; m1.scoreB = 15; m1.winner = m1.fencerB;
+    propagateWinners(matches, 16);
+    expect(matches.find(x => x.id === '8-0')!.fencerB?.id).toBe('b1');
+  });
+});

--- a/src/renderer/components/tableau/tableauTypes.ts
+++ b/src/renderer/components/tableau/tableauTypes.ts
@@ -52,10 +52,35 @@ export function resolveWinnerFromScores(match: TableauMatch): void {
   else if (match.scoreB > match.scoreA) match.winner = match.fencerB;
 }
 
+/**
+ * Déduit le premier tour du tableau principal à partir des matchs existants.
+ * Source de vérité robuste face à un `size` absent (0), périmé (restauration de
+ * session avant que `tableauSize` ne soit recalculé) ou trop grand (round de
+ * barrage = mainSize*2). Le premier tour est le plus grand round (hors petite
+ * finale round=3) dont le nombre de matchs vaut round/2 : un round de barrage,
+ * partiellement rempli, est ainsi écarté.
+ */
+function deriveFirstRound(matchList: TableauMatch[]): number {
+  const counts = new Map<number, number>();
+  for (const m of matchList) {
+    if (m.round === 3) continue; // petite finale
+    counts.set(m.round, (counts.get(m.round) ?? 0) + 1);
+  }
+  let best = 0;
+  for (const [round, count] of counts) {
+    if (count === round / 2 && round > best) best = round;
+  }
+  return best;
+}
+
 export function propagateWinners(matchList: TableauMatch[], size: number): void {
   // Normalise les vainqueurs manquants avant toute propagation : un match dont
   // les deux scores sont saisis a forcément un vainqueur (hors égalité).
   for (const m of matchList) resolveWinnerFromScores(m);
+
+  // Ignore un `size` invalide/périmé : on repart toujours du premier tour réel.
+  const firstRound = deriveFirstRound(matchList);
+  const effectiveSize = firstRound > 0 ? firstRound : size;
 
   // Indexe les matchs par (round, position). L'appariement feeder→tour suivant se fait
   // STRICTEMENT par `position`, jamais par index de tableau : l'ordre de `matchList`
@@ -71,7 +96,7 @@ export function propagateWinners(matchList: TableauMatch[], size: number): void 
   }
   const emptyRound = new Map<number, TableauMatch>();
 
-  let currentRound = size;
+  let currentRound = effectiveSize;
 
   while (currentRound > 2) {
     const nextRound = currentRound / 2;
@@ -124,7 +149,7 @@ export function propagateWinners(matchList: TableauMatch[], size: number): void 
   }
 
   const thirdPlaceMatchEntry = matchList.find(m => m.round === 3);
-  if (thirdPlaceMatchEntry && size >= 4) {
+  if (thirdPlaceMatchEntry && effectiveSize >= 4) {
     const semiFinalMatches = [...(byRoundPos.get(4) ?? emptyRound).values()].sort(
       (a, b) => a.position - b.position
     );


### PR DESCRIPTION
## Problème
Vainqueur d'un match (ex: tableau de 16) pas transféré au tour suivant (quart).

## Cause
`propagateWinners` partait du `size` passé en paramètre. Si `size` invalide :
- saisie de score juste après restauration de session (`tableauSize` encore à `0`)
- chemin distant `applyRemoteScore` (`Math.max` incluant le round de barrage)

→ boucle `while (currentRound > 2)` jamais exécutée → propagation no-op.

## Fix
`propagateWinners` déduit le premier tour réel des matchs (plus grand round, hors petite finale round=3, dont le nombre de matchs vaut round/2). Robuste face à un `size` à 0, périmé ou trop grand.

## Tests
- `propage même si size vaut 0` (régression)
- propagation 8es → quarts (size correct)

https://claude.ai/code/session_01MA65ztzLDVRYLPQMhUodrS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA65ztzLDVRYLPQMhUodrS)_