### PR TITLE
feat(pools): refonte visuelle interface poules

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -1144,6 +1144,22 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           <span className={`badge ${pool.isComplete ? 'badge-success' : 'badge-warning'}`}>
             {pool.isComplete ? 'Terminée' : `${finishedCount}/${totalMatches}`}
           </span>
+          {!pool.isComplete && totalMatches > 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.375rem' }}>
+              <div style={{ width: '72px', height: '5px', background: '#e5e7eb', borderRadius: '3px', overflow: 'hidden' }}>
+                <div style={{
+                  height: '100%',
+                  width: `${(finishedCount / totalMatches) * 100}%`,
+                  background: finishedCount / totalMatches >= 0.7 ? '#10b981' : '#f59e0b',
+                  borderRadius: '3px',
+                  transition: 'width 0.4s ease',
+                }} />
+              </div>
+              <span style={{ fontSize: '0.7rem', color: '#9ca3af', fontWeight: 600, whiteSpace: 'nowrap' }}>
+                {finishedCount}/{totalMatches}
+              </span>
+            </div>
+          )}
           {(() => {
             const total = pool.fencers.length;
             const signed = signedFencerIds.filter(id => pool.fencers.some(f => f.id === id)).length;

--- a/src/renderer/components/pool/PoolMatchList.tsx
+++ b/src/renderer/components/pool/PoolMatchList.tsx
@@ -149,7 +149,7 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
 
   return (
   <div>
-    {/* Prochain match en gros */}
+    {/* Prochain match — carte sombre impactante */}
     {orderedMatches.pending.length > 0 &&
       (() => {
         const nextMatch = orderedMatches.pending[0];
@@ -167,60 +167,33 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
           return (
             <div
               style={{
-                background: '#6b7280',
-                borderRadius: '8px',
-                padding: '1.5rem',
+                background: '#374151',
+                borderRadius: '10px',
+                padding: '1.25rem 1.5rem',
                 marginBottom: '1rem',
                 color: 'white',
-                opacity: 0.7,
+                opacity: 0.75,
+                borderLeft: '4px solid #9ca3af',
               }}
             >
-              <div
-                style={{
-                  fontSize: '0.75rem',
-                  textTransform: 'uppercase',
-                  opacity: 0.8,
-                  marginBottom: '0.5rem',
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                }}
-              >
-                <span>✕ Match non disputé</span>
+              <div style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: '#9ca3af', marginBottom: '0.75rem' }}>
+                ✕ Match non disputé
               </div>
-              <div
-                style={ROW_BETWEEN}
-              >
-                <div style={CELL_CENTER}>
-                  <div
-                    style={{
-                      fontSize: '1.5rem',
-                      fontWeight: '700',
-                      textDecoration: fencerAAbandoned ? 'line-through' : 'none',
-                    }}
-                  >
-                    {nextMatch.match.fencerA?.lastName}
-                    {fencerAAbandoned && ' ✕'}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem' }}>
+                <div style={{ flex: 1, textAlign: 'right' }}>
+                  <div style={{ fontSize: '1.5rem', fontWeight: 800, textDecoration: fencerAAbandoned ? 'line-through' : 'none', lineHeight: 1.1 }}>
+                    {nextMatch.match.fencerA?.lastName}{fencerAAbandoned && ' ✕'}
                   </div>
-                  <div style={SUB_TEXT}>
+                  <div style={{ fontSize: '0.8rem', color: '#9ca3af', marginTop: '0.2rem' }}>
                     {nextMatch.match.fencerA?.firstName}
                   </div>
                 </div>
-                <div style={VS_SEP}>
-                  vs
-                </div>
-                <div style={CELL_CENTER}>
-                  <div
-                    style={{
-                      fontSize: '1.5rem',
-                      fontWeight: '700',
-                      textDecoration: fencerBAbandoned ? 'line-through' : 'none',
-                    }}
-                  >
-                    {nextMatch.match.fencerB?.lastName}
-                    {fencerBAbandoned && ' ✕'}
+                <div style={{ fontSize: '1.25rem', color: '#6b7280', flexShrink: 0 }}>vs</div>
+                <div style={{ flex: 1, textAlign: 'left' }}>
+                  <div style={{ fontSize: '1.5rem', fontWeight: 800, textDecoration: fencerBAbandoned ? 'line-through' : 'none', lineHeight: 1.1 }}>
+                    {nextMatch.match.fencerB?.lastName}{fencerBAbandoned && ' ✕'}
                   </div>
-                  <div style={SUB_TEXT}>
+                  <div style={{ fontSize: '0.8rem', color: '#9ca3af', marginTop: '0.2rem' }}>
                     {nextMatch.match.fencerB?.firstName}
                   </div>
                 </div>
@@ -232,25 +205,17 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
         return (
           <div
             style={{
-              background: 'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)',
-              borderRadius: '8px',
-              padding: '1.5rem',
+              background: '#0f172a',
+              borderRadius: '10px',
+              padding: '1.25rem 1.5rem',
               marginBottom: '1rem',
-              color: 'white',
+              borderLeft: '4px solid #f97316',
             }}
           >
-            <div
-              style={{
-                fontSize: '0.75rem',
-                textTransform: 'uppercase',
-                opacity: 0.8,
-                marginBottom: '0.5rem',
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-              }}
-            >
-              <span>⚔️ Prochain match</span>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+              <span style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: '#64748b', fontWeight: 600 }}>
+                ⚔ Prochain match
+              </span>
               <ArenaBadge
                 match={nextMatch.match}
                 defaultArena={defaultArena}
@@ -261,62 +226,56 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                 onClick={e => openArenaModal(nextMatch.match, e)}
               />
             </div>
-            <div
-              style={ROW_BETWEEN}
-            >
-              <div style={CELL_CENTER}>
-                <div style={NAME_BIG}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.75rem', marginBottom: '1.25rem' }}>
+              <div style={{ flex: 1, textAlign: 'right' }}>
+                <div style={{ fontSize: '1.75rem', fontWeight: 800, color: 'white', lineHeight: 1.1 }}>
                   {orderedMatches.pending[0].match.fencerA?.lastName}
                 </div>
-                <div style={SUB_TEXT}>
+                <div style={{ fontSize: '0.8rem', color: '#64748b', marginTop: '0.25rem' }}>
                   {orderedMatches.pending[0].match.fencerA?.firstName}
                 </div>
               </div>
-              <div style={VS_SEP}>VS</div>
-              <div style={CELL_CENTER}>
-                <div style={NAME_BIG}>
+              <div style={{ fontSize: '1.75rem', color: '#f97316', flexShrink: 0, fontWeight: 900, lineHeight: 1 }}>
+                ⚔
+              </div>
+              <div style={{ flex: 1, textAlign: 'left' }}>
+                <div style={{ fontSize: '1.75rem', fontWeight: 800, color: 'white', lineHeight: 1.1 }}>
                   {orderedMatches.pending[0].match.fencerB?.lastName}
                 </div>
-                <div style={SUB_TEXT}>
+                <div style={{ fontSize: '0.8rem', color: '#64748b', marginTop: '0.25rem' }}>
                   {orderedMatches.pending[0].match.fencerB?.firstName}
                 </div>
               </div>
             </div>
             <button
               onClick={() => openScoreModal(orderedMatches.pending[0].index)}
+              className="pool-cta-pulse"
               style={{
-                marginTop: '1rem',
                 width: '100%',
-                padding: '0.75rem',
-                background: 'rgba(255,255,255,0.2)',
-                border: '2px solid rgba(255,255,255,0.3)',
-                borderRadius: '6px',
+                padding: '0.875rem',
+                background: '#f97316',
+                border: 'none',
+                borderRadius: '7px',
                 color: 'white',
-                fontSize: '1rem',
-                fontWeight: '600',
+                fontSize: '0.95rem',
+                fontWeight: 700,
                 cursor: 'pointer',
+                letterSpacing: '0.02em',
               }}
             >
-              🎯 Saisir le score
+              Saisir le score
             </button>
           </div>
         );
       })()}
 
-    {/* Matches restants */}
+    {/* Matches restants — strip horizontal scrollable */}
     {orderedMatches.pending.length > 1 && (
       <div style={{ marginBottom: '1rem' }}>
-        <h4
-          style={{
-            fontSize: '0.875rem',
-            fontWeight: '600',
-            marginBottom: '0.5rem',
-            color: '#6b7280',
-          }}
-        >
-          Matches à venir ({orderedMatches.pending.length - 1})
-        </h4>
-        <div style={COL_GAP}>
+        <div style={{ fontSize: '0.7rem', fontWeight: 700, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '0.5rem' }}>
+          À venir ({orderedMatches.pending.length - 1})
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem', overflowX: 'auto', paddingBottom: '0.25rem' }}>
           {orderedMatches.pending.slice(1).map(({ match, index }, i) => {
             const fencerAAbandoned =
               match.fencerA?.status === FencerStatus.ABANDONED ||
@@ -332,56 +291,41 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
               <div
                 key={index}
                 onClick={() => !isAbandonMatch && openScoreModal(index)}
+                title={isAbandonMatch ? 'Match non disputé' : undefined}
                 style={{
+                  flexShrink: 0,
                   display: 'flex',
                   alignItems: 'center',
-                  justifyContent: 'space-between',
-                  padding: '0.75rem 1rem',
-                  background: isAbandonMatch ? '#e5e7eb' : '#f9fafb',
-                  borderRadius: '6px',
+                  gap: '0.35rem',
+                  padding: '0.375rem 0.75rem',
+                  background: isAbandonMatch ? '#f3f4f6' : '#f1f5f9',
+                  border: `1px solid ${isAbandonMatch ? '#d1d5db' : '#e2e8f0'}`,
+                  borderRadius: '20px',
                   cursor: isAbandonMatch ? 'not-allowed' : 'pointer',
-                  border: isAbandonMatch ? '1px dashed #9ca3af' : '1px solid #e5e7eb',
                   opacity: isAbandonMatch ? 0.5 : 1,
-                  gap: '0.5rem',
+                  transition: 'background 0.1s, border-color 0.1s',
                 }}
+                onMouseEnter={e => { if (!isAbandonMatch) { (e.currentTarget as HTMLElement).style.background = '#e2e8f0'; (e.currentTarget as HTMLElement).style.borderColor = '#cbd5e1'; } }}
+                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = isAbandonMatch ? '#f3f4f6' : '#f1f5f9'; (e.currentTarget as HTMLElement).style.borderColor = isAbandonMatch ? '#d1d5db' : '#e2e8f0'; }}
               >
-                <span style={NUM_BADGE}>
-                  #{i + 2}
-                </span>
-                <span
-                  style={{
-                    flex: 1,
-                    fontWeight: '500',
-                    textDecoration: fencerAAbandoned ? 'line-through' : 'none',
-                    color: fencerAAbandoned ? '#9ca3af' : 'inherit',
-                  }}
-                >
+                <span style={{ fontSize: '0.65rem', color: '#94a3b8', fontWeight: 700 }}>#{i + 2}</span>
+                <span style={{ fontSize: '0.8rem', fontWeight: 600, color: '#334155', textDecoration: fencerAAbandoned ? 'line-through' : 'none' }}>
                   {match.fencerA?.lastName}
-                  {fencerAAbandoned && ' ✕'}
                 </span>
-                <span style={{ color: '#9ca3af', padding: '0 0.5rem' }}>
-                  {isAbandonMatch ? '✕' : 'vs'}
-                </span>
-                <span
-                  style={{
-                    flex: 1,
-                    textAlign: 'right',
-                    fontWeight: '500',
-                    textDecoration: fencerBAbandoned ? 'line-through' : 'none',
-                    color: fencerBAbandoned ? '#9ca3af' : 'inherit',
-                  }}
-                >
+                <span style={{ fontSize: '0.7rem', color: '#94a3b8' }}>vs</span>
+                <span style={{ fontSize: '0.8rem', fontWeight: 600, color: '#334155', textDecoration: fencerBAbandoned ? 'line-through' : 'none' }}>
                   {match.fencerB?.lastName}
-                  {fencerBAbandoned && ' ✕'}
                 </span>
-                <ArenaBadge
-                  match={match}
-                  defaultArena={defaultArena}
-                  matchArenaOverrides={matchArenaOverrides}
-                  isRemoteActive={isRemoteActive}
-                  arenaCount={arenaCount}
-                  onClick={e => openArenaModal(match, e)}
-                />
+                {arenaCount > 0 && (
+                  <ArenaBadge
+                    match={match}
+                    defaultArena={defaultArena}
+                    matchArenaOverrides={matchArenaOverrides}
+                    isRemoteActive={isRemoteActive}
+                    arenaCount={arenaCount}
+                    onClick={e => openArenaModal(match, e)}
+                  />
+                )}
               </div>
             );
           })}
