### PR TITLE
Fix priorité séparation poules : relâchement progressif des critères

### DIFF
--- a/src/shared/utils/poolCalculations.ts
+++ b/src/shared/utils/poolCalculations.ts
@@ -439,10 +439,18 @@ export function distributeFencersToPoolsSerpentine(
 
     let chosen = 0;
     if (separation.length > 0) {
-      for (let i = 0; i < pending.length; i++) {
-        if (!hasConflictWith(pending[i], indexes[poolIndex], separation)) {
-          chosen = i;
-          break;
+      // Relâchement progressif : d'abord tous les critères, puis en retirant le moins
+      // prioritaire (dernier) jusqu'à ne garder que le plus prioritaire (premier).
+      // Garantit que le critère 1 n'est jamais sacrifié si une solution existe.
+      let found = false;
+      for (let take = separation.length; take >= 1 && !found; take--) {
+        const activeSub = separation.slice(0, take);
+        for (let i = 0; i < pending.length; i++) {
+          if (!hasConflictWith(pending[i], indexes[poolIndex], activeSub)) {
+            chosen = i;
+            found = true;
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
## Problème

Avec Club + Région actifs, l'algo cherchait un tireur sans conflit sur LES DEUX critères. Si impossible, il prenait le premier naturel — sacrifiant le critère Club alors que des solutions existaient.

## Fix

Relâchement progressif par priorité :
1. Cherche un tireur sans conflit sur **tous** les critères actifs
2. Si impossible, retire le critère le moins prioritaire (le dernier dans la liste) et réessaie
3. Continue jusqu'à ne garder que le critère 1 (le plus prioritaire)
4. En dernier recours seulement : premier tireur naturel

Le critère 1 (Club par défaut) n'est **jamais** sacrifié si une solution existe.

## Test plan
- [ ] Club + Région actifs : des tireurs du même club ne se retrouvent pas dans la même poule tant qu'une solution existe
- [ ] Drag-and-drop pour changer l'ordre : le critère en position 1 prend la priorité absolue

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdwKK62QiQf3PYt6yhduw)_