### PR TITLE
fix(remote): socket.io client via /bp-sio.js — corrige io is not defined

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -423,6 +423,21 @@ export class RemoteScoreServer {
   private setupRoutes(): void {
     console.log('[RemoteScoreServer] Configuration des routes...');
 
+    // Socket.IO client JS servi sous /bp-sio.js pour éviter l'interception Engine.IO.
+    // Engine.IO intercepte /socket.io/* avant Express → un require.resolve explicite
+    // sous un chemin neutre garantit que le fichier est toujours disponible.
+    this.app.get('/bp-sio.js', (_req, res) => {
+      try {
+        const clientPath = require.resolve('socket.io/client-dist/socket.io.js');
+        res.setHeader('Content-Type', 'application/javascript');
+        res.setHeader('Cache-Control', 'public, max-age=3600');
+        res.sendFile(clientPath);
+      } catch (e) {
+        console.error('[RemoteScoreServer] socket.io/client-dist introuvable:', e);
+        res.status(500).send('// socket.io client not found');
+      }
+    });
+
     // Redirect racine vers le lobby
     this.app.get('/', (_req, res) => {
       res.redirect('/lobby');

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Arène BellePoule</title>
     <script src="/i18n.js"></script>
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="/bp-sio.js"></script>
     <style>
 
       /* Police 7 segments — style radio-réveil LCD (embarquée en base64) */

--- a/src/remote/dashboard.html
+++ b/src/remote/dashboard.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"
     />
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="/bp-sio.js"></script>
     <style>
       * {
         margin: 0;

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kiosk - BellePoule Modern</title>
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="/bp-sio.js"></script>
     <script src="/i18n.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/remote/lobby.html
+++ b/src/remote/lobby.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>En attente — BellePoule Modern</title>
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="/bp-sio.js"></script>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       body {

--- a/src/remote/overlay.html
+++ b/src/remote/overlay.html
@@ -39,7 +39,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Overlay BellePoule</title>
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="/bp-sio.js"></script>
     <style>
       /* ── Police 7 segments (embarquée, identique à arena.html) ── */
       @font-face {

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Saisie Poule – BellePoule</title>
     <script src="/i18n.js"></script>
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="/bp-sio.js"></script>
     <style>
       * {
         margin: 0;

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vue Publique – BellePoule</title>
     <script src="/i18n.js"></script>
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="/bp-sio.js"></script>
     <style>
 @font-face {
       font-family: 'ArmadaBold';

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -8,7 +8,7 @@
     />
     <title>Arbitrage - Arène BellePoule</title>
     <script src="/i18n.js"></script>
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="/bp-sio.js"></script>
     <style>
       * {
         margin: 0;


### PR DESCRIPTION
## Cause racine

`socket.io.js` ne chargeait pas → `io is not defined` → toutes les tablettes bloquées à « Connexion... ».

Engine.IO intercepte **toutes** les requêtes vers `/socket.io/*` au niveau du serveur HTTP brut, avant même qu'Express entre en jeu. Son mécanisme interne de résolution du fichier client peut échouer dans certaines configs Electron (asar, chemins compilés, etc.).

## Fix

- Nouveau point de montage `/bp-sio.js` géré par Express directement via `require.resolve('socket.io/client-dist/socket.io.js')` — totalement hors du scope d'Engine.IO
- Les 8 fichiers HTML remote (`arena.html`, `referee.html`, `lobby.html`, `pool.html`, `public.html`, `dashboard.html`, `kiosk.html`, `overlay.html`) utilisent maintenant `<script src="/bp-sio.js">` au lieu de `<script src="/socket.io/socket.io.js">`

## Test plan

- [ ] Ouvrir `/arene1/arbitre` sur tablette → dot doit passer vert
- [ ] Ouvrir `/lobby` → tablette apparaît dans la télécommande
- [ ] Ouvrir `/arene1` → dot vert, statut « Connecté »

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYL2oWRfMueVpG4cmg8xtZ)_