### PR TITLE
fix(tableau): corrige perte de scores + non-validation en mode « jouer toutes les places » (#399)

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -7,7 +7,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Fencer, FencerStatus, PoolRanking } from '../../shared/types';
 export { TableauMatch, FinalResult, ConsolationBracket, propagateWinners } from './tableau/tableauTypes';
-import { TableauMatch, FinalResult, ConsolationBracket, propagateWinners } from './tableau/tableauTypes';
+import { TableauMatch, FinalResult, ConsolationBracket, propagateWinners, deriveFirstRound } from './tableau/tableauTypes';
 import { useToast } from './Toast';
 import { useModalResize } from '../hooks/useModalResize';
 import Bracket from './Bracket';
@@ -265,8 +265,9 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
       // En lecture seule, ne pas régénérer le tableau, mais déduire sa taille
       // des matches existants pour permettre l'affichage des rounds.
       if (matches.length > 0) {
-        const currentSize = Math.max(...matches.filter(m => m.round !== 3).map(m => m.round));
-        setTableauSize(currentSize);
+        // deriveFirstRound écarte le round de barrage (mainSize*2) : sinon la taille
+        // serait surévaluée à mainSize*2 et l'affichage des tours serait faussé.
+        setTableauSize(deriveFirstRound(matches));
       }
       return;
     }
@@ -278,7 +279,10 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     ).length;
     if (eligibleCount > 0) {
       const expectedSize = getMainTableauSize(eligibleCount);
-      const currentSize = matches.length > 0 ? Math.max(...matches.filter(m => m.round !== 3).map(m => m.round)) : 0;
+      // deriveFirstRound écarte le round de barrage (mainSize*2) et la petite finale.
+      // Avec un Math.max naïf, un tableau avec barrages restauré (tab switch) donnait
+      // currentSize = mainSize*2 ≠ expectedSize → regénération qui effaçait les scores saisis.
+      const currentSize = matches.length > 0 ? deriveFirstRound(matches) : 0;
 
       const hasThirdPlace = matches.some(m => m.round === 3);
       const thirdPlaceMismatch = thirdPlaceMatch !== hasThirdPlace;
@@ -320,8 +324,12 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   // playAllPositions : déclencher onComplete quand le tableau principal ET tous les brackets de consolation sont terminés
   useEffect(() => {
     if (readOnly || !playAllPositions || !onComplete || matches.length === 0) return;
-    // Ignorer au montage (données déjà complètes restaurées depuis DB)
-    if (matches === mountMatchesRef.current) return;
+    // NB : pas de garde « matches === mountMatchesRef » ici. La dernière saisie qui
+    // complète le classement est souvent un match de bracket de consolation, qui ne
+    // modifie PAS `matches`. Après un changement d'onglet (remontage), `matches` est
+    // identique au montage : la garde bloquait alors onComplete et l'étape tableau ne
+    // se validait jamais. Le cas « déjà complet restauré depuis DB » est couvert par
+    // le garde readOnly (finalResults.length > 0 ⇒ readOnly) en amont.
     const mainFinalDone = !!matches.find(m => m.round === 2)?.winner;
     const mainThirdEntry = matches.find(m => m.round === 3);
     const mainThirdDone = !mainThirdEntry || !!mainThirdEntry.winner;

--- a/src/renderer/components/tableau/tableauTypes.ts
+++ b/src/renderer/components/tableau/tableauTypes.ts
@@ -60,7 +60,7 @@ export function resolveWinnerFromScores(match: TableauMatch): void {
  * finale round=3) dont le nombre de matchs vaut round/2 : un round de barrage,
  * partiellement rempli, est ainsi écarté.
  */
-function deriveFirstRound(matchList: TableauMatch[]): number {
+export function deriveFirstRound(matchList: TableauMatch[]): number {
   const counts = new Map<number, number>();
   for (const m of matchList) {
     if (m.round === 3) continue; // petite finale


### PR DESCRIPTION
## Contexte
Bugs signalés dans l'issue #399 (mode « jouer toutes les places »), toujours présents en build 995.

## Bugs corrigés

### 1. Perte des scores au changement d'onglet (avec barrages)
À chaque tour avec barrages, `currentSize` était calculé par `Math.max(...rounds)`. Le round de barrage vaut `mainSize*2`, donc la taille était surévaluée. Au remontage (changement d'onglet) `currentSize !== expectedSize` → **régénération du tableau qui effaçait les scores saisis**.
→ Utilise désormais `deriveFirstRound()` qui écarte le round de barrage et la petite finale.

### 2. L'étape tableau ne se valide pas en fin de saisie
L'effet de complétion `playAllPositions` était bloqué par une garde `matches === mountMatchesRef`. Or la dernière saisie qui complète le classement est souvent un match de **bracket de consolation**, qui ne modifie pas `matches`. Après un changement d'onglet, `matches` restait identique au montage → `onComplete` ne se déclenchait jamais.
→ Garde supprimée ; le cas « déjà complet restauré depuis DB » reste couvert par `readOnly`.

## Tests
- `tsc --noEmit` : OK sur les fichiers touchés
- Tests de propagation : OK

https://claude.ai/code/session_01VzqQdWfeXCZ6V8GsxfCWLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzqQdWfeXCZ6V8GsxfCWLh)_