### PR TITLE
perf: analyse et optimisation du code (quick wins + serveur/main)

### DIFF
--- a/docs/PDF_EXPORT_OPTIMIZATION.md
+++ b/docs/PDF_EXPORT_OPTIMIZATION.md
@@ -196,12 +196,12 @@ describe('OptimizedPDFExporter', () => {
 describe('PDF Export Integration', () => {
   it('should export pool successfully', async () => {
     const pool = createTestPool();
-    await expect(exportOptimizedPoolToPDF(pool)).resolves.not.toThrow();
+    await expect(exportPoolToPDF(pool)).resolves.not.toThrow();
   });
   
   it('should handle errors gracefully', async () => {
     const invalidPool = { fencers: [], matches: [] };
-    await expect(exportOptimizedPoolToPDF(invalidPool)).rejects.toThrow();
+    await expect(exportPoolToPDF(invalidPool)).rejects.toThrow();
   });
 });
 ```
@@ -215,13 +215,13 @@ describe('PDF Export Integration', () => {
    import { exportPoolToPDF } from './pdfExport';
    
    // New
-   import { exportOptimizedPoolToPDF } from './pdfExport';
+   import { exportPoolToPDF } from './pdfExport';
    ```
 
 2. **Update function calls:**
    ```typescript
    // Old methods still work, but new optimized methods are preferred
-   await exportOptimizedPoolToPDF(pool, options);
+   await exportPoolToPDF(pool, options);
    ```
 
 ### For New Features:

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -626,15 +626,15 @@ function createWindow(): void {
     createMenu(currentMenuLanguage);
 
     // Restore persisted logo and sync to renderer localStorage if not already set
-    try {
-      const logoPath = path.join(app.getPath('userData'), 'logo.dat');
-      if (fs.existsSync(logoPath)) {
-        const logo = fs.readFileSync(logoPath, 'utf-8');
-        if (logo) mainWindow!.webContents.send('app:logoLoaded', logo);
-      }
-    } catch {
-      /* logo optionnel */
-    }
+    const logoPath = path.join(app.getPath('userData'), 'logo.dat');
+    fs.promises
+      .readFile(logoPath, 'utf-8')
+      .then(logo => {
+        if (logo) mainWindow?.webContents.send('app:logoLoaded', logo);
+      })
+      .catch(() => {
+        /* logo optionnel */
+      });
   });
 }
 
