### PR TITLE
fix(remote): connect_error + try-catch sur arena.html et lobby.html

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1460,7 +1460,11 @@
             this.updateConnectionStatus(false);
           });
 
-          this.socket.on(`arena:${this.arenaId}:update`, data => {
+          this.socket.on('connect_error', (err) => {
+            this.updateConnectionStatus(false);
+            const text = document.getElementById('connection-text');
+            if (text) text.textContent = `❌ ${err?.message || 'Erreur réseau'}`;
+          });
             this.handleArenaUpdate(data);
           });
 
@@ -2040,9 +2044,17 @@
 
       // Démarrer l'affichage
       document.addEventListener('DOMContentLoaded', async () => {
-        await window.initRemoteI18n();
-        document.title = window.T('arena.title');
-        new ArenaDisplay();
+        try {
+          await window.initRemoteI18n();
+          document.title = window.T('arena.title');
+          new ArenaDisplay();
+        } catch (e) {
+          console.error('[ArenaDisplay] Erreur init:', e);
+          const dot = document.getElementById('connection-dot');
+          const text = document.getElementById('connection-text');
+          if (dot) { dot.classList.add('disconnected'); dot.classList.remove('connected'); }
+          if (text) text.textContent = '❌ Erreur: ' + (e?.message || e);
+        }
       });
     </script>
   </body>

--- a/src/remote/lobby.html
+++ b/src/remote/lobby.html
@@ -165,6 +165,10 @@
         }
       });
 
+      socket.on('connect_error', (err) => {
+        console.error('[Lobby] Erreur Socket.IO:', err?.message || err);
+      });
+
       setInterval(() => { if (socket.connected) socket.emit('client:pong'); }, 30000);
 
       document.addEventListener('click', () => {


### PR DESCRIPTION
## Contexte

Suite au PR #809 (mergé), le même problème de diagnostic existe sur `arena.html` et `lobby.html` : si Socket.IO ne connecte pas (ou si `io` est indéfini), l'erreur est silencieuse et le dot reste à « Connexion... » sans explication.

## Corrections

- **arena.html** : handler `connect_error` → affiche ❌ + message d'erreur sur le dot
- **arena.html** : try-catch dans `DOMContentLoaded` → erreurs d'init visibles (ex: `io is not defined` si socket.io.js ne charge pas)
- **lobby.html** : handler `connect_error` → log console (pas de dot sur lobby, mais aide au debug DevTools)

## Diagnostic attendu

Après cette PR, si un écran reste bloqué à « Connexion... », il affichera le message d'erreur exact :
- `❌ websocket error` / `❌ xhr poll error` → firewall/réseau bloque Socket.IO
- `❌ Erreur: io is not defined` → socket.io.js ne charge pas (problème serveur)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYL2oWRfMueVpG4cmg8xtZ)_