### PR TITLE
feat(tableau): refonte UX complète — SVG connecteurs, zoom/pan, MatchCard, FAB

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useLayoutEffect, useMemo } from 'react';
 import { Fencer, FencerStatus, PoolRanking } from '../../shared/types';
 export { TableauMatch, FinalResult, ConsolationBracket, propagateWinners } from './tableau/tableauTypes';
 import { TableauMatch, FinalResult, ConsolationBracket, propagateWinners, deriveFirstRound } from './tableau/tableauTypes';
@@ -127,11 +127,111 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const [competitionReferees, setCompetitionReferees] = useState<Array<{ id: string; firstName: string; lastName: string; club?: string }>>([]);
   const [selectedMatchConsolationBracketId, setSelectedMatchConsolationBracketId] = useState<string | null>(null);
   const [pyramidViewMode, setPyramidViewMode] = useState<boolean>(false);
+  // Zoom / pan state (vue bracket full uniquement)
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const isPanningRef = useRef(false);
+  const panStartRef = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
+  // SVG connector measures
+  const colRefs = useRef<Map<number, HTMLDivElement | null>>(new Map());
+  const bracketWrapRef = useRef<HTMLDivElement | null>(null);
+  const [colMeasures, setColMeasures] = useState<Map<number, { left: number; width: number }>>(new Map());
   const [showPdfModal, setShowPdfModal] = useState(false);
   const [pdfMode, setPdfMode] = useState<'print' | 'pdf'>('pdf');
   const [pdfMatchesPerPage, setPdfMatchesPerPage] = useState<number>(MAX_MATCHES_PER_PAGE_TABLEAU);
   const [selectedRounds, setSelectedRounds] = useState<Set<number>>(new Set());
   const [autoAssignArenas, setAutoAssignArenas] = useState(false);
+  // Mesure les positions des colonnes pour les connecteurs SVG
+  useLayoutEffect(() => {
+    if (viewMode !== 'full' || pyramidViewMode || !bracketWrapRef.current) return;
+    const wrapLeft = bracketWrapRef.current.getBoundingClientRect().left;
+    const measures = new Map<number, { left: number; width: number }>();
+    colRefs.current.forEach((el, round) => {
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        measures.set(round, { left: rect.left - wrapLeft, width: rect.width });
+      }
+    });
+    setColMeasures(measures);
+  });
+
+  // Remet à zéro le zoom/pan si on change de mode
+  useEffect(() => { setZoom(1); setPan({ x: 0, y: 0 }); }, [viewMode, pyramidViewMode]);
+
+  const handleBracketWheel = useCallback((e: React.WheelEvent) => {
+    if (viewMode !== 'full' || pyramidViewMode) return;
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? -0.1 : 0.1;
+    setZoom(z => Math.max(0.3, Math.min(2.5, parseFloat((z + delta).toFixed(2)))));
+  }, [viewMode, pyramidViewMode]);
+
+  const handleBracketMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0 || viewMode !== 'full' || pyramidViewMode) return;
+    // Only pan on background (not on match cards)
+    if ((e.target as HTMLElement).closest('.match-card')) return;
+    isPanningRef.current = true;
+    panStartRef.current = { x: e.clientX, y: e.clientY, panX: pan.x, panY: pan.y };
+  }, [viewMode, pyramidViewMode, pan]);
+
+  const handleBracketMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isPanningRef.current) return;
+    setPan({
+      x: panStartRef.current.panX + (e.clientX - panStartRef.current.x),
+      y: panStartRef.current.panY + (e.clientY - panStartRef.current.y),
+    });
+  }, []);
+
+  const handleBracketMouseUp = useCallback(() => { isPanningRef.current = false; }, []);
+
+  // Connecteurs SVG entre les MatchCards
+  const svgConnectors = useMemo(() => {
+    if (viewMode !== 'full' || pyramidViewMode || colMeasures.size === 0 || tableauSize === 0) return null;
+    const totalH = (tableauSize / 2) * SLOT_HEIGHT;
+    const paths: React.ReactNode[] = [];
+
+    for (const match of matches) {
+      if (match.round <= 2 || match.round === 3) continue; // pas de parent pour la finale/petite-finale
+      const parentRound = match.round / 2;
+      const parentPos = Math.ceil(match.position / 2);
+
+      const childMeasure = colMeasures.get(match.round);
+      const parentMeasure = colMeasures.get(parentRound);
+      if (!childMeasure || !parentMeasure) continue;
+
+      const childRight = childMeasure.left + childMeasure.width;
+      const parentLeft = parentMeasure.left;
+      const midX = (childRight + parentLeft) / 2;
+
+      const childY = calculateMatchVerticalPosition(match.round, match.position, tableauSize) + BASE_MATCH_HEIGHT / 2;
+      const parentY = calculateMatchVerticalPosition(parentRound, parentPos, tableauSize) + BASE_MATCH_HEIGHT / 2;
+
+      const hasWinner = !!match.winner;
+      paths.push(
+        <path
+          key={`conn-${match.id}`}
+          d={`M ${childRight} ${childY} H ${midX} V ${parentY} H ${parentLeft}`}
+          stroke={hasWinner ? '#10b981' : '#d1d5db'}
+          strokeWidth={hasWinner ? 2 : 1.5}
+          strokeDasharray={hasWinner ? undefined : '5,3'}
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      );
+    }
+
+    return (
+      <svg
+        className="bracket-svg-overlay"
+        width="100%"
+        height={totalH}
+        style={{ width: '100%', height: totalH }}
+      >
+        {paths}
+      </svg>
+    );
+  }, [viewMode, pyramidViewMode, colMeasures, matches, tableauSize]);
+
   const isUnlimitedScore = maxScore === 999;
   const prevMatchesLengthRef = useRef(0);
   const mountMatchesRef = useRef(matches);
