### PR TITLE
fix(remote): empaqueter le client socket.io — corrige io is not defined

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -109,6 +109,9 @@ export class RemoteScoreServer {
   // Stocker le contenu des fichiers HTML en mémoire pour éviter les problèmes de chemin
   private htmlFiles: Map<string, string> = new Map();
 
+  // Client socket.io chargé en mémoire au démarrage (injecté inline dans le HTML)
+  private socketIoClientJs: string | null = null;
+
   // Tokens d'authentification par arène (password protection)
   private arenaTokens: Map<string, Set<string>> = new Map();
 
@@ -177,6 +180,8 @@ export class RemoteScoreServer {
       }
     }, 5 * 60_000);
 
+    // Charger le client socket.io AVANT le HTML (injection inline dans loadHtmlFiles)
+    this.loadSocketIoClient();
     // Charger les fichiers HTML en mémoire au démarrage
     this.loadHtmlFiles();
 
@@ -185,6 +190,51 @@ export class RemoteScoreServer {
     this.setupSocketHandlers();
     this.initializeArenas();
     console.log(`[RemoteScoreServer] Serveur initialisé avec ${this.arenaCount} arènes`);
+  }
+
+  // Localiser et charger le client socket.io en mémoire.
+  // Plusieurs stratégies pour couvrir dev, app.asar et asar.unpacked.
+  private loadSocketIoClient(): void {
+    const fs = require('fs');
+    const candidates: string[] = [];
+
+    // 1) Fichier copié dans dist/remote au build (cas packagé : node_modules absent)
+    candidates.push(
+      path.join(__dirname, '../remote/socket.io.min.js'), // dist/main → dist/remote
+      ...(process.resourcesPath
+        ? [
+            path.join(process.resourcesPath, 'app.asar.unpacked', 'dist/remote/socket.io.min.js'),
+            path.join(process.resourcesPath, 'app.asar', 'dist/remote/socket.io.min.js'),
+          ]
+        : []),
+      path.join(__dirname, '../../src/remote/socket.io.min.js'), // fallback dev sans webpack
+    );
+
+    // 2) Résolution via node_modules (dev / si présent dans le package)
+    for (const sub of ['client-dist/socket.io.min.js', 'client-dist/socket.io.js']) {
+      try {
+        candidates.push(require.resolve(`socket.io/${sub}`));
+      } catch {
+        /* ignore */
+      }
+    }
+
+    for (const candidate of candidates) {
+      try {
+        if (fs.existsSync(candidate)) {
+          this.socketIoClientJs = fs.readFileSync(candidate, 'utf-8');
+          console.log(`[RemoteScoreServer] Client socket.io chargé depuis: ${candidate}`);
+          return;
+        }
+      } catch (err) {
+        console.error(`[RemoteScoreServer] Erreur lecture client socket.io ${candidate}:`, err);
+      }
+    }
+
+    console.error(
+      '[RemoteScoreServer] ERREUR: client socket.io introuvable! Chemins testés:',
+      candidates
+    );
   }
 
   // Charger les fichiers HTML en mémoire pour éviter les problèmes de chemin
@@ -261,6 +311,25 @@ export class RemoteScoreServer {
     } else {
       console.log(
         `[RemoteScoreServer] Chargement terminé: ${Array.from(this.htmlFiles.keys()).join(', ')}`
+      );
+    }
+
+    // Injecter le client socket.io inline dans chaque HTML : élimine la requête
+    // séparée /bp-sio.js (cache service worker, résolution de chemin runtime…).
+    if (this.socketIoClientJs) {
+      const inlineTag = `<script>${this.socketIoClientJs}</script>`;
+      for (const [name, content] of this.htmlFiles) {
+        // Nouvelle instance de regex à chaque itération (évite l'état lastIndex partagé)
+        const updated = content.replace(
+          /<script\s+src=["'](?:\/socket\.io\.min\.js|\/bp-sio\.js|\/socket\.io\/socket\.io\.js)["']><\/script>/g,
+          inlineTag
+        );
+        if (updated !== content) this.htmlFiles.set(name, updated);
+      }
+      console.log('[RemoteScoreServer] Client socket.io injecté inline dans le HTML ✓');
+    } else {
+      console.error(
+        '[RemoteScoreServer] ATTENTION: client socket.io non chargé, fallback sur /bp-sio.js'
       );
     }
   }
