### PR TITLE
fix(tableau): remontée du résultat DE distant (émission non bloquée par la persistance)

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -3340,78 +3340,88 @@ export class RemoteScoreServer {
       );
     }
 
-    // Persister le timing en DB
-    if (arena.currentMatch.id && arena.startTime) {
-      const durationSec = arena.currentMatch.duration ?? 0;
-      this.db.updateMatchTiming(
-        arena.currentMatch.id,
-        arena.startTime.toISOString(),
-        arena.currentMatch.endTime!.toISOString(),
-        durationSec
-      );
-    }
-
-    // Persister les cartons accumulés en mémoire
-    const cards = this.arenaCards.get(arenaId) ?? { cardsA: [], cardsB: [] };
-    const now = new Date().toISOString();
-    const matchId = arena.currentMatch.id;
-    if (matchId) {
-      const persistCards = (list: string[], fencerId: string | undefined) => {
-        if (!fencerId) return;
-        for (const cardType of list) {
-          this.db.saveCard({
-            id: `${matchId}-${fencerId}-${cardType}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-            matchId,
-            fencerId,
-            cardType,
-            reason: 'unknown',
-            cardGroup: 1,
-            timestamp: now,
-            pointsAwarded: 0,
-            resultingExclusion: false,
-          });
-        }
-      };
-      persistCards(cards.cardsA, arena.currentMatch.fencerA?.id);
-      persistCards(cards.cardsB, arena.currentMatch.fencerB?.id);
-
-      // Persister les touches par zone
-      const touches = this.arenaTouches.get(arenaId) ?? { touchesA: [], touchesB: [] };
-      const persistTouches = (zoneList: string[], fencerId: string | undefined) => {
-        if (!fencerId) return;
-        const ZONE_POINTS: Record<string, number> = { A: 1, B: 3, C: 5 };
-        for (const zone of zoneList) {
-          this.db.saveTouch({
-            id: `${matchId}-${fencerId}-${zone}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-            matchId,
-            fencerId,
-            zone,
-            points: ZONE_POINTS[zone] ?? 1,
-            timestamp: now,
-            isValidInSuddenDeath: false,
-            isReversed: false,
-          });
-        }
-      };
-      persistTouches(touches.touchesA, arena.currentMatch.fencerA?.id);
-      persistTouches(touches.touchesB, arena.currentMatch.fencerB?.id);
-
-      // Persister les sorties d'arène
-      const exits = this.arenaExits.get(arenaId) ?? [];
-      for (const exit of exits) {
-        const fencerId = exit.fencer === 'A'
-          ? arena.currentMatch.fencerA?.id
-          : arena.currentMatch.fencerB?.id;
-        if (!fencerId) continue;
-        this.db.saveArenaExit({
-          id: `${matchId}-${fencerId}-exit-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-          matchId,
-          fencerId,
-          exitType: exit.isVoluntary ? 'arena_exit_voluntary' : 'arena_exit',
-          timestamp: now,
-          pointsAwarded: 3,
-        });
+    // Persistance secondaire (timing / cartons / touches / sorties) : ces écritures
+    // utilisent arena.currentMatch.id qui, pour un match de tableau, n'est PAS l'id DB
+    // (stocké en composite). Une éventuelle exception (ex: contrainte FK) NE DOIT PAS
+    // empêcher l'émission de match:finished vers le renderer (sinon : vainqueur jamais
+    // remonté, pas de passage au tour suivant). On isole donc tout ce bloc.
+    try {
+      // Persister le timing en DB
+      if (arena.currentMatch.id && arena.startTime) {
+        const durationSec = arena.currentMatch.duration ?? 0;
+        this.db.updateMatchTiming(
+          arena.currentMatch.id,
+          arena.startTime.toISOString(),
+          arena.currentMatch.endTime!.toISOString(),
+          durationSec
+        );
       }
+
+      // Persister les cartons accumulés en mémoire
+      const cards = this.arenaCards.get(arenaId) ?? { cardsA: [], cardsB: [] };
+      const now = new Date().toISOString();
+      const matchId = arena.currentMatch.id;
+      if (matchId) {
+        const persistCards = (list: string[], fencerId: string | undefined) => {
+          if (!fencerId) return;
+          for (const cardType of list) {
+            this.db.saveCard({
+              id: `${matchId}-${fencerId}-${cardType}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+              matchId,
+              fencerId,
+              cardType,
+              reason: 'unknown',
+              cardGroup: 1,
+              timestamp: now,
+              pointsAwarded: 0,
+              resultingExclusion: false,
+            });
+          }
+        };
+        persistCards(cards.cardsA, arena.currentMatch.fencerA?.id);
+        persistCards(cards.cardsB, arena.currentMatch.fencerB?.id);
+
+        // Persister les touches par zone
+        const touches = this.arenaTouches.get(arenaId) ?? { touchesA: [], touchesB: [] };
+        const persistTouches = (zoneList: string[], fencerId: string | undefined) => {
+          if (!fencerId) return;
+          const ZONE_POINTS: Record<string, number> = { A: 1, B: 3, C: 5 };
+          for (const zone of zoneList) {
+            this.db.saveTouch({
+              id: `${matchId}-${fencerId}-${zone}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+              matchId,
+              fencerId,
+              zone,
+              points: ZONE_POINTS[zone] ?? 1,
+              timestamp: now,
+              isValidInSuddenDeath: false,
+              isReversed: false,
+            });
+          }
+        };
+        persistTouches(touches.touchesA, arena.currentMatch.fencerA?.id);
+        persistTouches(touches.touchesB, arena.currentMatch.fencerB?.id);
+
+        // Persister les sorties d'arène
+        const exits = this.arenaExits.get(arenaId) ?? [];
+        for (const exit of exits) {
+          const fencerId = exit.fencer === 'A'
+            ? arena.currentMatch.fencerA?.id
+            : arena.currentMatch.fencerB?.id;
+          if (!fencerId) continue;
+          this.db.saveArenaExit({
+            id: `${matchId}-${fencerId}-exit-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+            matchId,
+            fencerId,
+            exitType: exit.isVoluntary ? 'arena_exit_voluntary' : 'arena_exit',
+            timestamp: now,
+            pointsAwarded: 3,
+          });
+        }
+      }
+    } catch (e) {
+      this.sendDiag(`[finishArenaMatch] persistance secondaire échouée (non bloquant): ${(e as Error)?.message}`);
+      console.warn('[RemoteScoreServer] Persistance secondaire (timing/cartons/touches) échouée:', e);
     }
 
     const nextMatch = this.peekNextMatch(arenaId);


