### PR TITLE
fix(tableau): vainqueur et propagation manquants en saisie distante

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -356,14 +356,26 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   // Appliquer un score distant au bon conteneur : tableau DE, consolante, ou poule.
   // Évite le warning "Match non trouvé" côté poule pour les matchs du tableau.
   const applyRemoteScore = useCallback(
-    (matchId: string, scoreA: number, scoreB: number, finished: boolean, winnerOverride?: 'A' | 'B') => {
+    (matchIdRaw: string, scoreARaw: number, scoreBRaw: number, finished: boolean, winnerOverride?: 'A' | 'B') => {
+      const matchId = matchIdRaw;
+      // Le score peut arriver sous forme d'objet Score ({ value }) ou de chaîne
+      // selon le chemin (IPC tablette, sync DB). On normalise en nombre, sinon les
+      // comparaisons scoreA > scoreB échouent (NaN) → aucun vainqueur, aucune
+      // propagation au tour suivant.
+      const toNum = (s: unknown): number =>
+        typeof s === 'object' && s !== null ? Number((s as { value?: number }).value ?? 0) : Number(s ?? 0);
+      const scoreA = toNum(scoreARaw);
+      const scoreB = toNum(scoreBRaw);
       const status = finished ? MatchStatus.FINISHED : MatchStatus.IN_PROGRESS;
+      // Le vainqueur transmis par le serveur (winnerOverride) fait foi : il gère les
+      // cas d'égalité (tirage au sort) et reste correct même si le score transporté
+      // est ambigu. On retombe sur la comparaison des scores en dernier recours.
       const resolveWinner = (match: TableauMatch) =>
         !finished ? (match.winner ?? null) :
-        scoreA > scoreB ? match.fencerA :
-        scoreB > scoreA ? match.fencerB :
         winnerOverride === 'A' ? match.fencerA :
         winnerOverride === 'B' ? match.fencerB :
+        scoreA > scoreB ? match.fencerA :
+        scoreB > scoreA ? match.fencerB :
         null;
 
       // La tablette/serveur peut renvoyer l'ID brut du match ('16-0') ou l'ID

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -141,12 +141,6 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const isUnlimitedScore = maxScore === 999;
   const prevMatchesLengthRef = useRef(0);
   const mountMatchesRef = useRef(matches);
-  const matchesRef = useRef(matches);
-  matchesRef.current = matches;
-  const tableauSizeRef = useRef(tableauSize);
-  tableauSizeRef.current = tableauSize;
-  const onMatchesChangeRef = useRef(onMatchesChange);
-  onMatchesChangeRef.current = onMatchesChange;
   const consolationBrackets = consolationBracketsprop;
   const setConsolationBrackets = (updater: ConsolationBracket[] | ((prev: ConsolationBracket[]) => ConsolationBracket[])) => {
     const next = typeof updater === 'function' ? updater(consolationBrackets) : updater;
@@ -317,30 +311,11 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [matches, readOnly]);
 
-  // Synchronisation temps réel depuis la tablette d'arbitrage (élimination directe)
-  useEffect(() => {
-    if (readOnly) return;
-    const unsub = window.electronAPI?.onRemoteMatchFinished?.((data: {
-      matchId: string;
-      scoreA: number;
-      scoreB: number;
-      winner: 'A' | 'B' | null;
-      isTableau: boolean;
-    }) => {
-      if (!data.isTableau) return;
-      const currentMatches = matchesRef.current;
-      const match = currentMatches.find(m => m.id === data.matchId);
-      if (!match) return;
-      const winner = data.winner === 'A' ? match.fencerA : data.winner === 'B' ? match.fencerB : null;
-      const updatedMatches = currentMatches.map(m =>
-        m.id === data.matchId ? { ...m, scoreA: data.scoreA, scoreB: data.scoreB, winner } : m
-      );
-      propagateWinners(updatedMatches, tableauSizeRef.current);
-      onMatchesChangeRef.current(updatedMatches.map(m => ({ ...m })));
-    });
-    return () => { unsub?.(); };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [readOnly]);
+  // NB : la synchronisation tablette → tableau (event match:finished) est gérée
+  // de façon centralisée par applyRemoteScore dans CompetitionView, qui fonctionne
+  // quel que soit l'onglet affiché. On ne s'abonne PLUS ici pour éviter une double
+  // mise à jour concurrente qui écrasait le vainqueur (course value vs functional).
+  // La complétion du tableau est détectée par le filet de sécurité ci-dessus.
 
   // playAllPositions : déclencher onComplete quand le tableau principal ET tous les brackets de consolation sont terminés
   useEffect(() => {


### PR DESCRIPTION
## Problème
En tableau final, un match terminé via la tablette d'arbitrage : le score s'affiche mais **pas de vainqueur** et **pas de passage au tour suivant**. Aucun souci en saisie manuelle.

## Cause
Deux abonnements concurrents à l'event IPC `match:finished` :
- `TableauView` (ajouté en c3d8ac4) — calculait le vainqueur depuis `data.winner`
- `CompetitionView.applyRemoteScore` (durci en 19d24bc) — mise à jour **fonctionnelle**, appliquée en **dernier**, écrasant le résultat de `TableauView`

`applyRemoteScore` privilégiait `scoreA > scoreB` au vainqueur transmis par le serveur. En cas d'égalité (tirage au sort) ou de score non strictement numérique, `winner` retombait à `null` → pas de vainqueur, donc `propagateWinners` ne remplissait pas le tour suivant.

## Correctif
- **TableauView** : suppression de l'abonnement redondant. Source unique = `applyRemoteScore`, active quel que soit l'onglet affiché.
- **applyRemoteScore** : normalisation des scores en nombre (objet `Score`/chaîne → `value`) + vainqueur serveur (`winnerOverride`) prioritaire, repli sur la comparaison des scores.

## À valider
Terminer un match de tableau depuis la tablette et vérifier : score affiché, vainqueur marqué (V/🥇), tireur propagé au tour suivant.

https://claude.ai/code/session_013ETyaNxPtUPV3LkgY5nnNn

---
_Generated by [Claude Code](https://claude.ai/code/session_013ETyaNxPtUPV3LkgY5nnNn)_