### PR TITLE
Fix bracket connector lines targeting wrong parent box

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -200,7 +200,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     for (const match of matches) {
       if (match.round <= 2 || match.round === 3) continue; // pas de parent pour la finale/petite-finale
       const parentRound = match.round / 2;
-      const parentPos = Math.ceil(match.position / 2);
+      const parentPos = Math.floor(match.position / 2);
 
       const childMeasure = colMeasures.get(match.round);
       const parentMeasure = colMeasures.get(parentRound);


### PR DESCRIPTION
## Résumé

- `Math.ceil(position/2)` → `Math.floor(position/2)` dans le calcul des connecteurs SVG du tableau
- Les positions sont 0-indexées : pos 0,1 → parent 0 ; pos 2,3 → parent 1. `Math.ceil` routait les matchs en position impaire vers le mauvais parent.

## Test

Ouvrir un tableau de 16, vérifier que toutes les lignes de la 2e colonne pointent vers la bonne case de la 3e colonne.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpMkiVEMa6eCoD2ppJc1qm)_