### PR TITLE
Fix illegible arena card header in light theme

### DIFF
--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -1738,8 +1738,13 @@ body {
   justify-content: space-between;
   padding: 0.5rem 0.75rem;
   background: var(--color-surface-raised, #1e293b);
+  color: #f1f5f9;
   border-bottom: 1px solid var(--color-border);
   border-radius: var(--border-radius) var(--border-radius) 0 0;
+}
+
+.arena-url-header strong {
+  color: #f1f5f9;
 }
 
 .arena-theme-picker {


### PR DESCRIPTION
En-tête carte piste (saisie distante) : fond foncé fixe, texte suivait le thème → illisible en thème clair. Texte forcé clair.

https://claude.ai/code/session_0177vdvgBjhRS9eXctpmbcA8

---
_Generated by [Claude Code](https://claude.ai/code/session_0177vdvgBjhRS9eXctpmbcA8)_