### PR TITLE
perf: requêtes N+1 supprimées, cache prepared statements, index composites, persist différé

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -33,6 +33,9 @@ import { ALL_MIGRATIONS } from './migrations/migrations';
 export class DatabaseManager {
   private db: Database.Database | null = null;
   private dbPath: string;
+  // Cache des prepared statements : évite de re-parser le SQL à chaque appel.
+  // SQLite re-prépare automatiquement un statement si le schéma change.
+  private stmtCache = new Map<string, Database.Statement>();
 
   constructor(dbPath?: string) {
     this.dbPath = dbPath || path.join(process.cwd(), 'bellepoule.db');
@@ -48,6 +51,7 @@ export class DatabaseManager {
     const dir = path.dirname(this.dbPath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
+    this.stmtCache.clear();
     this.db = new Database(this.dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('foreign_keys = ON');
@@ -59,19 +63,29 @@ export class DatabaseManager {
       this.saveSync();
       this.db.close();
       this.db = null;
+      this.stmtCache.clear();
     }
   }
 
+  private prepare(sql: string): Database.Statement {
+    let stmt = this.stmtCache.get(sql);
+    if (!stmt) {
+      stmt = this.db!.prepare(sql);
+      this.stmtCache.set(sql, stmt);
+    }
+    return stmt;
+  }
+
   private run(sql: string, params: unknown[] = []): Database.RunResult {
-    return this.db!.prepare(sql).run(...params);
+    return this.prepare(sql).run(...params);
   }
 
   private queryOne<T>(sql: string, params: unknown[] = []): T | null {
-    return (this.db!.prepare(sql).get(...params) as T) ?? null;
+    return (this.prepare(sql).get(...params) as T) ?? null;
   }
 
   private queryAll<T>(sql: string, params: unknown[] = []): T[] {
-    return this.db!.prepare(sql).all(...params) as T[];
+    return this.prepare(sql).all(...params) as T[];
   }
 
   // Toute mutation multi-statements doit passer ici : rollback automatique si une étape échoue.
@@ -186,6 +200,10 @@ export class DatabaseManager {
     if (!this.db) throw new Error('Database not open');
     const row = this.queryOne<any>('SELECT * FROM competitions WHERE id = ?', [id]);
     if (!row) return null;
+    return this.parseCompetitionRow(row);
+  }
+
+  private parseCompetitionRow(row: any): Competition {
     try {
       let settings: CompetitionSettings = {
         defaultPoolMaxScore: 5,
@@ -237,8 +255,8 @@ export class DatabaseManager {
 
   public getAllCompetitions(): Competition[] {
     if (!this.db) throw new Error('Database not open');
-    const rows = this.queryAll<{ id: string }>('SELECT id FROM competitions ORDER BY date DESC');
-    return rows.map(r => this.getCompetition(r.id)).filter(Boolean) as Competition[];
+    const rows = this.queryAll<any>('SELECT * FROM competitions ORDER BY date DESC');
+    return rows.map(r => this.parseCompetitionRow(r));
   }
 
   public deleteCompetition(id: string): void {
@@ -712,6 +730,11 @@ export class DatabaseManager {
   public getMatchesByPool(poolId: string): Match[] {
     if (!this.db) throw new Error('Database not open');
     const matchRows = this.queryAll<any>('SELECT * FROM matches WHERE pool_id = ? ORDER BY number', [poolId]);
+    return this.hydrateMatchRows(matchRows);
+  }
+
+  // Hydratation batch : charge tous les tireurs/arbitres en 2 requêtes au lieu d'un getMatch() par ligne.
+  private hydrateMatchRows(matchRows: any[]): Match[] {
     if (matchRows.length === 0) return [];
 
     const fencerIds = new Set<string>();
@@ -805,11 +828,11 @@ export class DatabaseManager {
     }
     if (poolIds.length === 0) return [];
     const placeholders = poolIds.map(() => '?').join(',');
-    const matchIds = this.queryAll<{ id: string }>(
-      `SELECT m.id FROM matches m JOIN pools p ON m.pool_id = p.id WHERE m.pool_id IN (${placeholders}) AND m.status IN ('not_started', 'in_progress') ORDER BY p.number, m.number`,
+    const matchRows = this.queryAll<any>(
+      `SELECT m.* FROM matches m JOIN pools p ON m.pool_id = p.id WHERE m.pool_id IN (${placeholders}) AND m.status IN ('not_started', 'in_progress') ORDER BY p.number, m.number`,
       poolIds
-    ).map(r => r.id);
-    return matchIds.map(id => this.getMatch(id)).filter(Boolean) as Match[];
+    );
+    return this.hydrateMatchRows(matchRows);
   }
 
   public getAllPendingMatchesFromPools(competitionId: string): Match[] {
@@ -826,18 +849,18 @@ export class DatabaseManager {
     }
     if (poolIds.length === 0) return [];
     const placeholders = poolIds.map(() => '?').join(',');
-    const matchIds = this.queryAll<{ id: string }>(
-      `SELECT m.id FROM matches m JOIN pools p ON m.pool_id = p.id WHERE m.pool_id IN (${placeholders}) AND m.status IN ('not_started', 'in_progress') ORDER BY p.number, m.number`,
+    const matchRows = this.queryAll<any>(
+      `SELECT m.* FROM matches m JOIN pools p ON m.pool_id = p.id WHERE m.pool_id IN (${placeholders}) AND m.status IN ('not_started', 'in_progress') ORDER BY p.number, m.number`,
       poolIds
-    ).map(r => r.id);
-    return matchIds.map(id => this.getMatch(id)).filter(Boolean) as Match[];
+    );
+    return this.hydrateMatchRows(matchRows);
   }
 
   public getPendingMatchesDirectly(competitionId: string): Match[] {
     if (!this.db) throw new Error('Database not open');
     try {
-      const matchIds = this.queryAll<{ id: string }>(
-        `SELECT DISTINCT m.id FROM matches m
+      const matchRows = this.queryAll<any>(
+        `SELECT m.* FROM matches m
          LEFT JOIN pools p ON m.pool_id = p.id
          INNER JOIN fencers fA ON m.fencer_a_id = fA.id
          INNER JOIN fencers fB ON m.fencer_b_id = fB.id
@@ -845,42 +868,31 @@ export class DatabaseManager {
          AND m.status IN ('not_started', 'in_progress')
          ORDER BY p.number, m.number`,
         [competitionId, competitionId]
-      ).map(r => r.id);
-      if (matchIds.length > 0) {
-        return matchIds.map(id => this.getMatch(id)).filter(Boolean) as Match[];
+      );
+      if (matchRows.length > 0) {
+        return this.hydrateMatchRows(matchRows);
       }
     } catch (e) {
       console.error('[Database] getPendingMatchesDirectly: Error:', e);
     }
     try {
-      return this.queryAll<{ id: string }>(
-        'SELECT id FROM matches WHERE status IN (?, ?)',
+      const compFencers = new Set(
+        this.queryAll<{ id: string }>('SELECT id FROM fencers WHERE competition_id = ?', [competitionId]).map(
+          r => r.id
+        )
+      );
+      const matchRows = this.queryAll<any>(
+        'SELECT * FROM matches WHERE status IN (?, ?)',
         ['not_started', 'in_progress']
-      )
-        .map(r => this.getMatch(r.id))
-        .filter(m => {
-          if (!m?.fencerA || !m?.fencerB) return false;
-          const a = this.getFencerCompetition(m.fencerA.id);
-          const b = this.getFencerCompetition(m.fencerB.id);
-          return a === competitionId || b === competitionId;
-        }) as Match[];
+      );
+      return this.hydrateMatchRows(matchRows).filter(m => {
+        if (!m.fencerA || !m.fencerB) return false;
+        return compFencers.has(m.fencerA.id) || compFencers.has(m.fencerB.id);
+      });
     } catch (e) {
       console.error('[Database] getPendingMatchesDirectly: Fallback error:', e);
     }
     return [];
-  }
-
-  private getFencerCompetition(fencerId: string): string | null {
-    if (!this.db) return null;
-    try {
-      const row = this.queryOne<{ competition_id: string }>(
-        'SELECT competition_id FROM fencers WHERE id = ?',
-        [fencerId]
-      );
-      return row?.competition_id ?? null;
-    } catch {
-      return null;
-    }
   }
 
   public getPoolCount(competitionId: string): number {

--- a/src/database/migrations/migrations.ts
+++ b/src/database/migrations/migrations.ts
@@ -304,4 +304,16 @@ export const ALL_MIGRATIONS: Migration[] = [
       try { db.run(`ALTER TABLE pools ADD COLUMN referee_id TEXT`); } catch { /* */ }
     },
   },
+  {
+    version: 10,
+    description: 'Index composites pour les requêtes fréquentes (matchs en attente, stats par tireur, export tableau)',
+    up(db) {
+      db.run(`CREATE INDEX IF NOT EXISTS idx_matches_pool_status ON matches(pool_id, status)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_matches_fencer_a ON matches(fencer_a_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_matches_fencer_b ON matches(fencer_b_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_matches_table_round ON matches(table_id, round)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_matches_referee ON matches(referee_id)`);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_referees_competition ON referees(competition_id)`);
+    },
+  },
 ];

--- a/src/features/penalties/hooks/usePenaltyStore.ts
+++ b/src/features/penalties/hooks/usePenaltyStore.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_PENALTY_CONFIG,
   PenaltyConfig,
 } from '../types/penalty.types';
+import { createDebouncedJSONStorage } from '../../../shared/utils/debouncedStorage';
 
 interface PenaltyState {
   penalties: Penalty[];
@@ -224,6 +225,8 @@ export const usePenaltyStore = create<PenaltyState & PenaltyActions>()(
         }),
         {
           name: 'penalty-store',
+          // Écriture différée : un carton en plein match ne doit pas resérialiser tout l'historique.
+          storage: createDebouncedJSONStorage(500),
           partialize: state => ({
             penalties: state.penalties,
             config: state.config,

--- a/src/features/pools/hooks/usePoolStore.ts
+++ b/src/features/pools/hooks/usePoolStore.ts
@@ -5,6 +5,7 @@ import { useShallow } from 'zustand/shallow';
 import { PoolState, PoolActions, PoolGenerationConfig, ScoreUpdateDTO } from '../types/pool.types';
 import { PoolService } from '../services/poolService';
 import { MatchStatus } from '../../../shared/types';
+import { createDebouncedJSONStorage } from '../../../shared/utils/debouncedStorage';
 
 const service = new PoolService();
 
@@ -118,6 +119,8 @@ export const usePoolStore = create<PoolState & PoolActions>()(
         }),
         {
           name: 'pool-store',
+          // Écriture différée : chaque saisie de score déclenchait un stringify de toutes les poules.
+          storage: createDebouncedJSONStorage(500),
           partialize: state => ({
             pools: state.pools,
             overallRanking: state.overallRanking,

--- a/src/shared/utils/debouncedStorage.ts
+++ b/src/shared/utils/debouncedStorage.ts
@@ -1,0 +1,69 @@
+/**
+ * BellePoule Modern - Storage localStorage à écriture différée pour zustand/persist
+ * Évite un JSON.stringify de tout le state à chaque action sur les stores
+ * très sollicités (saisie de scores, cartons). La DB reste la source de vérité ;
+ * ce cache ne sert qu'à la réhydratation de l'UI.
+ * Licensed under GPL-3.0
+ */
+
+import { PersistStorage, StorageValue } from 'zustand/middleware';
+
+export function createDebouncedJSONStorage<S>(delayMs = 500): PersistStorage<S> {
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  const pending = new Map<string, StorageValue<S>>();
+
+  const flush = (name: string): void => {
+    const value = pending.get(name);
+    if (value === undefined) return;
+    pending.delete(name);
+    try {
+      localStorage.setItem(name, JSON.stringify(value));
+    } catch {
+      /* quota plein ou stockage indisponible : l'état reste en mémoire */
+    }
+  };
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('beforeunload', () => {
+      for (const [name, timer] of timers) {
+        clearTimeout(timer);
+        flush(name);
+      }
+      timers.clear();
+    });
+  }
+
+  return {
+    getItem: name => {
+      // Une écriture en attente est plus fraîche que le localStorage.
+      const queued = pending.get(name);
+      if (queued !== undefined) return queued;
+      const raw = localStorage.getItem(name);
+      if (!raw) return null;
+      try {
+        return JSON.parse(raw) as StorageValue<S>;
+      } catch {
+        return null;
+      }
+    },
+    setItem: (name, value) => {
+      pending.set(name, value);
+      const existing = timers.get(name);
+      if (existing) clearTimeout(existing);
+      timers.set(
+        name,
+        setTimeout(() => {
+          timers.delete(name);
+          flush(name);
+        }, delayMs)
+      );
+    },
+    removeItem: name => {
+      const timer = timers.get(name);
+      if (timer) clearTimeout(timer);
+      timers.delete(name);
+      pending.delete(name);
+      localStorage.removeItem(name);
+    },
+  };
+}


### PR DESCRIPTION
## Perf DB (`src/database/`)

- **`getAllCompetitions()`** : 1 requête au lieu de N+1. Parsing factorisé dans `parseCompetitionRow()`.
- **`getPendingMatches()` / `getAllPendingMatchesFromPools()` / `getPendingMatchesDirectly()`** : hydratation batch via `hydrateMatchRows()` (2 requêtes pour tireurs + arbitres) au lieu d'un `getMatch()` par ligne (qui faisait 3 requêtes chacun). Sur 100 matchs en attente : ~300 requêtes → 3.
- **Cache de prepared statements** dans `DatabaseManager` : `prepare()` n'est plus appelé à chaque `run`/`queryOne`/`queryAll`. SQLite re-prépare automatiquement si le schéma change ; cache vidé à l'open/close.
- **Migration 10** : index `matches(pool_id, status)`, `matches(fencer_a_id)`, `matches(fencer_b_id)`, `matches(table_id, round)`, `matches(referee_id)`, `referees(competition_id)`. Couvre les requêtes pending, les stats par tireur (`getFencerCompetitionStats`) et l'export tableau.

## Perf renderer

- **`createDebouncedJSONStorage()`** (`src/shared/utils/debouncedStorage.ts`) : storage zustand/persist à écriture différée (500 ms, flush sur `beforeunload`). Appliqué à `pool-store` et `penalty-store` — chaque saisie de score déclenchait un `JSON.stringify` de toutes les poules. La DB reste la source de vérité, ce cache ne sert qu'à la réhydratation UI.

## Non modifié (volontaire)

- Broadcasts Socket.IO `io.emit` (`logo:update`, `kiosk:note`, `broadcastCommand`…) : globaux par conception (config d'affichage pour tous les écrans). Dashboard déjà scopé en room.
- `useCurrentPool` sans `useShallow` : retourne une référence directe, `Object.is` suffit.

## Vérification

- `npm run type-check` ✅
- `npm run test:run` : 961 tests, 87 fichiers ✅
- `npm run lint` : 0 erreur (warnings préexistants)

https://claude.ai/code/session_018KtHjQA9sSMdt1axf3oiES

---
_Generated by [Claude Code](https://claude.ai/code/session_018KtHjQA9sSMdt1axf3oiES)_