### PR TITLE
diag(tableau): traces prod sur remontée score distant DE

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -547,7 +547,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('arena:update', handler);
   },
   onRemoteMatchFinished: (callback: (data: any) => void) => {
-    const handler = (_: any, data: any) => callback(data);
+    const handler = (_: any, data: any) => {
+      // DIAGNOSTIC : confirmer que l'IPC match:finished atteint bien le renderer.
+      console.warn('[preload] IPC match:finished reçu', data?.matchId, data?.scoreA, data?.scoreB, 'tableau=', data?.isTableau);
+      callback(data);
+    };
     ipcRenderer.on('match:finished', handler);
     return () => ipcRenderer.removeListener('match:finished', handler);
   },

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -391,6 +391,14 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         b.matches.some(idMatches)
       );
 
+      // DIAGNOSTIC (visible en prod, niveau WARN) : tracer le routage du score distant.
+      logger.warn(
+        LogCategory.UI,
+        `[applyRemoteScore] match=${matchId} score=${scoreA}-${scoreB} fini=${finished} ` +
+          `→ tableau=${inTableau} consolante=${inConsolation} | ` +
+          `ids tableau=[${tableauMatchesRef.current.map(m => m.id).join(',')}]`
+      );
+
       if (inTableau) {
         setTableauMatches(prev => {
           const idx = prev.findIndex(idMatches);
@@ -425,6 +433,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
 
       // Match de poule uniquement s'il n'est pas dans le tableau/consolante
       if (!inTableau && !inConsolation) {
+        logger.warn(
+          LogCategory.UI,
+          `[applyRemoteScore] match=${matchId} routé vers POULES (non trouvé en tableau/consolante)`
+        );
         updateMatchFromRemote(matchId, scoreA, scoreB, status, winnerOverride);
       }
     },
@@ -474,10 +486,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       winner?: 'A' | 'B';
       isTableau?: boolean;
     }) => {
-      const { matchId, scoreA, scoreB, winner: winnerOverride } = data;
-      logger.debug(
+      const { matchId, scoreA, scoreB, winner: winnerOverride, isTableau } = data;
+      logger.warn(
         LogCategory.UI,
-        `[CompetitionView] Match terminé reçu: ${matchId} - Score: ${scoreA}-${scoreB}`
+        `[CompetitionView] match:finished REÇU matchId=${matchId} score=${scoreA}-${scoreB} tableau=${!!isTableau}`
       );
       applyRemoteScore(matchId, scoreA, scoreB, true, winnerOverride);
     };


### PR DESCRIPTION
## But

Bug « résultat tablette DE ne remonte pas dans l'appli » persiste en prod (build #1153) alors que le chemin paraît correct en analyse statique.

Cause du diagnostic aveugle : `logger.debug` est filtré en prod (`logger.ts:164`, `minLevel=WARN`). Les logs existants ne s'affichaient donc jamais → « rien dans la console ».

## Ajouts (traces WARN, visibles en prod)

- `preload.ts` : confirme la réception IPC `match:finished` côté renderer.
- `CompetitionView.tsx` : log de réception de l'event + routage (tableau / consolante / poule) + liste des ids tableau connus → détecte un mismatch d'id.

## Suite

Une fois mergé, le build dev (#115x) permet au DT de reproduire et de fournir la console. La trace dira exactement où ça casse :
1. pas de log `[preload] IPC match:finished` → le serveur n'émet pas / `mainWindow` absent
2. log preload mais routage `POULES` → mismatch d'id tableau (les ids connus seront affichés)
3. routage `tableau=true` mais pas de propagation → bug dans `propagateWinners`

Aucun changement fonctionnel. Traces à retirer après identification.

https://claude.ai/code/session_01RjnWibPAAZMK1oy9LHjLxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjnWibPAAZMK1oy9LHjLxZ)_