### PR TITLE
chore: sync version package-lock.json (build 1167)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.1163",
+  "version": "1.0.3-build.1167",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.1163",
+      "version": "1.0.3-build.1167",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {


### PR DESCRIPTION
Sync de version du lockfile avec `package.json` (1.0.3-build.1163 → 1167), généré par `npm install`. Aucun changement de dépendance.

https://claude.ai/code/session_018KtHjQA9sSMdt1axf3oiES

---
_Generated by [Claude Code](https://claude.ai/code/session_018KtHjQA9sSMdt1axf3oiES)_