### PR TITLE
Renommer 'En attente' en 'Liste des matchs' dans la toolbar tableau

### DIFF
--- a/src/renderer/components/tableau/TableauToolbar.tsx
+++ b/src/renderer/components/tableau/TableauToolbar.tsx
@@ -94,9 +94,9 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
             fontSize: '0.875rem',
             fontWeight: '500',
           }}
-          title={viewMode === 'full' ? 'Matchs en attente' : 'Tableau complet'}
+          title={viewMode === 'full' ? 'Liste des matchs' : 'Tableau complet'}
         >
-          {viewMode === 'full' ? '📋 En attente' : '📊 Tableau'}
+          {viewMode === 'full' ? '📋 Liste des matchs' : '📊 Tableau'}
         </button>
         <button
           onClick={onPyramidViewModeToggle}


### PR DESCRIPTION
Bouton de la toolbar tableau d'élimination directe : libellé `En attente` → `Liste des matchs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014rfaDbiszxC4wfZRYjG27w)_