### PR TITLE
feat(ui): refonte icônes Lucide + Toast unifié + header condensé + stepper amélioré

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,36 +1,17 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.1124",
+  "version": "1.0.3-build.1163",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.1124",
+      "version": "1.0.3-build.1163",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
-        "@types/express": "^5.0.6",
-        "@types/node": "^22.0.0",
-        "@types/qrcode": "^1.5.6",
-        "@types/react": "^19.1.4",
-        "@types/react-dom": "^19.1.5",
-        "@types/uuid": "^10.0.0",
-        "@types/xml2js": "^0.4.14",
         "better-sqlite3": "^12.10.0",
-        "express": "^5.2.1",
-        "immer": "^10.1.1",
-        "jspdf": "^4.1.0",
-        "jspdf-autotable": "^5.0.7",
-        "jszip": "^3.10.1",
-        "qrcode": "^1.5.4",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "socket.io": "^4.8.3",
-        "typescript": "^6.0.2",
-        "uuid": "^11.1.0",
-        "xml2js": "^0.6.2",
-        "zustand": "^5.0.3"
+        "lucide-react": "^1.17.0"
       },
       "devDependencies": {
         "@electron/rebuild": "^4.0.4",
@@ -40,6 +21,12 @@
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/better-sqlite3": "^7.6.13",
+        "@types/express": "^5.0.6",
+        "@types/node": "^22.0.0",
+        "@types/qrcode": "^1.5.6",
+        "@types/react": "^19.1.4",
+        "@types/react-dom": "^19.1.5",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.60.0",
         "@typescript-eslint/parser": "^8.60.0",
         "@vitest/coverage-v8": "^4.0.18",
@@ -53,20 +40,32 @@
         "eslint-plugin-prettier": "^5.1.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "express": "^5.2.1",
         "fake-indexeddb": "^6.2.5",
         "globals": "^16.5.0",
         "html-webpack-plugin": "^5.6.3",
+        "immer": "^10.1.1",
         "jsdom": "^25.0.0",
+        "jspdf": "^4.1.0",
+        "jspdf-autotable": "^5.0.7",
+        "jszip": "^3.10.1",
         "prettier": "^3.2.0",
+        "qrcode": "^1.5.4",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "socket.io": "^4.8.3",
         "style-loader": "^4.0.0",
         "terser-webpack-plugin": "^5.3.16",
         "ts-loader": "^9.5.2",
+        "typescript": "^6.0.2",
+        "uuid": "^11.1.0",
         "vitest": "^4.0.18",
         "wait-on": "^8.0.3",
         "webpack": "^5.99.7",
         "webpack-bundle-analyzer": "^4.10.1",
         "webpack-cli": "^6.0.1",
-        "webpack-dev-server": "^5.2.3"
+        "webpack-dev-server": "^5.2.3",
+        "zustand": "^5.0.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -161,6 +160,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2438,7 +2438,8 @@
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "dev": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2582,6 +2583,7 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2623,6 +2625,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2641,6 +2644,7 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2691,6 +2695,7 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2701,6 +2706,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2732,7 +2738,8 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.17",
@@ -2774,6 +2781,7 @@
       "version": "22.19.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
       "integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2781,7 +2789,8 @@
     "node_modules/@types/pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true
     },
     "node_modules/@types/plist": {
       "version": "3.0.5",
@@ -2798,6 +2807,7 @@
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
       "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2806,23 +2816,27 @@
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true
     },
     "node_modules/@types/raf": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
       "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "dev": true,
       "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "19.2.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
+      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2831,6 +2845,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2854,6 +2869,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2871,6 +2887,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
@@ -2889,12 +2906,14 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
       "optional": true
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@types/verror": {
       "version": "1.10.11",
@@ -2908,14 +2927,6 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/xml2js": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
-      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3575,6 +3586,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -3587,6 +3599,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3595,6 +3608,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -3610,6 +3624,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3751,6 +3766,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3759,6 +3775,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4220,6 +4237,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 0.6.0"
@@ -4248,6 +4266,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
@@ -4316,6 +4335,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -4339,6 +4359,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4523,6 +4544,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4585,6 +4607,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -4597,6 +4620,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -4632,6 +4656,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4661,6 +4686,7 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
       "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -4852,6 +4878,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4862,7 +4889,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -5004,6 +5032,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -5016,6 +5045,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5024,6 +5054,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5032,6 +5063,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -5075,6 +5107,7 @@
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
       "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "funding": {
@@ -5085,12 +5118,14 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
     },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -5140,6 +5175,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
       "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "utrie": "^1.0.2"
