### PR TITLE
Inclure signatures poules + TDE dans export PDF complet

### DIFF
--- a/src/renderer/components/ResultsView.tsx
+++ b/src/renderer/components/ResultsView.tsx
@@ -232,6 +232,36 @@ const ResultsView: React.FC<ResultsViewProps> = ({
         }, 'poules', []);
       }
 
+      // Signatures des poules : poolId → (fencerId → data URL)
+      const poolSignatures = await safe(async () => {
+        const entries = await Promise.all(
+          effectivePools.map(async (p) => {
+            const sigs = (await api?.db?.getPoolSignatures?.(p.id)) ?? [];
+            return [p.id, Object.fromEntries(sigs.map((s: { fencerId: string; signatureData: string }) => [s.fencerId, s.signatureData]))] as const;
+          })
+        );
+        return Object.fromEntries(entries) as Record<string, Record<string, string>>;
+      }, 'signatures poules', {} as Record<string, Record<string, string>>);
+
+      // Signatures des matchs de TDE : matchId → { A, B }
+      const allTableauMatches = [
+        ...(effectiveTableauMatches as TableauMatchForPDF[]),
+        ...(consolationBrackets ?? []).flatMap(b => b.matches as TableauMatchForPDF[]),
+      ];
+      const tableauSignatures = await safe(async () => {
+        const ids = allTableauMatches.map(m => m.id).filter(Boolean);
+        const rows = (await api?.db?.getDEMatchSignaturesByMatchIds?.(ids)) ?? [];
+        const out: Record<string, { A?: string; B?: string }> = {};
+        for (const row of rows as { matchId: string; fencerId: string; signatureData: string }[]) {
+          const match = allTableauMatches.find(m => m.id === row.matchId);
+          if (!match) continue;
+          const slot = match.fencerA?.id === row.fencerId ? 'A' : match.fencerB?.id === row.fencerId ? 'B' : null;
+          if (!slot) continue;
+          (out[row.matchId] ??= {})[slot] = row.signatureData;
+        }
+        return out;
+      }, 'signatures tableau', {} as Record<string, { A?: string; B?: string }>);
+
       const { exportFullCompetitionPDF } = await import('../../shared/utils/pdfExport');
       await exportFullCompetitionPDF({
         fencers: effectiveFencers,
@@ -248,6 +278,8 @@ const ResultsView: React.FC<ResultsViewProps> = ({
         competitionTitle: competition.title,
         isLaserSabre,
         template: rankingTemplate,
+        poolSignatures,
+        tableauSignatures,
       });
     } catch (e) {
       showToast((e as Error).message, 'error');

--- a/src/shared/utils/pdfExport/fullCompetitionPdf.ts
+++ b/src/shared/utils/pdfExport/fullCompetitionPdf.ts
@@ -41,6 +41,10 @@ export interface FullCompetitionExportData {
   competitionTitle: string;
   isLaserSabre?: boolean;
   template?: PdfTemplate;
+  /** Signatures des poules : poolId → (fencerId → data URL PNG) */
+  poolSignatures?: Record<string, Record<string, string>>;
+  /** Signatures des matchs de tableau : matchId → { A, B } data URL PNG */
+  tableauSignatures?: Record<string, { A?: string; B?: string }>;
 }
 
 export async function exportFullCompetitionPDF(data: FullCompetitionExportData): Promise<void> {
@@ -48,6 +52,7 @@ export async function exportFullCompetitionPDF(data: FullCompetitionExportData):
   const {
     fencers, appelVisibleColumns, pools, overallRanking, tableauMatches, consolationBrackets,
     finalResults, competitionTitle, isLaserSabre = false, template,
+    poolSignatures, tableauSignatures,
   } = data;
 
   const sections: string[] = [];
@@ -71,7 +76,12 @@ export async function exportFullCompetitionPDF(data: FullCompetitionExportData):
   for (const pool of pools) {
     sections.push(generatePoolHTML(
       pool,
-      { title: `Poule ${pool.number} — ${competitionTitle}`, logoBase64: logo, competitionName: competitionTitle },
+      {
+        title: `Poule ${pool.number} — ${competitionTitle}`,
+        logoBase64: logo,
+        competitionName: competitionTitle,
+        signatures: poolSignatures?.[pool.id],
+      },
       undefined
     ));
   }
@@ -93,7 +103,7 @@ export async function exportFullCompetitionPDF(data: FullCompetitionExportData):
     sections.push(generateTableauHTML(
       roundMatches, MAX_MATCHES_PER_PAGE_TABLEAU,
       `${getTableauRoundName(round)} — ${competitionTitle}`,
-      logo, undefined, true
+      logo, undefined, true, tableauSignatures
     ));
   }
 
@@ -105,7 +115,7 @@ export async function exportFullCompetitionPDF(data: FullCompetitionExportData):
       sections.push(generateTableauHTML(
         roundMatches, MAX_MATCHES_PER_PAGE_TABLEAU,
         `${bracket.name} — ${getTableauRoundName(round)} — ${competitionTitle}`,
-        logo, undefined, true
+        logo, undefined, true, tableauSignatures
       ));
     }
   }


### PR DESCRIPTION
Export PDF complet ne transmettait pas les signatures.

- `fullCompetitionPdf.ts` : nouveaux champs `poolSignatures` + `tableauSignatures`, transmis à `generatePoolHTML` et `generateTableauHTML`.
- `ResultsView.tsx` : fetch signatures poules (`getPoolSignatures`) et TDE (`getDEMatchSignaturesByMatchIds`) avant export.

https://claude.ai/code/session_01FqKfddNLZuK8r1Q1WeojNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqKfddNLZuK8r1Q1WeojNU)_