### PR TITLE
diag(tableau): sondes serveur pour la fin de match DE distante

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -5,6 +5,11 @@
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
+
+// DIAGNOSTIC inconditionnel : affiche les sondes serveur dans la console renderer.
+ipcRenderer.on('remote:diag', (_: any, msg: string) => {
+  console.warn('[DIAG serveur]', msg);
+});
 import type {
   ElectronAPI,
   CompetitionCreateData,

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1396,7 +1396,9 @@ export class RemoteScoreServer {
         // Vérifier que le match existe (en DB ou en mémoire)
         const dbMatch = this.db.getMatch(matchId);
         const inMemoryMatch = !dbMatch && this.sessionMatches.find((m: any) => m.id === matchId);
+        this.sendDiag(`[REST /finish] matchId=${matchId} dbMatch=${!!dbMatch} poolId=${(dbMatch as any)?.poolId ?? '-'} inMemory=${!!inMemoryMatch} sessionMatchesIds=[${this.sessionMatches.map((m: any) => m.id).join(',')}]`);
         if (!dbMatch && !inMemoryMatch) {
+          this.sendDiag(`[REST /finish] 404 match introuvable: ${matchId}`);
           return res.status(404).json({ error: 'Match non trouvé' });
         }
 
@@ -2460,6 +2462,7 @@ export class RemoteScoreServer {
         // Sélection d'un match par l'arbitre (depuis sa tablette)
         if (data.match) {
           const m = data.match;
+          this.sendDiag(`[select_match] arena=${data.arenaId} matchId=${m.id} isTableau=${(m as any).isTableau}`);
           // Restaurer isTableau depuis sessionMatches car la tablette ne le transmet pas
           const sessionMatch = this.sessionMatches.find(sm => sm.id === m.id);
           this.assignMatchToArena(data.arenaId, {
@@ -2486,6 +2489,7 @@ export class RemoteScoreServer {
         this.pauseArenaMatch(data.arenaId);
         break;
       case 'finish':
+        this.sendDiag(`[socket finish] arena=${data.arenaId}`);
         this.arenaSuddenDeath.set(data.arenaId, false);
         this.arenaOvertimeType.set(data.arenaId, null);
         this.arenaWaitingOvertime.set(data.arenaId, false);
@@ -3305,8 +3309,18 @@ export class RemoteScoreServer {
     }
   }
 
+  // DIAGNOSTIC : envoie un message visible dans la console DevTools du renderer
+  // (les console.log serveur ne sont pas visibles dans l'app packagée).
+  private sendDiag(msg: string): void {
+    try {
+      const w = (global as any).mainWindow;
+      if (w) w.webContents.send('remote:diag', msg);
+    } catch { /* non bloquant */ }
+  }
+
   public finishArenaMatch(arenaId: string): void {
     const arena = this.arenas.get(arenaId);
+    this.sendDiag(`[finishArenaMatch] arena=${arenaId} hasCurrent=${!!arena?.currentMatch} status=${arena?.status} matchId=${arena?.currentMatch?.id} isTableau=${(arena?.currentMatch as any)?.isTableau}`);
     if (!arena || !arena.currentMatch) return;
     // Éviter le double-déclenchement (REST + Socket.IO)
     if (arena.status === 'finished') return;


### PR DESCRIPTION
## But

Le tableau DE n'émet aucun `match:finished` (confirmé en prod : la poule log, le DE non). Les sondes côté serveur ne sont pas visibles dans l'app packagée → on les relaie vers la console DevTools du renderer via `remote:diag`.

## Sondes ajoutées

- `REST /api/matches/:id/finish` : matchId, dbMatch trouvé ?, poolId, inMemory ?, ids sessionMatches
- `finishArenaMatch` : arène, currentMatch présent ?, status, matchId, isTableau
- socket `action:finish`, `select_match`
- preload : listener inconditionnel `remote:diag` → `console.warn('[DIAG serveur] …')`

## Suite

Build dev → reproduire la validation DE → la console montrera exactement où ça s'arrête (sélection assignée ? finish reçu ? 404 ? finishArenaMatch sort tôt ?).

Temporaire. À retirer après identification.

https://claude.ai/code/session_01RjnWibPAAZMK1oy9LHjLxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjnWibPAAZMK1oy9LHjLxZ)_