@@ -5251,7 +5287,8 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -5329,6 +5366,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5345,6 +5383,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5493,6 +5532,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5536,6 +5576,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dir-compare": {
@@ -5663,6 +5704,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
       "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "dev": true,
       "optional": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5723,6 +5765,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -5742,7 +5785,8 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -5977,12 +6021,14 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5999,6 +6045,7 @@
       "version": "6.6.5",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
       "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+      "dev": true,
       "dependencies": {
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
@@ -6018,6 +6065,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
       "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -6026,6 +6074,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -6038,6 +6087,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6163,6 +6213,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6171,6 +6222,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6212,6 +6264,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -6324,7 +6377,8 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -6729,6 +6783,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6772,6 +6827,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6814,6 +6870,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6822,6 +6879,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -6901,6 +6959,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
       "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "dev": true,
       "dependencies": {
         "@types/pako": "^2.0.3",
         "iobuffer": "^5.3.2",
@@ -6956,7 +7015,8 @@
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -7023,6 +7083,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -7140,6 +7201,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7148,6 +7210,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7196,6 +7259,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7242,6 +7306,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -7250,6 +7315,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -7273,6 +7339,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -7425,6 +7492,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7537,6 +7605,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7563,6 +7632,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -7719,6 +7789,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
       "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "css-line-break": "^2.1.0",
@@ -7763,6 +7834,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -7926,12 +7998,14 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -8051,12 +8125,14 @@
     "node_modules/iobuffer": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
-      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "dev": true
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -8243,6 +8319,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8391,7 +8468,8 @@
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -8547,7 +8625,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
     },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
@@ -8824,6 +8903,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.1.0.tgz",
       "integrity": "sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "fast-png": "^6.2.0",
@@ -8840,6 +8920,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
       "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
+      "dev": true,
       "peerDependencies": {
         "jspdf": "^2 || ^3 || ^4"
       }
@@ -8863,6 +8944,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
@@ -8875,12 +8957,14 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -8896,12 +8980,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -8958,6 +9044,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
@@ -9051,6 +9138,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -9117,6 +9213,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9125,6 +9222,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9162,6 +9260,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -9213,6 +9312,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9221,6 +9321,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9330,7 +9431,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -9545,6 +9647,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9553,6 +9656,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9661,6 +9765,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -9816,6 +9921,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9823,7 +9929,8 @@
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "dev": true
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -9878,6 +9985,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9896,6 +10004,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9928,6 +10037,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
       "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -9950,6 +10060,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true,
       "optional": true
     },
     "node_modules/picocolors": {
@@ -10116,6 +10227,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -10390,7 +10502,8 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -10446,6 +10559,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -10500,6 +10614,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
       "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
@@ -10517,6 +10632,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -10528,6 +10644,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -10541,6 +10658,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -10553,6 +10671,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -10568,6 +10687,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -10580,12 +10700,14 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/qrcode/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^6.0.0",
@@ -10608,6 +10730,7 @@
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -10621,6 +10744,7 @@
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
       "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "dev": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -10647,6 +10771,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "performance-now": "^2.1.0"
@@ -10665,6 +10790,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10673,6 +10799,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -10687,6 +10814,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -10734,6 +10862,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "dev": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10842,6 +10971,7 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/regexp.prototype.flags": {
@@ -10890,6 +11020,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10907,6 +11038,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/requires-port": {
@@ -10987,6 +11119,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
       "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 0.8.15"
@@ -11059,6 +11192,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -11184,7 +11318,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.3",
@@ -11199,6 +11334,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "dev": true,
       "engines": {
         "node": ">=11.0.0"
       }
@@ -11219,7 +11355,8 @@
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -11315,6 +11452,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -11340,6 +11478,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11348,6 +11487,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -11494,6 +11634,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -11512,6 +11653,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/set-function-length": {
@@ -11564,12 +11706,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -11620,6 +11764,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -11638,6 +11783,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -11653,6 +11799,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -11670,6 +11817,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -11793,6 +11941,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
       "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
@@ -11810,6 +11959,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
       "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "dev": true,
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.18.3"
@@ -11819,6 +11969,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
       "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1"
@@ -11831,6 +11982,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -11843,6 +11995,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11943,6 +12096,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
       "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.1.14"
@@ -11961,6 +12115,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11997,6 +12152,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12103,6 +12259,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12192,6 +12349,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
       "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=12.0.0"
@@ -12399,6 +12557,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
       "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "utrie": "^1.0.2"
@@ -12570,6 +12729,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -12738,6 +12898,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -12751,6 +12912,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12759,6 +12921,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -12848,6 +13011,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12887,7 +13051,8 @@
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -12902,6 +13067,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -12975,6 +13141,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
       "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
@@ -12984,6 +13151,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
       "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -12996,6 +13164,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -14070,6 +14239,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
@@ -14129,6 +14299,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -14147,6 +14318,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14186,26 +14358,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xml2js/node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xmlbuilder": {
@@ -14292,6 +14444,7 @@
       "version": "5.0.11",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
       "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
     }
   },
   "dependencies": {
-    "better-sqlite3": "^12.10.0"
+    "better-sqlite3": "^12.10.0",
+    "lucide-react": "^1.17.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.4",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useCallback, useState, Suspense } from 'react';
+import { Home, Plus, Radio, Sun, Moon, Contrast, BookOpen, Settings, X, Swords } from 'lucide-react';
 import { Competition, PhaseType } from '../shared/types';
 import type { CompetitionCreateData } from '../shared/types/preload';
 import { logger, LogCategory } from '@shared/services/logger';