@@ -794,7 +894,11 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     const isExpanded = expandedRounds.size === 0 || expandedRounds.has(round);
 
     return (
-      <div key={round} style={TV_STYLES.roundCol}>
+      <div
+        key={round}
+        ref={(el: HTMLDivElement | null) => { colRefs.current.set(round, el); }}
+        style={TV_STYLES.roundCol}
+      >
         <div onClick={() => toggleRoundExpansion(round)} style={TV_STYLES.roundHeader}>
           <span style={TV_STYLES.roundHeaderChevron}>
             {isExpanded ? '▼' : '▶'}
@@ -964,7 +1068,28 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         champion={champion}
       />
 
-      <div style={TV_STYLES.scrollArea}>
+      <div
+        style={{
+          ...TV_STYLES.scrollArea,
+          overflow: viewMode === 'full' && !pyramidViewMode ? 'hidden' : TV_STYLES.scrollArea.overflowY,
+          cursor: isPanningRef.current ? 'grabbing' : (viewMode === 'full' && !pyramidViewMode && zoom !== 1 ? 'grab' : 'default'),
+          position: 'relative',
+          userSelect: 'none',
+        }}
+        onWheel={handleBracketWheel}
+        onMouseDown={handleBracketMouseDown}
+        onMouseMove={handleBracketMouseMove}
+        onMouseUp={handleBracketMouseUp}
+        onMouseLeave={handleBracketMouseUp}
+      >
+        {viewMode === 'full' && !pyramidViewMode && (
+          <div className="bracket-zoom-controls">
+            <button className="bracket-zoom-btn" onClick={() => setZoom(z => Math.min(2.5, parseFloat((z + 0.1).toFixed(2))))} title="Zoom avant">+</button>
+            <span className="bracket-zoom-level">{Math.round(zoom * 100)}%</span>
+            <button className="bracket-zoom-btn" onClick={() => { setZoom(1); setPan({ x: 0, y: 0 }); }} title="Réinitialiser">⊙</button>
+            <button className="bracket-zoom-btn" onClick={() => setZoom(z => Math.max(0.3, parseFloat((z - 0.1).toFixed(2))))} title="Zoom arrière">−</button>
+          </div>
+        )}
         {viewMode === 'pending' ? (
           pendingViewRounds.length > 0 ? (
             <>
@@ -1031,7 +1156,13 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         ) : pyramidViewMode ? (
           <Bracket matches={convertToBracketMatches()} tableSize={tableauSize} />
         ) : (
-          <>
+          <div
+            style={{
+              transform: `scale(${zoom}) translate(${pan.x / zoom}px, ${pan.y / zoom}px)`,
+              transformOrigin: 'top left',
+              willChange: 'transform',
+            }}
+          >
             {playAllPositions && matches.some(m => m.round === tableauSize * 2) && (
               <div style={TV_STYLES.barragesBox}>
                 <div style={TV_STYLES.barragesTitle}>Barrages</div>
@@ -1051,12 +1182,15 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
                 </div>
               </div>
             )}
-            <div style={TV_STYLES.fullRoundsRow}>
-              {rounds.map(round => renderRound(round))}
+            <div style={{ position: 'relative' }} ref={bracketWrapRef}>
+              {svgConnectors}
+              <div style={TV_STYLES.fullRoundsRow}>
+                {rounds.map(round => renderRound(round))}
+              </div>
             </div>
-          </>
+          </div>
         )}
-      </div>
+      </div>{/* scrollArea */}
 
       <SeedingTable ranking={ranking} tableauSize={tableauSize} />
 

--- a/src/renderer/components/tableau/MatchCard.tsx
+++ b/src/renderer/components/tableau/MatchCard.tsx
@@ -27,8 +27,6 @@ const MatchCard: React.FC<MatchCardProps> = ({
   const canEdit = !readOnly && !!(match.fencerA && match.fencerB && !match.isBye) && !!onMatchClick;
   const hasScore = match.scoreA !== null && match.scoreB !== null;
 
-  // Filet d'affichage : déduit le vainqueur des scores s'il n'a pas été fixé
-  // (match restauré depuis la DB, saisie partielle). Ne mute pas l'objet source.
   let winner = match.winner;
   if (!winner && hasScore) {
     if (match.scoreA! > match.scoreB!) winner = match.fencerA;
@@ -36,6 +34,8 @@ const MatchCard: React.FC<MatchCardProps> = ({
   }
 
   const isMatchComplete = winner !== null;
+  const hasBothFencers = !!(match.fencerA && match.fencerB && !match.isBye);
+  const isInProgress = hasBothFencers && !isMatchComplete;
 
   const winnerA = !!winner && winner.id === match.fencerA?.id;
   const winnerB = !!winner && winner.id === match.fencerB?.id;
@@ -52,6 +52,13 @@ const MatchCard: React.FC<MatchCardProps> = ({
 
   const fencerName = (f: typeof match.fencerA) =>
     f ? `${f.lastName} ${f.firstName.charAt(0)}.` : '—';
+
+  // Status dot color
+  const statusColor = isMatchComplete
+    ? '#10b981'
+    : isInProgress
+      ? '#f59e0b'
+      : '#d1d5db';
 
   const posStyle: React.CSSProperties =
     verticalPosition !== undefined
@@ -71,13 +78,19 @@ const MatchCard: React.FC<MatchCardProps> = ({
       style={posStyle}
       onClick={() => canEdit && onMatchClick && onMatchClick(match)}
     >
+      {/* Status dot */}
+      <span
+        className="match-status-dot"
+        style={{ background: statusColor }}
+        title={isMatchComplete ? 'Terminé' : isInProgress ? 'À jouer' : 'En attente'}
+      />
+
       {/* Arena + Referee badges */}
       {canEdit && !isMatchComplete && (onArenaClick || onRefereeClick) && (
-        <div style={{ position: 'absolute', top: '4px', right: '4px', display: 'flex', gap: '0.2rem' }}>
+        <div className="match-badges">
           {onArenaClick && (
             <button
-              className={`match-arena-btn ${match.arena ? 'match-arena-btn-active' : ''}`}
-              style={{ position: 'static' }}
+              className={`match-badge-btn ${match.arena ? 'match-badge-btn--active' : ''}`}
               onClick={handleArenaClick}
               title={match.arena ? `Piste ${match.arena}` : 'Assigner une piste'}
             >
@@ -86,21 +99,22 @@ const MatchCard: React.FC<MatchCardProps> = ({
           )}
           {onRefereeClick && (
             <button
-              className={`match-arena-btn ${match.referee ? 'match-arena-btn-active' : ''}`}
-              style={{ position: 'static' }}
+              className={`match-badge-btn ${match.referee ? 'match-badge-btn--active' : ''}`}
               onClick={handleRefereeClick}
               title={match.referee ? `Arbitre : ${match.referee.lastName} ${match.referee.firstName}` : 'Assigner un arbitre'}
             >
-              {match.referee ? `A:${match.referee.lastName.charAt(0)}${match.referee.firstName.charAt(0)}` : '+A'}
+              {match.referee
+                ? `${match.referee.lastName.charAt(0)}${match.referee.firstName.charAt(0)}`
+                : '+A'}
             </button>
           )}
         </div>
       )}
 
       {/* Fencer A */}
-      <div className={`match-fencer ${winnerA ? 'match-fencer-winner' : ''} ${!match.fencerA ? 'match-fencer-empty' : ''}`}>
+      <div className={`match-fencer ${winnerA ? 'match-fencer-winner' : ''} ${isMatchComplete && !winnerA && match.fencerA ? 'match-fencer-loser' : ''} ${!match.fencerA ? 'match-fencer-empty' : ''}`}>
         <div className="match-fencer-info">
-          {winnerA && <span className="match-winner-crown">🥇</span>}
+          {winnerA && <span className="match-winner-mark">✓</span>}
           <div className="match-fencer-details">
             <span className="match-fencer-name">{fencerName(match.fencerA)}</span>
             {match.fencerA?.club && (
@@ -113,7 +127,6 @@ const MatchCard: React.FC<MatchCardProps> = ({
         </div>
         {hasScore && (
           <span className={`match-score ${winnerA ? 'match-score-winner' : 'match-score-loser'}`}>
-            {winnerA && <span className="match-score-victory">V</span>}
             {match.scoreA}
           </span>
         )}
@@ -123,9 +136,9 @@ const MatchCard: React.FC<MatchCardProps> = ({
       <div className="match-divider" />
 
       {/* Fencer B */}
-      <div className={`match-fencer ${winnerB ? 'match-fencer-winner' : ''} ${!match.fencerB ? 'match-fencer-empty' : ''}`}>
+      <div className={`match-fencer ${winnerB ? 'match-fencer-winner' : ''} ${isMatchComplete && !winnerB && match.fencerB ? 'match-fencer-loser' : ''} ${!match.fencerB ? 'match-fencer-empty' : ''}`}>
         <div className="match-fencer-info">
-          {winnerB && <span className="match-winner-crown">🥇</span>}
+          {winnerB && <span className="match-winner-mark">✓</span>}
           <div className="match-fencer-details">
             <span className="match-fencer-name">{fencerName(match.fencerB)}</span>
             {match.fencerB?.club && (
@@ -138,7 +151,6 @@ const MatchCard: React.FC<MatchCardProps> = ({
         </div>
         {hasScore && (
           <span className={`match-score ${winnerB ? 'match-score-winner' : 'match-score-loser'}`}>
-            {winnerB && <span className="match-score-victory">V</span>}
             {match.scoreB}
           </span>
         )}
@@ -149,7 +161,7 @@ const MatchCard: React.FC<MatchCardProps> = ({
         <div className="match-bye">Exempt</div>
       )}
 
-      {/* CTA bar */}
+      {/* CTA bar — mode liste seulement */}
       {canEdit && viewMode !== 'full' && (
         <div className={`match-cta ${hasScore ? 'match-cta-edit' : 'match-cta-enter'}`}>
           {hasScore ? '✏️ Modifier' : '➕ Saisir score'}

--- a/src/renderer/components/tableau/TableauToolbar.tsx
+++ b/src/renderer/components/tableau/TableauToolbar.tsx
@@ -4,7 +4,7 @@
  * Licensed under GPL-3.0
  */
 
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Fencer } from '../../../shared/types';
 
 interface TableauToolbarProps {
@@ -42,84 +42,46 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
   onExportTreeClick,
   champion,
 }) => {
+  const [fabOpen, setFabOpen] = useState(false);
+  const fabRef = useRef<HTMLDivElement>(null);
+
+  // Close FAB when clicking outside
+  useEffect(() => {
+    if (!fabOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (fabRef.current && !fabRef.current.contains(e.target as Node)) {
+        setFabOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [fabOpen]);
+
+  const closeAndRun = (fn: () => void) => {
+    setFabOpen(false);
+    fn();
+  };
+
   return (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginBottom: '1rem',
-      }}
-    >
-      <h2 style={{ fontSize: '1.25rem', fontWeight: '600' }}>
-        Tableau de {tableauSize} - {rankingCount} qualifiés
-      </h2>
-      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-        {arenaCount > 0 && (
-          <>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.4rem',
-                fontSize: '0.875rem',
-                color: '#374151',
-                cursor: 'pointer',
-                padding: '0.5rem 0.75rem',
-                background: autoAssignArenas ? '#eff6ff' : '#f3f4f6',
-                border: `1px solid ${autoAssignArenas ? '#3b82f6' : '#d1d5db'}`,
-                borderRadius: '6px',
-                userSelect: 'none',
-              }}
-              title="Assigne automatiquement les matchs aux arènes disponibles en round-robin"
-            >
-              <input
-                type="checkbox"
-                checked={autoAssignArenas}
-                onChange={e => onAutoAssignToggle(e.target.checked)}
-                style={{ cursor: 'pointer' }}
-              />
-              <span>🏟️ Assignation auto</span>
-            </label>
-            <button
-              onClick={onBulkDeassign}
-              style={{
-                background: '#ef4444',
-                color: 'white',
-                border: 'none',
-                padding: '0.5rem 0.75rem',
-                borderRadius: '6px',
-                cursor: 'pointer',
-                fontSize: '0.875rem',
-                fontWeight: '500',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.25rem',
-              }}
-              title="Désaffecter tous les matches de toutes les arènes"
-            >
-              ❌ Désaffecter tout
-            </button>
-          </>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem', gap: '0.75rem' }}>
+      {/* Left: title + champion */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', minWidth: 0 }}>
+        <h2 style={{ fontSize: '1.25rem', fontWeight: '600', margin: 0, whiteSpace: 'nowrap' }}>
+          Tableau de {tableauSize}
+          <span style={{ fontWeight: 400, color: '#6b7280', fontSize: '1rem', marginLeft: '0.375rem' }}>
+            — {rankingCount} qualifiés
+          </span>
+        </h2>
+        {champion && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', background: '#fef3c7', padding: '0.375rem 0.75rem', borderRadius: '999px', fontSize: '0.875rem', fontWeight: '600', border: '1px solid #fcd34d' }}>
+            🏆 {champion.lastName} {champion.firstName}
+          </div>
         )}
-        <button
-          onClick={onAutoFillScores}
-          style={{
-            background: '#f59e0b',
-            color: 'white',
-            border: 'none',
-            padding: '0.5rem 1rem',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            fontWeight: '500',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.25rem',
-          }}
-        >
-          🎲 Remplir auto
-        </button>
+      </div>
+
+      {/* Right: view toggles + FAB */}
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexShrink: 0 }}>
+        {/* View mode toggles — toujours visibles */}
         <button
           onClick={onViewModeToggle}
           style={{
@@ -131,17 +93,10 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
             cursor: 'pointer',
             fontSize: '0.875rem',
             fontWeight: '500',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.25rem',
           }}
-          title={
-            viewMode === 'full'
-              ? 'Afficher les matches en attente'
-              : 'Afficher le tableau complet'
-          }
+          title={viewMode === 'full' ? 'Matchs en attente' : 'Tableau complet'}
         >
-          {viewMode === 'full' ? '📋 Matchs en attente' : '📊 Tableau complet'}
+          {viewMode === 'full' ? '📋 En attente' : '📊 Tableau'}
         </button>
         <button
           onClick={onPyramidViewModeToggle}
@@ -154,88 +109,63 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
             cursor: 'pointer',
             fontSize: '0.875rem',
             fontWeight: '500',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.25rem',
           }}
           title={pyramidViewMode ? 'Vue tableau' : 'Vue pyramidale'}
         >
           {pyramidViewMode ? '🔲 Tableau' : '🔺 Pyramide'}
         </button>
-        <button
-          onClick={onPrintClick}
-          style={{
-            background: '#6366f1',
-            color: 'white',
-            border: 'none',
-            padding: '0.5rem 0.75rem',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            fontWeight: '500',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.25rem',
-          }}
-          title="Imprimer les feuilles de match"
-        >
-          🖨️ Imprimer
-        </button>
-        <button
-          onClick={onExportPdfClick}
-          style={{
-            background: '#10b981',
-            color: 'white',
-            border: 'none',
-            padding: '0.5rem 0.75rem',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            fontWeight: '500',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.25rem',
-          }}
-          title="Exporter les feuilles de match en PDF"
-        >
-          📄 Export PDF
-        </button>
-        <button
-          onClick={onExportTreeClick}
-          style={{
-            background: '#0d9488',
-            color: 'white',
-            border: 'none',
-            padding: '0.5rem 0.75rem',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            fontWeight: '500',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.25rem',
-          }}
-          title="Exporter l'arbre du tableau en PDF"
-        >
-          🌲 Arbre PDF
-        </button>
-        {champion && (
-          <div
-            style={{
-              background: '#fef3c7',
-              padding: '0.5rem 1rem',
-              borderRadius: '8px',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.5rem',
-            }}
+
+        {/* FAB */}
+        <div className="tableau-fab-wrapper" ref={fabRef}>
+          <button
+            className="tableau-fab-trigger"
+            onClick={() => setFabOpen(o => !o)}
+            title="Options du tableau"
           >
-            <span style={{ fontSize: '1.5rem' }}>🏆</span>
-            <span style={{ fontWeight: '600' }}>
-              {champion.lastName} {champion.firstName}
-            </span>
-          </div>
-        )}
+            {fabOpen ? '✕' : '⋮'} Options
+          </button>
+
+          {fabOpen && (
+            <div className="tableau-fab-menu">
+              {arenaCount > 0 && (
+                <>
+                  <span className="tableau-fab-section-label">Pistes</span>
+                  <label
+                    style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.5rem 0.75rem', borderRadius: '4px', cursor: 'pointer', fontSize: '0.875rem', fontWeight: '500', background: autoAssignArenas ? 'rgba(59,130,246,0.08)' : 'transparent', color: autoAssignArenas ? '#2563eb' : 'var(--color-text)' }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={autoAssignArenas}
+                      onChange={e => onAutoAssignToggle(e.target.checked)}
+                    />
+                    🏟️ Assignation auto
+                  </label>
+                  <button className="tableau-fab-item tableau-fab-item--danger" onClick={() => closeAndRun(onBulkDeassign)}>
+                    ❌ Désaffecter tout
+                  </button>
+                  <div className="tableau-fab-divider" />
+                </>
+              )}
+
+              <span className="tableau-fab-section-label">Actions</span>
+              <button className="tableau-fab-item" onClick={() => closeAndRun(onAutoFillScores)}>
+                🎲 Remplir auto (test)
+              </button>
+
+              <div className="tableau-fab-divider" />
+              <span className="tableau-fab-section-label">Export</span>
+              <button className="tableau-fab-item" onClick={() => closeAndRun(onPrintClick)}>
+                🖨️ Imprimer
+              </button>
+              <button className="tableau-fab-item" onClick={() => closeAndRun(onExportPdfClick)}>
+                📄 Export PDF
+              </button>
+              <button className="tableau-fab-item" onClick={() => closeAndRun(onExportTreeClick)}>
+                🌲 Arbre PDF
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/styles/design.css
+++ b/src/renderer/styles/design.css
@@ -1281,7 +1281,54 @@ select:focus {
 }
 
 .match-card-done {
-  border-color: var(--color-border);
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+/* Status indicator dot (top-left) */
+.match-status-dot {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  z-index: 1;
+}
+
+/* Arena / referee badges (top-right) */
+.match-badges {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  gap: 0.2rem;
+  z-index: 1;
+}
+
+.match-badge-btn {
+  padding: 1px 5px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
+  transition: background var(--duration-fast) ease;
+  letter-spacing: 0.03em;
+  line-height: 1.4;
+}
+
+.match-badge-btn--active {
+  background: #0d9488;
+  color: #fff;
+  border-color: #0d9488;
+}
+
+.match-badge-btn:hover {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
 }
 
 .match-fencer {
@@ -1296,6 +1343,11 @@ select:focus {
 
 .match-fencer-winner {
   background: rgba(13, 148, 136, 0.1);
+  border-left: 3px solid #10b981;
+}
+
+.match-fencer-loser {
+  opacity: 0.45;
 }
 
 .match-fencer-empty {
@@ -1330,6 +1382,21 @@ select:focus {
   flex-shrink: 0;
 }
 
+.match-winner-mark {
+  font-size: 0.7rem;
+  font-weight: 800;
+  color: #10b981;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(16, 185, 129, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
 .match-fencer-name {
   font-size: 0.8125rem;
   font-weight: 500;
@@ -1354,11 +1421,12 @@ select:focus {
 }
 
 .match-score {
-  font-size: 1rem;
-  font-weight: 700;
-  min-width: 1.5rem;
+  font-size: 1.25rem;
+  font-weight: 800;
+  min-width: 1.75rem;
   text-align: right;
   flex-shrink: 0;
+  letter-spacing: -0.02em;
 }
 
 .match-score-winner {
@@ -1433,6 +1501,145 @@ select:focus {
   color: var(--color-text-light);
 }
 
+/* ─── SVG bracket connectors ─────────────────────────────────── */
+.bracket-svg-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+
+/* ─── Zoom controls ──────────────────────────────────────────── */
+.bracket-zoom-controls {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  z-index: 10;
+}
+
+.bracket-zoom-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-sm);
+  transition: background var(--duration-fast) ease;
+}
+
+.bracket-zoom-btn:hover {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.bracket-zoom-level {
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-align: center;
+  line-height: 1;
+}
+
+/* ─── FAB toolbar ────────────────────────────────────────────── */
+.tableau-fab-wrapper {
+  position: relative;
+}
+
+.tableau-fab-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.875rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-md);
+  transition: background var(--duration-fast) ease;
+}
+
+.tableau-fab-trigger:hover {
+  background: var(--color-primary-dark, #2563eb);
+}
+
+.tableau-fab-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 200px;
+  z-index: 100;
+}
+
+.tableau-fab-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: left;
+  transition: background var(--duration-fast) ease;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.tableau-fab-item:hover {
+  background: var(--color-bg);
+}
+
+.tableau-fab-item--danger {
+  color: #ef4444;
+}
+
+.tableau-fab-item--danger:hover {
+  background: #fef2f2;
+}
+
+.tableau-fab-divider {
+  height: 1px;
+  background: var(--color-border);
+  margin: 0.25rem 0;
+}
+
+.tableau-fab-section-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  padding: 0.25rem 0.75rem 0;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ─── Dark mode ──────────────────────────────────────────────── */
 /* Dark mode */
 .theme-dark .match-fencer-winner {
   background: rgba(13, 148, 136, 0.18);


### PR DESCRIPTION
## Résumé

Refonte UX de la vue tableau d'élimination directe sur 4 axes.

### Axe 1 – SVG connecteurs
- Overlay SVG en absolu sur le bracket (positions mesurées via `colRefs + useLayoutEffect`)
- Lignes en coude (H → V → H) entre chaque MatchCard et son match parent
- Vert plein si vainqueur connu, gris pointillé sinon

### Axe 2 – MatchCard redesign
- Pastille statut colorée (gris = en attente, orange = à jouer, vert = terminé)
- Rangée perdante : `opacity: 0.45`
- Rangée gagnante : bordure gauche verte + fond léger
- Score plus grand (1.25rem, weight 800)
- Badge ✓ discret remplace le crown 🥇
- Badges +P/+A refaits (`.match-badge-btn --active`)

### Axe 3 – Zoom / Pan
- Molette sur le bracket : zoom 0.3× – 2.5×
- Clic-glisser sur le fond : pan libre (ignore les clics sur les cards)
- Boutons overlay +/⊙/− en bas à droite
- Reset auto au changement de mode

### Axe 4 – FAB toolbar
- Titre + badge champion à gauche
- Boutons vue (En attente / Pyramide) toujours visibles
- Actions (pistes, export, remplir auto) dans un menu FAB déroulant
- Fermeture au clic extérieur

## Plan de test
- [ ] Vue bracket : vérifier que les connecteurs SVG apparaissent entre les colonnes
- [ ] Match terminé : perdant grisé, gagnant avec bordure verte
- [ ] Ctrl+scroll ou molette sur le bracket : zoom in/out
- [ ] Glisser sur fond : pan fonctionne, clic sur card ouvre le modal score
- [ ] Bouton ⊙ : reset zoom+pan
- [ ] FAB "Options" : ouvre le menu, se ferme au clic extérieur
- [ ] Mode "En attente" : zoom/pan désactivés, scroll normal
- [ ] Dark mode : vérifier que les nouvelles classes respectent le thème

https://claude.ai/code/session_013CtBvNXKec3QewB3R2noTT

---
_Generated by [Claude Code](https://claude.ai/code/session_013CtBvNXKec3QewB3R2noTT)_