### PR TITLE
fix: tronquer noms longs tireurs sur tablette arbitre

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -111,6 +111,8 @@
         text-align: center;
         border: 3px solid transparent;
         transition: all 0.2s;
+        min-width: 0;
+        overflow: hidden;
       }
 
       .fencer-box.red-side {


### PR DESCRIPTION
## Problème

Quand le nom d'un combattant est long (ex: "GANONDORF Ganondorf"), il débordait hors de sa boîte sur la tablette arbitre.

## Cause

`.fencer-box` est une cellule CSS Grid (`1fr`). Sans `min-width: 0`, les items grid s'étendent pour contenir leur contenu, ce qui désactive `text-overflow: ellipsis` sur les enfants.

## Fix

`src/remote/referee.html` — ajout de `min-width: 0` et `overflow: hidden` sur `.fencer-box` :

```css
.fencer-box {
  /* ... */
  min-width: 0;      /* permet à ellipsis de fonctionner dans le grid */
  overflow: hidden;
}
```

`.fencer-name` avait déjà `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` — le fix du parent suffit.

https://claude.ai/code/session_014zCkANjTUScmgZKLwQL6sB

---
_Generated by [Claude Code](https://claude.ai/code/session_014zCkANjTUScmgZKLwQL6sB)_