### PR TITLE
fix(arena): afficheurs restent en "Connexion..." — erreur syntaxe JS

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1465,6 +1465,8 @@
             const text = document.getElementById('connection-text');
             if (text) text.textContent = `❌ ${err?.message || 'Erreur réseau'}`;
           });
+
+          this.socket.on(`arena:${this.arenaId}:update`, data => {
             this.handleArenaUpdate(data);
           });
 

--- a/src/remote/sw.js
+++ b/src/remote/sw.js
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-const CACHE_NAME = 'bellepoule-referee-v2';
+const CACHE_NAME = 'bellepoule-referee-v3';
 // Seuls les fichiers réellement servis (pas de /styles.css ni /app.js qui sont inline)
 const ASSETS = ['/', '/referee.html', '/arena.html'];
 


### PR DESCRIPTION
## Cause racine

Lors de l'ajout du gestionnaire `connect_error` dans arena.html (PR précédente), la ligne d'ouverture du listener `arena:update` a été supprimée par erreur :

```js
// Manquait :
this.socket.on(`arena:${this.arenaId}:update`, data => {
    this.handleArenaUpdate(data);
});
```

Il restait le corps orphelin (`this.handleArenaUpdate(data); });`) qui produisait une **erreur de syntaxe JavaScript**. Résultat : le script entier ne s'exécutait pas, le socket n'était jamais créé, et l'afficheur restait bloqué sur le point rouge « Connexion... ».

## Corrections

- `arena.html` : restaure le `socket.on(arena:update)` manquant
- `sw.js` : cache v2 → v3 pour forcer le rechargement sur les écrans qui ont l'ancien fichier en cache

https://claude.ai/code/session_01JYL2oWRfMueVpG4cmg8xtZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYL2oWRfMueVpG4cmg8xtZ)_