### PR TITLE
feat: minuteur vocal (TTS) configurable depuis les paramètres globaux

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1520,6 +1520,16 @@ ipcMain.handle('remote:startServer', async (_event, competitionId: string, port?
     remoteServers.set(competitionId, { server, port: effectivePort, host: effectiveHost });
     usedPorts.add(effectivePort);
 
+    // Appliquer la config TTS persistée aux tablettes de ce nouveau serveur
+    try {
+      const ttsPath = path.join(app.getPath('userData'), 'tts-config.json');
+      if (fs.existsSync(ttsPath)) {
+        server.setTtsConfig(JSON.parse(fs.readFileSync(ttsPath, 'utf-8')));
+      }
+    } catch {
+      /* config TTS optionnelle */
+    }
+
     (global as any).mainWindow = mainWindow;
 
     return {
@@ -2026,6 +2036,28 @@ ipcMain.handle('remote:setClientKioskMode', async (_, competitionId: string, soc
     return { success: true };
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('remote:setTtsConfig', async (_, config: unknown) => {
+  try {
+    const ttsPath = path.join(app.getPath('userData'), 'tts-config.json');
+    fs.writeFileSync(ttsPath, JSON.stringify(config), 'utf-8');
+    for (const { server } of remoteServers.values()) {
+      server.setTtsConfig(config as any);
+    }
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('app:getTtsConfig', async () => {
+  const ttsPath = path.join(app.getPath('userData'), 'tts-config.json');
+  try {
+    return JSON.parse(fs.readFileSync(ttsPath, 'utf-8'));
+  } catch {
+    return null;
   }
 });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -514,6 +514,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:updateArenaTheme', competitionId, arenaId, theme, customTheme),
     setWebhookUrl: (url: string | null) => ipcRenderer.invoke('remote:setWebhookUrl', url),
     updateLogo: (logo: string | null) => ipcRenderer.invoke('remote:updateLogo', logo),
+    setTtsConfig: (config: unknown) => ipcRenderer.invoke('remote:setTtsConfig', config),
     setWallpaper: (competitionId: string, wallpaper: string | null) =>
       ipcRenderer.invoke('remote:setWallpaper', competitionId, wallpaper),
     changePort: (competitionId: string, newPort: number) =>
@@ -594,6 +595,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   getLogo: () => ipcRenderer.invoke('app:getLogo'),
+  getTtsConfig: () => ipcRenderer.invoke('app:getTtsConfig'),
   onLogoLoaded: (callback: (logo: string | null) => void) => {
     const handler = (_: any, logo: string | null) => callback(logo);
     ipcRenderer.on('app:logoLoaded', handler);

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -75,6 +75,16 @@ export class RemoteScoreServer {
   private orgNote: OrgNote | null = null; // Note d'organisation affichée sur le kiosk
   private sessionLogo: string | null = null; // Logo organisateur (base64) pour kiosk et affichages publics
   private sessionWallpaper: string | null = null; // Fond d'écran (base64) affiché sur les arènes en attente
+  // Config TTS (minuteur vocal) poussée aux tablettes d'arbitrage depuis les paramètres globaux
+  private ttsConfig: {
+    voiceName: string | null;
+    rate: number;
+    announce: Record<string, boolean>;
+  } = {
+    voiceName: null,
+    rate: 1.1,
+    announce: { '60': true, '30': true, '10': true, '5': true, countdown: true, '0': true },
+  };
   private currentLang: string = 'fr'; // Langue courante de l'interface (fr, en, zh-HK, ...)
   private sessionKioskViews: {
     poules: boolean;
@@ -474,6 +484,11 @@ export class RemoteScoreServer {
 
     this.app.get('/api/wallpaper', (req, res) => {
       res.json({ wallpaper: this.sessionWallpaper });
+    });
+
+    // Config TTS (minuteur vocal) pour les tablettes d'arbitrage
+    this.app.get('/api/tts-config', (req, res) => {
+      res.json(this.ttsConfig);
     });
 
     // Arena routes
@@ -4709,6 +4724,17 @@ export class RemoteScoreServer {
   public setLogo(logo: string | null): void {
     this.sessionLogo = logo;
     this.io.emit('logo:update', { logo });
+  }
+
+  public setTtsConfig(config: {
+    voiceName?: string | null;
+    rate?: number;
+    announce?: Record<string, boolean>;
+  }): void {
+    if (config.voiceName !== undefined) this.ttsConfig.voiceName = config.voiceName;
+    if (typeof config.rate === 'number' && config.rate > 0) this.ttsConfig.rate = config.rate;
+    if (config.announce) this.ttsConfig.announce = { ...this.ttsConfig.announce, ...config.announce };
+    this.io.emit('tts:update', this.ttsConfig);
   }
 
   public setWallpaper(wallpaper: string | null): void {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1606,6 +1606,12 @@
           this.offlineQueue = new OfflineQueueInline();
           this.ttsEnabled = false;
           this._ttsAnnouncedSeconds = new Set();
+          // Config TTS poussée depuis les paramètres globaux de l'application
+          this.ttsConfig = {
+            voiceName: null,
+            rate: 1.1,
+            announce: { '60': true, '30': true, '10': true, '5': true, 'countdown': true, '0': true },
+          };
 
           this.init();
         }
@@ -1640,6 +1646,11 @@
               }
             }
             })
+            .catch(() => {});
+          // Config TTS (voix + paliers annoncés) depuis les paramètres globaux
+          fetch('/api/tts-config')
+            .then(r => (r.ok ? r.json() : null))
+            .then(c => { if (c) this.applyTtsConfig(c); })
             .catch(() => {});
           // Service Worker PWA
           if ('serviceWorker' in navigator) {
@@ -1921,6 +1932,9 @@
             _screenId = 'scr_' + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
             localStorage.setItem('bp_screen_id', _screenId);
           }
+
+          // Mise à jour live de la config TTS depuis les paramètres globaux
+          this.socket.on('tts:update', d => { if (d) this.applyTtsConfig(d); });
 
           this.socket.on('connect', () => {
             this.updateConnectionStatus(true);
@@ -2793,13 +2807,29 @@
           if (this.ttsEnabled) this.ttsSpeak('Minuteur vocal activé');
         }
 
+        // Fusionne une config TTS partielle reçue du serveur dans la config locale
+        applyTtsConfig(c) {
+          if (!c || typeof c !== 'object') return;
+          if (typeof c.voiceName === 'string' || c.voiceName === null) this.ttsConfig.voiceName = c.voiceName;
+          if (typeof c.rate === 'number' && c.rate > 0) this.ttsConfig.rate = c.rate;
+          if (c.announce && typeof c.announce === 'object') {
+            this.ttsConfig.announce = { ...this.ttsConfig.announce, ...c.announce };
+          }
+        }
+
         ttsSpeak(text) {
           if (!this.ttsEnabled || !window.speechSynthesis) return;
           window.speechSynthesis.cancel();
           const utt = new SpeechSynthesisUtterance(text);
           const lang = (document.documentElement.lang || 'fr').toLowerCase();
           utt.lang = lang.startsWith('de') ? 'de-DE' : lang.startsWith('en') ? 'en-GB' : 'fr-FR';
-          utt.rate = 1.1;
+          // Voix choisie dans les paramètres globaux (sinon voix par défaut de la langue)
+          const wanted = this.ttsConfig.voiceName;
+          if (wanted && window.speechSynthesis.getVoices) {
+            const v = window.speechSynthesis.getVoices().find(x => x.name === wanted);
+            if (v) { utt.voice = v; utt.lang = v.lang; }
+          }
+          utt.rate = this.ttsConfig.rate || 1.1;
           utt.volume = 1.0;
           window.speechSynthesis.speak(utt);
         }
@@ -2818,6 +2848,16 @@
             5:  '5', 4: '4', 3: '3', 2: '2', 1: '1',
             0:  isFr ? 'Halte !' : isEn ? 'Stop!' : 'Halt!',
           };
+          // Quel palier (clé de config announce) correspond à cette seconde ?
+          const a = this.ttsConfig.announce || {};
+          let key = null;
+          if (s === 60) key = '60';
+          else if (s === 30) key = '30';
+          else if (s === 10) key = '10';
+          else if (s === 5) key = '5';
+          else if (s >= 1 && s <= 4) key = 'countdown';
+          else if (s === 0) key = '0';
+          if (key && a[key] === false) { this._ttsAnnouncedSeconds.add(s); return; }
           if (s in THRESHOLDS) {
             this._ttsAnnouncedSeconds.add(s);
             this.ttsSpeak(THRESHOLDS[s]);

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -16,6 +16,46 @@ import { logger, LogCategory } from '@shared/services/logger';
 const LOGO_STORAGE_KEY = 'bellepoule-logo';
 const WEBHOOK_STORAGE_KEY = 'bellepoule-webhook-url';
 const AUDIT_LOG_KEY = 'bellepoule-audit-log-enabled';
+const TTS_CONFIG_KEY = 'bellepoule-tts-config';
+
+interface TtsConfig {
+  voiceName: string | null;
+  rate: number;
+  announce: Record<string, boolean>;
+}
+
+const DEFAULT_TTS_CONFIG: TtsConfig = {
+  voiceName: null,
+  rate: 1.1,
+  announce: { '60': true, '30': true, '10': true, '5': true, countdown: true, '0': true },
+};
+
+// Paliers annoncés par le minuteur vocal — clé de config + libellé affiché
+const TTS_THRESHOLDS: { key: string; label: string }[] = [
+  { key: '60', label: '1 minute' },
+  { key: '30', label: '30 secondes' },
+  { key: '10', label: '10 secondes' },
+  { key: '5', label: '5 secondes' },
+  { key: 'countdown', label: 'Décompte 4 → 1' },
+  { key: '0', label: '« Halte ! » (fin)' },
+];
+
+function loadTtsConfig(): TtsConfig {
+  try {
+    const raw = localStorage.getItem(TTS_CONFIG_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      return {
+        ...DEFAULT_TTS_CONFIG,
+        ...parsed,
+        announce: { ...DEFAULT_TTS_CONFIG.announce, ...(parsed.announce ?? {}) },
+      };
+    }
+  } catch {
+    /* config corrompue → défaut */
+  }
+  return { ...DEFAULT_TTS_CONFIG, announce: { ...DEFAULT_TTS_CONFIG.announce } };
+}
 
 function isWebhookUrlSafe(rawUrl: string): boolean {
   try {
@@ -92,6 +132,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
   const [webhookTestStatus, setWebhookTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [webhookTestMessage, setWebhookTestMessage] = useState<string>('');
 
+  // Paramètres minuteur vocal (TTS) des tablettes d'arbitrage
+  const [ttsConfig, setTtsConfig] = useState<TtsConfig>(() => loadTtsConfig());
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+
   useEffect(() => {
     setSettings(prev => ({ ...prev, language, theme }));
   }, [language, theme]);
@@ -117,6 +161,44 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
     return () => { if (typeof unsub === 'function') unsub(); };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Liste des voix disponibles (peut arriver de façon asynchrone)
+  useEffect(() => {
+    if (!('speechSynthesis' in window)) return;
+    const refresh = () => setVoices(window.speechSynthesis.getVoices());
+    refresh();
+    window.speechSynthesis.onvoiceschanged = refresh;
+    return () => { window.speechSynthesis.onvoiceschanged = null; };
+  }, []);
+
+  // Pousse la config TTS : persistance locale + serveurs distants actifs
+  const persistTtsConfig = useCallback((next: TtsConfig) => {
+    setTtsConfig(next);
+    localStorage.setItem(TTS_CONFIG_KEY, JSON.stringify(next));
+    (window as any).electronAPI?.remote?.setTtsConfig?.(next)?.catch?.(() => {/* serveur inactif */});
+  }, []);
+
+  const handleTtsVoiceChange = (voiceName: string) => {
+    persistTtsConfig({ ...ttsConfig, voiceName: voiceName || null });
+  };
+
+  const handleTtsRateChange = (rate: number) => {
+    persistTtsConfig({ ...ttsConfig, rate });
+  };
+
+  const handleTtsThresholdToggle = (key: string, enabled: boolean) => {
+    persistTtsConfig({ ...ttsConfig, announce: { ...ttsConfig.announce, [key]: enabled } });
+  };
+
+  const handleTtsTestVoice = () => {
+    if (!('speechSynthesis' in window)) return;
+    window.speechSynthesis.cancel();
+    const utt = new SpeechSynthesisUtterance('30 secondes');
+    const v = voices.find(x => x.name === ttsConfig.voiceName);
+    if (v) { utt.voice = v; utt.lang = v.lang; }
+    utt.rate = ttsConfig.rate;
+    window.speechSynthesis.speak(utt);
+  };
 
   const handleLanguageChange = (newLanguage: Language) => {
     setSettings(prev => ({ ...prev, language: newLanguage }));
@@ -380,6 +462,61 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
                 {webhookTestMessage}
               </p>
             )}
+          </div>
+
+          {/* Tableau arbitrage — minuteur vocal (TTS) */}
+          <div className="form-group" style={SECTION_DIVIDER}>
+            <label style={BOLD}>Tableau arbitrage — minuteur vocal</label>
+            <p style={HINT}>
+              Voix et paliers de temps annoncés sur les tablettes d'arbitrage.
+            </p>
+
+            <label style={{ fontSize: '0.85rem' }}>Voix</label>
+            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.5rem' }}>
+              <select
+                className="form-input form-select"
+                value={ttsConfig.voiceName ?? ''}
+                onChange={e => handleTtsVoiceChange(e.target.value)}
+                style={{ flex: 1 }}
+              >
+                <option value="">Voix par défaut (selon la langue)</option>
+                {voices.map(v => (
+                  <option key={v.name} value={v.name}>{v.name} ({v.lang})</option>
+                ))}
+              </select>
+              <button className="btn btn-secondary" style={SMALL_BTN} onClick={handleTtsTestVoice}>
+                🔊 Tester
+              </button>
+            </div>
+
+            <label style={{ fontSize: '0.85rem' }}>
+              Vitesse : {ttsConfig.rate.toFixed(1)}×
+            </label>
+            <input
+              type="range"
+              min="0.5"
+              max="2"
+              step="0.1"
+              value={ttsConfig.rate}
+              onChange={e => handleTtsRateChange(parseFloat(e.target.value))}
+              style={{ width: '100%', marginBottom: '0.5rem' }}
+            />
+
+            <label style={{ fontSize: '0.85rem', display: 'block', marginBottom: '0.25rem' }}>
+              Paliers annoncés
+            </label>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+              {TTS_THRESHOLDS.map(({ key, label }) => (
+                <label key={key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={ttsConfig.announce[key] !== false}
+                    onChange={e => handleTtsThresholdToggle(key, e.target.checked)}
+                  />
+                  <span style={{ fontSize: '0.875rem' }}>{label}</span>
+                </label>
+              ))}
+            </div>
           </div>
         </div>
 

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -21,6 +21,13 @@ import {
 // Re-export Pool for preload
 export type { Pool } from '../types';
 
+// Config TTS (minuteur vocal) des tablettes d'arbitrage, réglée dans les paramètres globaux
+export interface TtsConfig {
+  voiceName: string | null; // Nom de la voix (SpeechSynthesisVoice.name) ; null = voix par défaut de la langue
+  rate: number; // Vitesse d'élocution (0.5 – 2)
+  announce: Record<string, boolean>; // Paliers annoncés : '60','30','10','5','countdown','0'
+}
+
 // ============================================================================
 // Database API Types
 // ============================================================================
@@ -436,6 +443,7 @@ export interface RemoteServerAPI {
   ) => Promise<{ success: boolean; error?: string }>;
   setWebhookUrl: (url: string | null) => Promise<{ success: boolean; error?: string }>;
   updateLogo: (logo: string | null) => Promise<{ success: boolean; error?: string }>;
+  setTtsConfig: (config: TtsConfig) => Promise<{ success: boolean; error?: string }>;
   setWallpaper: (
     competitionId: string,
     wallpaper: string | null
@@ -785,5 +793,6 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   onPoolSignatureUpdated: (callback: (data: { poolId: string; signedFencerIds: string[]; totalFencers: number }) => void) => () => void;
   notifyLanguageChanged: (lang: string) => void;
   getLogo: () => Promise<string | null>;
+  getTtsConfig: () => Promise<TtsConfig | null>;
   onLogoLoaded: (callback: (logo: string | null) => void) => () => void;
 }


### PR DESCRIPTION
## Résumé
Le minuteur vocal (TTS) des tablettes d'arbitrage est maintenant configurable dans les paramètres globaux de l'application (nouvelle section « Tableau arbitrage »).

## Fonctionnalités
- **Choix de la voix** : liste des voix `speechSynthesis` disponibles + bouton de test
- **Vitesse d'élocution** réglable (0.5× → 2×)
- **Sélection des paliers annoncés** (décochables) : 1 min / 30s / 10s / 5s / décompte 4→1 / « Halte ! »

## Implémentation
- `referee.html` : `ttsConfig` local, fetch `/api/tts-config`, écoute socket `tts:update`, respect des paliers + voix dans `ttsSpeak`/`ttsCheckAnnounce`
- `remoteScoreServer.ts` : champ `ttsConfig`, endpoint `GET /api/tts-config`, méthode `setTtsConfig` (émet `tts:update`)
- `main.ts` : IPC `remote:setTtsConfig` / `app:getTtsConfig`, persistance `tts-config.json`, application aux nouveaux serveurs
- `preload.ts` + `preload.ts` types : `remote.setTtsConfig`, `getTtsConfig`, type `TtsConfig`
- `SettingsModal.tsx` : section UI + persistance localStorage + push distant

https://claude.ai/code/session_01B1b2NogziQJQSCFfgrixom

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1b2NogziQJQSCFfgrixom)_