### PR TITLE
tts: remplace « Halte » par « Temps » (toutes langues)

### DIFF
--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -2999,10 +2999,10 @@
           if (this._ttsAnnouncedSeconds.has(s)) return;
           const L = this.ttsLangCode();
           const PHRASES = {
-            fr: { 60: 'Une minute', 30: 'Trente secondes', 10: 'Dix secondes', 0: 'Halte !' },
-            en: { 60: 'One minute', 30: 'Thirty seconds', 10: 'Ten seconds', 0: 'Stop!' },
-            de: { 60: 'Eine Minute', 30: 'Dreißig Sekunden', 10: 'Zehn Sekunden', 0: 'Halt!' },
-            'zh-HK': { 60: '一分鐘', 30: '三十秒', 10: '十秒', 0: '停' },
+            fr: { 60: 'Une minute', 30: 'Trente secondes', 10: 'Dix secondes', 0: 'Temps !' },
+            en: { 60: 'One minute', 30: 'Thirty seconds', 10: 'Ten seconds', 0: 'Time!' },
+            de: { 60: 'Eine Minute', 30: 'Dreißig Sekunden', 10: 'Zehn Sekunden', 0: 'Zeit!' },
+            'zh-HK': { 60: '一分鐘', 30: '三十秒', 10: '十秒', 0: '時間！' },
           };
           const NUMS = {
             fr: { 5: '5', 4: '4', 3: '3', 2: '2', 1: '1' },

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -37,7 +37,7 @@ const TTS_THRESHOLDS: { key: string; label: string }[] = [
   { key: '10', label: '10 secondes' },
   { key: '5', label: '5 secondes' },
   { key: 'countdown', label: 'Décompte 4 → 1' },
-  { key: '0', label: '« Halte ! » (fin)' },
+  { key: '0', label: '« Temps ! » (fin)' },
 ];
 
 function loadTtsConfig(): TtsConfig {


### PR DESCRIPTION
## Changement

Annonce TTS à 0 seconde : `Halte` → `Temps` pour toutes les langues.

| Langue | Avant | Après |
|--------|-------|-------|
| fr | Halte ! | Temps ! |
| en | Stop! | Time! |
| de | Halt! | Zeit! |
| zh-HK | 停 | 時間！ |

Label UI dans `SettingsModal.tsx` mis à jour : `« Halte ! » (fin)` → `« Temps ! » (fin)`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfiomQE5HHWmt5oWx13c8G)_