### PR TITLE
fix(tableau): infinite loop useLayoutEffect — boucle infinie au chargement du tableau

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -152,8 +152,16 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         measures.set(round, { left: rect.left - wrapLeft, width: rect.width });
       }
     });
-    setColMeasures(measures);
-  });
+    // Updater fonctionnel : retourne prev si valeurs identiques → évite re-render inutile
+    setColMeasures(prev => {
+      if (prev.size !== measures.size) return measures;
+      for (const [round, { left, width }] of measures) {
+        const p = prev.get(round);
+        if (!p || p.left !== left || p.width !== width) return measures;
+      }
+      return prev;
+    });
+  }, [viewMode, pyramidViewMode, tableauSize]);
 
   // Remet à zéro le zoom/pan si on change de mode
   useEffect(() => { setZoom(1); setPan({ x: 0, y: 0 }); }, [viewMode, pyramidViewMode]);


### PR DESCRIPTION
## Problème

`Maximum update depth exceeded` au chargement de la vue Tableau.

Cause : `useLayoutEffect` sans tableau de dépendances → s'exécutait après chaque render → `setColMeasures` déclenchait un re-render → boucle infinie.

## Fix

- Ajout des deps `[viewMode, pyramidViewMode, tableauSize]` : l'effet ne se relance que si le mode ou la taille du tableau change
- Updater fonctionnel qui compare old/new values avant d'appeler `setColMeasures` : si les positions des colonnes sont identiques, retourne `prev` → React skip le re-render

## Test
- [ ] Ouvrir un tableau d'élimination directe → ne doit plus crasher
- [ ] Les connecteurs SVG s'affichent correctement entre les colonnes
- [ ] Changer de mode (En attente ↔ Tableau) → pas de boucle

https://claude.ai/code/session_013CtBvNXKec3QewB3R2noTT

---
_Generated by [Claude Code](https://claude.ai/code/session_013CtBvNXKec3QewB3R2noTT)_