@@ -392,17 +336,10 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
     {/* Matches terminés */}
     {orderedMatches.finished.length > 0 && (
       <div>
-        <h4
-          style={{
-            fontSize: '0.875rem',
-            fontWeight: '600',
-            marginBottom: '0.5rem',
-            color: '#6b7280',
-          }}
-        >
-          Matches terminés ({orderedMatches.finished.length})
-        </h4>
-        <div style={COL_GAP}>
+        <div style={{ fontSize: '0.7rem', fontWeight: 700, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '0.5rem' }}>
+          Terminés ({orderedMatches.finished.length})
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
           {orderedMatches.finished.map(({ match, index }) => {
             const fencerAAbandoned =
               match.fencerA?.status === FencerStatus.ABANDONED ||
@@ -413,6 +350,7 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
               match.fencerB?.status === FencerStatus.FORFAIT ||
               match.fencerB?.status === FencerStatus.EXCLUDED;
             const isAbandonMatch = fencerAAbandoned || fencerBAbandoned;
+            const winnerA = !!match.scoreA?.isVictory;
 
             return (
               <div
@@ -421,71 +359,55 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                 style={{
                   display: 'flex',
                   alignItems: 'center',
-                  justifyContent: 'space-between',
-                  padding: '0.75rem 1rem',
-                  background: isAbandonMatch
-                    ? '#e5e7eb'
-                    : match.scoreA?.isVictory
-                      ? '#f0fdf4'
-                      : '#fef2f2',
-                  borderRadius: '6px',
-                  cursor: isAbandonMatch || isLocked ? 'not-allowed' : 'pointer',
-                  border: isAbandonMatch ? '1px dashed #9ca3af' : '1px solid #e5e7eb',
-                  opacity: isAbandonMatch ? 0.5 : 1,
+                  padding: '0.5rem 0.75rem 0.5rem 0.875rem',
+                  background: 'white',
+                  borderRadius: '7px',
+                  border: '1px solid #e5e7eb',
+                  borderLeft: isAbandonMatch ? '3px solid #9ca3af' : winnerA ? '3px solid #059669' : '3px solid #dc2626',
+                  cursor: isAbandonMatch || isLocked ? 'default' : 'pointer',
+                  opacity: isAbandonMatch ? 0.55 : 1,
+                  gap: '0.5rem',
                 }}
               >
                 <span
                   style={{
                     flex: 1,
-                    fontWeight: match.scoreA?.isVictory ? '600' : '400',
-                    color: isAbandonMatch
-                      ? '#9ca3af'
-                      : match.scoreA?.isVictory
-                        ? '#16a34a'
-                        : '#6b7280',
+                    fontWeight: winnerA && !isAbandonMatch ? 700 : 400,
+                    color: isAbandonMatch ? '#9ca3af' : winnerA ? '#065f46' : '#6b7280',
                     textDecoration: fencerAAbandoned ? 'line-through' : 'none',
+                    fontSize: '0.875rem',
                   }}
                 >
-                  {match.scoreA?.isVictory ? '✓ ' : ''}
                   {match.fencerA?.lastName}
                   {fencerAAbandoned && ' ✕'}
                 </span>
                 <span
                   style={{
-                    padding: '0.25rem 0.75rem',
-                    background: isAbandonMatch ? '#e5e7eb' : 'white',
-                    borderRadius: '4px',
-                    fontWeight: '600',
-                    fontSize: '0.875rem',
-                    color: isAbandonMatch ? '#9ca3af' : 'inherit',
+                    padding: '0.2rem 0.625rem',
+                    background: isAbandonMatch ? '#f3f4f6' : '#f8fafc',
+                    border: '1px solid #e5e7eb',
+                    borderRadius: '5px',
+                    fontWeight: 700,
+                    fontSize: '0.8rem',
+                    color: isAbandonMatch ? '#9ca3af' : '#374151',
+                    flexShrink: 0,
+                    letterSpacing: '0.03em',
                   }}
                 >
-                  {isAbandonMatch ? (
-                    '✕ Non disputé'
-                  ) : (
-                    <>
-                      {match.scoreA?.isVictory ? 'V' : ''}
-                      {match.scoreA?.value} - {match.scoreB?.isVictory ? 'V' : ''}
-                      {match.scoreB?.value}
-                    </>
-                  )}
+                  {isAbandonMatch ? '–' : `${match.scoreA?.isVictory ? 'V' : ''}${match.scoreA?.value ?? 0} : ${match.scoreB?.isVictory ? 'V' : ''}${match.scoreB?.value ?? 0}`}
                 </span>
                 <span
                   style={{
                     flex: 1,
                     textAlign: 'right',
-                    fontWeight: match.scoreB?.isVictory ? '600' : '400',
-                    color: isAbandonMatch
-                      ? '#9ca3af'
-                      : match.scoreB?.isVictory
-                        ? '#16a34a'
-                        : '#6b7280',
+                    fontWeight: !winnerA && !isAbandonMatch ? 700 : 400,
+                    color: isAbandonMatch ? '#9ca3af' : !winnerA ? '#065f46' : '#6b7280',
                     textDecoration: fencerBAbandoned ? 'line-through' : 'none',
+                    fontSize: '0.875rem',
                   }}
                 >
                   {match.fencerB?.lastName}
                   {fencerBAbandoned && ' ✕'}
-                  {match.scoreB?.isVictory && !isAbandonMatch ? ' ✓' : ''}
                 </span>
                 {onShowMatchAudit && (
                   <button
@@ -495,9 +417,8 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                     }}
                     title="Journal du match"
                     style={{
-                      marginLeft: '0.5rem',
-                      padding: '0.25rem 0.5rem',
-                      fontSize: '0.75rem',
+                      padding: '0.2rem 0.4rem',
+                      fontSize: '0.7rem',
                       background: 'rgba(139,92,246,0.1)',
                       border: '1px solid rgba(139,92,246,0.3)',
                       borderRadius: '4px',
@@ -517,9 +438,8 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                     }}
                     title="Annuler ce résultat"
                     style={{
-                      marginLeft: '0.5rem',
-                      padding: '0.25rem 0.5rem',
-                      fontSize: '0.75rem',
+                      padding: '0.2rem 0.4rem',
+                      fontSize: '0.7rem',
                       background: 'rgba(239,68,68,0.1)',
                       border: '1px solid rgba(239,68,68,0.3)',
                       borderRadius: '4px',
@@ -540,11 +460,11 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
 
     {/* Matches annulés */}
     {orderedMatches.cancelled.length > 0 && (
-      <div style={{ marginBottom: '1.5rem' }}>
-        <h4 style={SECTION_TITLE}>
-          Matches annulés ({orderedMatches.cancelled.length})
-        </h4>
-        <div style={COL_GAP}>
+      <div style={{ marginBottom: '1.5rem', marginTop: '0.75rem' }}>
+        <div style={{ fontSize: '0.7rem', fontWeight: 700, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '0.5rem' }}>
+          Annulés ({orderedMatches.cancelled.length})
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
           {orderedMatches.cancelled.map(({ match, index }) => (
             <div
               key={index}
@@ -552,15 +472,16 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'space-between',
-                padding: '0.75rem 1rem',
-                background: '#f3f4f6',
-                borderRadius: '6px',
+                padding: '0.5rem 0.875rem',
+                background: '#f9fafb',
+                borderRadius: '7px',
                 border: '1px dashed #d1d5db',
                 opacity: 0.8,
+                gap: '0.5rem',
               }}
             >
-              <span style={{ color: '#9ca3af', fontSize: '0.875rem', minWidth: '30px' }}>⏸</span>
-              <span style={{ flex: 1, textAlign: 'center', color: '#6b7280', textDecoration: 'line-through' }}>
+              <span style={{ color: '#9ca3af', fontSize: '0.8rem', minWidth: '24px' }}>⏸</span>
+              <span style={{ flex: 1, textAlign: 'center', color: '#6b7280', fontSize: '0.875rem', textDecoration: 'line-through' }}>
                 {match.fencerA?.lastName} vs {match.fencerB?.lastName}
               </span>
               {!isLocked && onMatchReset && (
@@ -568,8 +489,7 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                   onClick={() => onMatchReset(index)}
                   title="Relancer ce match"
                   style={{
-                    marginLeft: '0.5rem',
-                    padding: '0.25rem 0.5rem',
+                    padding: '0.2rem 0.5rem',
                     fontSize: '0.75rem',
                     background: 'rgba(59,130,246,0.1)',
                     border: '1px solid rgba(59,130,246,0.3)',
@@ -590,10 +510,10 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
 
     {/* Poule terminée */}
     {orderedMatches.pending.length === 0 && orderedMatches.cancelled.length === 0 && (
-      <div style={{ textAlign: 'center', padding: '2rem', color: '#6b7280' }}>
-        <div style={{ fontSize: '3rem', marginBottom: '0.5rem' }}>🏁</div>
-        <div style={{ fontWeight: '600' }}>Poule terminée !</div>
-        <div style={{ fontSize: '0.875rem' }}>Tous les matches ont été joués</div>
+      <div style={{ textAlign: 'center', padding: '2.5rem 2rem', color: '#6b7280' }}>
+        <div style={{ fontSize: '2.5rem', marginBottom: '0.75rem' }}>🏁</div>
+        <div style={{ fontWeight: 700, fontSize: '1rem', color: '#374151' }}>Poule terminée</div>
+        <div style={{ fontSize: '0.8rem', marginTop: '0.25rem' }}>Tous les matches ont été joués</div>
       </div>
     )}
 

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -332,11 +332,11 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
         const rankEntry = rowDataMap.rankById.get(rowFencer.id);
         const rankRatio = (rankEntry?.rank ?? fencers.length) / fencers.length;
         const rowBg =
-          rankRatio <= 0.7
-            ? 'rgba(16,185,129,0.08)'
-            : rankRatio <= 0.9
+          rankRatio <= 0.4
+            ? 'rgba(16,185,129,0.12)'
+            : rankRatio <= 0.75
               ? 'rgba(245,158,11,0.10)'
-              : 'rgba(239,68,68,0.08)';
+              : 'rgba(239,68,68,0.10)';
 
         const sparkBars = rowDataMap.sparkById.get(rowFencer.id) ?? [];
 
@@ -345,24 +345,46 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
             <div
               className="pool-cell pool-cell-header pool-cell-name"
               title={`${rowFencer.firstName} ${rowFencer.lastName}`}
-              style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}
+              style={{ display: 'flex', alignItems: 'center', gap: '0.375rem' }}
             >
-              <span style={{ fontWeight: 500 }}>{rowIndex + 1}.</span>
-              <span className="truncate" style={{ flex: 1 }}>
-                {rowFencer.lastName}
-                <span style={{ fontSize: '0.75rem', color: '#6b7280', marginLeft: '0.25rem' }}>
-                  {rowFencer.firstName}
+              {(() => {
+                const avatarColor =
+                  rankRatio <= 0.4 ? '#059669' : rankRatio <= 0.75 ? '#3b82f6' : '#dc2626';
+                const initials = `${rowFencer.firstName?.charAt(0) ?? ''}${rowFencer.lastName?.charAt(0) ?? ''}`.toUpperCase();
+                return (
+                  <div style={{
+                    width: '26px',
+                    height: '26px',
+                    borderRadius: '50%',
+                    background: avatarColor,
+                    color: 'white',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '0.6rem',
+                    fontWeight: 700,
+                    flexShrink: 0,
+                  }}>
+                    {initials}
+                  </div>
+                );
+              })()}
+              <span className="truncate" style={{ flex: 1, fontSize: '0.8rem' }}>
+                <span style={{ fontWeight: 700 }}>{rowFencer.lastName}</span>
+                <span style={{ fontSize: '0.7rem', color: '#6b7280', marginLeft: '0.25rem' }}>
+                  {rowFencer.firstName?.charAt(0)}.
                 </span>
               </span>
               {sparkBars.length > 0 && (
-                <svg width="16" height="10" style={{ flexShrink: 0 }} aria-hidden="true">
+                <svg width="28" height="14" style={{ flexShrink: 0 }} aria-hidden="true">
                   {sparkBars.map((won, i) => (
                     <rect
                       key={i}
-                      x={i * (16 / sparkBars.length)}
-                      y={won ? 0 : 4}
-                      width={Math.max(1, 16 / sparkBars.length - 1)}
-                      height={won ? 10 : 6}
+                      x={i * (28 / sparkBars.length) + 0.5}
+                      y={won ? 0 : 6}
+                      width={Math.max(1, 28 / sparkBars.length - 1.5)}
+                      height={won ? 14 : 8}
+                      rx="1"
                       fill={won ? '#22c55e' : '#ef4444'}
                     />
                   ))}

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -340,6 +340,7 @@ body {
   border: 2px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow: hidden;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.06);
 }
 
 .pool-row {
@@ -347,47 +348,70 @@ body {
 }
 
 .pool-cell {
-  width: 48px;
-  height: 48px;
+  width: 52px;
+  height: 52px;
   display: flex;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--color-border);
   font-weight: 500;
+  font-size: 0.875rem;
+  transition: background 0.1s, transform 0.1s;
 }
 
 .pool-cell-header {
   background: var(--color-bg);
-  font-weight: 600;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .pool-cell-name {
-  width: 150px;
+  width: 210px;
   justify-content: flex-start;
   padding-left: 0.5rem;
+  padding-right: 0.25rem;
 }
 
 .pool-cell-diagonal {
-  background: #374151;
+  background: #1e293b;
 }
 
 .pool-cell-victory {
-  background: #d1fae5;
-  color: #065f46;
+  background: #059669;
+  color: #fff;
+  font-weight: 700;
 }
 
 .pool-cell-defeat {
-  background: #fee2e2;
-  color: #991b1b;
+  background: #fff1f2;
+  color: #9f1239;
+  font-weight: 500;
 }
 
 .pool-cell-editable {
   cursor: pointer;
+  background: #f8fafc;
+  color: #9ca3af;
 }
 
 .pool-cell-editable:hover {
   background: var(--color-primary-light);
   color: white;
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 2px 8px rgba(59,130,246,0.25);
+}
+
+@keyframes pool-cta-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(249,115,22,0.5); }
+  50% { box-shadow: 0 0 0 10px rgba(249,115,22,0); }
+}
+
+.pool-cta-pulse {
+  animation: pool-cta-pulse 1.8s ease infinite;
 }
 
 /* Tableau (Direct Elimination) */
@@ -785,9 +809,9 @@ body {
 }
 
 /* Dark mode overrides for hardcoded colors */
-.theme-dark .pool-cell-diagonal { background: #1f2937; }
-.theme-dark .pool-cell-victory { background: #14532d; color: #86efac; }
-.theme-dark .pool-cell-defeat { background: #450a0a; color: #fca5a5; }
+.theme-dark .pool-cell-diagonal { background: #0f172a; }
+.theme-dark .pool-cell-victory { background: #065f46; color: #a7f3d0; }
+.theme-dark .pool-cell-defeat { background: #4c0519; color: #fda4af; }
 .theme-dark .tableau-fencer-winner { background: #14532d; color: #86efac; }
 .theme-dark .badge-success { background: #14532d; color: #86efac; }
 .theme-dark .badge-warning { background: #451a03; color: #fcd34d; }


### PR DESCRIPTION
## Résumé

- **Grille matricielle** : cellules 52px (vs 48), colonne noms 210px, avatars circulaires colorés par rang (initiales), sparkline 28px avec coins arrondis, fond de ligne gradient vert/amber/rouge plus marqué, victoire = vert solide blanc, défaite = fond rosé discret
- **En-tête de poule** : barre de progression animée (orange → vert) avec compteur `X/N`
- **Vue Matches — Prochain match** : carte sombre slate-900 avec bordure orange, noms en 1.75rem bold, icône ⚔ orange au centre, bouton CTA orange avec animation pulse CSS
- **Vue Matches — À venir** : strip horizontal scrollable (chips arrondies) au lieu d'une liste verticale
- **Vue Matches — Terminés** : bordure gauche verte (gagnant A) ou rouge (gagnant B), score centré dans un chip, gagnant en gras

## Plan de test

- [ ] Ouvrir une poule avec des matches en cours — vérifier la barre de progression
- [ ] Vue Tableau : grille, avatars, couleurs victoire/défaite
- [ ] Vue Matches : carte "Prochain match" sombre + bouton pulse
- [ ] Strip horizontal "À venir" — scroll si beaucoup de matches
- [ ] Matches terminés — bordure colorée gauche correcte
- [ ] Thème sombre — vérifier les overrides CSS

https://claude.ai/code/session_01BUzom5nu2CeQzrCnB6YY4J

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUzom5nu2CeQzrCnB6YY4J)_