@@ -32,8 +33,12 @@ const PHASE_BADGE: Record<string, { label: string; cls: string }> = {
   [PhaseType.CLASSIFICATION]: { label: 'Résultats', cls: 'badge-results' },
 };
 
-const THEME_ICONS: Record<string, string> = { default: '🌓', light: '☀️', dark: '🌙' };
 const THEME_CYCLE: Theme[] = ['default', 'light', 'dark'];
+const ThemeIcon: React.FC<{ theme: Theme }> = ({ theme }) => {
+  if (theme === 'light') return <Sun size={16} />;
+  if (theme === 'dark') return <Moon size={16} />;
+  return <Contrast size={16} />;
+};
 
 const AppContent: React.FC = () => {
   const { t, isLoading: translationLoading, theme, changeTheme } = useTranslation();
@@ -309,19 +314,7 @@ const AppContent: React.FC = () => {
       <div className="app">
         <header className="header">
           <div className="header-title">
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="M14.5 17.5L3 6V3h3l11.5 11.5" />
-              <path d="M13 19l6-6" />
-              <path d="M16 16l4 4" />
-              <path d="M19 21a2 2 0 100-4 2 2 0 000 4z" />
-            </svg>
+            <Swords size={22} strokeWidth={1.75} />
             {t('app.title')}
           </div>
           {/* Ctrl+K hint — clickable */}
@@ -336,28 +329,31 @@ const AppContent: React.FC = () => {
           <div className="header-nav">
             {openCompetitions.length > 0 && view === 'competition' && (
               <button
-                className="btn btn-secondary"
+                className="btn btn-secondary btn-icon-label"
                 onClick={() => {
                   setView('home');
                   setActiveTabId(null);
                 }}
                 title={t('app.back_to_list')}
               >
-                🏠 {t('app.home')}
+                <Home size={15} />
+                {t('app.home')}
               </button>
             )}
-            <button className="btn btn-primary" onClick={() => setShowNewCompetitionModal(true)}>
-              + {t('menu.new_competition')}
+            <button className="btn btn-primary btn-icon-label" onClick={() => setShowNewCompetitionModal(true)}>
+              <Plus size={15} />
+              {t('menu.new_competition')}
             </button>
             {view === 'competition' && currentCompetition && (
               <button
-                className="btn btn-secondary"
+                className="btn btn-secondary btn-icon-label"
                 onClick={() => {
                   setRequestedPhase('remote');
                 }}
                 title={t('phases.remote')}
               >
-                📡 {t('phases.remote')}
+                <Radio size={15} />
+                {t('phases.remote')}
               </button>
             )}
             <button
@@ -368,21 +364,22 @@ const AppContent: React.FC = () => {
               }}
               title={`Thème : ${theme}`}
             >
-              {THEME_ICONS[theme]}
+              <ThemeIcon theme={theme} />
             </button>
             <button
-              className="btn btn-secondary"
+              className="btn btn-icon"
               onClick={() => setShowWikiModal(true)}
               title={t('wiki.button_title')}
             >
-              📖
+              <BookOpen size={16} />
             </button>
             <button
-              className="btn btn-secondary"
+              className="btn btn-secondary btn-icon-label"
               onClick={() => setShowSettingsModal(true)}
               title={t('settings.title')}
             >
-              ⚙️ {t('settings.title')}
+              <Settings size={15} />
+              {t('settings.title')}
             </button>
           </div>
         </header>
@@ -445,7 +442,7 @@ const AppContent: React.FC = () => {
                   gap: '0.5rem',
                 }}
               >
-                🏠 {t('app.home')}
+                <Home size={13} /> {t('app.home')}
               </span>
             </div>
 
@@ -539,7 +536,7 @@ const AppContent: React.FC = () => {
                   onMouseLeave={e => { e.currentTarget.style.background = 'none'; e.currentTarget.style.color = '#6b7280'; }}
                   title={t('app.close_tab')}
                 >
-                  ×
+                  <X size={12} />
                 </button>
               </div>
             ))}
