### PR TITLE
feat: refonte UX panneau saisie distante (état inactif)

### DIFF
--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -535,92 +535,126 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   if (!isVisible) return null;
 
   if (!isRemoteActive) {
+    const portValid = remotePort >= 1 && remotePort <= 65535 && !isNaN(remotePort);
+    const previewHost = selectedInterface === '0.0.0.0'
+      ? (networkInterfaces.find(i => i.address !== '0.0.0.0')?.address ?? 'localhost')
+      : selectedInterface;
+    const networkPreview = `http://${previewHost}:${remotePort}`;
+
+    const kioskPills = (
+      [
+        { key: 'poules', label: 'Poules' },
+        { key: 'classement', label: 'Classement' },
+        { key: 'direct', label: 'En direct' },
+        { key: 'suivants', label: 'Suivants' },
+      ] as const
+    ).map(({ key, label }) => (
+      <button
+        key={key}
+        type="button"
+        className={`rsm-pill${kioskViews[key] ? ' rsm-pill--on' : ''}`}
+        onClick={() => setKioskViews(v => ({ ...v, [key]: !v[key] }))}
+      >
+        {kioskViews[key] ? '✓' : '○'} {label}
+      </button>
+    ));
+
     return (
       <div className="remote-score-manager">
-        <div className="remote-status inactive">
-          <h3>🔴 Saisie distante inactive</h3>
-          <p>
-            La saisie distante permet aux arbitres de saisir les scores depuis une tablette. Les
-            arbitres se connectent via un navigateur web sur le réseau local.
-          </p>
-          <div style={RSM_STYLES.stripCountRow}>
-            <span>Pistes :</span>
-            {stripCountControls}
+        <div className="rsm-inactive">
+          {/* Hero */}
+          <div className="rsm-hero">
+            <span className="rsm-status-dot rsm-status-dot--off" />
+            <div>
+              <h3 className="rsm-hero-title">Saisie distante inactive</h3>
+              <p className="rsm-hero-desc">
+                Les arbitres saisissent les scores depuis une tablette via navigateur web sur le réseau local.
+              </p>
+            </div>
           </div>
-          <label style={RSM_STYLES.checkboxLabel}>
-            <input
-              type="checkbox"
-              checked={showPhotos}
-              onChange={e => setShowPhotos(e.target.checked)}
-            />
-            Afficher les photos des combattants avant le combat
-          </label>
-          <label style={RSM_STYLES.checkboxLabel}>
-            <input
-              type="checkbox"
-              checked={cardAnnounce}
-              onChange={e => setCardAnnounce(e.target.checked)}
-            />
-            📣 Carton avancer (afficher bandeau + raison sur les écrans)
-          </label>
-          <div style={RSM_STYLES.kioskViewsSection}>
-            <div style={RSM_STYLES.kioskViewsTitle}>Vues kiosk :</div>
-            {(
-              [
-                { key: 'poules', label: 'Poules' },
-                { key: 'classement', label: 'Classement' },
-                { key: 'direct', label: 'Matchs en direct' },
-                { key: 'suivants', label: 'Matchs suivants' },
-              ] as const
-            ).map(({ key, label }) => (
-              <label key={key} style={RSM_STYLES.kioskViewLabel}>
+
+          {/* Sections grid */}
+          <div className="rsm-sections">
+            {/* Pistes */}
+            <div className="rsm-section">
+              <div className="rsm-section-label">Pistes</div>
+              <div className="rsm-strip-row">{stripCountControls}</div>
+            </div>
+
+            {/* Options d'affichage */}
+            <div className="rsm-section">
+              <div className="rsm-section-label">Affichage</div>
+              <label className="rsm-toggle-row">
                 <input
                   type="checkbox"
-                  checked={kioskViews[key]}
-                  onChange={e => setKioskViews(v => ({ ...v, [key]: e.target.checked }))}
+                  checked={showPhotos}
+                  onChange={e => setShowPhotos(e.target.checked)}
                 />
-                {label}
+                Photos combattants
               </label>
-            ))}
+              <label className="rsm-toggle-row">
+                <input
+                  type="checkbox"
+                  checked={cardAnnounce}
+                  onChange={e => setCardAnnounce(e.target.checked)}
+                />
+                📣 Bandeau carton
+              </label>
+            </div>
+
+            {/* Vues kiosque — pills */}
+            <div className="rsm-section rsm-section--full">
+              <div className="rsm-section-label">Vues kiosque</div>
+              <div className="rsm-pills">{kioskPills}</div>
+            </div>
+
+            {/* Réseau */}
+            <div className="rsm-section rsm-section--full">
+              <div className="rsm-section-label">Réseau</div>
+              <div className="rsm-network-grid">
+                <select
+                  id="remote-interface"
+                  value={selectedInterface}
+                  onChange={e => {
+                    setSelectedInterface(e.target.value);
+                    localStorage.setItem('bellepoule-remote-interface', e.target.value);
+                  }}
+                  disabled={isLoading}
+                >
+                  {networkInterfaces.map(iface => (
+                    <option key={iface.address} value={iface.address}>
+                      {iface.name}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  id="remote-port"
+                  type="number"
+                  min={1}
+                  max={65535}
+                  value={remotePort}
+                  onChange={e => handlePortChange(parseInt(e.target.value, 10))}
+                  className={portValid ? '' : 'rsm-input-error'}
+                  disabled={isLoading}
+                />
+              </div>
+              {!portValid && (
+                <div className="rsm-port-error">Port invalide (1–65535)</div>
+              )}
+              <span className="rsm-network-preview">{networkPreview}</span>
+            </div>
           </div>
-          <div style={RSM_STYLES.interfaceRow}>
-            <label htmlFor="remote-interface" style={RSM_STYLES.interfaceLabel}>
-              Interface :
-            </label>
-            <select
-              id="remote-interface"
-              value={selectedInterface}
-              onChange={e => {
-                setSelectedInterface(e.target.value);
-                localStorage.setItem('bellepoule-remote-interface', e.target.value);
-              }}
-              disabled={isLoading}
-            >
-              {networkInterfaces.map(iface => (
-                <option key={iface.address} value={iface.address}>
-                  {iface.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div style={RSM_STYLES.portRow}>
-            <label htmlFor="remote-port" style={RSM_STYLES.interfaceLabel}>
-              Port :
-            </label>
-            <input
-              id="remote-port"
-              type="number"
-              min={1}
-              max={65535}
-              value={remotePort}
-              onChange={e => handlePortChange(parseInt(e.target.value, 10))}
-              style={RSM_STYLES.portInput}
-              disabled={isLoading}
-            />
-            <span style={RSM_STYLES.portHint}>1–65535, défaut 8066</span>
-          </div>
-          <button className="btn-primary" onClick={onStartRemote}>
-            ⚡ Démarrer la saisie distante
+
+          {/* CTA */}
+          <button
+            className="rsm-start-btn"
+            onClick={onStartRemote}
+            disabled={!portValid || isLoading}
+          >
+            {isLoading
+              ? <span className="rsm-spinner" />
+              : '⚡'}
+            Démarrer la saisie distante
           </button>
         </div>
       </div>

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -1962,6 +1962,246 @@ body {
   border: 1px solid #86efac;
 }
 
+/* ─── RSM Inactive panel redesign ─────────────────────────────────────────── */
+.rsm-inactive {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Hero */
+.rsm-hero {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--border-radius) * 1.5);
+}
+
+.rsm-status-dot {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  margin-top: 4px;
+}
+
+.rsm-status-dot--off {
+  background: #ef4444;
+  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4);
+  animation: rsm-pulse-red 2s ease-in-out infinite;
+}
+
+@keyframes rsm-pulse-red {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.5); }
+  50%       { box-shadow: 0 0 0 6px rgba(239, 68, 68, 0); }
+}
+
+.rsm-hero-title {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.rsm-hero-desc {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+/* Sections grid */
+.rsm-sections {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.rsm-section {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.rsm-section--full {
+  grid-column: 1 / -1;
+}
+
+.rsm-section-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+  margin-bottom: 0.1rem;
+}
+
+/* Strip counter inside section */
+.rsm-strip-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Toggle rows (checkboxes) */
+.rsm-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: var(--color-text);
+}
+
+.rsm-toggle-row input[type='checkbox'] {
+  accent-color: var(--color-primary);
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+}
+
+/* Kiosk pill toggles */
+.rsm-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.rsm-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+}
+
+.rsm-pill--on {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+/* Network section */
+.rsm-network-grid {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.4rem 0.6rem;
+  align-items: center;
+  font-size: 0.875rem;
+}
+
+.rsm-network-grid select,
+.rsm-network-grid input[type='number'] {
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.85rem;
+}
+
+.rsm-network-grid input[type='number'] {
+  width: 70px;
+}
+
+.rsm-network-preview {
+  display: inline-flex;
+  align-items: center;
+  font-family: monospace;
+  font-size: 0.78rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  color: var(--color-primary);
+  white-space: nowrap;
+}
+
+.rsm-port-error {
+  font-size: 0.75rem;
+  color: #ef4444;
+  margin-top: 0.1rem;
+}
+
+.rsm-network-grid input[type='number'].rsm-input-error {
+  border-color: #ef4444;
+}
+
+/* CTA button */
+.rsm-start-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border: none;
+  border-radius: var(--border-radius);
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  color: #fff;
+  background: linear-gradient(135deg, #7c3aed 0%, #4f46e5 50%, #2563eb 100%);
+  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.4);
+  transition: opacity 0.15s, box-shadow 0.15s, transform 0.1s;
+  letter-spacing: 0.01em;
+}
+
+.rsm-start-btn:hover:not(:disabled) {
+  opacity: 0.92;
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.55);
+  transform: translateY(-1px);
+}
+
+.rsm-start-btn:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.rsm-start-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.rsm-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255,255,255,0.35);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: rsm-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes rsm-spin {
+  to { transform: rotate(360deg); }
+}
+
+.theme-dark .rsm-section,
+.theme-dark .rsm-hero { border-color: #334155; background: #1e293b; }
+.theme-dark .rsm-network-preview { background: #0f172a; border-color: #334155; }
+.theme-dark .rsm-network-grid select,
+.theme-dark .rsm-network-grid input[type='number'] { background: #0f172a; border-color: #334155; color: #e2e8f0; }
+.theme-dark .rsm-pill { background: #0f172a; border-color: #334155; color: #94a3b8; }
+.theme-dark .rsm-pill--on { background: var(--color-primary); border-color: var(--color-primary); color: #fff; }
+
 .remote-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Hero card avec indicateur de statut animé (pulse rouge)
- Sections visuelles groupées : Pistes / Affichage / Réseau
- Vues kiosque remplacées par des toggle pills interactifs
- Badge preview URL en temps réel (`interface:port`)
- Validation port inline (rouge si invalide), bouton désactivé si port invalide
- Bouton CTA pleine largeur, dégradé violet→bleu, spinner pendant le démarrage
- Support dark mode complet

## Plan de test

- [ ] Ouvrir l'onglet "Saisie distante" sur une compétition
- [ ] Vérifier l'animation pulse rouge sur le dot de statut
- [ ] Cliquer les pills kiosque → toggle on/off visuel
- [ ] Entrer un port invalide (ex: 0) → message d'erreur + bouton grisé
- [ ] Vérifier le badge preview URL se met à jour en changeant l'interface/port
- [ ] Tester en dark mode

https://claude.ai/code/session_016bF2cnPxsXDHKsYvdk7tfV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016bF2cnPxsXDHKsYvdk7tfV)_