### PR TITLE
Signature des combattants sur tablette après chaque match du tableau

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -213,6 +213,7 @@ export class DatabaseManager {
         poolRounds: 1,
         hasDirectElimination: true,
         thirdPlaceMatch: true,
+        signTableauMatches: true,
         manualRanking: false,
         defaultRanking: 0,
         randomScore: false,
@@ -1788,6 +1789,37 @@ export class DatabaseManager {
       `SELECT fencer_id, signature_data FROM pool_signatures WHERE pool_id = ?`,
       [poolId]
     ).map(row => ({ fencerId: row.fencer_id, signatureData: row.signature_data }));
+  }
+
+  // ── Signatures des matchs de tableau (élimination directe) ──
+  public saveDEMatchSignature(matchId: string, fencerId: string, signatureData: string): void {
+    if (!this.db) throw new Error('Database not open');
+    this.run(
+      `INSERT INTO de_match_signatures (id, match_id, fencer_id, signature_data, signed_at) VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(match_id, fencer_id) DO UPDATE SET signature_data = excluded.signature_data, signed_at = excluded.signed_at`,
+      [uuidv4(), matchId, fencerId, signatureData, new Date().toISOString()]
+    );
+  }
+
+  public getDEMatchSignatures(matchId: string): { fencerId: string; signatureData: string }[] {
+    if (!this.db) throw new Error('Database not open');
+    return this.queryAll<{ fencer_id: string; signature_data: string }>(
+      `SELECT fencer_id, signature_data FROM de_match_signatures WHERE match_id = ?`,
+      [matchId]
+    ).map(row => ({ fencerId: row.fencer_id, signatureData: row.signature_data }));
+  }
+
+  /** Signatures de tableau pour un ensemble de matchs (pour export PDF). */
+  public getDEMatchSignaturesByMatchIds(
+    matchIds: string[]
+  ): { matchId: string; fencerId: string; signatureData: string }[] {
+    if (!this.db) throw new Error('Database not open');
+    if (matchIds.length === 0) return [];
+    const placeholders = matchIds.map(() => '?').join(',');
+    return this.queryAll<{ match_id: string; fencer_id: string; signature_data: string }>(
+      `SELECT match_id, fencer_id, signature_data FROM de_match_signatures WHERE match_id IN (${placeholders})`,
+      matchIds
+    ).map(row => ({ matchId: row.match_id, fencerId: row.fencer_id, signatureData: row.signature_data }));
   }
 }
 

--- a/src/database/migrations/migrations.ts
+++ b/src/database/migrations/migrations.ts
@@ -316,4 +316,21 @@ export const ALL_MIGRATIONS: Migration[] = [
       db.run(`CREATE INDEX IF NOT EXISTS idx_referees_competition ON referees(competition_id)`);
     },
   },