@@ -551,7 +548,7 @@ const AppContent: React.FC = () => {
             <ErrorBoundary
               fallback={
                 <div style={{ padding: '20px', textAlign: 'center' }}>
-                  <h3>🏠 {t('app.load_error_title')}</h3>
+                  <h3>{t('app.load_error_title')}</h3>
                   <p>{t('app.load_error_message')}</p>
                   <button onClick={() => window.location.reload()}>{t('app.reload')}</button>
                 </div>

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -1,146 +1,209 @@
 /**
- * BellePoule Modern - Toast Notification Component
- * Replaces native alert() to avoid focus issues in Electron
+ * BellePoule Modern - Toast Notification System (unified)
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, createContext, useContext, useCallback } from 'react';
+import React, { useState, useEffect, createContext, useContext, useCallback, useRef } from 'react';
+import { CheckCircle2, AlertTriangle, XCircle, Info } from 'lucide-react';
 import { logger, LogCategory } from '@shared/services/logger';
 
-type ToastType = 'info' | 'success' | 'warning' | 'error';
+export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
-interface Toast {
+export interface ToastOptions {
+  title?: string;
+  message?: string;
+  duration?: number;
+  persistent?: boolean;
+  action?: { label: string; onClick: () => void };
+}
+
+interface ToastItem {
   id: number;
-  message: string;
   type: ToastType;
+  title?: string;
+  message: string;
+  duration: number;
+  persistent: boolean;
+  action?: { label: string; onClick: () => void };
+  createdAt: number;
 }
 
 interface ToastContextType {
-  showToast: (message: string, type?: ToastType) => void;
+  showToast: (message: string, type?: ToastType, options?: ToastOptions) => void;
 }
 
 const ToastContext = createContext<ToastContextType | null>(null);
 
 let toastId = 0;
 
-export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [toasts, setToasts] = useState<Toast[]>([]);
+const TOAST_COLORS: Record<ToastType, { bg: string; border: string; text: string; accent: string }> = {
+  success: { bg: '#f0fdf4', border: '#22c55e', text: '#166534', accent: '#22c55e' },
+  warning: { bg: '#fffbeb', border: '#f59e0b', text: '#92400e', accent: '#f59e0b' },
+  error:   { bg: '#fef2f2', border: '#ef4444', text: '#991b1b', accent: '#ef4444' },
+  info:    { bg: '#eff6ff', border: '#3b82f6', text: '#1e40af', accent: '#3b82f6' },
+};
 
-  const showToast = useCallback((message: string, type: ToastType = 'info') => {
-    const id = ++toastId;
-    setToasts(prev => [...prev, { id, message, type }]);
+const TOAST_ICONS: Record<ToastType, React.ReactNode> = {
+  success: <CheckCircle2 size={18} />,
+  warning: <AlertTriangle size={18} />,
+  error:   <XCircle size={18} />,
+  info:    <Info size={18} />,
+};
 
-    // Auto-remove after 4 seconds
-    setTimeout(() => {
-      setToasts(prev => prev.filter(t => t.id !== id));
-    }, 4000);
+const MAX_TOASTS = 3;
+
+const ToastItemComponent: React.FC<{
+  toast: ToastItem;
+  onRemove: (id: number) => void;
+}> = ({ toast, onRemove }) => {
+  const [visible, setVisible] = useState(false);
+  const [progress, setProgress] = useState(100);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const colors = TOAST_COLORS[toast.type];
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 10);
+    return () => clearTimeout(t);
   }, []);
 
-  const removeToast = (id: number) => {
+  useEffect(() => {
+    if (toast.persistent) return;
+    const start = Date.now();
+    intervalRef.current = setInterval(() => {
+      const elapsed = Date.now() - start;
+      const pct = Math.max(0, 100 - (elapsed / toast.duration) * 100);
+      setProgress(pct);
+      if (pct === 0) {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        onRemove(toast.id);
+      }
+    }, 50);
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
+  }, [toast.id, toast.duration, toast.persistent, onRemove]);
+
+  return (
+    <div
+      role="alert"
+      style={{
+        background: '#ffffff',
+        borderLeft: `4px solid ${colors.accent}`,
+        borderRadius: '8px',
+        padding: '12px 14px',
+        boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '4px',
+        minWidth: '280px',
+        maxWidth: '420px',
+        transform: visible ? 'translateX(0)' : 'translateX(110%)',
+        opacity: visible ? 1 : 0,
+        transition: 'transform 0.28s cubic-bezier(0.16,1,0.3,1), opacity 0.28s ease',
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: '10px' }}>
+        <span style={{ color: colors.accent, flexShrink: 0, marginTop: '1px' }}>
+          {TOAST_ICONS[toast.type]}
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {toast.title && (
+            <div style={{ fontWeight: 600, fontSize: '0.875rem', color: '#111827', marginBottom: toast.message ? '2px' : 0 }}>
+              {toast.title}
+            </div>
+          )}
+          <div style={{ fontSize: '0.8125rem', color: '#374151', lineHeight: 1.45, wordBreak: 'break-word' }}>
+            {toast.message}
+          </div>
+          {toast.action && (
+            <button
+              onClick={toast.action.onClick}
+              style={{
+                marginTop: '6px', padding: '4px 10px', fontSize: '0.75rem',
+                background: colors.accent, color: 'white', border: 'none',
+                borderRadius: '4px', cursor: 'pointer', fontWeight: 600,
+              }}
+            >
+              {toast.action.label}
+            </button>
+          )}
+        </div>
+        <button
+          onClick={() => onRemove(toast.id)}
+          style={{
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: '#9ca3af', padding: '1px', flexShrink: 0,
+            display: 'flex', alignItems: 'center',
+          }}
+          aria-label="Fermer"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
+      </div>
+      {!toast.persistent && (
+        <div style={{
+          position: 'absolute', bottom: 0, left: 0,
+          height: '3px', background: colors.accent,
+          width: `${progress}%`,
+          transition: 'width 50ms linear',
+          opacity: 0.6,
+        }} />
+      )}
+    </div>
+  );
+};
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const showToast = useCallback((message: string, type: ToastType = 'info', options?: ToastOptions) => {
+    const id = ++toastId;
+    const duration = options?.duration ?? (type === 'error' ? 6000 : 4000);
+    const newToast: ToastItem = {
+      id,
+      type,
+      message,
+      title: options?.title,
+      duration,
+      persistent: options?.persistent ?? false,
+      action: options?.action,
+      createdAt: Date.now(),
+    };
+    setToasts(prev => {
+      const next = [...prev, newToast];
+      return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+    });
+  }, []);
+
+  const removeToast = useCallback((id: number) => {
     setToasts(prev => prev.filter(t => t.id !== id));
-  };
-
-  const getIcon = (type: ToastType) => {
-    switch (type) {
-      case 'success':
-        return '✅';
-      case 'warning':
-        return '⚠️';
-      case 'error':
-        return '❌';
-      default:
-        return 'ℹ️';
-    }
-  };
-
-  const getColors = (type: ToastType) => {
-    switch (type) {
-      case 'success':
-        return { bg: '#f0fdf4', border: '#22c55e', text: '#166534' };
-      case 'warning':
-        return { bg: '#fffbeb', border: '#f59e0b', text: '#92400e' };
-      case 'error':
-        return { bg: '#fef2f2', border: '#ef4444', text: '#991b1b' };
-      default:
-        return { bg: '#eff6ff', border: '#3b82f6', text: '#1e40af' };
-    }
-  };
+  }, []);
 
   return (
     <ToastContext.Provider value={{ showToast }}>
       {children}
-
-      {/* Toast Container */}
       <div
         role="status"
         aria-live="polite"
         aria-atomic="false"
         style={{
           position: 'fixed',
-          top: '1rem',
-          right: '1rem',
+          bottom: '1.25rem',
+          right: '1.25rem',
           zIndex: 10000,
           display: 'flex',
           flexDirection: 'column',
           gap: '0.5rem',
           pointerEvents: 'none',
+          alignItems: 'flex-end',
         }}
       >
-        {toasts.map(toast => {
-          const colors = getColors(toast.type);
-          return (
-            <div
-              key={toast.id}
-              style={{
-                background: colors.bg,
-                border: `2px solid ${colors.border}`,
-                borderRadius: '8px',
-                padding: '0.75rem 1rem',
-                boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.75rem',
-                maxWidth: '400px',
-                pointerEvents: 'auto',
-                animation: 'slideIn 0.3s ease-out',
-              }}
-            >
-              <span style={{ fontSize: '1.25rem' }}>{getIcon(toast.type)}</span>
-              <span style={{ color: colors.text, fontWeight: '500', flex: 1 }}>
-                {toast.message}
-              </span>
-              <button
-                onClick={() => removeToast(toast.id)}
-                style={{
-                  background: 'transparent',
-                  border: 'none',
-                  color: colors.text,
-                  cursor: 'pointer',
-                  padding: '0.25rem',
-                  opacity: 0.7,
-                  fontSize: '1rem',
-                }}
-              >
-                ✕
-              </button>
-            </div>
-          );
-        })}
+        {toasts.map(toast => (
+          <div key={toast.id} style={{ pointerEvents: 'auto' }}>
+            <ToastItemComponent toast={toast} onRemove={removeToast} />
+          </div>
+        ))}
       </div>
-
-      {/* Animation styles */}
-      <style>{`
-        @keyframes slideIn {
-          from {
-            transform: translateX(100%);
-            opacity: 0;
-          }
-          to {
-            transform: translateX(0);
-            opacity: 1;
-          }
-        }
-      `}</style>
     </ToastContext.Provider>
   );
 };