@@ -929,7 +929,7 @@ async function handleImport(format: string): Promise<void> {
         // Fichier binaire : envoyer uniquement le chemin, le renderer appellera importFencersArchive
         mainWindow?.webContents.send('menu:import', format, filepath, '');
       } else {
-        const content = fs.readFileSync(filepath, 'utf-8');
+        const content = await fs.promises.readFile(filepath, 'utf-8');
         mainWindow?.webContents.send('menu:import', format, filepath, content);
       }
     } catch (error) {
@@ -1214,6 +1214,22 @@ ipcMain.handle('file:import', async (_, filepath) => {
   await db.importFromFile(filepath);
 });
 
+// Écriture atomique asynchrone (temp + rename) — ne bloque pas le main thread
+async function writeFileAtomic(filepath: string, content: Buffer | string): Promise<void> {
+  const tmpPath = filepath + '.tmp';
+  try {
+    await fs.promises.writeFile(tmpPath, content);
+    try {
+      await fs.promises.rename(tmpPath, filepath);
+    } catch {
+      await fs.promises.writeFile(filepath, content);
+      await fs.promises.unlink(tmpPath).catch(() => {});
+    }
+  } catch {
+    await fs.promises.writeFile(filepath, content);
+  }
+}
+
 // File content write handler
 ipcMain.handle('file:writeContent', async (_, filepath: string, content: string) => {
   if (!filepath || typeof filepath !== 'string' || !path.isAbsolute(filepath)) {
@@ -1224,7 +1240,7 @@ ipcMain.handle('file:writeContent', async (_, filepath: string, content: string)
   if (resolved.startsWith(appDir)) {
     throw new Error('Writing inside app directory is not allowed');
   }
-  fs.writeFileSync(resolved, content, 'utf-8');
+  await fs.promises.writeFile(resolved, content, 'utf-8');
 });
 
 // Photo ZIP export handler
@@ -1242,29 +1258,14 @@ ipcMain.handle('file:exportPhotos', async (_, competitionId: string, filepath: s
   }
 
   const content = await zip.generateAsync({ type: 'nodebuffer' });
-  const tmpPath = filepath + '.tmp';
-  try {
-    fs.writeFileSync(tmpPath, content);
-    try {
-      fs.renameSync(tmpPath, filepath);
-    } catch {
-      fs.writeFileSync(filepath, content);
-      try {
-        fs.unlinkSync(tmpPath);
-      } catch {
-        /* ignore */
-      }
-    }
-  } catch {
-    fs.writeFileSync(filepath, content);
-  }
+  await writeFileAtomic(filepath, content);
 
   return { count: photos.length };
 });
 
 // Photo ZIP import handler
 ipcMain.handle('file:importPhotos', async (_, competitionId: string, filepath: string) => {
-  const buffer = fs.readFileSync(filepath);
+  const buffer = await fs.promises.readFile(filepath);
   const zip = await JSZip.loadAsync(buffer);
 
   const photos: { license: string; photo: string }[] = [];
@@ -1298,28 +1299,13 @@ ipcMain.handle('file:exportFencersArchive', async (_, competitionId: string, fil
   );
   zip.file('fencers.json', JSON.stringify(fencers));
   const content = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
-  const tmpPath = filepath + '.tmp';
-  try {
-    fs.writeFileSync(tmpPath, content);
-    try {
-      fs.renameSync(tmpPath, filepath);
-    } catch {
-      fs.writeFileSync(filepath, content);
-      try {
-        fs.unlinkSync(tmpPath);
-      } catch {
-        /* ignore */
-      }
-    }
-  } catch {
-    fs.writeFileSync(filepath, content);
-  }
+  await writeFileAtomic(filepath, content);
   return { count: fencers.length };
 });
 
 // Fencer archive (.bpf) import handler
 ipcMain.handle('file:importFencersArchive', async (_, competitionId: string, filepath: string) => {
-  const buffer = fs.readFileSync(filepath);
+  const buffer = await fs.promises.readFile(filepath);
   const zip = await JSZip.loadAsync(buffer);
   const fencersFile = zip.file('fencers.json');
   if (!fencersFile) throw new Error('Format .bpf invalide : fencers.json manquant');
@@ -1334,7 +1320,7 @@ ipcMain.handle('dialog:openFile', async (_, options) => {
   if (!result.canceled && result.filePaths.length > 0) {
     const filePath = result.filePaths[0];
     try {
-      const content = fs.readFileSync(filePath, 'utf-8');
+      const content = await fs.promises.readFile(filePath, 'utf-8');
       return { filePath, content };
     } catch (error) {
       console.error('Error reading file:', error);
@@ -1358,15 +1344,14 @@ ipcMain.handle('window:print', async () => {
 
 // Print via hidden BrowserWindow — opens system print dialog on clean HTML
 ipcMain.handle('file:printHtml', async (_, html: string) => {
-  return new Promise<{ success: boolean; error?: string }>(resolve => {
-    const tmpFile = path.join(os.tmpdir(), `bp-print-${Date.now()}.html`);
-    try {
-      fs.writeFileSync(tmpFile, html, 'utf-8');
-    } catch (e) {
-      resolve({ success: false, error: `Impossible de créer le fichier temporaire: ${e}` });
-      return;
-    }
+  const tmpFile = path.join(os.tmpdir(), `bp-print-${Date.now()}.html`);
+  try {
+    await fs.promises.writeFile(tmpFile, html, 'utf-8');
+  } catch (e) {
+    return { success: false, error: `Impossible de créer le fichier temporaire: ${e}` };
+  }
 
+  return new Promise<{ success: boolean; error?: string }>(resolve => {
     const printWin = new BrowserWindow({
       show: false,
       width: 1200,
@@ -1404,15 +1389,14 @@ ipcMain.handle('file:printHtml', async (_, html: string) => {
 
 // PDF generation via hidden BrowserWindow (propre, sans menus d'application)
 ipcMain.handle('file:printHtmlToPDF', async (_, html: string, outputPath: string) => {
-  return new Promise<{ success: boolean; path?: string; error?: string }>(resolve => {
-    const tmpFile = path.join(os.tmpdir(), `bp-pdf-${Date.now()}.html`);
-    try {
-      fs.writeFileSync(tmpFile, html, 'utf-8');
-    } catch (e) {
-      resolve({ success: false, error: `Impossible de créer le fichier temporaire: ${e}` });
-      return;
-    }
+  const tmpFile = path.join(os.tmpdir(), `bp-pdf-${Date.now()}.html`);
+  try {
+    await fs.promises.writeFile(tmpFile, html, 'utf-8');
+  } catch (e) {
+    return { success: false, error: `Impossible de créer le fichier temporaire: ${e}` };
+  }
 
+  return new Promise<{ success: boolean; path?: string; error?: string }>(resolve => {
     const pdfWin = new BrowserWindow({
       show: false,
       width: 1200,
@@ -1437,18 +1421,14 @@ ipcMain.handle('file:printHtmlToPDF', async (_, html: string, outputPath: string
           preferCSSPageSize: true,
           margins: { marginType: 'none' },
         })
-        .then((data: Buffer) => {
+        .then(async (data: Buffer) => {
           try {
-            fs.writeFileSync(outputPath, data);
+            await fs.promises.writeFile(outputPath, data);
             resolve({ success: true, path: outputPath });
           } catch (writeErr) {
             resolve({ success: false, error: `Impossible d'écrire le PDF: ${writeErr}` });
           } finally {
-            try {
-              fs.unlinkSync(tmpFile);
-            } catch {
-              /* ignore */
-            }
+            fs.promises.unlink(tmpFile).catch(() => {});
             pdfWin.destroy();
           }
         })
@@ -1523,9 +1503,7 @@ ipcMain.handle('remote:startServer', async (_event, competitionId: string, port?
     // Appliquer la config TTS persistée aux tablettes de ce nouveau serveur
     try {
       const ttsPath = path.join(app.getPath('userData'), 'tts-config.json');
-      if (fs.existsSync(ttsPath)) {
-        server.setTtsConfig(JSON.parse(fs.readFileSync(ttsPath, 'utf-8')));
-      }
+      server.setTtsConfig(JSON.parse(await fs.promises.readFile(ttsPath, 'utf-8')));
     } catch {
       /* config TTS optionnelle */
     }
@@ -1907,7 +1885,7 @@ ipcMain.handle('remote:updateLogo', async (_, logo: string | null) => {
   try {
     const logoPath = path.join(app.getPath('userData'), 'logo.dat');
     if (logo) {
-      fs.writeFileSync(logoPath, logo, 'utf-8');
+      await fs.promises.writeFile(logoPath, logo, 'utf-8');
     } else {
       try {
         fs.unlinkSync(logoPath);
@@ -2042,7 +2020,7 @@ ipcMain.handle('remote:setClientKioskMode', async (_, competitionId: string, soc
 ipcMain.handle('remote:setTtsConfig', async (_, config: unknown) => {
   try {
     const ttsPath = path.join(app.getPath('userData'), 'tts-config.json');
-    fs.writeFileSync(ttsPath, JSON.stringify(config), 'utf-8');
+    await fs.promises.writeFile(ttsPath, JSON.stringify(config), 'utf-8');
     for (const { server } of remoteServers.values()) {
       server.setTtsConfig(config as any);
     }
@@ -2055,7 +2033,7 @@ ipcMain.handle('remote:setTtsConfig', async (_, config: unknown) => {
 ipcMain.handle('app:getTtsConfig', async () => {
   const ttsPath = path.join(app.getPath('userData'), 'tts-config.json');
   try {
-    return JSON.parse(fs.readFileSync(ttsPath, 'utf-8'));
+    return JSON.parse(await fs.promises.readFile(ttsPath, 'utf-8'));
   } catch {
     return null;
   }
@@ -2064,7 +2042,7 @@ ipcMain.handle('app:getTtsConfig', async () => {
 ipcMain.handle('app:getLogo', async () => {
   const logoPath = path.join(app.getPath('userData'), 'logo.dat');
   try {
-    return fs.readFileSync(logoPath, 'utf-8');
+    return await fs.promises.readFile(logoPath, 'utf-8');
   } catch {
     return null;
   }
@@ -2249,10 +2227,13 @@ app.whenReady().then(async () => {
   // Autosave every 2 minutes
   let autosaveInterval: NodeJS.Timeout | null = null;
 
+  let autosaveInFlight = false;
   const startAutosave = () => {
     if (autosaveInterval) clearInterval(autosaveInterval);
     autosaveInterval = setInterval(
       async () => {
+        if (autosaveInFlight) return; // éviter l'empilement si la sauvegarde précédente traîne
+        autosaveInFlight = true;
         try {
           await db.saveAsync(); // async I/O — ne bloque pas le main thread
           console.log('Autosave completed at', new Date().toISOString());
@@ -2260,6 +2241,8 @@ app.whenReady().then(async () => {
         } catch (error) {
           console.error('Autosave failed:', error);
           mainWindow?.webContents.send('autosave:failed');
+        } finally {
+          autosaveInFlight = false;
         }
       },
       2 * 60 * 1000

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -114,6 +114,8 @@ export class RemoteScoreServer {
 
   // Rate limiting pour le login : { ip → { count, resetAt } }
   private loginAttempts: Map<string, { count: number; resetAt: number }> = new Map();
+  private readonly LOGIN_ATTEMPTS_MAX_ENTRIES = 1000;
+  private cleanupInterval: NodeJS.Timeout | null = null;
   // Rate limiting pour les soumissions de score : { ip → { count, resetAt } }
   private scoreRateLimiter: Map<string, { count: number; resetAt: number }> = new Map();
   private readonly SCORE_RATE_LIMIT = 30; // soumissions par minute par IP
@@ -161,11 +163,17 @@ export class RemoteScoreServer {
       },
     });
 
-    // Purge des entrées expirées dans loginAttempts toutes les 5 minutes
-    setInterval(() => {
+    // Purge périodique des maps de rate-limiting/debounce (évite la croissance non bornée)
+    this.cleanupInterval = setInterval(() => {
       const now = Date.now();
       for (const [ip, attempt] of this.loginAttempts) {
         if (now >= attempt.resetAt) this.loginAttempts.delete(ip);
+      }
+      for (const [ip, entry] of this.scoreRateLimiter) {
+        if (now >= entry.resetAt) this.scoreRateLimiter.delete(ip);
+      }
+      for (const [key, ts] of this.scoreUpdateDebounce) {
+        if (now - ts > 60_000) this.scoreUpdateDebounce.delete(key);
       }
     }, 5 * 60_000);
 
@@ -473,7 +481,7 @@ export class RemoteScoreServer {
     });
 
     this.app.post('/api/session/stop', (req, res) => {
-      this.session = null;
+      this.stopSession();
       res.json({ success: true });
     });
 
@@ -937,6 +945,11 @@ export class RemoteScoreServer {
           this.loginAttempts.set(ip, { count: 1, resetAt: now + 60_000 });
         }
       } else {
+        // Plafond : éviction de l'entrée la plus ancienne (ordre d'insertion des Map)
+        if (this.loginAttempts.size >= this.LOGIN_ATTEMPTS_MAX_ENTRIES) {
+          const oldest = this.loginAttempts.keys().next().value;
+          if (oldest !== undefined) this.loginAttempts.delete(oldest);
+        }
         this.loginAttempts.set(ip, { count: 1, resetAt: now + 60_000 });
       }
 
@@ -2434,6 +2447,18 @@ export class RemoteScoreServer {
   private scoreUpdateDebounce: Map<string, number> = new Map();
   private readonly SCORE_UPDATE_DEBOUNCE_MS = 200;
 
+  /** Purge l'état de combat par arène (cartons, touches, mort subite…) — fin de session ou réinit des arènes. */
+  private clearArenaCombatState(): void {
+    this.arenaCards.clear();
+    this.arenaTouches.clear();
+    this.arenaExits.clear();
+    this.arenaSuddenDeath.clear();
+    this.arenaOvertimeType.clear();
+    this.arenaWaitingOvertime.clear();
+    this.arenaRefereeSelected.clear();
+    this.scoreUpdateDebounce.clear();
+  }
+
   private handleArenaControl(
     socket: any,
     data: {
@@ -2912,6 +2937,7 @@ export class RemoteScoreServer {
     this.arenaEventBuffer.clear();
     this.arenaMatchQueue.clear();
     this.arenaNextMatchIndex.clear();
+    this.clearArenaCombatState();
 
     for (let i = 1; i <= arenaCount; i++) {
       const arena: Arena = {
@@ -4014,6 +4040,10 @@ export class RemoteScoreServer {
   }
 
   public stop(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
     if (this.server) {
       this.server.close();
       console.log('Remote score server stopped');
@@ -4359,6 +4389,8 @@ export class RemoteScoreServer {
     this.poolSignaturesCache.clear();
     this.sessionMatchScores.clear();
     this.arenaTokens.clear();
+    this.arenaEventBuffer.clear();
+    this.clearArenaCombatState();
   }
 
   public updateStripCount(newCount: number): RemoteSession | null {

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -199,14 +199,15 @@ const FencerListComponent: React.FC<FencerListProps> = ({
 
   const useVirtual = filteredFencers.length > VIRTUAL_THRESHOLD;
 
-  const checkedInCount = useMemo(
-    () => fencers.filter(f => f.status === FencerStatus.CHECKED_IN).length,
-    [fencers]
-  );
-  const notCheckedInCount = useMemo(
-    () => fencers.filter(f => f.status === FencerStatus.NOT_CHECKED_IN).length,
-    [fencers]
-  );
+  const { checkedInCount, notCheckedInCount } = useMemo(() => {
+    let checkedIn = 0;
+    let notCheckedIn = 0;
+    for (const f of fencers) {
+      if (f.status === FencerStatus.CHECKED_IN) checkedIn++;
+      else if (f.status === FencerStatus.NOT_CHECKED_IN) notCheckedIn++;
+    }
+    return { checkedInCount: checkedIn, notCheckedInCount: notCheckedIn };
+  }, [fencers]);
 
   const handleEditSave = (id: string, updates: Partial<Fencer>) => {
     if (onEditFencer) {

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -1040,9 +1040,9 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           </button>
           {showFinishedLog && (
           <div style={LOG_WRAP}>
-            {orderedMatches.finished.map(({ match, index }) => (
+            {orderedMatches.finished.map(({ match }) => (
               <button
-                key={index}
+                key={match.id}
                 onClick={() => setAuditMatchId(match.id)}
                 style={LOG_ITEM}
                 title="Voir le journal du match"

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -14,6 +14,106 @@ interface PoolScoreMatrixProps {
   isLocked?: boolean;
 }
 
+interface ScoreCellProps {
+  rowFencer: Fencer;
+  colFencer: Fencer;
+  abandoned: boolean;
+  score: Score | null;
+  isFlashing: boolean;
+  isLocked: boolean;
+  onCellClick: (rowFencer: Fencer, colFencer: Fencer) => void;
+  onMatchReset?: (rowFencer: Fencer, colFencer: Fencer) => void;
+}
+
+// Cellule mémoïsée : seules les cellules dont le score/flash change re-rendent
+// (la grille est O(n²), un re-rendu global coûte cher sur les grandes poules).
+const ScoreCell = React.memo<ScoreCellProps>(
+  ({ rowFencer, colFencer, abandoned, score, isFlashing, isLocked, onCellClick, onMatchReset }) => {
+    if (abandoned) {
+      return (
+        <div
+          className="pool-cell pool-cell-forfeit"
+          style={{
+            cursor: 'not-allowed',
+            backgroundColor: '#e5e7eb',
+            color: '#9ca3af',
+          }}
+          title="Match non disputé (abandon/forfait)"
+        >
+          <span>-</span>
+        </div>
+      );
+    }
+
+    const cellClass = score
+      ? score.isVictory
+        ? 'pool-cell-victory'
+        : 'pool-cell-defeat'
+      : 'pool-cell-editable';
+
+    return (
+      <div
+        className={`pool-cell ${cellClass} ${isFlashing ? 'pool-cell-flash' : ''}`}
+        onClick={() => !isLocked && onCellClick(rowFencer, colFencer)}
+        onKeyDown={e => {
+          if (!isLocked && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            onCellClick(rowFencer, colFencer);
+          }
+        }}
+        role="button"
+        tabIndex={isLocked ? -1 : 0}
+        aria-label={`${rowFencer.lastName} ${rowFencer.firstName} contre ${colFencer.lastName} ${colFencer.firstName}${
+          score ? ` : ${score.isVictory ? 'victoire ' : 'défaite '}${score.value}` : ', saisir le score'
+        }`}
+        style={{ cursor: isLocked ? 'default' : 'pointer', position: 'relative' }}
+      >
+        {score ? (
+          <>
+            <span>
+              {score.isVictory ? 'V' : ''}
+              {score.value}
+            </span>
+            {onMatchReset && (
+              <button
+                onClick={e => {
+                  e.stopPropagation();
+                  onMatchReset(rowFencer, colFencer);
+                }}
+                title="Annuler ce résultat"
+                aria-label="Annuler ce résultat"
+                className="pool-cell-reset-btn"
+                style={{
+                  position: 'absolute',
+                  top: '1px',
+                  right: '1px',
+                  padding: '0 2px',
+                  fontSize: '0.55rem',
+                  lineHeight: 1,
+                  background: 'rgba(239,68,68,0.15)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  opacity: 0,
+                  transition: 'opacity 0.15s',
+                  color: '#dc2626',
+                }}
+                onMouseEnter={e => (e.currentTarget.style.opacity = '1')}
+                onMouseLeave={e => (e.currentTarget.style.opacity = '0')}
+              >
+                ↺
+              </button>
+            )}
+          </>
+        ) : (
+          <span style={{ color: '#9CA3AF' }}>-</span>
+        )}
+      </div>
+    );
+  }
+);
+ScoreCell.displayName = 'ScoreCell';
+
 const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
   pool,
   isLaserSabre,
@@ -92,6 +192,21 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
 
   const calculateFencerStats = (fencer: Fencer): Stats =>
     statsMap.get(fencer.id) ?? { v: 0, d: 0, td: 0, tr: 0, index: 0, ratio: 0 };
+
+  // Tireurs hors-jeu (abandon/forfait/exclusion) : lookup O(1) dans la grille.
+  const abandonedIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const f of fencers) {
+      if (
+        f.status === FencerStatus.ABANDONED ||
+        f.status === FencerStatus.FORFAIT ||
+        f.status === FencerStatus.EXCLUDED
+      ) {
+        set.add(f.id);
+      }
+    }
+    return set;
+  }, [fencers]);
 
   // Données par ligne précalculées : sparkline + rang. Évite un filtre O(n·m) par rendu.
   const rowDataMap = useMemo(() => {
@@ -284,102 +399,21 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                 return <div key={colFencer.id} className="pool-cell pool-cell-diagonal"></div>;
               }
 
-              const rowFencerAbandoned =
-                rowFencer.status === FencerStatus.ABANDONED ||
-                rowFencer.status === FencerStatus.FORFAIT ||
-                rowFencer.status === FencerStatus.EXCLUDED;
-              const colFencerAbandoned =
-                colFencer.status === FencerStatus.ABANDONED ||
-                colFencer.status === FencerStatus.FORFAIT ||
-                colFencer.status === FencerStatus.EXCLUDED;
-
-              if (rowFencerAbandoned || colFencerAbandoned) {
-                return (
-                  <div
-                    key={colFencer.id}
-                    className="pool-cell pool-cell-forfeit"
-                    style={{
-                      cursor: 'not-allowed',
-                      backgroundColor: '#e5e7eb',
-                      color: '#9ca3af',
-                    }}
-                    title="Match non disputé (abandon/forfait)"
-                  >
-                    <span>-</span>
-                  </div>
-                );
-              }
-
-              const score = getScore(rowFencer, colFencer);
-              const cellClass = score
-                ? score.isVictory
-                  ? 'pool-cell-victory'
-                  : 'pool-cell-defeat'
-                : 'pool-cell-editable';
-
               const cellKey = `${rowFencer.id}-${colFencer.id}`;
               const mirrorKey = `${colFencer.id}-${rowFencer.id}`;
-              const isFlashing = flashCell === cellKey || flashCell === mirrorKey;
 
               return (
-                <div
+                <ScoreCell
                   key={colFencer.id}
-                  className={`pool-cell ${cellClass} ${isFlashing ? 'pool-cell-flash' : ''}`}
-                  onClick={() => !isLocked && onCellClick(rowFencer, colFencer)}
-                  onKeyDown={e => {
-                    if (!isLocked && (e.key === 'Enter' || e.key === ' ')) {
-                      e.preventDefault();
-                      onCellClick(rowFencer, colFencer);
-                    }
-                  }}
-                  role="button"
-                  tabIndex={isLocked ? -1 : 0}
-                  aria-label={`${rowFencer.lastName} ${rowFencer.firstName} contre ${colFencer.lastName} ${colFencer.firstName}${
-                    score ? ` : ${score.isVictory ? 'victoire ' : 'défaite '}${score.value}` : ', saisir le score'
-                  }`}
-                  style={{ cursor: isLocked ? 'default' : 'pointer', position: 'relative' }}
-                >
-                  {score ? (
-                    <>
-                      <span>
-                        {score.isVictory ? 'V' : ''}
-                        {score.value}
-                      </span>
-                      {onMatchReset && (
-                        <button
-                          onClick={e => {
-                            e.stopPropagation();
-                            onMatchReset(rowFencer, colFencer);
-                          }}
-                          title="Annuler ce résultat"
-                          aria-label="Annuler ce résultat"
-                          className="pool-cell-reset-btn"
-                          style={{
-                            position: 'absolute',
-                            top: '1px',
-                            right: '1px',
-                            padding: '0 2px',
-                            fontSize: '0.55rem',
-                            lineHeight: 1,
-                            background: 'rgba(239,68,68,0.15)',
-                            border: 'none',
-                            borderRadius: '2px',
-                            cursor: 'pointer',
-                            opacity: 0,
-                            transition: 'opacity 0.15s',
-                            color: '#dc2626',
-                          }}
-                          onMouseEnter={e => (e.currentTarget.style.opacity = '1')}
-                          onMouseLeave={e => (e.currentTarget.style.opacity = '0')}
-                        >
-                          ↺
-                        </button>
-                      )}
-                    </>
-                  ) : (
-                    <span style={{ color: '#9CA3AF' }}>-</span>
-                  )}
-                </div>
+                  rowFencer={rowFencer}
+                  colFencer={colFencer}
+                  abandoned={abandonedIds.has(rowFencer.id) || abandonedIds.has(colFencer.id)}
+                  score={getScore(rowFencer, colFencer)}
+                  isFlashing={flashCell === cellKey || flashCell === mirrorKey}
+                  isLocked={isLocked}
+                  onCellClick={onCellClick}
+                  onMatchReset={onMatchReset}
+                />
               );
             })}
 

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -314,12 +314,13 @@ export function generatePoolHTML(pool: Pool, options: PoolExportOptions, templat
       </tr>`;
   }).join('');
 
+  const matchIndexById = new Map(matches.map((m, i) => [m.id, i + 1]));
   const pending = matches.filter(m => m.status !== MatchStatus.FINISHED);
   const pendingSection = pending.length === 0 ? '' : `
     <div class="section-label">Matchs à jouer (${pending.length})</div>
     <div class="match-grid">
       ${pending.map(m => {
-        const idx = matches.indexOf(m) + 1;
+        const idx = matchIndexById.get(m.id) ?? 0;
         const rA = rankMap.get(m.fencerA?.id ?? '')?.rank ?? '?';
         const rB = rankMap.get(m.fencerB?.id ?? '')?.rank ?? '?';
         return `<div class="match-item match-pending">${idx}. (${rA}) ${m.fencerA?.lastName ?? '?'} — (${rB}) ${m.fencerB?.lastName ?? '?'}</div>`;
@@ -331,7 +332,7 @@ export function generatePoolHTML(pool: Pool, options: PoolExportOptions, templat
     <div class="section-label" style="margin-top:4mm">Résultats (${finished.length})</div>
     <div class="match-grid match-grid-2col">
       ${finished.map(m => {
-        const idx = matches.indexOf(m) + 1;
+        const idx = matchIndexById.get(m.id) ?? 0;
         const sA = m.scoreA?.isVictory ? `V${m.scoreA.value}` : `${m.scoreA?.value ?? 0}`;
         const sB = m.scoreB?.isVictory ? `V${m.scoreB.value}` : `${m.scoreB?.value ?? 0}`;
         return `<div class="match-item match-done">${idx}. ${m.fencerA?.lastName ?? '?'} <b>${sA}–${sB}</b> ${m.fencerB?.lastName ?? '?'}</div>`;
@@ -523,8 +524,6 @@ export async function exportMultiplePoolsToPDF(
   }
 }
 
-export const exportOptimizedPoolToPDF = exportPoolToPDF;
-
 // ─── Export Tableau Élimination Directe ──────────────────────────────────────
 
 export interface TableauMatchForPDF {
@@ -542,6 +541,11 @@ export interface TableauMatchForPDF {
 
 export { MAX_MATCHES_PER_PAGE_TABLEAU } from './pdfConstants';
 import { MAX_MATCHES_PER_PAGE_TABLEAU } from './pdfConstants';
+
+/** Matchs réels (non-exempts, deux tireurs assignés). */
+function realMatches(matches: TableauMatchForPDF[]): TableauMatchForPDF[] {
+  return matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
+}
 
 function getTableauRoundName(round: number): string {
   const names: Record<number, string> = {
@@ -565,7 +569,7 @@ export function generateTableauHTML(
   template?: PdfTemplate,
   showScores = false
 ): string {
-  const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
+  const real = realMatches(matches);
   const now = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
 
   const renderMatchCard = (match: TableauMatchForPDF, num: number): string => {
@@ -870,7 +874,7 @@ export async function exportTableauToPDF(
   logoBase64?: string,
   template?: PdfTemplate
 ): Promise<void> {
-  const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
+  const real = realMatches(matches);
   if (real.length === 0) {
     throw new Error('Aucun match à exporter (tous sont des exempts ou sans tireurs assignés)');
   }
@@ -886,7 +890,7 @@ export async function printTableauHTML(
   logoBase64?: string,
   template?: PdfTemplate
 ): Promise<void> {
-  const real = matches.filter(m => !m.isBye && m.fencerA && m.fencerB);
+  const real = realMatches(matches);
   if (real.length === 0) {
     throw new Error('Aucun match à imprimer (tous sont des exempts ou sans tireurs assignés)');
   }

--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -425,6 +425,7 @@ export function distributeFencersToPoolsSerpentine(
     );
   }
   const pools: Fencer[][] = Array.from({ length: poolCount }, () => []);
+  const indexes = createPoolIndexes(pools);
 
   // Trier les tireurs par classement (meilleur classement = premier, non-classés = derniers)
   const pending = [...fencers].sort((a, b) => (a.ranking ?? 99999) - (b.ranking ?? 99999));
@@ -441,14 +442,16 @@ export function distributeFencersToPoolsSerpentine(
     let chosen = 0;
     if (separation.byClub || separation.byRegion || separation.byNation) {
       for (let i = 0; i < pending.length; i++) {
-        if (!hasConflictWith(pending[i], pool, separation)) {
+        if (!hasConflictWith(pending[i], indexes[poolIndex], separation)) {
           chosen = i;
           break;
         }
       }
     }
 
-    pool.push(pending.splice(chosen, 1)[0]);
+    const picked = pending.splice(chosen, 1)[0];
+    pool.push(picked);
+    indexAddFencer(indexes[poolIndex], picked);
 
     poolIndex += direction;
     if (poolIndex >= poolCount) {
@@ -461,7 +464,7 @@ export function distributeFencersToPoolsSerpentine(
   }
 
   // Rééquilibrer les poules pour assurer un nombre égal (ou presque égal) de tireurs
-  rebalancePools(pools, separation);
+  rebalancePools(pools, separation, indexes);
 
   // Tirage au sort des positions dans la poule (FIE §3)
   for (const pool of pools) {
@@ -475,32 +478,60 @@ export function distributeFencersToPoolsSerpentine(
 }
 
 /**
+ * Index multiensemble (valeur → occurrences) des clubs/régions/nations d'une poule,
+ * pour vérifier les conflits en O(1) au lieu de scanner la poule à chaque test.
+ * Les nations conservent les valeurs vides/undefined (égalité brute, cf. rééquilibrage).
+ */
+interface PoolConflictIndex {
+  clubs: Map<string, number>;
+  regions: Map<string, number>;
+  nations: Map<string | undefined, number>;
+}
+
+function indexAdd<K>(map: Map<K, number>, key: K): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function indexRemove<K>(map: Map<K, number>, key: K): void {
+  const count = map.get(key);
+  if (count === undefined) return;
+  if (count > 1) map.set(key, count - 1);
+  else map.delete(key);
+}
+
+function indexAddFencer(index: PoolConflictIndex, fencer: Fencer): void {
+  if (fencer.club) indexAdd(index.clubs, fencer.club);
+  if (fencer.region) indexAdd(index.regions, fencer.region);
+  indexAdd(index.nations, fencer.nationality);
+}
+
+function indexRemoveFencer(index: PoolConflictIndex, fencer: Fencer): void {
+  if (fencer.club) indexRemove(index.clubs, fencer.club);
+  if (fencer.region) indexRemove(index.regions, fencer.region);
+  indexRemove(index.nations, fencer.nationality);
+}
+
+function createPoolIndexes(pools: Fencer[][]): PoolConflictIndex[] {
+  return pools.map(pool => {
+    const index: PoolConflictIndex = { clubs: new Map(), regions: new Map(), nations: new Map() };
+    for (const fencer of pool) indexAddFencer(index, fencer);
+    return index;
+  });
+}
+
+/**
  * Vérifie si un tireur crée un conflit (club/région/nation) avec une poule existante.
  */
 function hasConflictWith(
   fencer: Fencer,
-  pool: Fencer[],
+  index: PoolConflictIndex,
   separation: { byClub: boolean; byRegion: boolean; byNation: boolean }
 ): boolean {
-  return pool.some(existing => {
-    if (separation.byClub && fencer.club && fencer.club !== '' && fencer.club === existing.club)
-      return true;
-    if (
-      separation.byRegion &&
-      fencer.region &&
-      fencer.region !== '' &&
-      fencer.region === existing.region
-    )
-      return true;
-    if (
-      separation.byNation &&
-      fencer.nationality &&
-      fencer.nationality !== '' &&
-      fencer.nationality === existing.nationality
-    )
-      return true;
-    return false;
-  });
+  if (separation.byClub && fencer.club && index.clubs.has(fencer.club)) return true;
+  if (separation.byRegion && fencer.region && index.regions.has(fencer.region)) return true;
+  if (separation.byNation && fencer.nationality && index.nations.has(fencer.nationality))
+    return true;
+  return false;
 }
 
 /**
@@ -509,7 +540,8 @@ function hasConflictWith(
  */
 function rebalancePools(
   pools: Fencer[][],
-  separation: { byClub: boolean; byRegion: boolean; byNation: boolean }
+  separation: { byClub: boolean; byRegion: boolean; byNation: boolean },
+  indexes: PoolConflictIndex[] = createPoolIndexes(pools)
 ): void {
   const poolCount = pools.length;
   if (poolCount === 0) return;
@@ -517,7 +549,6 @@ function rebalancePools(
   // Calculer la taille idéale
   const totalFencers = pools.reduce((sum, pool) => sum + pool.length, 0);
   const idealSize = Math.floor(totalFencers / poolCount);
-  const maxSize = idealSize + (totalFencers % poolCount > 0 ? 1 : 0);
 
   let rebalanced = true;
   let iterations = 0;
@@ -530,15 +561,15 @@ function rebalancePools(
     // Trouver les poules sources (> idealSize) et sous-chargées (< idealSize)
     // On utilise idealSize comme seuil source (pas maxSize) pour corriger les cas où
     // toutes les poules sont à maxSize mais certaines restent sous idealSize
-    const overloaded = pools
-      .map((pool, idx) => ({ idx, pool, size: pool.length }))
-      .filter(p => p.size > idealSize)
-      .sort((a, b) => b.size - a.size);
-
-    const underloaded = pools
-      .map((pool, idx) => ({ idx, pool, size: pool.length }))
-      .filter(p => p.size < idealSize)
-      .sort((a, b) => a.size - b.size);
+    const overloaded: { idx: number; pool: Fencer[]; size: number }[] = [];
+    const underloaded: { idx: number; pool: Fencer[]; size: number }[] = [];
+    pools.forEach((pool, idx) => {
+      const size = pool.length;
+      if (size > idealSize) overloaded.push({ idx, pool, size });
+      else if (size < idealSize) underloaded.push({ idx, pool, size });
+    });
+    overloaded.sort((a, b) => b.size - a.size);
+    underloaded.sort((a, b) => a.size - b.size);
 
     if (overloaded.length === 0 || underloaded.length === 0) break;
 
@@ -546,27 +577,25 @@ function rebalancePools(
     for (const source of overloaded) {
       for (const target of underloaded) {
         if (source.size <= idealSize || target.size >= idealSize) continue;
+        const targetIndex = indexes[target.idx];
 
         // Chercher un tireur à déplacer qui ne crée pas de conflit
         for (let i = source.pool.length - 1; i >= 0; i--) {
           const fencer = source.pool[i];
 
           // Vérifier que le déplacement ne crée pas de conflit sur les critères actifs
-          const clubVal = fencer.club ?? '';
-          const regionVal = fencer.region ?? '';
+          // (nation : égalité brute, y compris valeurs vides — comportement historique)
           const wouldCreateConflict =
-            (separation.byClub &&
-              clubVal !== '' &&
-              target.pool.some(f => (f.club ?? '') === clubVal)) ||
-            (separation.byRegion &&
-              regionVal !== '' &&
-              target.pool.some(f => (f.region ?? '') === regionVal)) ||
-            (separation.byNation && target.pool.some(f => f.nationality === fencer.nationality));
+            (separation.byClub && !!fencer.club && targetIndex.clubs.has(fencer.club)) ||
+            (separation.byRegion && !!fencer.region && targetIndex.regions.has(fencer.region)) ||
+            (separation.byNation && targetIndex.nations.has(fencer.nationality));
 
           if (!wouldCreateConflict) {
             // Déplacer le tireur
             source.pool.splice(i, 1);
             target.pool.push(fencer);
+            indexRemoveFencer(indexes[source.idx], fencer);
+            indexAddFencer(targetIndex, fencer);
             source.size--;
             target.size++;
             rebalanced = true;


### PR DESCRIPTION
## Optimisations

### Lot A — algorithmes & React
- `poolCalculations.ts` : conflits club/région/nation via index `Map` O(1) (serpentine + rééquilibrage) au lieu de scans `.some()` répétés ; catégorisation des poules en une passe. Comportement identique (25 tests verts).
- `pdfExport.ts` : index des matchs précalculé (`Map`) au lieu de `indexOf` O(n) par match ; helper `realMatches()` factorisé ; alias mort `exportOptimizedPoolToPDF` supprimé (doc mise à jour).
- `PoolScoreMatrix` : cellule extraite en composant `React.memo` — la grille O(n²) ne re-rend plus entièrement à chaque flash/score ; statuts abandon précalculés en `Set`.
- `PoolView` : `key={match.id}` au lieu de `key={index}` (journal des matchs terminés).
- `FencerList` : comptages check-in fusionnés en une passe.

### Lot B — serveur distant & main process
- `remoteScoreServer.ts` : purge de l'état de combat par arène (cartons, touches, mort subite, débounce) en fin de session et à la réinit des arènes ; nettoyage périodique étendu à `scoreRateLimiter`/`scoreUpdateDebounce` ; plafond 1000 entrées sur `loginAttempts` (anti-DoS mémoire) ; `clearInterval` au `stop()` ; `/api/session/stop` passe par `stopSession()`.
- `main.ts` : handlers IPC fichiers en `fs.promises` (print/PDF, photos, archives .bpf, logo, TTS, dialogues) — plus de gel UI sur gros fichiers ; `writeFileAtomic` factorisé ; garde anti-empilement sur l'autosave.

### Hors périmètre (acté)
Découpage TableauView/CompetitionView/pdfExport, broadcast deltas Socket.IO, virtualisation Kiosk.

### Vérification
- `type-check` ✅, `lint` 0 erreur ✅
- `poolCalculations` 25/25 ✅ ; suite complète : 937 verts, 23 échecs **pré-existants** (mocks vitest `remoteScoreServer.test.ts`, `OfflineStatus`, `refereeManager` — identiques avant modifications)

https://claude.ai/code/session_01JuM5bKKEiRGN2T1U99iNcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuM5bKKEiRGN2T1U99iNcY)_