### PR TITLE
fix(remote): connexion Socket.IO tablette arbitre + indicateur d'erreur

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1759,7 +1759,7 @@
 
         getArenaId() {
           const path = window.location.pathname;
-          const match = path.match(/arene(\d+)/i);
+          const match = path.match(/arene(\d+)/i) || path.match(/arena(\d+)/i);
           return match ? `arena${match[1]}` : 'arena1';
         }
 
@@ -1812,18 +1812,11 @@
         }
 
         updateConnectionUI(online) {
-          const dot = document.getElementById('status-dot');
-          const text = document.getElementById('connection-text');
+          // Gère uniquement le badge hors-ligne ; la dot est pilotée par l'état socket
           const badge = document.getElementById('offline-badge');
           if (online) {
-            if (dot) dot.classList.add('connected');
-            if (dot) dot.classList.remove('disconnected');
-            if (text) text.textContent = window.T('remote.connected');
             if (badge) badge.style.display = 'none';
           } else {
-            if (dot) dot.classList.remove('connected');
-            if (dot) dot.classList.add('disconnected');
-            if (text) text.textContent = window.T('remote.offline');
             if (badge) badge.style.display = 'inline';
             this.updateOfflineBadge();
           }
@@ -2104,6 +2097,12 @@
           this.socket.on('disconnect', () => {
             this.updateConnectionStatus(false);
             this.showNotification('❌ Déconnecté', true);
+          });
+
+          this.socket.on('connect_error', (err) => {
+            this.updateConnectionStatus(false);
+            const text = document.getElementById('connection-text');
+            if (text) text.textContent = `❌ ${err?.message || 'Erreur réseau'}`;
           });
 
           this.socket.on('auth_error', () => {
@@ -3857,9 +3856,17 @@
       // Initialisation
       let refereeApp;
       document.addEventListener('DOMContentLoaded', async () => {
-        await window.initRemoteI18n();
-        document.title = window.T('referee.title');
-        refereeApp = new RefereeApp();
+        try {
+          await window.initRemoteI18n();
+          document.title = window.T('referee.title');
+          refereeApp = new RefereeApp();
+        } catch (e) {
+          console.error('[RefereeApp] Erreur init:', e);
+          const dot = document.getElementById('status-dot');
+          const text = document.getElementById('connection-text');
+          if (dot) { dot.classList.add('disconnected'); dot.classList.remove('connected'); }
+          if (text) text.textContent = '❌ Erreur: ' + (e?.message || e);
+        }
       });
     </script>
 

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -1204,7 +1204,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           {connectedClients.map(client => {
             const clientLabel = client.label || client.screenId?.slice(0, 8) || client.socketId.slice(0, 8);
             const typeLabel: Record<string, string> = {
-              kiosk: 'Kiosk', arena: 'Arène', public: 'Public', pool: 'Poule', dashboard: 'Dashboard', lobby: 'Lobby',
+              kiosk: 'Kiosk', arena: 'Arène', public: 'Public', pool: 'Poule', dashboard: 'Dashboard', lobby: 'Lobby', referee: 'Arbitre',
             };
             return (
               <div key={client.socketId} style={{


### PR DESCRIPTION
## Problème

Sur tablette, l'indicateur restait orange « Connexion... » indéfiniment. Les erreurs Socket.IO étaient silencieuses, et les tablettes lobby n'apparaissaient pas dans la télécommande avec le bon label.

## Corrections

- **connect_error handler** : affiche l'erreur réseau directement sur le dot (❌ + message) — aide à diagnostiquer firewall/réseau
- **getArenaId()** : matchait uniquement `/arene(\d+)/i`, ajoute `/arena(\d+)/i` pour les URLs en format anglais
- **updateConnectionUI** : ne gère plus la dot (évite le conflit avec `updateConnectionStatus`) — la dot est désormais pilotée exclusivement par l'état socket
- **DOMContentLoaded try/catch** : erreurs d'initialisation visibles sur l'écran plutôt qu'en console invisible
- **RemoteScoreManager typeLabel** : ajoute `referee: 'Arbitre'` (les tablettes arbitre apparaissaient avec le type brut `"referee"`)

## Test plan

- [ ] Tablette sur `/arene1/arbitre` → si Socket.IO connecte → dot verte
- [ ] Tablette sur `/arene1/arbitre` → si réseau bloqué → dot rouge + message d'erreur explicite
- [ ] Tablette sur `/lobby` → apparaît dans la télécommande avec label « Lobby »
- [ ] Tablette arbitre connectée → apparaît dans la télécommande avec label « Arbitre »

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYL2oWRfMueVpG4cmg8xtZ)_