### PR TITLE
fix(#387): persister le champ strip des poules en mode expert

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -937,7 +937,7 @@ export class DatabaseManager {
   public updatePool(pool: Pool): void {
     if (!this.db) throw new Error('Database not open');
     const now = new Date().toISOString();
-    this.run('UPDATE pools SET updated_at = ?, is_complete = ? WHERE id = ?', [now, pool.isComplete ? 1 : 0, pool.id]);
+    this.run('UPDATE pools SET updated_at = ?, is_complete = ?, strip = ? WHERE id = ?', [now, pool.isComplete ? 1 : 0, pool.strip ?? null, pool.id]);
     for (const match of pool.matches || []) {
       if (match.scoreA !== undefined || match.scoreB !== undefined || match.status !== undefined) {
         this.updateMatch(match.id, { scoreA: match.scoreA, scoreB: match.scoreB, status: match.status });

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1221,6 +1221,9 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
               setPools(confirmedPools);
               setSkipPoolPhase(false);
               setCurrentPhase('pools');
+              confirmedPools.forEach(pool => {
+                if (pool.strip != null) window.electronAPI?.db?.updatePool(pool);
+              });
             }}
             onSkipPools={handleSkipToRanking}
             onSettingsChange={(min, max) => {


### PR DESCRIPTION
## Résumé

- `db.updatePool()` sauvegarde maintenant la colonne `strip` (le champ existait en DB mais n'était jamais écrit)
- `onPoolsConfirm` dans CompetitionView appelle `updatePool` pour chaque poule ayant un strip défini

## Comment activer le mode expert

1. Ouvrir une compétition → **Propriétés** (icône engrenage)
2. Descendre en bas du formulaire → cocher **Mode expert**
3. Deux champs apparaissent : **Arbitres max / poule** et **Arbitres max / match DE**
4. Valider → retourner à la phase **Appel**
5. Dans la vue **Préparer les poules**, chaque poule affiche un champ **Piste** pour assigner un N° de piste

Fixes #387

https://claude.ai/code/session_01B33bU8d62vFkMV2sRwPuVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01B33bU8d62vFkMV2sRwPuVU)_