### PR TITLE
fix(bracket): corriger labels, connecteurs et position dans la vue SVG pyramidale

### DIFF
--- a/src/renderer/components/Bracket.tsx
+++ b/src/renderer/components/Bracket.tsx
@@ -92,7 +92,8 @@ const Bracket: React.FC<BracketProps> = ({
       const roundSpacing = MATCH_HEIGHT + VERTICAL_GAP;
 
       let yOffset = 0;
-      const totalMatchesForRound = tableSize / Math.pow(2, round - 1);
+      // Avec round=1=Finale, round=N=premier tour → 2^(round-1) matchs par round
+      const totalMatchesForRound = Math.pow(2, round - 1);
       const matchesCount = Math.max(matchesInRound, totalMatchesForRound);
 
       if (matchesCount > 1) {
@@ -175,28 +176,29 @@ const Bracket: React.FC<BracketProps> = ({
   };
 
   const renderConnectionLines = (match: BracketMatch, pos: MatchPosition) => {
-    if (match.round <= 1) return null;
+    // round=1=Finale, round=N=premier tour. Les feeders ont round+1 (plus à gauche).
+    const feederRound = match.round + 1;
+    if (!rounds.has(feederRound)) return null;
 
-    const parentRound = match.round - 1;
     const parentPositionA = match.position * 2 - 1;
     const parentPositionB = match.position * 2;
 
-    const parentPosA = calculateMatchPosition(parentRound, parentPositionA);
-    const parentPosB = calculateMatchPosition(parentRound, parentPositionB);
+    const parentPosA = calculateMatchPosition(feederRound, parentPositionA);
+    const parentPosB = calculateMatchPosition(feederRound, parentPositionB);
 
     return (
       <g>
-        {/* Line from parent A */}
+        {/* Line from feeder A (left) to current match (right) */}
         <path
-          d={`M ${parentPosA.x + MATCH_WIDTH} ${parentPosA.y + MATCH_HEIGHT / 2} 
+          d={`M ${parentPosA.x + MATCH_WIDTH} ${parentPosA.y + MATCH_HEIGHT / 2}
               L ${pos.x} ${pos.y + MATCH_HEIGHT / 2}`}
           stroke="#adb5bd"
           strokeWidth={2}
           fill="none"
         />
-        {/* Line from parent B */}
+        {/* Line from feeder B (left) to current match (right) */}
         <path
-          d={`M ${parentPosB.x + MATCH_WIDTH} ${parentPosB.y + MATCH_HEIGHT / 2} 
+          d={`M ${parentPosB.x + MATCH_WIDTH} ${parentPosB.y + MATCH_HEIGHT / 2}
               L ${pos.x} ${pos.y + MATCH_HEIGHT / 2}`}
           stroke="#adb5bd"
           strokeWidth={2}
@@ -273,20 +275,15 @@ const Bracket: React.FC<BracketProps> = ({
   const renderPyramidLayout = () => {
     const sortedRounds = Array.from(rounds.keys()).sort((a, b) => b - a);
 
+    // round=1=Finale, round=2=Demi, round=3=Quarts, round=4=16èmes, ...
     const roundName = (round: number) =>
-      round === 1
-        ? 'Finale'
-        : round === 2
-          ? 'Demi-finales'
-          : round === 4
-            ? 'Quarts'
-            : round === 8
-              ? '8èmes'
-              : round === 16
-                ? '16èmes'
-                : round === 32
-                  ? '32èmes'
-                  : `Tour ${round}`;
+      round === 1 ? 'Finale'
+      : round === 2 ? 'Demi-finales'
+      : round === 3 ? 'Quarts'
+      : round === 4 ? '16èmes'
+      : round === 5 ? '32èmes'
+      : round === 6 ? '64èmes'
+      : `Tour ${round}`;
 
     return (
       <div
@@ -555,14 +552,15 @@ const Bracket: React.FC<BracketProps> = ({
           {/* Round labels */}
           {Array.from(rounds.keys()).map(round => {
             const pos = calculateMatchPosition(round, 1);
+            // round=1=Finale, round=2=Demi, round=3=Quarts, round=4=16èmes, ...
             const roundNames: Record<number, string> = {
               1: 'Finale',
               2: 'Demi-finales',
-              4: 'Quarts',
-              8: '8èmes',
-              16: '16èmes',
-              32: '32èmes',
-              64: '64èmes',
+              3: 'Quarts',
+              4: '16èmes',
+              5: '32èmes',
+              6: '64èmes',
+              7: '128èmes',
             };
 
             return (

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -940,7 +940,8 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     );
     return mainMatches.map(match => ({
       id: match.id,
-      round: Math.log2(tableauSize / match.round) + 1,
+      // round=1 = Finale (match.round=2), round=log2(tableauSize) = premier tour
+      round: Math.log2(match.round),
       position: match.position,
       fencerA: match.fencerA,
       fencerB: match.fencerB,


### PR DESCRIPTION
## Problème

Même après le fix #837, la vue SVG horizontale dans Bracket.tsx restait illisible :
- Labels inversés ("Finale" sur le premier tour, "Quarts" sur la finale)
- Lignes de connexion pointant dans la mauvaise direction
- Espacement vertical 2× trop grand

## Cause racine

La formule `Math.log2(tableauSize / match.round) + 1` dans `convertToBracketMatches()` **invertissait et décalait** le système de numérotation :
- Finale (match.round=2, T16) → Bracket round = `log2(8)+1 = 4` (le plus grand)
- Premier tour (match.round=16) → Bracket round = `log2(1)+1 = 1` (le plus petit)

Or `x = 50 + (maxRound - round) × GAP` place le round le plus grand à **gauche** → Finale à gauche, premier tour à droite = affichage inversé.

De plus `roundNames` utilisait des clés puissance-de-2 (4='Quarts') alors que les rounds convertis sont des entiers consécutifs.

## Fix

**`TableauView.tsx`** : `Math.log2(match.round)` → Finale=1, premier tour=log2(tableauSize)

**`Bracket.tsx`** :
- `roundNames` : clés entières `{1:'Finale', 2:'Demi-finales', 3:'Quarts', 4:'16èmes'…}`
- `renderConnectionLines` : `feederRound = round + 1` (les feeders ont un numéro plus grand = plus à gauche), skip si `!rounds.has(feederRound)`
- `totalMatchesForRound` : `2^(round-1)` au lieu de `tableSize / 2^(round-1)`

## Résultat attendu

- Premier tour à gauche, Finale à droite ✓
- Labels corrects par round ✓
- Connecteurs de gauche à droite (feeder → avancement) ✓

https://claude.ai/code/session_01WY6RBUAYvx5img1pETnBiq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6RBUAYvx5img1pETnBiq)_