### PR TITLE
fix: langue splash non appliquée au démarrage

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -581,6 +581,7 @@ function createWindow(initialLang?: string): void {
       contextIsolation: true,
       preload: path.join(__dirname, 'preload.js'),
       v8CacheOptions: 'code',
+      additionalArguments: initialLang ? [`--initial-lang=${initialLang}`] : [],
     },
     icon: path.join(__dirname, '../../resources/icons/icon.png'),
   });
@@ -665,16 +666,8 @@ function createWindow(initialLang?: string): void {
 
   // Create application menu using saved language preference
   mainWindow.webContents.once('did-finish-load', async () => {
-    // Inject language chosen in splash into localStorage before renderer reads it
     if (initialLang) {
-      try {
-        await mainWindow!.webContents.executeJavaScript(
-          `localStorage.setItem('bellepoule-language', ${JSON.stringify(initialLang)}); true`
-        );
-        currentMenuLanguage = initialLang;
-      } catch {
-        // ignore
-      }
+      currentMenuLanguage = initialLang;
     } else {
       try {
         const savedLang = await mainWindow!.webContents.executeJavaScript(
@@ -684,7 +677,7 @@ function createWindow(initialLang?: string): void {
           currentMenuLanguage = savedLang;
         }
       } catch {
-        // Fallback to default language
+        // ignore
       }
     }
     createMenu(currentMenuLanguage);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -609,6 +609,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Notify main process of language change (to rebuild native menu)
   notifyLanguageChanged: (lang: string) => ipcRenderer.send('app:language-changed', lang),
+
+  // Language injected before renderer loads (avoids race with localStorage read)
+  initialLanguage: (() => {
+    const arg = process.argv.find(a => a.startsWith('--initial-lang='));
+    return arg ? arg.slice('--initial-lang='.length) : null;
+  })(),
 });
 
 // Type declarations for the renderer

--- a/src/renderer/contexts/TranslationContext.tsx
+++ b/src/renderer/contexts/TranslationContext.tsx
@@ -156,7 +156,9 @@ export const TranslationProvider: React.FC<TranslationProviderProps> = ({ childr
 
   useEffect(() => {
     const initialize = async () => {
-      const savedLanguage = (localStorage.getItem('bellepoule-language') as Language) || 'fr';
+      const injectedLang = window.electronAPI?.initialLanguage as Language | null;
+      const savedLanguage = injectedLang || (localStorage.getItem('bellepoule-language') as Language) || 'fr';
+      if (injectedLang) localStorage.setItem('bellepoule-language', injectedLang);
       const savedTheme = (localStorage.getItem('bellepoule-theme') as Theme) || 'default';
 
       applyTheme(savedTheme);

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -795,6 +795,7 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   onScoreIpConflict: (callback: (data: ScoreIpConflict) => void) => () => void;
   onPoolSignatureUpdated: (callback: (data: { poolId: string; signedFencerIds: string[]; totalFencers: number }) => void) => () => void;
   notifyLanguageChanged: (lang: string) => void;
+  initialLanguage: string | null;
   getLogo: () => Promise<string | null>;
   getTtsConfig: () => Promise<TtsConfig | null>;
   onLogoLoaded: (callback: (logo: string | null) => void) => () => void;


### PR DESCRIPTION
## Problème

Race condition : `executeJavaScript` injectait la langue dans localStorage **après** que React avait déjà lu localStorage dans son `useEffect`. Résultat : la langue choisie dans le splash était ignorée.

## Fix

- `main.ts` : passe `initialLang` via `additionalArguments` dans `webPreferences` → disponible dans le preload **avant** que React s'initialise
- `preload.ts` : lit `--initial-lang=XX` depuis `process.argv`, l'expose comme `electronAPI.initialLanguage`
- `TranslationContext.tsx` : lit `electronAPI.initialLanguage` en priorité sur localStorage
- Supprime le `executeJavaScript` devenu inutile

---
_Generated by [Claude Code](https://claude.ai/code/session_014j87J8qzw5GktoyJ2D7MSW)_