### PR TITLE
fix(build): app packagée cassée (localStorage SecurityError)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:main": "webpack --config webpack.main.config.js",
     "build:renderer": "webpack --config webpack.renderer.config.js",
     "dev": "concurrently \"npm run dev:main\" \"npm run dev:renderer\"",
-    "dev:main": "webpack --watch --config webpack.main.config.js",
+    "dev:main": "webpack --watch --mode development --config webpack.main.config.js",
     "dev:renderer": "webpack serve --config webpack.renderer.config.js",
     "package": "npm run build && electron-builder",
     "package:win": "npm run build && electron-builder --win",

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -1,10 +1,16 @@
 const path = require('path');
 const TerserPlugin = require('terser-webpack-plugin');
 
-const isProd = process.env.NODE_ENV === 'production';
+// La minification est pilotée par --mode (défaut: production pour les builds).
+// Les scripts dev passent --mode development.
+const argvMode = process.argv.includes('--mode')
+  ? process.argv[process.argv.indexOf('--mode') + 1]
+  : undefined;
+const mode = argvMode || (process.env.NODE_ENV === 'development' ? 'development' : 'production');
+const isProd = mode === 'production';
 
 const common = {
-  mode: isProd ? 'production' : 'development',
+  mode,
   devtool: isProd ? false : 'source-map',
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],
@@ -36,6 +42,10 @@ const common = {
     ],
   },
   optimization: {
+    // Ne PAS inliner process.env.NODE_ENV dans le bundle main :
+    // main.ts choisit loadFile/loadURL via process.env.NODE_ENV AU RUNTIME.
+    // Sans ceci, webpack fige la branche dev (loadURL localhost:8066) dans l'app packagée.
+    nodeEnv: false,
     minimize: isProd,
     minimizer: [
       new TerserPlugin({


### PR DESCRIPTION
## Cause
Build #1145 a migré le build du main de `tsc` vers webpack. Webpack inline `process.env.NODE_ENV` (= `development`, faute de `NODE_ENV=production` dans `build`) dans le bundle. La branche est figée dans l'app packagée :

```js
if (process.env.NODE_ENV === 'development') // -> TRUE figé
  mainWindow.loadURL('http://localhost:8066'); // serveur distant, pas le renderer
```

→ écran cassé + `SecurityError: Failed to read 'localStorage' ... Access is denied`.

Avant (tsc), `NODE_ENV` était lu au runtime → `undefined` en prod → `loadFile`.

## Fix
- `optimization.nodeEnv: false` : pas d'inlining, `NODE_ENV` relu au runtime → `loadFile` en prod.
- Minification pilotée par `--mode` (défaut `production`).
- `dev:main` passe `--mode development`.

https://claude.ai/code/session_01MrMPB1KYqA4d3kMyBndCCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrMPB1KYqA4d3kMyBndCCk)_