@@ -148,7 +211,6 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 export const useToast = (): ToastContextType => {
   const context = useContext(ToastContext);
   if (!context) {
-    // Fallback if used outside provider
     return {
       showToast: (message: string) => {
         logger.warn(LogCategory.UI, 'Toast used outside provider', { message });

--- a/src/renderer/components/competition/CompetitionHeader.tsx
+++ b/src/renderer/components/competition/CompetitionHeader.tsx
@@ -3,7 +3,8 @@
  * Licensed under GPL-3.0
  */
 
-import React from 'react';
+import React, { useState, useCallback } from 'react';
+import { MoreHorizontal, Swords, BarChart2, Share2, Monitor, Smartphone, Settings, ChevronDown, ChevronUp } from 'lucide-react';
 import { Competition, MatchStatus } from '../../../shared/types';
 import Confetti from '../Confetti';
 import CoachMark from '../CoachMark';
@@ -59,14 +60,27 @@ const CompetitionHeaderComponent: React.FC<CompetitionHeaderProps> = ({
   setShowKiosk,
   setShowKioskDisplay,
   setShowPropertiesModal,
-}) => (
+}) => {
+  const storageKey = `bellepoule-header-expanded-${competition.id}`;
+  const [expanded, setExpanded] = useState(() => {
+    try { return localStorage.getItem(storageKey) !== 'false'; } catch { return true; }
+  });
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded(prev => {
+      const next = !prev;
+      try { localStorage.setItem(storageKey, String(next)); } catch { /* noop */ }
+      return next;
+    });
+  }, [storageKey]);
+
+  return (
   <>
     <Confetti active={showConfetti} />
-    {/* Header — glassmorphism redesign */}
-    <div className="comp-header" style={{ '--comp-color': competition.color } as React.CSSProperties}>
+    <div className={`comp-header${expanded ? '' : ' comp-header-compact'}`} style={{ '--comp-color': competition.color } as React.CSSProperties}>
       <div className="comp-header-bg" />
       <div className="comp-header-content">
-        {/* Infos */}
+        {/* Infos — ligne compacte toujours visible */}
         <div className="comp-header-info">
           <div className="comp-header-pills">
             <span className="comp-header-pill">{competition.weapon}</span>
@@ -74,39 +88,52 @@ const CompetitionHeaderComponent: React.FC<CompetitionHeaderProps> = ({
             <span className="comp-header-pill">{competition.gender}</span>
           </div>
           <h1 className="comp-header-title">{competition.title}</h1>
-          <p className="comp-header-meta">
-            {new Date(competition.date).toLocaleDateString(language === 'zh-HK' ? 'zh-HK' : language, {
-              weekday: 'long', day: 'numeric', month: 'long', year: 'numeric',
-            })}
-            {competition.location && ` · ${competition.location}`}
-          </p>
+          {expanded && (
+            <p className="comp-header-meta">
+              {new Date(competition.date).toLocaleDateString(language === 'zh-HK' ? 'zh-HK' : language, {
+                weekday: 'long', day: 'numeric', month: 'long', year: 'numeric',
+              })}
+              {competition.location && ` · ${competition.location}`}
+            </p>
+          )}
         </div>
 
         {/* Stats + actions */}
         <div className="comp-header-right">
-          {/* Stats */}
-          <div className="comp-header-stats">
-            <div className="comp-stat">
-              <span className="comp-stat-value">{fencersCount}</span>
-              <span className="comp-stat-label">{t('fencer.label')}</span>
+          {expanded && (
+            <div className="comp-header-stats">
+              <div className="comp-stat">
+                <span className="comp-stat-value">{fencersCount}</span>
+                <span className="comp-stat-label">{t('fencer.label')}</span>
+              </div>
+              <div className="comp-stat-sep" />
+              <div className="comp-stat">
+                <span className="comp-stat-value">{checkedInCount}</span>
+                <span className="comp-stat-label">{t('fencer.present_label')}</span>
+              </div>
+              {matchProgress && (
+                <>
+                  <div className="comp-stat-sep" />
+                  <div className="comp-stat">
+                    <span className="comp-stat-value">{matchProgress.done}/{matchProgress.total}</span>
+                    <span className="comp-stat-label">matchs</span>
+                  </div>
+                </>
+              )}
             </div>
-            <div className="comp-stat-sep" />
-            <div className="comp-stat">
-              <span className="comp-stat-value">{checkedInCount}</span>
-              <span className="comp-stat-label">{t('fencer.present_label')}</span>
-            </div>
-            {matchProgress && (
-              <>
-                <div className="comp-stat-sep" />
-                <div className="comp-stat">
-                  <span className="comp-stat-value">{matchProgress.done}/{matchProgress.total}</span>
-                  <span className="comp-stat-label">matchs</span>
-                </div>
-              </>
-            )}
-          </div>
+          )}
 
-          {/* Menu actions ⋯ */}
+          {/* Collapse toggle */}
+          <button
+            className="comp-header-collapse-btn"
+            onClick={toggleExpanded}
+            title={expanded ? 'Réduire' : 'Développer'}
+            aria-expanded={expanded}
+          >
+            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </button>
+
+          {/* Menu actions */}
           <div className="comp-header-actions" ref={actionsMenuRef}>
             <CoachMark id="actions-menu" message="Comparaison, analytiques, partage QR..." position="left">
               <button
@@ -114,38 +141,38 @@ const CompetitionHeaderComponent: React.FC<CompetitionHeaderProps> = ({
                 onClick={() => setShowActionsMenu(v => !v)}
                 title="Actions"
               >
-                ⋯
+                <MoreHorizontal size={18} />
               </button>
             </CoachMark>
             {showActionsMenu && (
               <div className="comp-header-dropdown">
                 <button className="comp-header-dropdown-item" onClick={() => { setShowFencerComparison(true); setShowActionsMenu(false); }}>
-                  ⚔️ {t('competition.comparisons')}
+                  <Swords size={14} /> {t('competition.comparisons')}
                 </button>
                 <button className="comp-header-dropdown-item" onClick={() => { setShowAnalytics(true); setShowActionsMenu(false); }}>
-                  📊 {t('competition.analytics')}
+                  <BarChart2 size={14} /> {t('competition.analytics')}
                 </button>
                 <button className="comp-header-dropdown-item" onClick={() => { setShowQRCode(true); setShowActionsMenu(false); }}>
-                  📱 Partager
+                  <Share2 size={14} /> Partager
                 </button>
                 {currentPhase === 'pools' && pools.length > 0 && (
                   <>
                     <button className="comp-header-dropdown-item" onClick={() => { setShowPresentation(true); setShowActionsMenu(false); }}>
-                      🖥️ Mode Présentation
+                      <Monitor size={14} /> Mode Présentation
                     </button>
                     <button className="comp-header-dropdown-item" onClick={() => { setShowKiosk(true); setShowActionsMenu(false); }}>
-                      📱 Mode Kiosk
+                      <Smartphone size={14} /> Mode Kiosk
                     </button>
                   </>
                 )}
                 {(pools.length > 0 || tableauMatches.length > 0) && (
                   <button className="comp-header-dropdown-item" onClick={() => { setShowKioskDisplay(true); setShowActionsMenu(false); }}>
-                    🖥️ Kiosk Public
+                    <Monitor size={14} /> Kiosk Public
                   </button>
                 )}
                 <div className="comp-header-dropdown-sep" />
                 <button className="comp-header-dropdown-item" onClick={() => { setShowPropertiesModal(true); setShowActionsMenu(false); }}>
-                  ⚙️ Propriétés
+                  <Settings size={14} /> Propriétés
                 </button>
               </div>
             )}
@@ -153,8 +180,8 @@ const CompetitionHeaderComponent: React.FC<CompetitionHeaderProps> = ({
         </div>
       </div>
 
-      {/* Barre de progression matchs */}
-      {matchProgress && matchProgress.total > 0 && (
+      {/* Barre de progression — visible seulement en mode étendu */}
+      {expanded && matchProgress && matchProgress.total > 0 && (
         <div className="comp-header-progress">
           <div
             className="comp-header-progress-fill"
@@ -164,7 +191,8 @@ const CompetitionHeaderComponent: React.FC<CompetitionHeaderProps> = ({
       )}
     </div>
   </>
-);
+  );
+};
 
 const CompetitionHeader = React.memo(CompetitionHeaderComponent);
 export default CompetitionHeader;

--- a/src/renderer/components/competition/CompetitionNav.tsx
+++ b/src/renderer/components/competition/CompetitionNav.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useRef, useEffect } from 'react';
+import { ChevronLeft, ChevronRight, Wrench, Wifi, Tv2, Swords, Target, Zap, Trophy } from 'lucide-react';
 import { Competition, MatchStatus, QuestPhaseConfig, Fencer } from '../../../shared/types';
 import { Phase } from '../../hooks/useCompetitionSession';
 import CoachMark from '../CoachMark';
@@ -118,33 +119,33 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
             <span>{phase.label}</span>
           </div>
           {index < phases.length - 1 && (
-            <div style={{ display: 'flex', alignItems: 'center', color: '#9CA3AF' }}>→</div>
+            <div className={`phase-step-connector${!phase.disabled && !phases[index + 1]?.disabled ? ' connector-done' : ''}`} />
           )}
         </React.Fragment>
       ))}
       <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
         {currentPhase !== 'checkin' && (
-          <button className="btn btn-secondary" onClick={handleGoBack}>
-            ← Retour
+          <button className="btn btn-secondary btn-icon-label" onClick={handleGoBack}>
+            <ChevronLeft size={15} /> Retour
           </button>
         )}
         {currentPhase === 'checkin' && questEnabled && !questConfig?.hasPreliminaryPools && (
           <button
-            className="btn btn-primary"
+            className="btn btn-primary btn-icon-label"
             onClick={() => setCurrentPhase('quest')}
             disabled={getCheckedInFencers().length < 2}
           >
-            Tour Quest →
+            Tour Quest <ChevronRight size={15} />
           </button>
         )}
         {currentPhase === 'checkin' && (!questEnabled || questConfig?.hasPreliminaryPools) && (
           <CoachMark id="generate-pools" message="Cliquez ici après avoir pointé tous vos tireurs" position="bottom">
             <button
-              className="btn btn-primary"
+              className="btn btn-primary btn-icon-label"
               onClick={handleGeneratePools}
               disabled={getCheckedInFencers().length < 4}
             >
-              Générer les poules →
+              Générer les poules <ChevronRight size={15} />
             </button>
           </CoachMark>
         )}
@@ -158,13 +159,13 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
         <div ref={toolsMenuRef} style={{ position: 'relative' }}>
           <button
             ref={toolsBtnRef}
-            className="btn btn-secondary"
+            className="btn btn-secondary btn-icon-label"
             onClick={() => setShowToolsMenu(v => !v)}
             title="Outils"
             aria-haspopup="true"
             aria-expanded={showToolsMenu}
           >
-            🔧 Outils
+            <Wrench size={15} /> Outils
           </button>
           {showToolsMenu && (
             <div
@@ -185,16 +186,16 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
               <button
                 className="comp-header-dropdown-item"
                 onClick={() => { setShowWifiQR(true); setShowToolsMenu(false); }}
-                style={{ width: '100%', textAlign: 'left' }}
+                style={{ width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '0.5rem' }}
               >
-                📶 QR Code WiFi
+                <Wifi size={15} /> QR Code WiFi
               </button>
               <button
                 className="comp-header-dropdown-item"
                 onClick={() => { setShowTVRemote(true); setShowToolsMenu(false); }}
-                style={{ width: '100%', textAlign: 'left' }}
+                style={{ width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: '0.5rem' }}
               >
-                📺 Télécommande TV
+                <Tv2 size={15} /> Télécommande TV
               </button>
             </div>
           )}
@@ -206,19 +207,19 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
     {(pools.length > 0 || tableauMatches.length > 0 || fencers.length > 0) && (
       <div className="comp-stats-bar">
         <div className="comp-stats-bar-item">
-          <span className="comp-stats-bar-icon">🤺</span>
+          <span className="comp-stats-bar-icon"><Swords size={13} /></span>
           <span>{getCheckedInFencers().length}/{fencers.length} tireurs</span>
         </div>
         {pools.length > 0 && (
           <>
             <div className="comp-stats-bar-sep" />
             <div className="comp-stats-bar-item">
-              <span className="comp-stats-bar-icon">🎯</span>
+              <span className="comp-stats-bar-icon"><Target size={13} /></span>
               <span>{pools.filter(p => p.isComplete).length}/{pools.length} poules</span>
             </div>
             <div className="comp-stats-bar-sep" />
             <div className="comp-stats-bar-item">
-              <span className="comp-stats-bar-icon">⚡</span>
+              <span className="comp-stats-bar-icon"><Zap size={13} /></span>
               <span>
                 {pools.reduce((s, p) => s + p.matches.filter(m => m.status === MatchStatus.FINISHED).length, 0)}/
                 {pools.reduce((s, p) => s + p.matches.length, 0)} matchs
@@ -230,7 +231,7 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
           <>
             <div className="comp-stats-bar-sep" />
             <div className="comp-stats-bar-item">
-              <span className="comp-stats-bar-icon">🏆</span>
+              <span className="comp-stats-bar-icon"><Trophy size={13} /></span>
               <span>
                 {tableauMatches.filter(m => m.winner !== null).length}/
                 {tableauMatches.filter(m => m.fencerA && m.fencerB).length} tableau

--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -393,12 +393,29 @@ select:focus {
    ============================================================ */
 
 .phase-nav {
-  padding: 0.75rem 1rem;
+  padding: 0.625rem 1rem;
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
-  gap: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0;
   overflow-x: auto;
   scrollbar-width: none;
+}
+
+/* Connecteur ligne entre les steps */
+.phase-step-connector {
+  flex-shrink: 0;
+  width: 24px;
+  height: 2px;
+  background: var(--color-border);
+  border-radius: 1px;
+  margin: 0 2px;
+  transition: background var(--duration-base) ease;
+}
+
+.phase-step-connector.connector-done {
+  background: var(--color-success);
 }
 
 .phase-nav::-webkit-scrollbar { display: none; }
@@ -1047,6 +1064,37 @@ select:focus {
   width: 1px;
   height: 2rem;
   background: rgba(255, 255, 255, 0.2);
+}
+
+/* Collapse button */
+.comp-header-collapse-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--duration-fast) ease;
+  margin-right: 0.25rem;
+}
+
+.comp-header-collapse-btn:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+/* Compact mode — single line */
+.comp-header-compact .comp-header-content {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.comp-header-compact .comp-header-title {
+  font-size: 1rem;
+  margin-bottom: 0;
 }
 
 /* Actions dropdown */

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -204,6 +204,15 @@ body {
 .btn-icon {
   padding: 0.5rem;
   border-radius: var(--radius);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-icon-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .btn-sm {


### PR DESCRIPTION
## Résumé

- **Axe 1 — Icônes Lucide React** : remplacement de tous les emoji (`⚙️`, `🏠`, `📡`, `🔧`, `🤺`, `🏆`...) par des icônes SVG `lucide-react` dans `App.tsx`, `CompetitionNav.tsx`, `CompetitionHeader.tsx` et `Toast.tsx`. Rendu cross-OS cohérent, sizing précis, animable.
- **Axe 3 — Toolbar** : boutons header en mode `icon + label` (classe `.btn-icon-label`), bouton Wiki en icon-only (`.btn-icon`).
- **Axe 4 — Stepper phases** : connecteur ligne CSS (`.phase-step-connector`) entre les steps en remplacement de la flèche `→` textuelle ; indicateur vert sur les steps accessibles.
- **Axe 5 — Header condensable** : bouton chevron toggle expand/collapse sur `CompetitionHeader`, mode compact (`.comp-header-compact`), état persisté dans `localStorage` par compétition.
- **Axe 6 — Toast unifié** : fusion `Toast.tsx` + `EnhancedToast.tsx` en un seul composant avec progress bar animée, stack max 3, slide depuis la droite, icônes Lucide, bouton close accessible (`✕`).

## Plan de test

- [ ] `npm run type-check` → 0 erreur
- [ ] `npm run test:run` → Toast.test.tsx vert (3 fichiers pré-existants restent en échec sans lien)
- [ ] Lancer `npm start`, vérifier les icônes dans la toolbar header
- [ ] Ouvrir une compétition, vérifier le chevron collapse/expand du header
- [ ] Vérifier le connecteur ligne dans la navigation de phases
- [ ] Déclencher un toast (ex: sauvegarder) — vérifier la progress bar et le slide

https://claude.ai/code/session_01WkpdJrf6ninsW4xKnvBKit

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkpdJrf6ninsW4xKnvBKit)_