### PR TITLE
fix(remote): readFileSync pour /bp-sio.js — fs.createReadStream KO dans app.asar

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -424,17 +424,18 @@ export class RemoteScoreServer {
     console.log('[RemoteScoreServer] Configuration des routes...');
 
     // Socket.IO client JS servi sous /bp-sio.js pour éviter l'interception Engine.IO.
-    // Engine.IO intercepte /socket.io/* avant Express → un require.resolve explicite
-    // sous un chemin neutre garantit que le fichier est toujours disponible.
+    // sendFile utilise fs.createReadStream qui échoue depuis app.asar → readFileSync
+    // (patché par Electron pour lire dans l'asar) + res.send().
     this.app.get('/bp-sio.js', (_req, res) => {
       try {
         const clientPath = require.resolve('socket.io/client-dist/socket.io.js');
+        const content = require('fs').readFileSync(clientPath, 'utf-8');
         res.setHeader('Content-Type', 'application/javascript');
         res.setHeader('Cache-Control', 'public, max-age=3600');
-        res.sendFile(clientPath);
-      } catch (e) {
+        res.send(content);
+      } catch (e: any) {
         console.error('[RemoteScoreServer] socket.io/client-dist introuvable:', e);
-        res.status(500).send('// socket.io client not found');
+        res.status(500).send(`// socket.io client not found: ${e?.message}`);
       }
     });
 


### PR DESCRIPTION
## Cause

`res.sendFile()` utilise `fs.createReadStream` en interne, qui **ne fonctionne pas pour les fichiers dans `app.asar`** d'Electron — même si `require.resolve` trouve le chemin correctement.

## Fix

Remplace `res.sendFile(clientPath)` par `fs.readFileSync(clientPath, 'utf-8')` + `res.send(content)`.

Electron patche `fs.readFileSync` pour lire transparemment depuis l'intérieur de l'asar, ce qui garantit que le fichier est toujours accessible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYL2oWRfMueVpG4cmg8xtZ)_