### PR DESCRIPTION
## Cause racine (confirmée par les sondes)

Les logs `[DIAG serveur]` montrent que pour un match DE :
- `select_match … matchId=16-1`, `REST /finish … inMemory=true`, `finishArenaMatch … status=in_progress` ✅ entrée OK
- **mais aucun `match:finished` émis** → exception **avant** l'émission.

`finishArenaMatch` persiste timing/cartons/touches/sorties via `arena.currentMatch.id` = `"16-1"`, qui **n'est pas** l'id DB du match de tableau (stocké en composite). L'`INSERT` touche/carton lève une exception (contrainte FK) **non capturée** → la fonction avorte avant d'émettre. Les poules marchent car leur id mémoire **est** l'id DB (uuid).

## Correctif

Isoler toute la persistance secondaire (timing/cartons/touches/sorties) dans un `try/catch`. L'émission de `match:finished` (chemin critique) n'est plus jamais bloquée par un échec d'écriture annexe. Le score reste persisté via l'id composite dans son bloc dédié.

## Vérif attendue

Build dev → valider un match DE sur tablette → le résultat remonte, vainqueur désigné, passage au tour suivant. La console montre alors `[preload] IPC match:finished … tableau=true` puis `[applyRemoteScore] … tableau=true`.

Sondes `[DIAG serveur]` conservées temporairement pour confirmation ; à retirer ensuite.

https://claude.ai/code/session_01RjnWibPAAZMK1oy9LHjLxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjnWibPAAZMK1oy9LHjLxZ)_