@@ -423,19 +492,17 @@ export class RemoteScoreServer {
   private setupRoutes(): void {
     console.log('[RemoteScoreServer] Configuration des routes...');
 
-    // Socket.IO client JS servi sous /bp-sio.js pour éviter l'interception Engine.IO.
-    // sendFile utilise fs.createReadStream qui échoue depuis app.asar → readFileSync
-    // (patché par Electron pour lire dans l'asar) + res.send().
+    // Fallback /bp-sio.js : sert le client socket.io déjà chargé en mémoire au
+    // démarrage. Normalement inutile (le client est injecté inline dans le HTML),
+    // mais couvre le cas d'un HTML mis en cache par le service worker.
     this.app.get('/bp-sio.js', (_req, res) => {
-      try {
-        const clientPath = require.resolve('socket.io/client-dist/socket.io.js');
-        const content = require('fs').readFileSync(clientPath, 'utf-8');
+      if (this.socketIoClientJs) {
         res.setHeader('Content-Type', 'application/javascript');
-        res.setHeader('Cache-Control', 'public, max-age=3600');
-        res.send(content);
-      } catch (e: any) {
-        console.error('[RemoteScoreServer] socket.io/client-dist introuvable:', e);
-        res.status(500).send(`// socket.io client not found: ${e?.message}`);
+        res.setHeader('Cache-Control', 'no-store');
+        res.send(this.socketIoClientJs);
+      } else {
+        console.error('[RemoteScoreServer] /bp-sio.js demandé mais client non chargé');
+        res.status(500).send('// socket.io client not loaded');
       }
     });
 

--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Arène BellePoule</title>
     <script src="/i18n.js"></script>
-    <script src="/bp-sio.js"></script>
+    <script src="/socket.io.min.js"></script>
     <style>
 
       /* Police 7 segments — style radio-réveil LCD (embarquée en base64) */

--- a/src/remote/dashboard.html
+++ b/src/remote/dashboard.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"
     />
-    <script src="/bp-sio.js"></script>
+    <script src="/socket.io.min.js"></script>
     <style>
       * {
         margin: 0;

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kiosk - BellePoule Modern</title>
-    <script src="/bp-sio.js"></script>
+    <script src="/socket.io.min.js"></script>
     <script src="/i18n.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/remote/lobby.html
+++ b/src/remote/lobby.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>En attente — BellePoule Modern</title>
-    <script src="/bp-sio.js"></script>
+    <script src="/socket.io.min.js"></script>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       body {

--- a/src/remote/overlay.html
+++ b/src/remote/overlay.html
@@ -39,7 +39,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Overlay BellePoule</title>
-    <script src="/bp-sio.js"></script>
+    <script src="/socket.io.min.js"></script>
     <style>
       /* ── Police 7 segments (embarquée, identique à arena.html) ── */
       @font-face {

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Saisie Poule – BellePoule</title>
     <script src="/i18n.js"></script>
-    <script src="/bp-sio.js"></script>
+    <script src="/socket.io.min.js"></script>
     <style>
       * {
         margin: 0;

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vue Publique – BellePoule</title>
     <script src="/i18n.js"></script>
-    <script src="/bp-sio.js"></script>
+    <script src="/socket.io.min.js"></script>
     <style>
 @font-face {
       font-family: 'ArmadaBold';

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -8,7 +8,7 @@
     />
     <title>Arbitrage - Arène BellePoule</title>
     <script src="/i18n.js"></script>
-    <script src="/bp-sio.js"></script>
+    <script src="/socket.io.min.js"></script>
     <style>
       * {
         margin: 0;

--- a/src/remote/sw.js
+++ b/src/remote/sw.js
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-const CACHE_NAME = 'bellepoule-referee-v1';
+const CACHE_NAME = 'bellepoule-referee-v2';
 // Seuls les fichiers réellement servis (pas de /styles.css ni /app.js qui sont inline)
 const ASSETS = ['/', '/referee.html', '/arena.html'];
 

--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -120,6 +120,13 @@ module.exports = (env = {}) => ({
           noErrorOnMissing: true,
         },
         {
+          // Le client socket.io n'est PAS dans node_modules de l'app packagée
+          // (socket.io est bundlé côté serveur, node_modules non inclus).
+          // On le copie dans dist/remote → servi en statique par le serveur distant.
+          from: 'node_modules/socket.io/client-dist/socket.io.min.js',
+          to: '../remote/socket.io.min.js',
+        },
+        {
           from: 'src/main/splash.html',
           to: path.resolve(__dirname, 'dist/main/splash.html'),
           noErrorOnMissing: true,


### PR DESCRIPTION
## Cause racine (enfin identifiée)

L'erreur `io is not defined` venait du fait que **le fichier client socket.io n'est jamais livré dans l'app packagée** :

- webpack **bundle socket.io côté serveur** dans `main.js` (socket.io n'est pas dans `externals`)
- le client (`socket.io.js`) vit dans `node_modules/socket.io/client-dist/`
- mais `build.files` = `["dist/**", ...]` → **node_modules n'est PAS dans le package**

Conséquence : `/socket.io/socket.io.js` (auto-servi par Engine.IO) renvoyait 404, et mes correctifs précédents via `require.resolve(...)` échouaient aussi. `io` n'était donc jamais défini → toutes les tablettes bloquées à « Connexion... ». C'est pour ça que **chaque correctif précédent ne changeait rien** : ils lisaient tous un fichier absent du build.

## Fix

1. **webpack copie** `node_modules/socket.io/client-dist/socket.io.min.js` → `dist/remote/socket.io.min.js` (au build, node_modules existe). Garanti présent dans le package (`dist/remote/**` est dans `build.files` + `asarUnpack`).
2. Les 8 HTML référencent `/socket.io.min.js` (servi en statique).
3. Le serveur **charge le client en mémoire au démarrage** et l'**injecte inline** dans le HTML servi → supprime la requête séparée et tout problème de cache service worker.
4. `/bp-sio.js` sert désormais la copie en mémoire (fallback pour HTML caché).
5. `sw.js` cache `v1` → `v2` pour purger les vieux HTML mis en cache sur les tablettes.

## Test plan

Après **rebuild complet** (`npm run build` + repackage) et reload tablette :
- [ ] `/arene1` → dot vert, plus de « io is not defined »
- [ ] `/arene1/arbitre` → connecté
- [ ] `/lobby` → apparaît dans la télécommande
- [ ] Vérifier les logs Electron : `Client socket.io chargé depuis: ...` + `injecté inline ✓`

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYL2oWRfMueVpG4cmg8xtZ)_