### PR TITLE
fix: perte de focus dans les modales de saisie combattant

### DIFF
--- a/src/renderer/hooks/useFocusTrap.ts
+++ b/src/renderer/hooks/useFocusTrap.ts
@@ -15,6 +15,8 @@ export function useFocusTrap<T extends HTMLElement>(
   onClose?: () => void
 ) {
   const ref = useRef<T>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     if (!active) return;
@@ -31,7 +33,7 @@ export function useFocusTrap<T extends HTMLElement>(
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onClose?.();
+        onCloseRef.current?.();
         return;
       }
       if (e.key !== 'Tab') return;
@@ -53,7 +55,7 @@ export function useFocusTrap<T extends HTMLElement>(
       container?.removeEventListener('keydown', handleKeyDown);
       previouslyFocused?.focus?.();
     };
-  }, [active, onClose]);
+  }, [active]);
 
   return ref;
 }


### PR DESCRIPTION
## Problème

Cliquer sur un champ de saisie (nom, prénom…) dans `AddFencerModal` ou `EditFencerModal` faisait immédiatement perdre le focus, rendant la frappe impossible.

## Cause

`useFocusTrap` avait `onClose` dans le tableau de dépendances de `useEffect`. Or `onClose` est une arrow function inline dans `CompetitionView` (`() => setShowAddFencerModal(false)`) → nouvelle référence à chaque re-render → l'effet se ré-exécutait → cleanup restaurait le focus *avant* la modale → focus perdu en pleine saisie.

## Fix (`src/renderer/hooks/useFocusTrap.ts`)

- `onClose` stocké dans un `useRef` (valeur toujours à jour)
- Retiré des deps de `useEffect` (seul `active` reste)
- Le handler `keydown` lit `onCloseRef.current` → Échap fonctionne toujours

Corrige AddFencerModal **et** EditFencerModal (même hook).

https://claude.ai/code/session_015DBz4kf2yWDNMf4yyVdGSh

---
_Generated by [Claude Code](https://claude.ai/code/session_015DBz4kf2yWDNMf4yyVdGSh)_