### PR TITLE
Fix CI : test PoolMatchList désynchronisé

### DIFF
--- a/src/renderer/components/pool/PoolMatchList.test.tsx
+++ b/src/renderer/components/pool/PoolMatchList.test.tsx
@@ -63,6 +63,6 @@ describe('PoolMatchList', () => {
 
   it('affiche « Poule terminée » sans match en attente', () => {
     renderList({ pending: [], finished: [], cancelled: [] });
-    expect(screen.getByText('Poule terminée !')).toBeInTheDocument();
+    expect(screen.getByText('Poule terminée')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problème

Le build CI échouait avec :
```
Unable to find an element with the text: Poule terminée !
```

## Cause

Le composant `PoolMatchList.tsx` avait été modifié pour rendre `"Poule terminée"` (sans `!`), mais le test `PoolMatchList.test.tsx:66` cherchait encore l'ancienne chaîne `"Poule terminée !"`.

## Fix

Une ligne : `'Poule terminée !'` → `'Poule terminée'`

https://claude.ai/code/session_01R6QaAwnLCmQcwyik88koGa

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6QaAwnLCmQcwyik88koGa)_