### PR TITLE
fix: boucle infinie React (Maximum update depth exceeded)

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -121,6 +121,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const [finalResults, setFinalResults] = useState<FinalResult[]>([]);
   const [appelFencers, setAppelFencers] = useState<Fencer[]>([]);
   const [appelVisibleColumns, setAppelVisibleColumns] = useState<string[]>([]);
+  const handleAppelStateChange = useCallback((f: Fencer[], cols: string[]) => {
+    setAppelFencers(f);
+    setAppelVisibleColumns(cols);
+  }, []);
   const [tableauEditUnlocked, setTableauEditUnlocked] = useState(false);
   const [showFencerComparison, setShowFencerComparison] = useState(false);
   const [showAnalytics, setShowAnalytics] = useState(false);
@@ -1184,7 +1188,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onUncheckAll={uncheckAll}
             onImport={(type) => handleOpenImportDialog(type)}
             onFencersImported={loadFencers}
-            onAppelStateChange={(f, cols) => { setAppelFencers(f); setAppelVisibleColumns(cols); }}
+            onAppelStateChange={handleAppelStateChange}
             onSetFencerStatus={(id, status) => {
               // Si forfait, abandon ou exclusion, mettre à jour tous les matchs du tireur
               if (status === FencerStatus.FORFAIT) {


### PR DESCRIPTION
## Cause

`CompetitionView.tsx` passait une fonction inline comme prop `onAppelStateChange` :

```tsx
onAppelStateChange={(f, cols) => { setAppelFencers(f); setAppelVisibleColumns(cols); }}
```

Dans `FencerList.tsx`, cette fonction était dans les dépendances d'un `useEffect` :

```tsx
useEffect(() => {
  onAppelStateChange?.(filteredFencers, visibleColIds);
}, [filteredFencers, visibleColIds, onAppelStateChange]);
```

Boucle : nouvelle fonction chaque render → effect fire → `setState` → re-render → nouvelle fonction → 142× "Maximum update depth exceeded".

## Fix

`useCallback` stable (deps vides, les setters React sont garantis stables) :

```tsx
const handleAppelStateChange = useCallback((f: Fencer[], cols: string[]) => {
  setAppelFencers(f);
  setAppelVisibleColumns(cols);
}, []);
```

https://claude.ai/code/session_01K5abfuqHVoqNDCAf4TbXHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5abfuqHVoqNDCAf4TbXHs)_