+  {
+    version: 11,
+    description: 'Table de_match_signatures pour signatures des matchs de tableau (élimination directe)',
+    up(db) {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS de_match_signatures (
+          id TEXT PRIMARY KEY,
+          match_id TEXT NOT NULL,
+          fencer_id TEXT NOT NULL,
+          signature_data TEXT NOT NULL,
+          signed_at TEXT NOT NULL,
+          UNIQUE(match_id, fencer_id)
+        )
+      `);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_de_sigs_match ON de_match_signatures(match_id)`);
+    },
+  },
 ];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1102,6 +1102,9 @@ ipcMain.handle('db:getPoolsByPhase', async (_, phaseId) => {
 ipcMain.handle('db:getPoolSignatures', async (_, poolId: string) => {
   return db.getPoolSignatures(poolId);
 });
+ipcMain.handle('db:getDEMatchSignaturesByMatchIds', async (_, matchIds: string[]) => {
+  return db.getDEMatchSignaturesByMatchIds(matchIds);
+});
 
 // Phase handlers
 ipcMain.handle('db:createPhase', async (_, competitionId, type, order, name) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -200,6 +200,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
     getPoolsByPhase: (phaseId: string) => ipcRenderer.invoke('db:getPoolsByPhase', phaseId),
     getPoolSignatures: (poolId: string) => ipcRenderer.invoke('db:getPoolSignatures', poolId),
+    getDEMatchSignaturesByMatchIds: (matchIds: string[]) =>
+      ipcRenderer.invoke('db:getDEMatchSignaturesByMatchIds', matchIds),
     updatePoolReferee: (poolId: string, refereeId: string | null) =>
       ipcRenderer.invoke('db:updatePoolReferee', poolId, refereeId),
 

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -1296,6 +1296,45 @@ export class RemoteScoreServer {
       }
     });
 
+    // API : signature numérique d'un combattant pour un match de tableau (élimination directe)
+    this.app.post('/api/matches/:matchId/fencers/:fencerId/signature', (req, res) => {
+      if (!this.hasAnyValidToken(req.headers.cookie)) {
+        return res.status(401).json({ error: 'Non authentifié' });
+      }
+      const { matchId, fencerId } = req.params;
+      const { signatureData } = req.body as { signatureData: string };
+
+      if (!signatureData || !signatureData.startsWith('data:image/png;base64,')) {
+        return res.status(400).json({ error: 'Données de signature invalides' });
+      }
+      if (signatureData.length > 200_000) {
+        return res.status(400).json({ error: 'Signature trop volumineuse (max 150 Ko)' });
+      }
+
+      const dbMatch = this.db.getMatch(matchId);
+      if (!dbMatch) {
+        return res.status(404).json({ error: 'Match non trouvé' });
+      }
+      // Réservé aux matchs de tableau (pas de poule)
+      if ((dbMatch as any).poolId) {
+        return res.status(400).json({ error: 'Signature de match réservée au tableau' });
+      }
+
+      try {
+        this.db.saveDEMatchSignature(matchId, fencerId, signatureData);
+
+        const mainWin = (global as any).mainWindow;
+        if (mainWin) {
+          mainWin.webContents.send('tableau:signature:updated', { matchId, fencerId });
+        }
+
+        res.json({ success: true });
+      } catch (err) {
+        console.error('[RemoteScoreServer] Erreur signature tableau:', err);
+        res.status(500).json({ error: 'Erreur enregistrement signature' });
+      }
+    });
+
     // API pour récupérer les matchs d'une arène/poule
     this.app.get('/api/arenas/:arenaId/matches', (req, res) => {
       try {
@@ -1601,8 +1640,19 @@ export class RemoteScoreServer {
           sender: 'server',
         });
 
+        // Signature requise après le match si c'est un match de tableau et l'option est activée
+        const matchObjForSig: any = dbMatch || inMemoryMatch;
+        const isTableauMatch = !(matchObjForSig?.poolId);
+        let requireSignature = false;
+        if (isTableauMatch && this.session) {
+          try {
+            const comp = this.db.getCompetition(this.session.competitionId);
+            requireSignature = comp?.settings?.signTableauMatches !== false;
+          } catch { /* défaut: false */ }
+        }
+
         console.log(`[RemoteScoreServer] Match ${matchId} terminé et enregistré`);
-        res.json({ success: true, winner });
+        res.json({ success: true, winner, requireSignature });
       } catch (error) {
         console.error('[RemoteScoreServer] Erreur fin de match:', error);
         res.status(500).json({ error: 'Erreur lors de la fin du match' });

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1037,6 +1037,112 @@
         .next-matches-screen { background: rgba(0,0,0,0.5); }
       }
 
+      /* ── Overlay signature des combattants (match tableau) ── */
+      .match-sig-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        z-index: 950;
+        background: rgba(0, 0, 0, 0.85);
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+      }
+      .match-sig-overlay.visible { display: flex; }
+      .match-sig-box {
+        background: #1e293b;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        width: 760px;
+        max-width: 96vw;
+        max-height: 94vh;
+        overflow: auto;
+        box-shadow: 0 25px 50px rgba(0, 0, 0, 0.6);
+      }
+      .match-sig-box h2 {
+        margin: 0 0 0.25rem;
+        text-align: center;
+        font-size: 1.25rem;
+        color: #e2e8f0;
+      }
+      .match-sig-instructions {
+        margin: 0 0 1rem;
+        text-align: center;
+        font-size: 0.85rem;
+        color: #94a3b8;
+      }
+      .match-sig-grid {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .match-sig-pad {
+        flex: 1 1 320px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+      .match-sig-fencer {
+        font-size: 0.95rem;
+        color: #e2e8f0;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .match-sig-letter {
+        background: #4f46e5;
+        color: #fff;
+        font-weight: 800;
+        border-radius: 0.4rem;
+        padding: 0.1rem 0.55rem;
+      }
+      .match-sig-canvas {
+        background: #fff;
+        border-radius: 0.5rem;
+        touch-action: none;
+        cursor: crosshair;
+        width: 100%;
+        height: 170px;
+        display: block;
+      }
+      .match-sig-clear {
+        align-self: flex-start;
+        background: #334155;
+        color: #cbd5e1;
+        border: none;
+        border-radius: 0.5rem;
+        padding: 0.4rem 0.9rem;
+        font-size: 0.8rem;
+        cursor: pointer;
+      }
+      .match-sig-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.75rem;
+        margin-top: 1.25rem;
+      }
+      .match-sig-skip {
+        background: transparent;
+        color: #94a3b8;
+        border: 1px solid #475569;
+        border-radius: 0.6rem;
+        padding: 0.7rem 1.3rem;
+        font-size: 0.95rem;
+        cursor: pointer;
+      }
+      .match-sig-validate {
+        background: #16a34a;
+        color: #fff;
+        border: none;
+        border-radius: 0.6rem;
+        padding: 0.7rem 1.5rem;
+        font-size: 0.95rem;
+        font-weight: 700;
+        cursor: pointer;
+      }
+      .match-sig-validate:disabled { opacity: 0.5; cursor: default; }
+
       /* ── Overlay fin de poule / signature ── */
       .pool-complete-overlay {
         display: none;
@@ -3154,12 +3260,15 @@
         async confirmFinish() {
           if (!this.currentMatch) return;
 
+          // Conserver les infos du match avant réinitialisation (pour la signature)
+          const finishedMatch = this.currentMatch;
+
           this.matchStatus = 'finished';
           this.stopTimer();
           this.hideFinishModal();
 
           try {
-            await fetch(`/api/matches/${this.currentMatch.id}/finish`, {
+            const resp = await fetch(`/api/matches/${this.currentMatch.id}/finish`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({
@@ -3169,6 +3278,7 @@
                 cardsB: this.cardsB,
               }),
             });
+            const result = await resp.json().catch(() => ({}));
 
             this.updateMatchStatus();
             this.updateControlButtons();
@@ -3179,6 +3289,11 @@
             });
 
             this.showNotification('✅ Match terminé et enregistré !');
+
+            // Signature requise sur tablette après un match du tableau
+            if (result.requireSignature && finishedMatch.fencerA?.id && finishedMatch.fencerB?.id) {
+              this.openMatchSignature(finishedMatch);
+            }
 
             // Afficher l'écran des prochains matchs
             setTimeout(() => {
@@ -3203,6 +3318,102 @@
           } catch (error) {
             console.error('Erreur fin de match:', error);
             this.showNotification(window.T('referee.error_save'), true);
+          }
+        }
+
+        // ── Signature des combattants après un match du tableau ──
+        openMatchSignature(match) {
+          this.signMatch = match;
+          const overlay = document.getElementById('match-sig-overlay');
+          const fullName = f => `${(f.lastName || '').toUpperCase()} ${f.firstName || ''}`.trim();
+          document.getElementById('match-sig-name-a').textContent = fullName(match.fencerA);
+          document.getElementById('match-sig-name-b').textContent = fullName(match.fencerB);
+          overlay.classList.add('visible');
+          this._setupSigCanvas('match-sig-canvas-a');
+          this._setupSigCanvas('match-sig-canvas-b');
+        }
+
+        _setupSigCanvas(canvasId) {
+          const canvas = document.getElementById(canvasId);
+          const ctx = canvas.getContext('2d');
+          const rect = canvas.getBoundingClientRect();
+          canvas.width = rect.width * window.devicePixelRatio;
+          canvas.height = rect.height * window.devicePixelRatio;
+          ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+          ctx.strokeStyle = '#1e293b';
+          ctx.lineWidth = 2.5;
+          ctx.lineCap = 'round';
+          ctx.lineJoin = 'round';
+          ctx.clearRect(0, 0, rect.width, rect.height);
+          canvas._hasInk = false;
+
+          if (canvas._sigBound) return;
+          canvas._sigBound = true;
+          let drawing = false;
+          const pos = e => {
+            const r = canvas.getBoundingClientRect();
+            return { x: e.clientX - r.left, y: e.clientY - r.top };
+          };
+          canvas.addEventListener('pointerdown', e => {
+            drawing = true;
+            const p = pos(e);
+            ctx.beginPath();
+            ctx.moveTo(p.x, p.y);
+            canvas.setPointerCapture(e.pointerId);
+          });
+          canvas.addEventListener('pointermove', e => {
+            if (!drawing) return;
+            const p = pos(e);
+            ctx.lineTo(p.x, p.y);
+            ctx.stroke();
+            canvas._hasInk = true;
+          });
+          canvas.addEventListener('pointerup', () => { drawing = false; });
+          canvas.addEventListener('pointercancel', () => { drawing = false; });
+        }
+
+        clearMatchSig(slot) {
+          const canvas = document.getElementById(`match-sig-canvas-${slot}`);
+          const ctx = canvas.getContext('2d');
+          const rect = canvas.getBoundingClientRect();
+          ctx.clearRect(0, 0, rect.width, rect.height);
+          canvas._hasInk = false;
+        }
+
+        closeMatchSignature() {
+          document.getElementById('match-sig-overlay').classList.remove('visible');
+          this.signMatch = null;
+        }
+
+        async submitMatchSignatures() {
+          const match = this.signMatch;
+          if (!match) return;
+          const canvasA = document.getElementById('match-sig-canvas-a');
+          const canvasB = document.getElementById('match-sig-canvas-b');
+          if (!canvasA._hasInk || !canvasB._hasInk) {
+            this.showNotification('✍️ Les deux tireurs doivent signer', true);
+            return;
+          }
+          const btn = document.getElementById('match-sig-submit');
+          btn.disabled = true;
+          try {
+            const send = (fencerId, dataURL) =>
+              fetch(`/api/matches/${match.id}/fencers/${fencerId}/signature`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ signatureData: dataURL }),
+              });
+            await Promise.all([
+              send(match.fencerA.id, canvasA.toDataURL('image/png')),
+              send(match.fencerB.id, canvasB.toDataURL('image/png')),
+            ]);
+            this.showNotification('✅ Signatures enregistrées');
+            this.closeMatchSignature();
+          } catch (e) {
+            console.error('Erreur signatures match:', e);
+            this.showNotification(window.T('referee.error_save'), true);
+          } finally {
+            btn.disabled = false;
           }
         }
 
@@ -3635,6 +3846,30 @@
       <button class="pco-btn" onclick="window.open(`/arene${refereeApp.arenaNumber}/journal`, '_blank')" style="margin-top:1rem; background:#4c1d95; animation:none; font-size:1.2rem; padding:0.9rem 2rem;">
         📋 JOURNAL
       </button>
+    </div>
+
+    <!-- Overlay signature des combattants après un match du tableau -->
+    <div id="match-sig-overlay" class="match-sig-overlay">
+      <div class="match-sig-box">
+        <h2>✍️ Signature des combattants</h2>
+        <p class="match-sig-instructions">Chaque tireur signe pour valider le score du match</p>
+        <div class="match-sig-grid">
+          <div class="match-sig-pad">
+            <div class="match-sig-fencer"><span class="match-sig-letter">A</span> <strong id="match-sig-name-a"></strong></div>
+            <canvas id="match-sig-canvas-a" class="match-sig-canvas"></canvas>
+            <button class="match-sig-clear" onclick="refereeApp.clearMatchSig('a')">Effacer</button>
+          </div>
+          <div class="match-sig-pad">
+            <div class="match-sig-fencer"><span class="match-sig-letter">B</span> <strong id="match-sig-name-b"></strong></div>
+            <canvas id="match-sig-canvas-b" class="match-sig-canvas"></canvas>
+            <button class="match-sig-clear" onclick="refereeApp.clearMatchSig('b')">Effacer</button>
+          </div>
+        </div>
+        <div class="match-sig-actions">
+          <button class="match-sig-skip" onclick="refereeApp.closeMatchSignature()">Passer</button>
+          <button id="match-sig-submit" class="match-sig-validate" onclick="refereeApp.submitMatchSignatures()">Valider les signatures</button>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/src/renderer/components/CompetitionPropertiesModal.tsx
+++ b/src/renderer/components/CompetitionPropertiesModal.tsx
@@ -47,6 +47,9 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
   const [thirdPlaceMatch, setThirdPlaceMatch] = useState(
     competition.settings?.thirdPlaceMatch ?? false
   );
+  const [signTableauMatches, setSignTableauMatches] = useState(
+    competition.settings?.signTableauMatches ?? true
+  );
   const [playAllPositions, setPlayAllPositions] = useState(
     competition.settings?.playAllPositions ?? false
   );
@@ -125,6 +128,7 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
       poolRounds,
       hasDirectElimination,
       thirdPlaceMatch,
+      signTableauMatches,
       playAllPositions,
       defaultPoolMaxScore: poolMaxScore,
       defaultTableMaxScore: tableMaxScore,
@@ -273,6 +277,20 @@ const CompetitionPropertiesModal: React.FC<CompetitionPropertiesModalProps> = ({
                 </label>
                 <small style={HINT_INDENT}>
                   {t('competition.third_place_match_description')}
+                </small>
+              </div>
+              <div className="form-group">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={signTableauMatches}
+                    onChange={e => setSignTableauMatches(e.target.checked)}
+                    style={MR}
+                  />
+                  {t('competition.sign_tableau_matches_label')}
+                </label>
+                <small style={HINT_INDENT}>
+                  {t('competition.sign_tableau_matches_description')}
                 </small>
               </div>
               <div className="form-group">

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -647,11 +647,29 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const title = `Tableau de ${tableauSize}${roundLabel ? ` — ${roundLabel}` : ''}`;
     const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
     try {
+      // Récupérer les signatures des combattants (saisies sur tablette)
+      let signatures: Record<string, { A?: string; B?: string }> | undefined;
+      try {
+        const api = (window as any).electronAPI;
+        const ids = filteredMatches.map(m => m.id).filter(Boolean);
+        const rows = (await api?.db?.getDEMatchSignaturesByMatchIds?.(ids)) ?? [];
+        if (rows.length > 0) {
+          signatures = {};
+          for (const row of rows) {
+            const match = filteredMatches.find(m => m.id === row.matchId);
+            if (!match) continue;
+            const slot = match.fencerA?.id === row.fencerId ? 'A' : match.fencerB?.id === row.fencerId ? 'B' : null;
+            if (!slot) continue;
+            (signatures[row.matchId] ??= {})[slot] = row.signatureData;
+          }
+        }
+      } catch { /* signatures optionnelles */ }
+
       const { printTableauHTML, exportTableauToPDF } = await import('../../shared/utils/pdfExport');
       if (pdfMode === 'print') {
-        await printTableauHTML(filteredMatches, perPage, title, logo, tableauTemplate);
+        await printTableauHTML(filteredMatches, perPage, title, logo, tableauTemplate, signatures);
       } else {
-        await exportTableauToPDF(filteredMatches, perPage, title, logo, tableauTemplate);
+        await exportTableauToPDF(filteredMatches, perPage, title, logo, tableauTemplate, signatures);
       }
       setShowPdfModal(false);
     } catch (e) {

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -12,7 +12,7 @@
     "new_competition": "Nevezompetañ",
     "import": "Importañ",
     "export": "Ezporñ",
-    "competition_properties": "Perzhioùioù ar c'hoarzh", 
+    "competition_properties": "Perzhioùioù ar c'hoarzh",
     "report_issue": "Danebenn ur pediñ",
     "quit": "Kuitaat"
   },
@@ -32,7 +32,9 @@
     "third_place_match_label": "Bras bihan (match evit an 3de plas)",
     "third_place_match_description": "Aoz ur match ouzhpenn etre an daou c'hoarzer a yaouank en hanter gourfenn evit derminiñ an 3de ha 4de plas",
     "comparisons": "Kenstrivañ",
-    "analytics": "Analiz"
+    "analytics": "Analiz",
+    "sign_tableau_matches_label": "Sinadur an dud-emgann war an tablezenn (taolenn)",
+    "sign_tableau_matches_description": "Diskouez a ra ur skramm sinadur evit an daou dud-emgann war an tablezenn goude pep emgann eus an taolenn dilamañ war-eeun"
   },
   "weapons": {
     "epee": "Spes",
@@ -222,7 +224,7 @@
     "import_failed": "TODO(br): révision par un locuteur natif breton requise — Importañ c'hwitet",
     "no_fencers": "Hini eb henger ebet",
     "no_competitions": "Hini kenstrrenn.",
-	"create_competition": "Krouit ur genstrivadeg en ur glikañ war",
+    "create_competition": "Krouit ur genstrivadeg en ur glikañ war",
     "loading": "O kargañ...",
     "error": "Fazienn",
     "success": "Berzh mat",
@@ -241,17 +243,34 @@
   "pdfTemplate": {
     "modalTitle": "Personelañ ezporzhioù PDF",
     "openButton": "Personelañ PDF",
-    "docType": { "pool": "Poelloù", "tableau": "Taolenn", "ranking": "Renk" },
+    "docType": {
+      "pool": "Poelloù",
+      "tableau": "Taolenn",
+      "ranking": "Renk"
+    },
     "customTitle": "Titl personelaet",
     "customTitlePlaceholder": "Lezel goullo evit titl emgefreek",
-    "colors": { "navy": "Liv pennañ", "gold": "Liv mouezh", "green": "Liv trechañ" },
-    "elements": {
-      "header": "Penn-bann", "gold-bar": "Barenn aour", "competition-name": "Anv ar genstrivadeg", "meta-chips": "Chips titouroù",
-      "score-grid": "Reizh poentoù", "pending-matches": "Emgavioù o vont",
-      "finished-matches": "Disoc'hoù", "match-cards": "Kartennoù emgav",
-      "ranking-table": "Taolenn renk", "footer": "Troad-pajenn"
+    "colors": {
+      "navy": "Liv pennañ",
+      "gold": "Liv mouezh",
+      "green": "Liv trechañ"
     },
-    "reset": "Adderaouiñ", "exportJson": "Ezporzhiañ JSON", "importJson": "Enporzhiañ JSON", "importError": "Restr JSON fall"
+    "elements": {
+      "header": "Penn-bann",
+      "gold-bar": "Barenn aour",
+      "competition-name": "Anv ar genstrivadeg",
+      "meta-chips": "Chips titouroù",
+      "score-grid": "Reizh poentoù",
+      "pending-matches": "Emgavioù o vont",
+      "finished-matches": "Disoc'hoù",
+      "match-cards": "Kartennoù emgav",
+      "ranking-table": "Taolenn renk",
+      "footer": "Troad-pajenn"
+    },
+    "reset": "Adderaouiñ",
+    "exportJson": "Ezporzhiañ JSON",
+    "importJson": "Enporzhiañ JSON",
+    "importError": "Restr JSON fall"
   },
   "cardModal": {
     "title": "Kartennik evit {{name}}",

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -32,7 +32,9 @@
     "third_place_match_label": "Petita final (combat pel 3r lloc)",
     "third_place_match_description": "Organitza un combat addicional entre els dos semifinalistes perdedors per determinar el 3r i 4t lloc",
     "comparisons": "Comparacions",
-    "analytics": "Analytics"
+    "analytics": "Analytics",
+    "sign_tableau_matches_label": "Signatura dels tiradors a la tauleta (quadre)",
+    "sign_tableau_matches_description": "Mostra una pantalla de signatura per als dos tiradors a la tauleta després de cada combat del quadre d’eliminació directa"
   },
   "weapons": {
     "epee": "Espasa",
@@ -241,17 +243,34 @@
   "pdfTemplate": {
     "modalTitle": "Personalitzar exportacions PDF",
     "openButton": "Personalitzar PDFs",
-    "docType": { "pool": "Grups", "tableau": "Quadre", "ranking": "Classificació" },
+    "docType": {
+      "pool": "Grups",
+      "tableau": "Quadre",
+      "ranking": "Classificació"
+    },
     "customTitle": "Títol personalitzat",
     "customTitlePlaceholder": "Deixar buit per al títol automàtic",
-    "colors": { "navy": "Color principal", "gold": "Color d'accent", "green": "Color de victòria" },
-    "elements": {
-      "header": "Capçalera", "gold-bar": "Separador daurat", "competition-name": "Nom de la competició", "meta-chips": "Xips d'info",
-      "score-grid": "Quadrícula de puntuació", "pending-matches": "Combats pendents",
-      "finished-matches": "Resultats", "match-cards": "Fitxes de combat",
-      "ranking-table": "Taula de classificació", "footer": "Peu de pàgina"
+    "colors": {
+      "navy": "Color principal",
+      "gold": "Color d'accent",
+      "green": "Color de victòria"
     },
-    "reset": "Restablir", "exportJson": "Exportar JSON", "importJson": "Importar JSON", "importError": "Fitxer JSON no vàlid"
+    "elements": {
+      "header": "Capçalera",
+      "gold-bar": "Separador daurat",
+      "competition-name": "Nom de la competició",
+      "meta-chips": "Xips d'info",
+      "score-grid": "Quadrícula de puntuació",
+      "pending-matches": "Combats pendents",
+      "finished-matches": "Resultats",
+      "match-cards": "Fitxes de combat",
+      "ranking-table": "Taula de classificació",
+      "footer": "Peu de pàgina"
+    },
+    "reset": "Restablir",
+    "exportJson": "Exportar JSON",
+    "importJson": "Importar JSON",
+    "importError": "Fitxer JSON no vàlid"
   },
   "cardModal": {
     "title": "Targeta per a {{name}}",

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -103,7 +103,9 @@
     "third_place_match_label": "Kleines Finale (Spiel um den 3. Platz)",
     "third_place_match_ok": "Klicken Sie auf OK, um das kleine Finale hinzuzufügen",
     "title": "Titel",
-    "weapon": "Waffe"
+    "weapon": "Waffe",
+    "sign_tableau_matches_label": "Unterschrift der Fechter auf Tablet (Tableau)",
+    "sign_tableau_matches_description": "Zeigt nach jedem K.-o.-Match auf dem Tablet einen Unterschriftsbildschirm für beide Fechter an"
   },
   "fencer": {
     "abandon": "Aufgeben",

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -32,7 +32,9 @@
     "third_place_match_label": "Bronze medal match (3rd place match)",
     "third_place_match_description": "Organizes an additional match between the two losing semi-finalists to determine 3rd and 4th place",
     "comparisons": "Comparisons",
-    "analytics": "Analytics"
+    "analytics": "Analytics",
+    "sign_tableau_matches_label": "Fencer signature on tablet (bracket)",
+    "sign_tableau_matches_description": "Shows a signature screen for both fencers on the tablet after each direct-elimination bracket match"
   },
   "weapons": {
     "epee": "Epee",
@@ -222,7 +224,7 @@
     "import_failed": "Import failed",
     "no_fencers": "No fencers",
     "no_competitions": "No competitions.",
-	"create_competition": "Create one by clicking on",
+    "create_competition": "Create one by clicking on",
     "loading": "Loading...",
     "error": "Error",
     "success": "Success",
@@ -241,17 +243,34 @@
   "pdfTemplate": {
     "modalTitle": "Customize PDF Exports",
     "openButton": "Customize PDFs",
-    "docType": { "pool": "Pools", "tableau": "Tableau", "ranking": "Ranking" },
+    "docType": {
+      "pool": "Pools",
+      "tableau": "Tableau",
+      "ranking": "Ranking"
+    },
     "customTitle": "Custom title",
     "customTitlePlaceholder": "Leave empty for automatic title",
-    "colors": { "navy": "Primary color", "gold": "Accent color", "green": "Victory color" },
-    "elements": {
-      "header": "Header", "gold-bar": "Gold separator", "competition-name": "Competition name", "meta-chips": "Info chips",
-      "score-grid": "Score grid", "pending-matches": "Pending matches",
-      "finished-matches": "Results", "match-cards": "Match cards",
-      "ranking-table": "Ranking table", "footer": "Footer"
+    "colors": {
+      "navy": "Primary color",
+      "gold": "Accent color",
+      "green": "Victory color"
     },
-    "reset": "Reset", "exportJson": "Export JSON", "importJson": "Import JSON", "importError": "Invalid JSON file"
+    "elements": {
+      "header": "Header",
+      "gold-bar": "Gold separator",
+      "competition-name": "Competition name",
+      "meta-chips": "Info chips",
+      "score-grid": "Score grid",
+      "pending-matches": "Pending matches",
+      "finished-matches": "Results",
+      "match-cards": "Match cards",
+      "ranking-table": "Ranking table",
+      "footer": "Footer"
+    },
+    "reset": "Reset",
+    "exportJson": "Export JSON",
+    "importJson": "Import JSON",
+    "importError": "Invalid JSON file"
   },
   "cardModal": {
     "title": "Card for {{name}}",

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -32,7 +32,9 @@
     "third_place_match_label": "Pequeña final (partido por el 3er lugar)",
     "third_place_match_description": "Organiza un partido adicional entre los dos semifinalistas perdedores para determinar el 3er y 4to lugar",
     "comparisons": "Comparaciones",
-    "analytics": "Analytics"
+    "analytics": "Analytics",
+    "sign_tableau_matches_label": "Firma de los tiradores en tableta (cuadro)",
+    "sign_tableau_matches_description": "Muestra una pantalla de firma para ambos tiradores en la tableta después de cada combate del cuadro de eliminación directa"
   },
   "weapons": {
     "epee": "Espada",
@@ -241,17 +243,34 @@
   "pdfTemplate": {
     "modalTitle": "Personalizar exportaciones PDF",
     "openButton": "Personalizar PDFs",
-    "docType": { "pool": "Grupos", "tableau": "Cuadro", "ranking": "Clasificación" },
+    "docType": {
+      "pool": "Grupos",
+      "tableau": "Cuadro",
+      "ranking": "Clasificación"
+    },
     "customTitle": "Título personalizado",
     "customTitlePlaceholder": "Dejar vacío para título automático",
-    "colors": { "navy": "Color principal", "gold": "Color de acento", "green": "Color de victoria" },
-    "elements": {
-      "header": "Encabezado", "gold-bar": "Separador dorado", "competition-name": "Nombre de competición", "meta-chips": "Chips de info",
-      "score-grid": "Cuadrícula de puntuación", "pending-matches": "Combates pendientes",
-      "finished-matches": "Resultados", "match-cards": "Fichas de combate",
-      "ranking-table": "Tabla de clasificación", "footer": "Pie de página"
+    "colors": {
+      "navy": "Color principal",
+      "gold": "Color de acento",
+      "green": "Color de victoria"
     },
-    "reset": "Restablecer", "exportJson": "Exportar JSON", "importJson": "Importar JSON", "importError": "Archivo JSON inválido"
+    "elements": {
+      "header": "Encabezado",
+      "gold-bar": "Separador dorado",
+      "competition-name": "Nombre de competición",
+      "meta-chips": "Chips de info",
+      "score-grid": "Cuadrícula de puntuación",
+      "pending-matches": "Combates pendientes",
+      "finished-matches": "Resultados",
+      "match-cards": "Fichas de combate",
+      "ranking-table": "Tabla de clasificación",
+      "footer": "Pie de página"
+    },
+    "reset": "Restablecer",
+    "exportJson": "Exportar JSON",
+    "importJson": "Importar JSON",
+    "importError": "Archivo JSON inválido"
   },
   "cardModal": {
     "title": "Tarjeta para {{name}}",

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -32,7 +32,9 @@
     "third_place_match_label": "Petite finale (match pour la 3ème place)",
     "third_place_match_description": "Organise un match supplémentaire entre les deux demi-finalistes perdants pour déterminer la 3ème et 4ème place",
     "comparisons": "Comparaisons",
-    "analytics": "Analytics"
+    "analytics": "Analytics",
+    "sign_tableau_matches_label": "Signature des combattants sur tablette (tableau)",
+    "sign_tableau_matches_description": "Affiche un écran de signature pour les deux tireurs sur la tablette après chaque match du tableau d’élimination directe"
   },
   "weapons": {
     "epee": "Épée",
@@ -222,7 +224,7 @@
     "import_failed": "Importation échouée",
     "no_fencers": "Aucun tireur",
     "no_competitions": "Aucune compétition.",
-	"create_competition": "Créez une compétition en cliquant sur",
+    "create_competition": "Créez une compétition en cliquant sur",
     "loading": "Chargement...",
     "error": "Erreur",
     "success": "Succès",

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -32,7 +32,9 @@
     "third_place_match_label": "銅牌賽（季軍賽）",
     "third_place_match_description": "為兩位落敗半準決賽選手安排額外比賽，以決定第三及第四名",
     "comparisons": "比較",
-    "analytics": "分析"
+    "analytics": "分析",
+    "sign_tableau_matches_label": "選手在平板上簽名（淘汰表）",
+    "sign_tableau_matches_description": "在每場直接淘汰賽後於平板上向兩位選手顯示簽名畫面"
   },
   "weapons": {
     "epee": "重劍",
@@ -241,17 +243,34 @@
   "pdfTemplate": {
     "modalTitle": "自訂PDF匯出",
     "openButton": "自訂PDF",
-    "docType": { "pool": "分組", "tableau": "淘汰賽", "ranking": "排名" },
+    "docType": {
+      "pool": "分組",
+      "tableau": "淘汰賽",
+      "ranking": "排名"
+    },
     "customTitle": "自訂標題",
     "customTitlePlaceholder": "留空使用自動標題",
-    "colors": { "navy": "主色", "gold": "強調色", "green": "勝利色" },
-    "elements": {
-      "header": "頁首", "gold-bar": "金色分隔線", "competition-name": "比賽名稱", "meta-chips": "資訊標籤",
-      "score-grid": "分數表格", "pending-matches": "待打比賽",
-      "finished-matches": "結果", "match-cards": "比賽卡片",
-      "ranking-table": "排名表", "footer": "頁尾"
+    "colors": {
+      "navy": "主色",
+      "gold": "強調色",
+      "green": "勝利色"
     },
-    "reset": "重設", "exportJson": "匯出JSON", "importJson": "匯入JSON", "importError": "JSON檔案無效"
+    "elements": {
+      "header": "頁首",
+      "gold-bar": "金色分隔線",
+      "competition-name": "比賽名稱",
+      "meta-chips": "資訊標籤",
+      "score-grid": "分數表格",
+      "pending-matches": "待打比賽",
+      "finished-matches": "結果",
+      "match-cards": "比賽卡片",
+      "ranking-table": "排名表",
+      "footer": "頁尾"
+    },
+    "reset": "重設",
+    "exportJson": "匯出JSON",
+    "importJson": "匯入JSON",
+    "importError": "JSON檔案無效"
   },
   "cardModal": {
     "title": "{{name}} 的罰牌",

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -569,6 +569,7 @@ export interface CompetitionSettings {
   poolRounds: number; // Nombre de tours de poules (défaut: 1)
   hasDirectElimination: boolean; // Phase d'élimination directe activée (défaut: true)
   thirdPlaceMatch: boolean; // Match pour la 3ème place activé (défaut: false)
+  signTableauMatches?: boolean; // Signature des combattants sur tablette après chaque match du tableau (défaut: true)
   manualRanking: boolean; // Classement manuel
   defaultRanking: number; // Classement par défaut pour non-classés
   randomScore: boolean; // Scores aléatoires (pour tests)

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -549,6 +549,9 @@ export interface DatabaseAPI {
   getPoolsByPhase: (phaseId: string) => Promise<Pool[]>;
   updatePool: (pool: Pool) => Promise<void>;
   getPoolSignatures: (poolId: string) => Promise<{ fencerId: string; signatureData: string }[]>;
+  getDEMatchSignaturesByMatchIds: (
+    matchIds: string[]
+  ) => Promise<{ matchId: string; fencerId: string; signatureData: string }[]>;
   updatePoolReferee: (poolId: string, refereeId: string | null) => Promise<void>;
 
   // Phases

--- a/src/shared/utils/pdfExport/tableauPdf.ts
+++ b/src/shared/utils/pdfExport/tableauPdf.ts
@@ -47,7 +47,8 @@ export function generateTableauHTML(
   title: string,
   logoBase64?: string,
   template?: PdfTemplate,
-  showScores = false
+  showScores = false,
+  signatures?: Record<string, { A?: string; B?: string }>
 ): string {
   const real = realMatches(matches);
   const now = new Date().toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' });
@@ -64,6 +65,11 @@ export function generateTableauHTML(
     const isWinnerB = winnerId != null && winnerId === (match.fencerB as any)?.id;
     const scoreCellA = showScores && match.scoreA != null ? `${isWinnerA ? 'V' : ''}${match.scoreA}` : '';
     const scoreCellB = showScores && match.scoreB != null ? `${isWinnerB ? 'V' : ''}${match.scoreB}` : '';
+    const sig = signatures?.[match.id];
+    const sigImg = (data?: string) =>
+      data ? `<img src="${data}" style="max-height:14mm;max-width:36mm;display:block;margin:auto;" />` : '';
+    const sigCellA = sigImg(sig?.A);
+    const sigCellB = sigImg(sig?.B);
     return `
 <div class="match-card">
   <div class="match-card-header">
@@ -90,13 +96,13 @@ export function generateTableauHTML(
         <td class="row-letter">A</td>
         <td class="fencer-name">${nameA}${clubA ? `<br><span class="fencer-club">${clubA}</span>` : ''}</td>
         <td class="score-box">${scoreCellA}</td>
-        <td class="sig-box"></td>
+        <td class="sig-box">${sigCellA}</td>
       </tr>
       <tr class="row-b">
         <td class="row-letter">B</td>
         <td class="fencer-name">${nameB}${clubB ? `<br><span class="fencer-club">${clubB}</span>` : ''}</td>
         <td class="score-box">${scoreCellB}</td>
-        <td class="sig-box"></td>
+        <td class="sig-box">${sigCellB}</td>
       </tr>
     </tbody>
   </table>
@@ -352,14 +358,15 @@ export async function exportTableauToPDF(
   matchesPerPage: number,
   title: string = 'Tableau Élimination Directe',
   logoBase64?: string,
-  template?: PdfTemplate
+  template?: PdfTemplate,
+  signatures?: Record<string, { A?: string; B?: string }>
 ): Promise<void> {
   const real = realMatches(matches);
   if (real.length === 0) {
     throw new Error('Aucun match à exporter (tous sont des exempts ou sans tireurs assignés)');
   }
 
-  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64, template);
+  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64, template, false, signatures);
   await savePDF(html, `tableau-elimination.pdf`);
 }
 
@@ -368,13 +375,14 @@ export async function printTableauHTML(
   matchesPerPage: number,
   title: string = 'Tableau Élimination Directe',
   logoBase64?: string,
-  template?: PdfTemplate
+  template?: PdfTemplate,
+  signatures?: Record<string, { A?: string; B?: string }>
 ): Promise<void> {
   const real = realMatches(matches);
   if (real.length === 0) {
     throw new Error('Aucun match à imprimer (tous sont des exempts ou sans tireurs assignés)');
   }
-  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64, template);
+  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64, template, false, signatures);
   const api = (window as any).electronAPI;
   if (!api?.file?.printHtml) {
     throw new Error('API Electron non disponible');


### PR DESCRIPTION
## Quoi

Après chaque match du tableau d'élimination directe, la tablette arbitre affiche un écran où les **deux tireurs signent** (dessin tactile) pour valider le score.

## Option

Case à cocher **« Signature des combattants sur tablette (tableau) »** dans les propriétés de compétition. Activée par défaut, décochable.

## Détails techniques

- `CompetitionSettings.signTableauMatches` (défaut `true`)
- Réponse `/api/matches/:id/finish` renvoie `requireSignature` pour les matchs de tableau si l'option est active
- Endpoint `POST /api/matches/:matchId/fencers/:fencerId/signature`
- Modal double-canvas dans `referee.html` (réutilise le pattern de signature des poules)
- Migration v11 : table `de_match_signatures`
- Méthodes DB `saveDEMatchSignature` / `getDEMatchSignatures` / `getDEMatchSignaturesByMatchIds`
- Signatures intégrées dans l'export PDF du tableau (`tableauPdf.ts`, colonne signature)
- Clés i18n ajoutées (7 langues)

## À noter

`npm run type-check` échoue uniquement sur des modules non installés (node_modules absent de l'environnement) — aucune erreur introduite par ces changements.

https://claude.ai/code/session_01JBUpGzzLDinDjqwq6nHZP7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBUpGzzLDinDjqwq6nHZP7)_