### PR TITLE
fix(bracket): corriger "Tour 3.415..." et lignes SVG chaotiques dans la vue pyramidale

### DIFF
--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -932,7 +932,13 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   };
 
   const convertToBracketMatches = (): BracketMatch[] => {
-    return matches.map(match => ({
+    // Exclure la petite finale (round=3) et les barrages (round=tableauSize*2) :
+    // ces rounds ne s'insèrent pas dans l'arbre puissance-de-2 de Bracket.tsx et
+    // produiraient des indices flottants (ex. log2(16/3)+1 ≈ 3.415).
+    const mainMatches = matches.filter(
+      m => m.round !== 3 && m.round !== tableauSize * 2
+    );
+    return mainMatches.map(match => ({
       id: match.id,
       round: Math.log2(tableauSize / match.round) + 1,
       position: match.position,


### PR DESCRIPTION
## Cause

`convertToBracketMatches()` convertissait tous les matchs via `Math.log2(tableauSize / match.round) + 1`. Pour la petite finale (`match.round = 3`) dans un T16 : `Math.log2(16/3) + 1 ≈ 3.415037499278844` — index flottant non prévu dans Bracket.tsx.

Conséquences :
- Colonne "Tour 3.415037499278844" apparaissant dans la vue
- `renderConnectionLines` calculait un `parentRound = 3.415 - 1 = 2.415` inexistant → lignes SVG chaotiques dans tous les sens
- Même problème pour les barrages (`round = tableauSize * 2`) → `Math.log2(0.5) + 1 = 0`

## Fix

Filtrer la petite finale (`round === 3`) et les barrages (`round === tableauSize * 2`) avant conversion. Ces rounds ne s'insèrent pas dans l'arbre puissance-de-2 de Bracket.tsx.

## Test

- Créer un tableau avec petite finale activée
- Activer la vue pyramidale → aucun "Tour 3.41..." visible
- Les lignes de connexion SVG restent propres

https://claude.ai/code/session_01WY6RBUAYvx5img1pETnBiq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6RBUAYvx5img1pETnBiq)_