### PR TITLE
Redesign interface classement après poules

### DIFF
--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -313,6 +313,18 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     return [headers, ...rows].map(row => row.join(';')).join('\n');
   };
 
+  const activeRanking =
+    splitCriteria && splitTab !== 'all'
+      ? (splitRankings?.get(splitTab) ?? [])
+      : editedRanking;
+
+  const getRankBadgeClass = (rank: number) => {
+    if (rank === 1) return 'ranking-rank-badge ranking-rank-badge--gold';
+    if (rank === 2) return 'ranking-rank-badge ranking-rank-badge--silver';
+    if (rank === 3) return 'ranking-rank-badge ranking-rank-badge--bronze';
+    return 'ranking-rank-badge';
+  };
+
   return (
     <div className="content" style={{ padding: '1rem' }}>
       <div
@@ -334,100 +346,40 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
             {isEditing && ' (mode édition)'}
           </p>
         </div>
-        <div style={FLEX_GAP}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
           {!isInitialRanking && (
-            <button
-              className="btn btn-secondary"
-              onClick={handleRecalculate}
-              title="Recalculer le classement"
-            >
-              🔄 Recalculer
+            <button className="btn btn-secondary" onClick={handleRecalculate} title="Recalculer le classement" style={{ fontSize: '0.8rem' }}>
+              Recalculer
             </button>
           )}
-          <button
-            className="btn btn-secondary"
-            onClick={() => handleExport('csv')}
-            title="Exporter en CSV"
-          >
-            📄 CSV
-          </button>
-          <button
-            className="btn btn-secondary"
-            onClick={handleExportPDF}
-            title="Exporter le classement en PDF"
-          >
-            📋 Export PDF
-          </button>
-          <button className="btn btn-secondary" onClick={handlePrint} title="Imprimer">
-            🖨️ Imprimer
-          </button>
+          <div style={{ width: '1px', height: '22px', background: 'var(--color-border)', margin: '0 0.15rem' }} />
+          <button className="btn btn-secondary" onClick={() => handleExport('csv')} style={{ fontSize: '0.8rem' }}>CSV</button>
+          <button className="btn btn-secondary" onClick={handleExportPDF} style={{ fontSize: '0.8rem' }}>PDF</button>
+          <button className="btn btn-secondary" onClick={handlePrint} style={{ fontSize: '0.8rem' }}>Imprimer</button>
+          <div style={{ width: '1px', height: '22px', background: 'var(--color-border)', margin: '0 0.15rem' }} />
           {!isInSplitGroupTab && (
             <button
-              className="btn btn-secondary"
+              className={`btn ${isEditing ? 'btn-primary' : 'btn-secondary'}`}
               onClick={() => (isEditing ? saveChanges() : setIsEditing(true))}
-              title={isEditing ? 'Terminer la modification' : 'Modifier le classement'}
+              style={{ fontSize: '0.8rem' }}
             >
-              {isEditing ? '✓ Terminer' : '✏️ Modifier'}
+              {isEditing ? 'Terminer' : 'Modifier'}
             </button>
           )}
           <div style={{ position: 'relative' }} ref={columnMenuRef}>
             <button
               onClick={() => setShowColumnMenu(!showColumnMenu)}
-              style={{
-                padding: '0.375rem 0.75rem',
-                fontSize: '0.75rem',
-                background: showColumnMenu ? '#6b7280' : '#e5e7eb',
-                color: showColumnMenu ? 'white' : '#374151',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-              }}
+              className="btn btn-secondary"
+              style={{ fontSize: '0.8rem', padding: '0.375rem 0.65rem' }}
               title="Afficher/masquer les colonnes"
             >
-              ⚙️
+              Colonnes
             </button>
             {showColumnMenu && (
-              <div
-                style={{
-                  position: 'absolute',
-                  top: '100%',
-                  right: 0,
-                  marginTop: '0.25rem',
-                  background: 'white',
-                  border: '1px solid #e5e7eb',
-                  borderRadius: '6px',
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                  zIndex: 100,
-                  minWidth: '200px',
-                  padding: '0.5rem',
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: '0.75rem',
-                    fontWeight: 600,
-                    padding: '0.25rem 0.5rem',
-                    borderBottom: '1px solid #e5e7eb',
-                    marginBottom: '0.25rem',
-                  }}
-                >
-                  Colonnes à afficher
-                </div>
+              <div className="ranking-col-menu">
+                <div className="ranking-col-menu-title">Colonnes à afficher</div>
                 {RANKING_COLUMNS.filter(col => col.id !== 'quest' || isLaserSabre).map(col => (
-                  <label
-                    key={col.id}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '0.5rem',
-                      padding: '0.375rem 0.5rem',
-                      cursor: 'pointer',
-                      borderRadius: '4px',
-                      fontSize: '0.8rem',
-                    }}
-                    onMouseEnter={e => (e.currentTarget.style.background = '#f3f4f6')}
-                    onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-                  >
+                  <label key={col.id} className="ranking-col-menu-item">
                     <input
                       type="checkbox"
                       checked={isVisible(col.id)}
@@ -487,20 +439,20 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
             </tr>
           </thead>
           <tbody>
-            {(splitCriteria && splitTab !== 'all'
-              ? (splitRankings?.get(splitTab) ?? [])
-              : editedRanking
-            ).map((ranking, index) => (
+            {activeRanking.map((ranking, index) => {
+              const prevRank = index > 0 ? activeRanking[index - 1].rank : null;
+              const nextRank = index < activeRanking.length - 1 ? activeRanking[index + 1].rank : null;
+              const isTied = prevRank === ranking.rank || nextRank === ranking.rank;
+              const isQualified = poolWinnerIds?.has(ranking.fencer.id);
+              const dimmed = poolWinnersOnly && poolWinnerIds && !isQualified;
+              return (
               <tr
                 key={ranking.fencer.id}
-                style={
-                  poolWinnersOnly && poolWinnerIds && !poolWinnerIds.has(ranking.fencer.id)
-                    ? { opacity: 0.45 }
-                    : undefined
-                }
+                className={isTied ? 'ranking-row--tie' : undefined}
+                style={dimmed ? { opacity: 0.45 } : undefined}
               >
                 {isVisible('rank') && (
-                  <td style={{ fontWeight: '600' }}>
+                  <td>
                     {isEditing ? (
                       <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
                         <input
@@ -532,57 +484,45 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
                               (e.target as HTMLInputElement).blur();
                             }
                           }}
-                          style={{
-                            width: '44px',
-                            textAlign: 'center',
-                            padding: '1px 4px',
-                            fontWeight: '600',
-                          }}
+                          style={{ width: '44px', textAlign: 'center', padding: '1px 4px', fontWeight: '600' }}
                         />
                         <div style={{ display: 'flex', flexDirection: 'column' }}>
                           <button
                             onClick={() => moveUp(index)}
                             disabled={index === 0}
-                            style={{
-                              padding: '0 2px',
-                              fontSize: '10px',
-                              cursor: index === 0 ? 'not-allowed' : 'pointer',
-                              opacity: index === 0 ? 0.3 : 1,
-                            }}
-                          >
-                            ▲
-                          </button>
+                            className="pool-prep-btn-move"
+                            style={{ opacity: index === 0 ? 0.3 : 1 }}
+                          >▲</button>
                           <button
                             onClick={() => moveDown(index)}
                             disabled={index === editedRanking.length - 1}
-                            style={{
-                              padding: '0 2px',
-                              fontSize: '10px',
-                              cursor:
-                                index === editedRanking.length - 1 ? 'not-allowed' : 'pointer',
-                              opacity: index === editedRanking.length - 1 ? 0.3 : 1,
-                            }}
-                          >
-                            ▼
-                          </button>
+                            className="pool-prep-btn-move"
+                            style={{ opacity: index === editedRanking.length - 1 ? 0.3 : 1 }}
+                          >▼</button>
                         </div>
                       </div>
                     ) : (
-                      ranking.rank
+                      <span className={getRankBadgeClass(ranking.rank)}>{ranking.rank}</span>
                     )}
                   </td>
                 )}
                 {isVisible('lastName') && (
                   <td className="font-medium">
                     {ranking.fencer.lastName}
-                    {ranking.fencer.status === FencerStatus.ABANDONED && ' (A)'}
-                    {ranking.fencer.status === FencerStatus.FORFAIT && ' (F)'}
-                    {ranking.fencer.status === FencerStatus.EXCLUDED && ' (X)'}
+                    {ranking.fencer.status === FencerStatus.ABANDONED && (
+                      <span className="ranking-status-badge ranking-status-badge--abandon">A</span>
+                    )}
+                    {ranking.fencer.status === FencerStatus.FORFAIT && (
+                      <span className="ranking-status-badge ranking-status-badge--forfait">F</span>
+                    )}
+                    {ranking.fencer.status === FencerStatus.EXCLUDED && (
+                      <span className="ranking-status-badge ranking-status-badge--exclu">X</span>
+                    )}
                   </td>
                 )}
                 {isVisible('firstName') && <td>{ranking.fencer.firstName}</td>}
                 {isVisible('club') && (
-                  <td className="text-sm text-muted">{ranking.fencer.club || '-'}</td>
+                  <td className="text-sm text-muted">{ranking.fencer.club || '—'}</td>
                 )}
                 {isVisible('victories') && (
                   <td style={{ textAlign: 'center', fontWeight: '600' }}>{ranking.victories}</td>
@@ -593,12 +533,8 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
                 {isVisible('ratio') && (
                   <td style={CENTER}>{formatRatio(ranking.ratio)}</td>
                 )}
-                {isVisible('td') && (
-                  <td style={CENTER}>{ranking.touchesScored}</td>
-                )}
-                {isVisible('tr') && (
-                  <td style={CENTER}>{ranking.touchesReceived}</td>
-                )}
+                {isVisible('td') && <td style={CENTER}>{ranking.touchesScored}</td>}
+                {isVisible('tr') && <td style={CENTER}>{ranking.touchesReceived}</td>}
                 {isVisible('quest') && isLaserSabre && (
                   <td style={{ textAlign: 'center', fontWeight: '600', color: '#7c3aed' }}>
                     {isEditing ? (
@@ -620,29 +556,22 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
                   </td>
                 )}
                 {isVisible('index') && (
-                  <td
-                    style={{
-                      textAlign: 'center',
-                      color: ranking.index >= 0 ? '#059669' : '#DC2626',
-                      fontWeight: '600',
-                    }}
-                  >
-                    {formatIndex(ranking.index)}
+                  <td style={CENTER} className={ranking.index >= 0 ? 'ranking-index--positive' : 'ranking-index--negative'}>
+                    {ranking.index > 0 ? '+' : ''}{formatIndex(ranking.index)}
                   </td>
                 )}
                 {poolWinnersOnly && (
                   <td style={CENTER}>
-                    {poolWinnerIds?.has(ranking.fencer.id) ? (
-                      <span style={{ color: '#059669', fontWeight: '700', fontSize: '0.85rem' }}>
-                        ✓ Q
-                      </span>
+                    {isQualified ? (
+                      <span className="ranking-qualif-badge">Q</span>
                     ) : (
-                      <span style={{ color: '#9ca3af', fontSize: '0.8rem' }}>—</span>
+                      <span style={{ color: 'var(--color-text-muted)', fontSize: '0.85rem' }}>—</span>
                     )}
                   </td>
                 )}
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>
@@ -656,12 +585,23 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
           marginTop: '2rem',
         }}
       >
-        <div className="text-sm text-muted">
-          <strong>Légende :</strong> V = Victoires, M = Matchs, V/M = Ratio Victoires/Matchs, TD =
-          Touches Données, TR = Touches Reçues
-          {isLaserSabre && ', Quest = Points Quest (Sabre Laser)'}
-          {', Indice = TD - TR'}
-          {' • (A) = Abandon • (F) = Forfait • (X) = Exclu'}
+        <div className="ranking-legend">
+          {[
+            ['V', 'Victoires'],
+            ['M', 'Matchs'],
+            ['V/M', 'Ratio'],
+            ['TD', 'Touches données'],
+            ['TR', 'Touches reçues'],
+            ['Indice', 'TD − TR'],
+            ...(isLaserSabre ? [['Quest', 'Points Sabre Laser']] : []),
+          ].map(([abbr, full]) => (
+            <span key={abbr} className="ranking-legend-pill">
+              <strong>{abbr}</strong> {full}
+            </span>
+          ))}
+          <span className="ranking-legend-pill"><span className="ranking-status-badge ranking-status-badge--abandon" style={{ marginLeft: 0 }}>A</span> Abandon</span>
+          <span className="ranking-legend-pill"><span className="ranking-status-badge ranking-status-badge--forfait" style={{ marginLeft: 0 }}>F</span> Forfait</span>
+          <span className="ranking-legend-pill"><span className="ranking-status-badge ranking-status-badge--exclu" style={{ marginLeft: 0 }}>X</span> Exclu</span>
         </div>
         <div style={FLEX_GAP}>
           {hasDirectElimination ? (

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -1106,6 +1106,147 @@ body {
   transition: width 1s linear, background 0.5s;
 }
 .pool-prep-undo-bar-fill.expiring { background: var(--color-danger); }
+
+/* PoolRankingView */
+
+.ranking-rank-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 700;
+  background: var(--color-surface-2);
+  color: var(--color-text-light);
+  border: 1.5px solid var(--color-border);
+}
+.ranking-rank-badge--gold {
+  background: linear-gradient(135deg, #F59E0B, #D97706);
+  color: white;
+  border-color: #D97706;
+  box-shadow: 0 2px 6px rgba(217,119,6,0.35);
+}
+.ranking-rank-badge--silver {
+  background: linear-gradient(135deg, #9CA3AF, #6B7280);
+  color: white;
+  border-color: #6B7280;
+  box-shadow: 0 2px 5px rgba(107,114,128,0.3);
+}
+.ranking-rank-badge--bronze {
+  background: linear-gradient(135deg, #CD7F32, #A0522D);
+  color: white;
+  border-color: #A0522D;
+  box-shadow: 0 2px 5px rgba(160,82,45,0.3);
+}
+
+.ranking-status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.05rem 0.4rem;
+  border-radius: var(--radius-full);
+  font-size: 0.62rem;
+  font-weight: 700;
+  margin-left: 0.3rem;
+  vertical-align: middle;
+}
+.ranking-status-badge--abandon {
+  background: rgba(217,119,6,0.12);
+  color: var(--color-warning);
+  border: 1px solid rgba(217,119,6,0.25);
+}
+.ranking-status-badge--forfait {
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+}
+.ranking-status-badge--exclu {
+  background: rgba(220,38,38,0.10);
+  color: var(--color-danger);
+  border: 1px solid rgba(220,38,38,0.2);
+}
+
+.ranking-row--tie > td:first-child {
+  border-left: 3px solid rgba(217,119,6,0.5);
+}
+.ranking-row--tie {
+  background: rgba(217,119,6,0.03);
+}
+.theme-dark .ranking-row--tie {
+  background: rgba(217,119,6,0.05);
+}
+
+.ranking-qualif-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-full);
+  background: rgba(13,148,136,0.10);
+  color: var(--color-success);
+  font-size: 0.72rem;
+  font-weight: 700;
+  border: 1px solid rgba(13,148,136,0.2);
+}
+
+.ranking-col-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: 100;
+  min-width: 190px;
+  padding: 0.4rem;
+}
+.ranking-col-menu-title {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.5rem 0.4rem;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 0.3rem;
+}
+.ranking-col-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--color-text);
+  user-select: none;
+}
+.ranking-col-menu-item:hover { background: var(--color-surface-2); }
+.theme-dark .ranking-col-menu { background: var(--color-surface); border-color: var(--color-border); }
+
+.ranking-index--positive { color: var(--color-success); font-weight: 600; }
+.ranking-index--negative { color: var(--color-danger); font-weight: 600; }
+
+.ranking-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+.ranking-legend-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.18rem 0.55rem;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+.ranking-legend-pill strong { color: var(--color-text-light); font-weight: 600; }
 .theme-dark tr:hover td { background: rgba(255,255,255,0.04); }
 .theme-dark select { background: var(--color-bg); color: var(--color-text); border-color: var(--color-border); }
 .theme-dark input[type="text"],


### PR DESCRIPTION
## Changements

- **Badges rang** or/argent/bronze pour le top 3, pill neutre pour le reste
- **Ex-aequo** : bande orange gauche + fond teinté sur les lignes à rang identique
- **Statuts** A/F/X → pills colorées inline (orange=Abandon, gris=Forfait, rouge=Exclu)
- **Indice** : préfixe `+` pour les positifs, couleurs vert/rouge via classes CSS
- **Badge Q** qualifié en pill vert compact
- **Boutons d'action** nettoyés — sans emojis, groupés par séparateurs visuels
- **Dropdown colonnes** redesigné avec `.ranking-col-menu`
- **Légende footer** transformée en pills compactes (abbr + définition)
- **Boutons ▲▼** mode édition réutilisent `.pool-prep-btn-move`

Aucune logique fonctionnelle modifiée.

https://claude.ai/code/session_01R6QaAwnLCmQcwyik88koGa

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6QaAwnLCmQcwyik88koGa)_