### PR TITLE
fix(#389): corriger historique arbitres — bug SQL + vue résumé

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1670,11 +1670,11 @@ export class DatabaseManager {
       SELECT m.id FROM matches m
         LEFT JOIN pools p ON m.pool_id = p.id
         LEFT JOIN phases ph ON p.phase_id = ph.id
-        WHERE ph.competition_id = ?1
+        WHERE ph.competition_id = ?
       UNION
       SELECT m.id FROM matches m
         JOIN bracket_nodes bn ON m.id = bn.match_id
-        WHERE bn.competition_id = ?1
+        WHERE bn.competition_id = ?
     `;
     const sql = `
       SELECT sal.id, sal.match_id, 'score_change' AS event_type,
@@ -1725,7 +1725,9 @@ export class DatabaseManager {
       WHERE mae.match_id IN (${matchSubquery})
       ORDER BY timestamp ASC
     `;
-    return this.queryAll<any>(sql, [competitionId]).map(r => this.parseTimelineRow(r));
+    // 2 params per matchSubquery × 4 UNION branches = 8 bindings
+    const p = competitionId;
+    return this.queryAll<any>(sql, [p, p, p, p, p, p, p, p]).map(r => this.parseTimelineRow(r));
   }
 
   // ─── Arena state persistence ─────────────────────────────────────────────────

--- a/src/renderer/components/MatchAuditLog.tsx
+++ b/src/renderer/components/MatchAuditLog.tsx
@@ -54,6 +54,16 @@ function fencerLabel(entry: MatchEventEntry): { label: string; color: string } {
   };
 }
 
+function buildRefereeLastActions(entries: MatchEventEntry[]): { key: string; label: string; entry: MatchEventEntry }[] {
+  const map = new Map<string, { label: string; entry: MatchEventEntry }>();
+  for (const e of entries) {
+    if (e.eventType !== 'score_change') continue;
+    const key = e.refereeName ?? e.changedBy ?? e.ipAddress ?? 'inconnu';
+    map.set(key, { label: key, entry: e });
+  }
+  return Array.from(map.entries()).map(([key, v]) => ({ key, ...v }));
+}
+
 const MatchAuditLogComponent: React.FC<MatchAuditLogProps> = ({
   matchId,
   competitionId,
@@ -62,6 +72,7 @@ const MatchAuditLogComponent: React.FC<MatchAuditLogProps> = ({
   onClose,
 }) => {
   const { showToast } = useToast();
+  const [refereeView, setRefereeView] = useState(false);
   const { entries, isLoading, error, filterTypes, loadMatchTimeline, loadCompetitionTimeline, setFilterTypes, reset } =
     useMatchAuditStore();
 
@@ -79,6 +90,7 @@ const MatchAuditLogComponent: React.FC<MatchAuditLogProps> = ({
   }, [error]);
 
   const baseTs = entries.length > 0 ? entries[0].timestamp : null;
+  const refereeLastActions = buildRefereeLastActions(entries);
 
   const filtered =
     filterTypes.length === 0 ? entries : entries.filter(e => filterTypes.includes(e.eventType));
@@ -142,6 +154,21 @@ const MatchAuditLogComponent: React.FC<MatchAuditLogProps> = ({
           {filtered.length} événement{filtered.length !== 1 ? 's' : ''}
         </span>
         <button
+          onClick={() => setRefereeView(v => !v)}
+          style={{
+            padding: '0.3rem 0.75rem',
+            fontSize: '0.75rem',
+            fontWeight: '600',
+            borderRadius: '6px',
+            border: '1px solid #8b5cf6',
+            background: refereeView ? '#8b5cf6' : 'transparent',
+            color: refereeView ? 'white' : '#8b5cf6',
+            cursor: 'pointer',
+          }}
+        >
+          Par arbitre
+        </button>
+        <button
           onClick={handleExportJSON}
           disabled={entries.length === 0}
           style={{
@@ -163,6 +190,35 @@ const MatchAuditLogComponent: React.FC<MatchAuditLogProps> = ({
       <div style={{ overflowY: 'auto', flex: 1 }}>
         {isLoading ? (
           <div style={{ textAlign: 'center', padding: '3rem', color: '#6b7280' }}>Chargement…</div>
+        ) : refereeView ? (
+          refereeLastActions.length === 0 ? (
+            <div style={{ textAlign: 'center', padding: '3rem', color: '#9ca3af', fontSize: '0.875rem' }}>
+              Aucune saisie de score enregistrée.
+            </div>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+              <thead>
+                <tr style={{ background: '#f9fafb', borderBottom: '2px solid #e5e7eb' }}>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#6b7280' }}>Arbitre</th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#6b7280' }}>IP</th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#6b7280' }}>Dernière saisie</th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#6b7280' }}>Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                {refereeLastActions.map(({ key, label, entry }, i) => (
+                  <tr key={key} style={{ borderBottom: '1px solid #f3f4f6', background: i % 2 === 0 ? 'white' : '#fafafa' }}>
+                    <td style={{ padding: '0.5rem 0.75rem', fontWeight: '600', color: '#1f2937' }}>{label}</td>
+                    <td style={{ padding: '0.5rem 0.75rem', color: '#6b7280', fontFamily: 'monospace' }}>{entry.ipAddress ?? '—'}</td>
+                    <td style={{ padding: '0.5rem 0.75rem', color: '#6b7280', fontFamily: 'monospace', whiteSpace: 'nowrap' }}>
+                      {formatTimestamp(entry.timestamp, baseTs)}
+                    </td>
+                    <td style={{ padding: '0.5rem 0.75rem', color: '#374151' }}>{describeMatchEvent(entry)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )
         ) : filtered.length === 0 ? (
           <div style={{ textAlign: 'center', padding: '3rem', color: '#9ca3af', fontSize: '0.875rem' }}>
             Aucun événement enregistré pour ce match.


### PR DESCRIPTION
## Résumé

- **Bug SQL `getCompetitionTimeline`** : paramètres `?1` traités comme `?` positionnels par better-sqlite3 → 8 bindings nécessaires mais seulement 1 passé → historique compétition toujours vide. Corrigé : `?1` → `?` + tableau `[competitionId ×8]`.
- **Vue "Par arbitre"** : nouveau bouton dans le journal de match → tableau lisible : dernière saisie de score par arbitre (nom, IP, heure, score `X/Y → X'/Y'`).

Fixes #389

https://claude.ai/code/session_016udcCq2CgC3D7WMQ1sDp3L

---
_Generated by [Claude Code](https://claude.ai/code/session_016udcCq2CgC3D7WMQ1sDp3L)_