### PR TITLE
fix(pdf): corrige erreur TS2339 sur fencerA/fencerB.id

### DIFF
--- a/src/shared/utils/pdfExport/tableauPdf.ts
+++ b/src/shared/utils/pdfExport/tableauPdf.ts
@@ -13,8 +13,8 @@ export interface TableauMatchForPDF {
   id: string;
   round: number;
   position: number;
-  fencerA: { firstName?: string; lastName: string; club?: string } | null;
-  fencerB: { firstName?: string; lastName: string; club?: string } | null;
+  fencerA: { id?: string; firstName?: string; lastName: string; club?: string } | null;
+  fencerB: { id?: string; firstName?: string; lastName: string; club?: string } | null;
   scoreA: number | null;
   scoreB: number | null;
   winner: { id: string } | null;


### PR DESCRIPTION
Ajoute `id?` aux types `fencerA`/`fencerB` de `TableauMatchForPDF`.

Corrige les erreurs de build:
- ResultsView.tsx(258): Property 'id' does not exist...

`npm run type-check` OK.

https://claude.ai/code/session_01MB5m3yvUxmRKcDhsUqPHTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MB5m3yvUxmRKcDhsUqPHTq)_