### PR TITLE
feat(télécommande): affecter les tablettes d'arbitrage

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -119,7 +119,7 @@ export class RemoteScoreServer {
   // Registre des clients TV/affichage connectés (télécommande)
   private connectedClients: Map<string, {
     socketId: string;
-    clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard';
+    clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard' | 'lobby' | 'referee';
     arenaId?: string;
     ip: string;
     userAgent: string;
@@ -2316,7 +2316,7 @@ export class RemoteScoreServer {
 
       // Enregistrement client TV/affichage pour la télécommande
       socket.on('client:register', (data: {
-        clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard';
+        clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard' | 'lobby' | 'referee';
         arenaId?: string;
         userAgent?: string;
         screenId?: string;

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1892,14 +1892,57 @@
           }
         }
 
+        showIdentifyOverlay(label, durationMs) {
+          let ov = document.getElementById('bp-identify-overlay');
+          if (!ov) {
+            ov = document.createElement('div');
+            ov.id = 'bp-identify-overlay';
+            ov.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;pointer-events:none;animation:bp-identify-blink 0.5s ease-in-out infinite alternate;';
+            const style = document.createElement('style');
+            style.textContent = '@keyframes bp-identify-blink{from{background:rgba(59,130,246,0.55)}to{background:rgba(139,92,246,0.65)}}';
+            document.head.appendChild(style);
+            document.body.appendChild(ov);
+          }
+          ov.innerHTML = '<div style="background:rgba(0,0,0,0.85);border:3px solid #3b82f6;border-radius:1.5rem;padding:2rem 4rem;text-align:center;max-width:80vw;">'
+            + '<div style="font-size:2.5rem;font-weight:900;color:#fff;margin-bottom:0.5rem;">🤺 ' + String(label).replace(/[<>&]/g, c => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c])) + '</div>'
+            + '<div style="font-size:1rem;color:#94a3b8;">Identification tablette arbitre</div>'
+            + '</div>';
+          ov.style.display = 'flex';
+          clearTimeout(ov._t);
+          ov._t = setTimeout(() => { ov.style.display = 'none'; }, durationMs ?? 5000);
+        }
+
         setupSocketListeners() {
+          // Identifiant persistant de cette tablette (survit aux rechargements/reconnexions)
+          let _screenId = localStorage.getItem('bp_screen_id');
+          if (!_screenId) {
+            _screenId = 'scr_' + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+            localStorage.setItem('bp_screen_id', _screenId);
+          }
+
           this.socket.on('connect', () => {
             this.updateConnectionStatus(true);
             this.socket.emit('join_arena', { arenaId: this.arenaId, role: 'referee' });
+            this.socket.emit('client:register', { clientType: 'referee', arenaId: this.arenaId, userAgent: navigator.userAgent, screenId: _screenId });
             this.showNotification('✅ Connecté au serveur');
             // Synchroniser les actions mises en file hors-ligne
             this.syncOfflineQueue();
           });
+
+          this.socket.on('server:command', cmd => {
+            if (cmd.type === 'refresh') { location.reload(); return; }
+            if (cmd.type === 'navigate' && cmd.url) { location.href = cmd.url; return; }
+            if (cmd.type === 'ping') { this.socket.emit('client:pong'); return; }
+            if (cmd.type === 'identify') {
+              const lbl = cmd.screenLabel || localStorage.getItem('bp_screen_label') || _screenId;
+              if (cmd.screenLabel) localStorage.setItem('bp_screen_label', cmd.screenLabel);
+              this.showIdentifyOverlay(lbl, cmd.duration ?? 5000);
+              return;
+            }
+            if (cmd.type === 'message' && cmd.text) { this.showNotification(cmd.text); }
+          });
+
+          setInterval(() => { if (this.socket.connected) this.socket.emit('client:pong'); }, 30000);
 
           this.socket.on('disconnect', () => {
             this.updateConnectionStatus(false);

--- a/src/renderer/components/XiaomiRemotePanel.tsx
+++ b/src/renderer/components/XiaomiRemotePanel.tsx
@@ -21,6 +21,7 @@ const CLIENT_TYPE_LABELS: Record<string, string> = {
   public: 'Public',
   pool: 'Poules',
   dashboard: 'Dashboard',
+  referee: 'Arbitre',
 };
 
 function getOnlineStatus(lastSeen: string): 'online' | 'warn' | 'offline' {
@@ -44,6 +45,10 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 function clientDisplayUrl(base: string, client: ConnectedClient): string {
+  if (client.clientType === 'referee') {
+    const num = client.arenaId ? client.arenaId.replace('arena', '') : '1';
+    return `${base}/arene${num}/arbitre`;
+  }
   if (client.clientType === 'lobby' || !client.arenaId) return `${base}/lobby`;
   const num = client.arenaId.replace('arena', '');
   return `${base}/arene${num}`;
@@ -52,7 +57,7 @@ function clientDisplayUrl(base: string, client: ConnectedClient): string {
 function clientLabel(client: ConnectedClient): string {
   if (client.label) return client.label;
   const type = CLIENT_TYPE_LABELS[client.clientType] ?? client.clientType;
-  if (client.clientType === 'arena' && client.arenaId) {
+  if ((client.clientType === 'arena' || client.clientType === 'referee') && client.arenaId) {
     const num = client.arenaId.replace('arena', '');
     return `${type} ${num}`;
   }
@@ -288,6 +293,20 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
                       <option value={`${base}/lobby`}>Lobby</option>
                       {Array.from({ length: arenaCount }, (_, i) => (
                         <option key={i + 1} value={`${base}/arene${i + 1}`}>Arène {i + 1}</option>
+                      ))}
+                    </select>
+                  )}
+
+                  {/* Affecter à (tablette arbitre) */}
+                  {client.clientType === 'referee' && (
+                    <select
+                      value={clientDisplayUrl(base, client)}
+                      onChange={e => sendCmd(client.socketId, { type: 'navigate', url: e.target.value })}
+                      style={{ padding: '0.2rem 0.3rem', fontSize: '0.75rem', background: 'var(--color-bg)', border: '1px solid var(--color-border)', borderRadius: '5px', color: 'inherit', maxWidth: '120px' }}
+                      title="Affecter l'arbitre à une arène…"
+                    >
+                      {Array.from({ length: arenaCount }, (_, i) => (
+                        <option key={i + 1} value={`${base}/arene${i + 1}/arbitre`}>Arène {i + 1}</option>
                       ))}
                     </select>
                   )}

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -337,7 +337,7 @@ export interface RemoteServerInfo {
 
 export interface ConnectedClient {
   socketId: string;
-  clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard' | 'lobby';
+  clientType: 'arena' | 'kiosk' | 'public' | 'pool' | 'dashboard' | 'lobby' | 'referee';
   arenaId?: string;
   ip: string;
   userAgent: string;


### PR DESCRIPTION
## Quoi

Télécommande TV gère maintenant aussi les tablettes d'arbitrage.

## Changements

- `referee.html` : enregistre la tablette comme client (`clientType: 'referee'`), gère `server:command` (refresh, navigate, ping, identify, message) + overlay d'identification.
- `XiaomiRemotePanel.tsx` : libellé « Arbitre », menu « Affecter à une arène » → `/arene{N}/arbitre`, boutons Identifier/Renommer/Rafraîchir/Naviguer.
- Types `clientType` étendus (`referee`, `lobby`) dans `remoteScoreServer.ts` et `preload.ts`.

https://claude.ai/code/session_01M6AwJLfQtRjkSH2LLCNPqi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6AwJLfQtRjkSH2LLCNPqi)_