### PR TITLE
Export PDF complet sans signature

### DIFF
--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -256,6 +256,51 @@ const ResultsView: React.FC<ResultsViewProps> = ({
     }
   };
 
+  const exportNoSignaturePDF = async () => {
+    setIsExportingFull(true);
+    try {
+      const api = (window as any).electronAPI;
+
+      const safe = async <T,>(fn: () => Promise<T>, label: string, fallback: T): Promise<T> => {
+        try { return await fn(); } catch (e) {
+          logger.warn(LogCategory.DATABASE, `export sans signature — ${label} échoué`, e instanceof Error ? e : undefined);
+          return fallback;
+        }
+      };
+
+      const effectiveTableauMatches = (tableauMatches && tableauMatches.length > 0)
+        ? tableauMatches
+        : await safe(() => api?.db?.getTableauMatchesForExport?.(competition.id) ?? [], 'matchs tableau', []);
+
+      let effectivePools: Pool[] = pools && pools.length > 0 ? pools : [];
+      if (effectivePools.length === 0 && api?.db?.getPhasesByCompetition && api?.db?.getPoolsByPhase) {
+        effectivePools = await safe(async () => {
+          const phases = await api.db.getPhasesByCompetition(competition.id);
+          const poolPhases = phases.filter((p: { type: string }) => p.type === 'pool');
+          const poolArrays = await Promise.all(poolPhases.map((ph: { id: string }) => api.db.getPoolsByPhase(ph.id)));
+          return poolArrays.flat();
+        }, 'poules', []);
+      }
+
+      const { exportPoolsAndTableauxNoSignaturePDF } = await import('../../shared/utils/pdfExport');
+      await exportPoolsAndTableauxNoSignaturePDF({
+        pools: effectivePools,
+        tableauMatches: effectiveTableauMatches as TableauMatchForPDF[],
+        consolationBrackets: (consolationBrackets ?? []).map(b => ({
+          id: b.id,
+          name: b.name,
+          matches: b.matches as TableauMatchForPDF[],
+        })),
+        competitionTitle: competition.title,
+        template: rankingTemplate,
+      });
+    } catch (e) {
+      showToast((e as Error).message, 'error');
+    } finally {
+      setIsExportingFull(false);
+    }
+  };
+
   const champion = resultsToDisplay.find(r => r.rank === 1);
 
   return (
@@ -393,6 +438,20 @@ const ResultsView: React.FC<ResultsViewProps> = ({
             </>
           ) : (
             '📦 Export complet PDF'
+          )}
+        </button>
+        <button
+          onClick={exportNoSignaturePDF}
+          style={{ ...RV_STYLES.btnFullPdf, opacity: isExportingFull ? 0.6 : 1, cursor: isExportingFull ? 'wait' : 'pointer' }}
+          disabled={isExportingFull}
+          title="Poules et tableaux d'élimination directe, sans les signatures des combattants"
+        >
+          {isExportingFull ? (
+            <>
+              <span style={RV_STYLES.spinner} /> Génération…
+            </>
+          ) : (
+            '📄 Export PDF complet sans signature'
           )}
         </button>
       </div>

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -35,5 +35,5 @@ export { exportResultsToPDF } from './pdfExport/resultsPdf';
 export { exportAppelToPDF } from './pdfExport/appelPdf';
 
 // ─── Export complet compétition ───────────────────────────────────────────────
-export type { FullCompetitionExportData } from './pdfExport/fullCompetitionPdf';
-export { exportFullCompetitionPDF } from './pdfExport/fullCompetitionPdf';
+export type { FullCompetitionExportData, NoSignatureExportData } from './pdfExport/fullCompetitionPdf';
+export { exportFullCompetitionPDF, exportPoolsAndTableauxNoSignaturePDF } from './pdfExport/fullCompetitionPdf';

--- a/src/shared/utils/pdfExport/fullCompetitionPdf.ts
+++ b/src/shared/utils/pdfExport/fullCompetitionPdf.ts
@@ -138,3 +138,80 @@ ${allBodies}
 
   await savePDF(combined, `export-PDF_full.pdf`);
 }
+
+// ─── Export poules + tableaux sans signature ───────────────────────────────────
+
+export interface NoSignatureExportData {
+  pools: Pool[];
+  tableauMatches: TableauMatchForPDF[];
+  consolationBrackets: { id: string; name: string; matches: TableauMatchForPDF[] }[];
+  competitionTitle: string;
+  template?: PdfTemplate;
+}
+
+/**
+ * Exporte uniquement les poules et les tableaux d'élimination directe,
+ * sans les signatures des combattants (aucune signature n'est transmise aux générateurs).
+ */
+export async function exportPoolsAndTableauxNoSignaturePDF(data: NoSignatureExportData): Promise<void> {
+  const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+  const { pools, tableauMatches, consolationBrackets, competitionTitle, template } = data;
+
+  const sections: string[] = [];
+
+  for (const pool of pools) {
+    sections.push(generatePoolHTML(
+      pool,
+      { title: `Poule ${pool.number} — ${competitionTitle}`, logoBase64: logo, competitionName: competitionTitle },
+      template
+    ));
+  }
+
+  const rounds = [...new Set(tableauMatches.map(m => m.round))].sort((a, b) => b - a);
+  for (const round of rounds) {
+    const roundMatches = tableauMatches.filter(m => m.round === round && !m.isBye);
+    if (roundMatches.length === 0) continue;
+    sections.push(generateTableauHTML(
+      roundMatches, MAX_MATCHES_PER_PAGE_TABLEAU,
+      `${getTableauRoundName(round)} — ${competitionTitle}`,
+      logo, template, true
+    ));
+  }
+
+  for (const bracket of consolationBrackets) {
+    const bRounds = [...new Set(bracket.matches.map(m => m.round))].sort((a, b) => b - a);
+    for (const round of bRounds) {
+      const roundMatches = bracket.matches.filter(m => m.round === round && !m.isBye);
+      if (roundMatches.length === 0) continue;
+      sections.push(generateTableauHTML(
+        roundMatches, MAX_MATCHES_PER_PAGE_TABLEAU,
+        `${bracket.name} — ${getTableauRoundName(round)} — ${competitionTitle}`,
+        logo, template, true
+      ));
+    }
+  }
+
+  if (sections.length === 0) throw new Error('Aucune donnée à exporter');
+
+  const allStyles = sections.map(extractStyleContent).join('\n');
+  const allBodies = sections
+    .map((html, i) => (i === 0 ? '' : '<div class="full-export-break"></div>\n') + extractBodyContent(html))
+    .join('\n');
+
+  const combined = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Export sans signature — ${competitionTitle}</title>
+  <style>
+    ${allStyles}
+    .full-export-break { break-before: page; }
+  </style>
+</head>
+<body>
+${allBodies}
+</body>
+</html>`;
+
+  await savePDF(combined, `export-PDF_sans-signature.pdf`);
+}


### PR DESCRIPTION
Ajoute bouton "Export PDF complet sans signature" en fin de compétition (ResultsView).

Exporte poules + tableaux d'élimination directe (+ tableaux de consolation), sans signatures des combattants.

- `exportPoolsAndTableauxNoSignaturePDF` dans `fullCompetitionPdf.ts`
- export barrel `pdfExport.ts`
- bouton dans `ResultsView.tsx`

https://claude.ai/code/session_01Jhr5SfUofC5pjG8btvEpCR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jhr5SfUofC5pjG8btvEpCR)_