### PR TITLE
feat: analytics dashboard graphiques SVG + export CSV + roadmap P0→P3

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,604 +1,148 @@
 # Roadmap BellePoule Modern
 
-> Version : 1.0 · Date : 2026-05-09 · Statut : Vivant (mis à jour à chaque release)
+> Date : 2026-06-18 · Branche active : `claude/arbitrage-sabre-laser-improvements-0vt15z`
 
 ---
 
-## État actuel – v1.0.3 (build 711)
+## P0 — Fait (sprint courant)
 
-### Ce qui est production-ready
+### ✅ Dashboard analytics graphiques SVG
+**Fichiers :** `src/renderer/components/analytics/AnalyticsCharts.tsx`, `AnalyticsDashboard.tsx`
 
-| Domaine | Détail |
+- Heatmap zones A/B/C agrégée (tous tireurs) avec barres de progression
+- Donut chart répartition cartons (blanc/jaune/rouge)
+- Histogramme durées de match (buckets <1min, 1-2min, 2-3min, 3-4min, >4min)
+- Bar chart top 8 tireurs (points touches en Laser Sabre, matchs joués sinon)
+- Bar chart cartons par motif (17 motifs FFE, classé par fréquence)
+- Onglet "Graphiques" ajouté dans `AnalyticsDashboard` (3e onglet, rechargement DB)
+- Zéro dépendance externe — SVG natif
+
+### ✅ Export CSV analytics
+**Fichier :** `src/features/analytics/services/analyticsService.ts`
+
+- `exportAnalytics(id, 'csv')` générait `''` → génère maintenant du CSV UTF-8 valide
+- Export CSV per-fencer depuis `AnalyticsCharts` via dialog save (zones, cartons, durées)
+
+---
+
+## P1 — Ranking saisonnier Quest multi-compétitions
+
+**Objectif :** Classement cumulatif sur une saison FFE Quest (plusieurs tournois).
+
+### Étapes
+
+1. **Schéma DB** (`src/database/migrations/`)
+   - Table `season_rankings` : `fencerId, fencerLastName, fencerFirstName, club, totalVictories, totalQuestPoints, totalRedCards, touchDiff, competitions[]`
+   - Migration incrémentale (numéro suivant dans `migrations.ts`)
+
+2. **Service** (`src/features/analytics/services/seasonRankingService.ts`)
+   - `addCompetitionResults(competitionId)` : lit les classements Quest finaux et ajoute à la saison
+   - `getSeasonRanking()` : trie par V/M → Quest Points → cartons rouges → TD-TR (règles FFE)
+   - `resetSeason()` : vide la table (nouvelle saison)
+   - `exportSeasonCSV()` / `exportSeasonPDF()`
+
+3. **IPC handler** (`src/main/main.ts`)
+   - `db.getSeasonRanking`, `db.addCompetitionToSeason`, `db.resetSeason`
+
+4. **Composant** (`src/renderer/components/SeasonRankingView.tsx`)
+   - Table triable avec colonnes : Rang, Nom, Club, V/M, QP, Cartons rouges, TD-TR, Compétitions
+   - Boutons : Ajouter compétition, Exporter CSV/PDF, Réinitialiser saison
+   - Accessible depuis le menu principal (hors compétition active)
+
+5. **Tests** (`src/features/analytics/services/seasonRankingService.test.ts`)
+   - Vérifier tri FFE (égalités V/M → QP → cartons rouges → TD-TR)
+
+---
+
+## P1 — Interface équipes complète
+
+**Objectif :** Rendre les compétitions par équipes utilisables en prod.
+
+### Étapes
+
+1. **Audit** du store existant (`src/features/teams/`)
+   - Vérifier `useTeamStore.ts`, `teamCalculations.ts`, `team.types.ts`
+   - Identifier ce qui manque dans le renderer
+
+2. **Vue poule équipes** (`src/renderer/components/TeamPoolView.tsx`)
+   - Affiche les matchs équipe-vs-équipe (agrégat des tireurs)
+   - Score total d'équipe, victoires collectives
+
+3. **Tableau équipes** (`src/renderer/components/TeamTableauView.tsx`)
+   - Bracket direct élimination entre équipes
+
+4. **Intégration dans CompetitionView** (`src/renderer/components/CompetitionView.tsx`)
+   - Détecter `competition.isTeam === true`
+   - Router vers les vues équipes au lieu des vues individuelles
+
+5. **PDF export** équipes (extension de `pdfExport.ts`)
+
+---
+
+## P2 — Audit log UI organisateur
+
+**Objectif :** Permettre à l'organisateur de consulter l'historique complet des modifications de scores.
+
+### Étapes
+
+1. **Vérifier le store** (`src/features/matchAuditLog/`)
+   - Confirmer que les entrées sont bien enregistrées en DB depuis `remoteScoreServer.ts`
+
+2. **Composant** (`src/renderer/components/AuditLogViewer.tsx`)
+   - Table : horodatage, arène, match, action (score/carte/undo), ancien/nouveau score, IP arbitre, identifiant
+   - Filtre par arène, par match, par plage horaire
+   - Export CSV
+
+3. **Accès** : bouton dans `AnalyticsDashboard` onglet "Performance" → modal
+
+---
+
+## P2 — OBS Overlay config UI
+
+**Objectif :** Configurer le stream overlay depuis l'app (endpoint `/api/arenas/{id}/obs-json` existe déjà).
+
+### Étapes
+
+1. **Composant** (`src/renderer/components/OBSOverlayConfig.tsx`)
+   - Sélection arène à afficher
+   - Preview temps réel du JSON OBS
+   - URL copiable (http://localhost:8066/api/arenas/{id}/obs-json)
+   - Options : afficher/masquer timer, cartons, nom tireurs, logo
+
+2. **Accès** depuis `RemoteScoreManager` (section "Streaming")
+
+---
+
+## P3 — PDF template editor visuel
+
+**Objectif :** Permettre aux clubs de personnaliser couleurs, logo, polices dans les PDFs.
+
+### Étapes
+
+1. **Composant editor** (`src/renderer/components/PdfTemplateEditor.tsx`)
+   - 3 onglets : Couleurs, Typographie, En-tête/Pied de page
+   - Prévisualisation en temps réel (iframe ou canvas)
+   - Persistance dans localStorage + export JSON template
+
+2. **Intégration** : passer le template au `SimplePdfTemplateManager` existant (`src/shared/utils/pdfTemplates.ts`)
+
+3. **Templates prédéfinis supplémentaires** : "Sabre Laser" (bleu/violet), "Compétition officielle FFE" (rouge/blanc)
+
+---
+
+## Hors scope (ne jamais merger vers main)
+
+- Application mobile native (scope trop large)
+- Multi-utilisateur réseau LAN (la tablette arbitre via Socket.IO couvre ce besoin)
+- Intégration FIE internationale (pas de spec publique disponible)
+
+---
+
+## Conventions de branche
+
+| Préfixe | Destination merge |
 |---|---|
-| Gestion compétitions | Création, phases, poules (round-robin), tableau direct |
-| Scores distants | Serveur Express + Socket.IO, 4 pistes, tablettes arbitres |
-| Attribution arbitres | `RefereeManager` – conflit club/temps/consécutif, score 100 pts |
-| Sabre Laser | Zones A/B/C (1/3/5 pts), Quest Points, mort subite |
-| Base de données | SQLite via better-sqlite3 (WAL), autosave 2 min |
-| Mise à jour auto | GitHub Releases, multi-plateforme (Win/Mac/Linux) |
-| Interface | 47+ composants React 19, toast, skeleton, virtual list, PDF preview |
-| Voice scoring | `VoiceScoreController` – saisie vocale des scores |
-| Internationalisation | 7 langues : fr, en, de, es, br, ca, zh-HK |
-| Export PDF | Feuilles de poule, résultats, classements (jsPDF) |
-| Performance | Cache TTL, memoization, monitoring (PerformanceService) |
-| Offline | Service Worker, offline queue tablettes |
-
-### Partiellement implémenté
-
-| Module | Infra | Données | Priorité fix |
-|---|---|---|---|
-| Cloud sync (Dropbox/GDrive/OneDrive) | ✅ AES-GCM + OAuth | ❌ stubs vides | P0 |
-| Analytics exports (CSV/PDF) | ✅ endpoints IPC | ❌ retournent `""` | P0 |
-| TournamentFlow scheduler | ✅ algorithme piste | ❌ completion stub | P1 |
-| Double élimination | ✅ store Zustand | ❌ UI incomplète | P1 |
-| Notifications Discord/Slack | ✅ UI webhooks | ❌ non câblées | P1 |
-
-### Non commencé
-
-- Export FFE officiel (format `.fff` en écriture)
-- Intégration API FFE (classements en live)
-- Application mobile / PWA installable
-- Mode multi-sites / P2P
-- Intelligence artificielle (prédiction, coach)
-- Portail tireur
-- Couverture tests < 80 % (cible PRD)
-
----
-
-## Phase 1 – v1.1 "Stabilité & Complétion" · Q2 2026
-
-> **Objectif :** terminer ce qui est à moitié fait et atteindre 80 % de couverture de tests.
-
-### 1.1 – Complétion cloud sync
-
-**Problème :** `getLocalData()` et `getRemoteData()` dans `cloudSyncService.ts` retournent des tableaux vides.
-
-| Livrable | Description |
-|---|---|
-| Bridge DB → sync | Brancher `DatabaseManager` dans `getLocalData()` – export sérialisé de toutes les entités |
-| Delta sync | Comparer timestamps `updatedAt`, n'uploader que les deltas |
-| Restauration | Implémenter `restoreFromBackup()` avec merge `conflictResolution.ts` |
-| Tests | Unit tests cloud sync (mock providers) |
-
-**Critère de done :** sync Dropbox round-trip sans perte de données sur une compétition de 64 tireurs.
-
----
-
-### 1.2 – Export analytics (CSV + PDF)
-
-**Problème :** `analyticsService.ts` retourne des chaînes vides pour `exportAnalytics('csv')` et `('pdf')`.
-
-| Livrable | Description |
-|---|---|
-| CSV | Format RFC 4180 : statistiques par tireur, par poule, classement |
-| PDF | Rapport complet via jsPDF existant (`pdfTemplates.ts`) |
-| Export multi-compétitions | Agrégation sur plusieurs fichiers .bp |
-| Tests | Unit tests formatage CSV, snapshot PDF |
-
-**Critère de done :** le comité technique peut générer un rapport PDF imprimable post-compétition.
-
----
-
-### 1.3 – TournamentFlow réel
-
-**Problème :** `getPoolCompletionPercentage()` retourne toujours 0, faussant le scheduler de pistes.
-
-| Livrable | Description |
-|---|---|
-| Complétion réelle | Calculer via `MatchStatus` en base |
-| Rest violations | Compter les violations de repos réellement |
-| Recommandations | Afficher dans `LiveDashboard.tsx` |
-
----
-
-### 1.4 – Double élimination (UI)
-
-**Problème :** `useDEBracketStore` existe, mais aucune vue ne le consomme.
-
-| Livrable | Description |
-|---|---|
-| Vue DE bracket | Visualisation arbre double élimination dans `Bracket.tsx` |
-| Génération matchs | Connecter `BracketGenerator` au mode DE |
-| Tests E2E | Parcours complet tournoi double élimination |
-
----
-
-### 1.5 – Export FFE (écriture)
-
-| Livrable | Description |
-|---|---|
-| Parser `.fff` sortie | Générer le fichier FFE de résultats conforme au format officiel |
-| Validation | Vérifier champs obligatoires (licence, club, date) avant export |
-| Tests | Comparer output avec fichier FFE de référence |
-
-**Critère de done :** le fichier peut être importé sans erreur dans Engarde.
-
----
-
-### 1.6 – Notifications opérationnelles
-
-| Livrable | Description |
-|---|---|
-| Câblage Discord/Slack | Brancher `notificationService.ts` sur les hooks webhooks UI |
-| Événements déclencheurs | Match assigné, poule terminée, phase suivante |
-| Notifications desktop | Electron `Notification` API pour l'organisateur |
-
----
-
-### 1.7 – Tests & qualité
-
-| Livrable | Cible |
-|---|---|
-| Couverture unitaire | ≥ 80 % (ajouter : cloudSync, analytics, pools, bracket) |
-| E2E Playwright | Couverture des 5 flux critiques (création → résultats) |
-| Type-check CI | Zéro erreur TS sur `npm run type-check` |
-| Lint CI | Zéro warning ESLint bloquant |
-
----
-
-### 1.8 – i18n : Breton & Catalan
-
-| Livrable | Description |
-|---|---|
-| `br.json` complet | Toutes les clés présentes en fr.json traduites |
-| `ca.json` complet | Idem Catalan |
-| CI check | Script qui vérifie que toutes les langues ont les mêmes clés |
-
----
-
-### KPIs v1.1
-
-| KPI | Cible |
-|---|---|
-| Bugs critiques ouverts | < 3 |
-| Couverture tests | ≥ 80 % |
-| Sync cloud round-trip | < 10 s pour 500 tireurs |
-| Export PDF | < 2 s |
-
----
-
-## Phase 2 – v1.2 "Cloud & Collaboration" · Q3 2026
-
-> **Objectif :** multi-utilisateurs, notifications avancées, compétitions par équipes.
-
-### 2.1 – Sync cloud temps réel (delta)
-
-| Livrable | Description |
-|---|---|
-| Delta sync | Upload uniquement les entités modifiées depuis le dernier sync |
-| Sync automatique | Toutes les 5 min en arrière-plan |
-| Indicateur UI | Barre de statut sync (dernière sync, conflits) |
-| Mode lecture seule | Un deuxième PC peut consulter la compétition en live |
-
----
-
-### 2.2 – Dashboard web organisateur
-
-| Livrable | Description |
-|---|---|
-| Route `/dashboard` | Sur le serveur port 8066, accès organisateur protégé |
-| Vue multi-pistes | Statut de toutes les pistes en un coup d'œil |
-| Actions à distance | Passer à la phase suivante, assigner un match depuis le dashboard |
-| Authentification | Token JWT généré à la création de la compétition |
-
----
-
-### 2.3 – Notifications WhatsApp / SMS
-
-| Livrable | Description |
-|---|---|
-| Intégration Twilio | SMS pour les tireurs : "Votre prochain match dans 5 min, piste 3" |
-| Intégration Whapi | WhatsApp Business API (alternative Twilio) |
-| Opt-in tireur | Le tireur fournit son numéro à l'inscription |
-| Throttling | Max 3 notifications/tireur/heure |
-
----
-
-### 2.4 – Co-arbitrage (multi-arbitres par piste)
-
-| Livrable | Description |
-|---|---|
-| Rôles arbitre | Principal + assistant (même piste) |
-| Consensus score | Les deux doivent valider avant d'enregistrer |
-| UI tablet | Différencier les rôles visuellement |
-
----
-
-### 2.5 – Compétitions par équipes
-
-| Livrable | Description |
-|---|---|
-| Création équipe | Grouper des tireurs en équipe (store `useTeamStore` existant) |
-| Matchs d'équipe | Relais : 3 tireurs × 3 matchs, score cumulé |
-| Classement équipes | Adapter `tableCalculations.ts` |
-| Export PDF | Feuille de match équipe |
-
-**Critère de done :** compétition d'équipes de 8 équipes jouable de A à Z.
-
----
-
-### 2.6 – Formule ASL Compétition
-
-| Livrable | Description |
-|---|---|
-| Définition règles | Alternative à Quest pour Sabre Laser (selon règlement FFE) |
-| Implémentation | Nouveau `PhaseType.ASL_COMPETITION` dans le state machine |
-| UI | Phase view dédiée |
-
----
-
-### 2.7 – Bilan automatique post-compétition
-
-| Livrable | Description |
-|---|---|
-| Déclencheur | Au clic "Terminer la compétition" |
-| Contenu | PDF : classement final, statistiques, podium, export FFE |
-| Archivage | Sauvegarder dans le dossier compétition + cloud si activé |
-
----
-
-### KPIs v1.2
-
-| KPI | Cible |
-|---|---|
-| Clubs actifs | 10 |
-| Compétitions/mois | 20 |
-| Temps sync tablette | < 500 ms |
-| Note satisfaction | ≥ 4/5 |
-
----
-
-## Phase 3 – v2.0 "Intelligence & Automatisation" · Q4 2026
-
-> **Objectif :** réduire la charge de l'organisateur, enrichir l'expérience avec de l'IA.
-
-### 3.1 – Prédiction IA des résultats
-
-| Livrable | Description |
-|---|---|
-| Modèle | TensorFlow.js, entraîné sur l'historique des compétitions locales |
-| Features | V/M, TD-TR, confrontations directes, catégorie |
-| Output | `{ winner, confidence, predictedScore }` affiché avant le match |
-| Opt-in | Désactivable par l'organisateur |
-
----
-
-### 3.2 – Coach intelligent
-
-| Livrable | Description |
-|---|---|
-| Rapport par tireur | Points forts/faibles, patterns (ex : perd souvent en zone B) |
-| Progression | Graphe V/M et TD-TR sur plusieurs compétitions |
-| Export | PDF rapport coach |
-
----
-
-### 3.3 – Scheduler de pistes avancé
-
-| Livrable | Description |
-|---|---|
-| Assignation auto complète | `TournamentFlow` câblé avec complétion réelle (v1.1) |
-| Contraintes | Repos min, piste préférée par tireur, distance domicile-compétition |
-| Simulation | Prévisualiser l'ordre des matchs avant de lancer |
-
----
-
-### 3.4 – Détection d'anomalies de score
-
-| Livrable | Description |
-|---|---|
-| Règle | Score improbable → alerte (ex : 5-0 en 30 s, ou même tireur qui gagne toujours) |
-| UI | Toast warning pour l'organisateur, log d'audit |
-| Validation | Arbitre peut confirmer ou corriger |
-
----
-
-### 3.5 – Overlay streaming (OBS)
-
-| Livrable | Description |
-|---|---|
-| Route `/overlay` | Page HTML transparente, WebSocket temps réel |
-| Sources OBS | Scoreboard, timer, classement poule |
-| Customisation | Couleurs club, logo organisateur |
-
----
-
-### 3.6 – API REST publique
-
-| Livrable | Description |
-|---|---|
-| Endpoints | `GET /api/competitions`, `/api/pools`, `/api/rankings`, `/api/fencers` |
-| Auth | API key par compétition |
-| Doc | OpenAPI 3.0 (Swagger UI sur `/api/docs`) |
-| Usage | Intégrations tierces, sites de clubs |
-
----
-
-### 3.7 – Statistiques historiques croisées
-
-| Livrable | Description |
-|---|---|
-| Agrégation | Combiner plusieurs fichiers `.bp` en une seule vue |
-| Classement saison | V/M et TD-TR agrégés sur la saison |
-| Export | CSV pour publication sur site club |
-
----
-
-### 3.8 – Analytics temps réel
-
-| Livrable | Description |
-|---|---|
-| Remplacement | Remplacer les snapshots statiques par des métriques live |
-| Graphes | Évolution du rythme (matchs/heure), temps moyen |
-| `AnalyticsDashboard.tsx` | Composant existant – brancher sur flux WebSocket |
-
----
-
-### KPIs v2.0
-
-| KPI | Cible |
-|---|---|
-| Précision prédiction IA | ≥ 65 % |
-| Réduction temps orga | − 30 % (mesure via analytics) |
-| Clubs actifs | 25 |
-
----
-
-## Phase 4 – v2.1 "Mobile & Accessibilité" · Q1 2027
-
-> **Objectif :** rendre BellePoule accessible depuis n'importe quel device, pour tous les utilisateurs.
-
-### 4.1 – PWA installable
-
-| Livrable | Description |
-|---|---|
-| Manifeste complet | `manifest.json` avec icônes 192/512, theme_color, standalone |
-| Service Worker amélioré | Stratégie cache-first pour assets, network-first pour scores |
-| Install prompt | Bannière "Installer l'app" sur mobile |
-| Offline complet | Toutes les vues fonctionnent sans réseau |
-
----
-
-### 4.2 – Application iOS/Android
-
-| Livrable | Description |
-|---|---|
-| Framework | Capacitor (réutilise le code React existant) |
-| Interface tactile | Boutons ≥ 48 px, gestes swipe pour navigation |
-| Notifications push | Firebase Cloud Messaging |
-| Publication | App Store + Google Play (open source, gratuit) |
-
----
-
-### 4.3 – Portail tireur
-
-| Livrable | Description |
-|---|---|
-| Page web `/fencer/:id` | Résultats, classement, prochains matchs |
-| QR Code | Généré pour chaque tireur à l'accréditation |
-| Notifications push | "Tu passes dans 5 min, piste 2" |
-| Historique | Toutes les compétitions passées sur BellePoule |
-
----
-
-### 4.4 – Accessibilité renforcée
-
-| Livrable | Description |
-|---|---|
-| Daltonisme | Palette alternative (Deuteranopia, Protanopia) |
-| Contraste élevé | Mode WCAG AA pour toute l'UI |
-| Screen reader | Attributs ARIA sur tous les composants interactifs |
-| Audit | axe-core intégré en CI |
-
----
-
-### 4.5 – Gamification tireurs
-
-| Livrable | Description |
-|---|---|
-| Badges | "Première victoire", "Comeback", "Clean sheet", "Flash", "Champion invaincu" |
-| Classements saisonniers | Top 10 club par catégorie |
-| Défis | Objectifs mensuels (ex : 5 victoires consécutives) |
-| Affichage | Dans le portail tireur + kiosk display |
-
----
-
-### 4.6 – Mode kiosque HD (affichage public)
-
-| Livrable | Description |
-|---|---|
-| Multi-piste | Afficher le statut de toutes les pistes simultanément |
-| Haute définition | Optimisé 4K (60 fps, CSS contain) |
-| Rotation auto | Alterner entre classement, matchs en cours, podium |
-| Mode salle | Un seul écran couvre toute la compétition |
-
----
-
-### KPIs v2.1
-
-| KPI | Cible |
-|---|---|
-| App mobile installée | 200 téléchargements |
-| Portail tireur actif | 60 % des tireurs se connectent |
-| Score accessibilité axe-core | 0 violation critique |
-
----
-
-## Phase 5 – v3.0 "Plateforme & International" · 2027+
-
-> **Objectif :** faire de BellePoule la plateforme de référence mondiale pour l'escrime.
-
-### 5.1 – Mode multi-sites (P2P)
-
-| Livrable | Description |
-|---|---|
-| Technologie | WebRTC DataChannel ou libp2p |
-| Usage | Compétitions réparties géographiquement (plusieurs salles) |
-| Classement global | Agréger les résultats de tous les sites en temps réel |
-| Fallback | Sync différée si latence > 200 ms |
-
----
-
-### 5.2 – Intégration FIE (Fédération Internationale)
-
-| Livrable | Description |
-|---|---|
-| Format FIE-XML | Export conforme au standard international |
-| Classements FIE | Import des classements mondiaux |
-| Règlement FIE | Support des règles d'exclusion et de pénalités FIE |
-
----
-
-### 5.3 – Fédérations nationales supplémentaires
-
-| Pays | Fédération | Format |
-|---|---|---|
-| Belgique | KBEF/LBFE | À définir |
-| Suisse | Swiss Fencing | À définir |
-| Canada | Escrime Canada | À définir |
-| Allemagne | DFeB | À définir |
-
----
-
-### 5.4 – Plugin / Extension system
-
-| Livrable | Description |
-|---|---|
-| API plugins | Interface TypeScript pour ajouter des formules de compétition |
-| Marketplace | Dépôt GitHub de plugins communautaires |
-| Sandbox | Plugin exécuté en Worker isolé |
-| Exemples | Plugin "Poule américaine", plugin "King of the Hill" |
-
----
-
-### 5.5 – Version web complète (sans Electron)
-
-| Livrable | Description |
-|---|---|
-| Framework | Next.js App Router, déployable sur VPS |
-| Backend | API REST + WebSocket (Express existant réutilisé) |
-| Base de données | PostgreSQL ou SQLite selon hébergement |
-| Déploiement | Docker Compose, Coolify/Caprover one-click |
-| Usage | Clubs sans PC fixe, accès depuis navigateur |
-
----
-
-### 5.6 – Internationalisation étendue
-
-| Langue | Code | Priorité |
-|---|---|---|
-| Portugais | `pt` | Haute (Brésil, Portugal) |
-| Italien | `it` | Haute |
-| Néerlandais | `nl` | Moyenne |
-| Japonais | `ja` | Basse |
-| Coréen | `ko` | Basse |
-
----
-
-### KPIs v3.0
-
-| KPI | Cible |
-|---|---|
-| Pays utilisateurs | 10 |
-| Compétitions/mois (total) | 200 |
-| Contributeurs GitHub | 20 actifs |
-| Note satisfaction | ≥ 4.5/5 |
-
----
-
-## Matrice de priorités
-
-```
-Impact ↑
-   │
-   │  [FFE export]     [Équipes]    [AI prédiction]
-   │  [Cloud sync]     [Dashboard]  [Multi-sites]
-   │  [Analytics]      [PWA]
-   │
-   │  [i18n complet]   [Co-arbitrage] [Streaming OBS]
-   │  [Notifs]         [Portail tireur]
-   │
-   └──────────────────────────────────────────── Effort →
-          Faible          Moyen           Élevé
-```
-
-### Matrice détaillée
-
-| Feature | Impact | Effort | Priorité | Phase |
-|---|---|---|---|---|
-| Cloud sync data bridge | Critique | Moyen | P0 | v1.1 |
-| Analytics CSV/PDF | Élevé | Faible | P0 | v1.1 |
-| Export FFE officiel | Élevé | Moyen | P0 | v1.1 |
-| Tests 80 % | Élevé | Moyen | P0 | v1.1 |
-| Double élimination UI | Moyen | Faible | P1 | v1.1 |
-| TournamentFlow réel | Moyen | Faible | P1 | v1.1 |
-| Notifications | Moyen | Faible | P1 | v1.1 |
-| Compétitions équipes | Élevé | Élevé | P1 | v1.2 |
-| Dashboard web | Élevé | Moyen | P1 | v1.2 |
-| Delta sync cloud | Élevé | Moyen | P1 | v1.2 |
-| Notifs WhatsApp/SMS | Moyen | Moyen | P2 | v1.2 |
-| AI prédiction | Élevé | Élevé | P2 | v2.0 |
-| Coach intelligent | Moyen | Élevé | P2 | v2.0 |
-| API REST publique | Élevé | Moyen | P2 | v2.0 |
-| Overlay OBS | Moyen | Faible | P2 | v2.0 |
-| PWA installable | Élevé | Moyen | P2 | v2.1 |
-| App mobile | Élevé | Très élevé | P3 | v2.1 |
-| Portail tireur | Élevé | Moyen | P2 | v2.1 |
-| Gamification | Faible | Moyen | P3 | v2.1 |
-| Multi-sites P2P | Très élevé | Très élevé | P3 | v3.0 |
-| Intégration FIE | Élevé | Élevé | P3 | v3.0 |
-| Plugin system | Moyen | Élevé | P3 | v3.0 |
-| Version web Next.js | Élevé | Très élevé | P3 | v3.0 |
-
----
-
-## Architecture cible (v3.0)
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     BellePoule Platform                      │
-├────────────────┬────────────────┬───────────────────────────┤
-│   Desktop App  │   Web App      │   Mobile App              │
-│   (Electron)   │   (Next.js)    │   (Capacitor)             │
-└────────────────┴────────────────┴───────────────────────────┘
-         │                │                    │
-         └────────────────┼────────────────────┘
-                          │
-               ┌──────────▼──────────┐
-               │   Core API Server   │
-               │  (Express + WS)     │
-               │  port 8066          │
-               └──────────┬──────────┘
-                          │
-         ┌────────────────┼────────────────┐
-         │                │                │
-┌────────▼──────┐ ┌───────▼──────┐ ┌──────▼───────┐
-│   SQLite/     │ │  Cloud Sync  │ │  Plugin      │
-│   PostgreSQL  │ │  (Dropbox/   │ │  Sandbox     │
-│   (better-sqlite3)    │ │   GDrive/    │ │  (Worker)    │
-└───────────────┘ │   OneDrive)  │ └──────────────┘
-                  └──────────────┘
-```
-
----
-
-## Principes directeurs
-
-1. **Open Source forever** – GPL-3.0, aucune feature derrière un paywall
-2. **Offline first** – tout doit fonctionner sans internet
-3. **Type safety** – TypeScript strict, zéro `any` implicite
-4. **Progressif** – chaque version est deployable indépendamment
-5. **Communautaire** – les issues GitHub sont la source de vérité des priorités
-6. **Rétrocompatible** – les fichiers `.bp` v1 s'ouvrent toujours en v3
-
----
-
-## Contribution
-
-Les contributions sont les bienvenues. Voir [`CONTRIBUTING.md`](CONTRIBUTING.md) pour les conventions.
-
-Pour proposer une feature : ouvrir une issue avec le label `roadmap` et décrire le use case.
-
----
-
-*BellePoule Modern – Logiciel libre sous GPL-3.0 · [github.com/klinnex/bellepoule-modern](https://github.com/klinnex/bellepoule-modern)*
+| `claude/*` | → `dev` uniquement (jamais `main`) |
+| `feature/*` | → `dev` |
+| `fix/*` | → `dev` |
+| Release finale | `dev` → `main` par l'utilisateur |

--- a/src/features/analytics/services/analyticsService.ts
+++ b/src/features/analytics/services/analyticsService.ts
@@ -119,6 +119,19 @@ export class AnalyticsService {
    */
   async exportAnalytics(competitionId: string, format: 'json' | 'csv' | 'pdf'): Promise<Blob> {
     const stats = await this.getCompetitionStats(competitionId);
+
+    if (format === 'csv') {
+      const headers = ['Nom', 'Prénom', 'Club', 'Victoires', 'Touches marquées', 'Touches reçues'];
+      const rows = stats.topFencers.map(f => [
+        f.fencer.lastName, f.fencer.firstName ?? '', f.fencer.club ?? '',
+        f.victories, f.touchesScored, f.touchesReceived,
+      ]);
+      const csv = [headers, ...rows]
+        .map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+        .join('\n');
+      return new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    }
+
     const content = format === 'json' ? JSON.stringify(stats, null, 2) : '';
     return new Blob([content], { type: format === 'json' ? 'application/json' : 'text/plain' });
   }

--- a/src/renderer/components/AnalyticsDashboard.tsx
+++ b/src/renderer/components/AnalyticsDashboard.tsx
@@ -4,10 +4,11 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useMemo , memo} from 'react';
+import React, { useState, useEffect, useMemo, useCallback, memo} from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
-import { Competition, Fencer, Pool, Match, MatchStatus } from '../../shared/types';
+import { Competition, Fencer, Pool, Match, MatchStatus, FencerCompetitionStats } from '../../shared/types';
 import { FencerStatsTable } from '../../features/analytics/components/FencerStatsTable';
+import { AnalyticsCharts } from './analytics/AnalyticsCharts';
 import { exportPostTournamentPDF } from '../../shared/utils/postTournamentReport';
 
 interface AnalyticsData {
@@ -273,11 +274,19 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
   onClose,
 }) => {
   const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
-  const [activeTab, setActiveTab] = useState<'performance' | 'stats'>('performance');
+  const [activeTab, setActiveTab] = useState<'performance' | 'stats' | 'charts'>('performance');
+  const [fencerStats, setFencerStats] = useState<FencerCompetitionStats[]>([]);
   const [selectedTimeframe, setSelectedTimeframe] = useState<'live' | 'last30min' | 'all'>('live');
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [lastUpdate, setLastUpdate] = useState(new Date());
   const [exporting, setExporting] = useState(false);
+
+  const loadFencerStats = useCallback(async () => {
+    const data = await window.electronAPI?.db?.getCompetitionFencerStats?.(competition.id);
+    if (data) setFencerStats(data as FencerCompetitionStats[]);
+  }, [competition.id]);
+
+  useEffect(() => { loadFencerStats(); }, [loadFencerStats]);
 
   const handleExportReport = async () => {
     setExporting(true);
@@ -369,9 +378,16 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
         >
           Statistiques
         </button>
+        <button
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${activeTab === 'charts' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'}`}
+          onClick={() => { setActiveTab('charts'); loadFencerStats(); }}
+        >
+          Graphiques
+        </button>
       </div>
 
       {activeTab === 'stats' && <FencerStatsTable competition={competition} />}
+      {activeTab === 'charts' && <AnalyticsCharts competition={competition} stats={fencerStats} />}
 
       {activeTab === 'performance' && <>
       {/* Key Metrics */}

--- a/src/renderer/components/analytics/AnalyticsCharts.tsx
+++ b/src/renderer/components/analytics/AnalyticsCharts.tsx
@@ -1,0 +1,366 @@
+/**
+ * BellePoule Modern - Graphiques SVG analytics (sans librairie externe)
+ * Licensed under GPL-3.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Competition, FencerCompetitionStats, Weapon } from '../../../shared/types';
+import { TouchZoneHeatmap } from './TouchZoneHeatmap';
+
+interface Props {
+  competition: Competition;
+  stats: FencerCompetitionStats[];
+}
+
+// ── Mini bar chart horizontal ──────────────────────────────────────────────────
+
+interface BarItem {
+  label: string;
+  value: number;
+  color: string;
+  sublabel?: string;
+}
+
+const HBar: React.FC<{ items: BarItem[]; maxValue?: number; title: string }> = ({ items, maxValue, title }) => {
+  const max = maxValue ?? Math.max(...items.map(i => i.value), 1);
+  return (
+    <div className="bg-white rounded-lg border border-gray-100 p-4">
+      <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">{title}</div>
+      <div className="space-y-2">
+        {items.map((item, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div className="w-20 text-right text-xs text-gray-600 truncate flex-shrink-0">{item.label}</div>
+            <div className="flex-1 h-5 bg-gray-100 rounded overflow-hidden">
+              <div
+                className="h-full rounded transition-all duration-500"
+                style={{ width: `${(item.value / max) * 100}%`, backgroundColor: item.color }}
+              />
+            </div>
+            <div className="w-10 text-xs font-mono text-gray-700 flex-shrink-0">
+              {item.value}
+              {item.sublabel && <span className="text-gray-400 ml-0.5">{item.sublabel}</span>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// ── Donut chart SVG ────────────────────────────────────────────────────────────
+
+interface DonutSlice {
+  value: number;
+  color: string;
+  label: string;
+}
+
+const Donut: React.FC<{ slices: DonutSlice[]; title: string; centerLabel?: string }> = ({ slices, title, centerLabel }) => {
+  const total = slices.reduce((s, x) => s + x.value, 0);
+  if (total === 0) return (
+    <div className="bg-white rounded-lg border border-gray-100 p-4">
+      <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">{title}</div>
+      <div className="text-center text-gray-300 text-sm py-8">Aucune donnée</div>
+    </div>
+  );
+
+  const r = 34;
+  const cx = 44;
+  const cy = 44;
+  const circ = 2 * Math.PI * r;
+
+  let offset = 0;
+  const arcs = slices.map(sl => {
+    const pct = sl.value / total;
+    const arc = { pct, offset, color: sl.color, label: sl.label, value: sl.value };
+    offset += pct;
+    return arc;
+  });
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-100 p-4">
+      <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">{title}</div>
+      <div className="flex items-center gap-4">
+        <svg width="88" height="88" viewBox="0 0 88 88" className="flex-shrink-0">
+          <circle cx={cx} cy={cy} r={r} fill="none" stroke="#f3f4f6" strokeWidth="14" />
+          {arcs.map((arc, i) => (
+            <circle
+              key={i}
+              cx={cx} cy={cy} r={r}
+              fill="none"
+              stroke={arc.color}
+              strokeWidth="14"
+              strokeDasharray={`${arc.pct * circ} ${circ}`}
+              strokeDashoffset={-arc.offset * circ}
+              transform={`rotate(-90 ${cx} ${cy})`}
+            />
+          ))}
+          {centerLabel && (
+            <text x={cx} y={cy + 5} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#374151">
+              {centerLabel}
+            </text>
+          )}
+        </svg>
+        <div className="space-y-1.5">
+          {arcs.map((arc, i) => (
+            <div key={i} className="flex items-center gap-1.5 text-xs">
+              <div className="w-2.5 h-2.5 rounded-sm flex-shrink-0" style={{ backgroundColor: arc.color }} />
+              <span className="text-gray-600">{arc.label}</span>
+              <span className="font-mono font-medium text-gray-800 ml-auto">{arc.value}</span>
+              <span className="text-gray-400">({(arc.pct * 100).toFixed(0)}%)</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ── Aggregated heatmap (moyenne sur tous les tireurs) ──────────────────────────
+
+const AggregateHeatmap: React.FC<{ stats: FencerCompetitionStats[] }> = ({ stats }) => {
+  const totA = stats.reduce((s, x) => s + x.touchesZoneA, 0);
+  const totB = stats.reduce((s, x) => s + x.touchesZoneB, 0);
+  const totC = stats.reduce((s, x) => s + x.touchesZoneC, 0);
+  const totalPts = totA * 1 + totB * 3 + totC * 5;
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-100 p-4">
+      <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+        Zones de touches — {stats.length} tireurs
+      </div>
+      <div className="flex items-center gap-6">
+        <TouchZoneHeatmap zoneA={totA} zoneB={totB} zoneC={totC} />
+        <div className="space-y-3 flex-1">
+          {[
+            { zone: 'A', count: totA, pts: 1, color: '#bfdbfe', border: '#93c5fd', text: 'Main/Arme' },
+            { zone: 'B', count: totB, pts: 3, color: '#60a5fa', border: '#3b82f6', text: 'Bras/Jambes' },
+            { zone: 'C', count: totC, pts: 5, color: '#1d4ed8', border: '#1e40af', text: 'Tête/Torse' },
+          ].map(z => {
+            const total = totA + totB + totC;
+            const pct = total > 0 ? ((z.count / total) * 100).toFixed(1) : '0.0';
+            return (
+              <div key={z.zone}>
+                <div className="flex justify-between text-xs text-gray-600 mb-1">
+                  <span>Zone {z.zone} · {z.text} · {z.pts}pt{z.pts > 1 ? 's' : ''}</span>
+                  <span className="font-mono">{z.count} ({pct}%)</span>
+                </div>
+                <div className="w-full h-3 bg-gray-100 rounded overflow-hidden">
+                  <div
+                    className="h-full rounded transition-all duration-700"
+                    style={{
+                      width: `${pct}%`,
+                      backgroundColor: z.color,
+                      border: `1px solid ${z.border}`,
+                    }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          <div className="text-xs text-gray-400 mt-2">Total points marqués : <span className="font-bold text-gray-700">{totalPts}</span></div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ── Top tireurs bar chart ──────────────────────────────────────────────────────
+
+const TopFencersChart: React.FC<{ stats: FencerCompetitionStats[]; isLaser: boolean }> = ({ stats, isLaser }) => {
+  const sorted = [...stats]
+    .sort((a, b) =>
+      isLaser
+        ? b.totalTouchPoints - a.totalTouchPoints
+        : b.matchesPlayed - a.matchesPlayed
+    )
+    .slice(0, 8);
+
+  if (sorted.length === 0) return null;
+
+  const max = isLaser
+    ? Math.max(...sorted.map(s => s.totalTouchPoints), 1)
+    : Math.max(...sorted.map(s => s.matchesPlayed), 1);
+
+  const items: BarItem[] = sorted.map((s, i) => ({
+    label: `${i + 1}. ${s.fencerLastName}`,
+    value: isLaser ? s.totalTouchPoints : s.matchesPlayed,
+    color: i === 0 ? '#f59e0b' : i === 1 ? '#9ca3af' : i === 2 ? '#b45309' : '#3b82f6',
+    sublabel: isLaser ? 'pts' : 'M',
+  }));
+
+  return (
+    <HBar
+      items={items}
+      maxValue={max}
+      title={isLaser ? 'Top tireurs — Points touches' : 'Top tireurs — Matchs joués'}
+    />
+  );
+};
+
+// ── Durée moyenne par tireur (histogram) ──────────────────────────────────────
+
+const DurationChart: React.FC<{ stats: FencerCompetitionStats[] }> = ({ stats }) => {
+  const withDuration = stats.filter(s => s.averageDurationSeconds > 0);
+  if (withDuration.length === 0) return null;
+
+  const buckets = [
+    { label: '<1min', min: 0, max: 60, color: '#10b981' },
+    { label: '1–2min', min: 60, max: 120, color: '#3b82f6' },
+    { label: '2–3min', min: 120, max: 180, color: '#8b5cf6' },
+    { label: '3–4min', min: 180, max: 240, color: '#f59e0b' },
+    { label: '>4min', min: 240, max: Infinity, color: '#ef4444' },
+  ];
+
+  const items: BarItem[] = buckets.map(b => ({
+    label: b.label,
+    value: withDuration.filter(s => s.averageDurationSeconds >= b.min && s.averageDurationSeconds < b.max).length,
+    color: b.color,
+    sublabel: 't.',
+  }));
+
+  return <HBar items={items} title="Distribution durée moyenne des matchs" />;
+};
+
+// ── Cards by reason ──────────────────────────────────────────────────────────
+
+const CARD_REASON_FR: Record<string, string> = {
+  EARLY_START: 'Départ anticipé',
+  LATE_STOP: 'Arrêt tardif',
+  BODY_CONTACT: 'Contact corporel',
+  COUNTER_ATTACK: 'Contre-attaque',
+  TARGET_SUBSTITUTION: 'Substitution cible',
+  VOLUNTARY_DROP: 'Abandon arme',
+  TIME_WASTING: 'Perte de temps',
+  NON_COMPLIANT_GEAR: 'Équip. non conforme',
+  ESTOC: 'Estoc',
+  UNARMED_HAND: 'Main libre',
+  VOLUNTARY_EXIT: 'Sortie volontaire',
+  HEAVY_HIT: 'Coup violent',
+  BRUTALITY: 'Brutalité',
+  DANGEROUS: 'Dangereux',
+  REFUSAL: 'Refus',
+  UNSPORTSMANLIKE: 'Antisportif',
+  CHEATING: 'Triche',
+};
+
+const CardsByReason: React.FC<{ stats: FencerCompetitionStats[] }> = ({ stats }) => {
+  const totals: Record<string, number> = {};
+  for (const s of stats) {
+    for (const [reason, count] of Object.entries(s.cardsByReason ?? {})) {
+      totals[reason] = (totals[reason] ?? 0) + (count as number);
+    }
+  }
+  const entries = Object.entries(totals)
+    .filter(([, v]) => v > 0)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 8);
+
+  if (entries.length === 0) return null;
+
+  const items: BarItem[] = entries.map(([reason, count]) => ({
+    label: CARD_REASON_FR[reason] ?? reason,
+    value: count,
+    color: '#f59e0b',
+  }));
+
+  return <HBar items={items} title="Cartons par motif" />;
+};
+
+// ── Export CSV ─────────────────────────────────────────────────────────────────
+
+async function exportCSV(competition: Competition, stats: FencerCompetitionStats[]) {
+  const isLaser = competition.weapon === Weapon.LASER;
+  const headers = [
+    'Nom', 'Prénom', 'Club',
+    ...(isLaser ? ['Zone A', 'Zone B', 'Zone C', 'Points total'] : []),
+    'Cartons blancs', 'Cartons jaunes', 'Cartons rouges',
+    'Sorties piste', 'Matchs joués', 'Durée moy. (s)', 'Fins anticipées',
+  ];
+
+  const rows = stats.map(s => [
+    s.fencerLastName, s.fencerFirstName, s.fencerClub ?? '',
+    ...(isLaser ? [s.touchesZoneA, s.touchesZoneB, s.touchesZoneC, s.totalTouchPoints] : []),
+    s.whiteCards, s.yellowCards, s.redCards,
+    s.arenaExits, s.matchesPlayed, s.averageDurationSeconds, s.matchesFinishedEarly,
+  ]);
+
+  const csv = [headers, ...rows]
+    .map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+
+  if (!window.electronAPI?.file) return;
+  const result = await window.electronAPI.dialog.saveFile({
+    filters: [{ name: 'CSV', extensions: ['csv'] }],
+    defaultPath: `stats-${competition.title.replace(/\s+/g, '-')}.csv`,
+  });
+  if (result?.filePath) {
+    await window.electronAPI.file.writeFileContent(result.filePath, csv);
+  }
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+export const AnalyticsCharts: React.FC<Props> = ({ competition, stats }) => {
+  const [exporting, setExporting] = useState(false);
+  const isLaser = competition.weapon === Weapon.LASER;
+
+  const totalWhite = stats.reduce((s, x) => s + x.whiteCards, 0);
+  const totalYellow = stats.reduce((s, x) => s + x.yellowCards, 0);
+  const totalRed = stats.reduce((s, x) => s + x.redCards, 0);
+
+  if (stats.length === 0) {
+    return (
+      <div className="text-center py-16 text-gray-400">
+        <div className="text-4xl mb-3">📊</div>
+        <div>Aucune statistique disponible — lancez des matchs d'abord.</div>
+      </div>
+    );
+  }
+
+  const handleExportCSV = async () => {
+    setExporting(true);
+    try { await exportCSV(competition, stats); }
+    finally { setExporting(false); }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar export */}
+      <div className="flex justify-end">
+        <button
+          onClick={handleExportCSV}
+          disabled={exporting}
+          className="px-3 py-1.5 bg-green-600 text-white text-sm rounded hover:bg-green-700 disabled:opacity-50"
+        >
+          {exporting ? 'Export…' : '⬇ CSV'}
+        </button>
+      </div>
+
+      {/* Zone heatmap — Laser Sabre only */}
+      {isLaser && <AggregateHeatmap stats={stats} />}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Donut cartons */}
+        <Donut
+          title="Répartition des cartons"
+          centerLabel={String(totalWhite + totalYellow + totalRed)}
+          slices={[
+            { label: 'Blancs', value: totalWhite, color: '#d1d5db' },
+            { label: 'Jaunes', value: totalYellow, color: '#f59e0b' },
+            { label: 'Rouges', value: totalRed, color: '#ef4444' },
+          ]}
+        />
+
+        {/* Durée */}
+        <DurationChart stats={stats} />
+      </div>
+
+      {/* Top fencers */}
+      <TopFencersChart stats={stats} isLaser={isLaser} />
+
+      {/* Cards by reason */}
+      <CardsByReason stats={stats} />
+    </div>
+  );
+};


### PR DESCRIPTION
## P0 — Analytics dashboard graphiques

### AnalyticsCharts.tsx (nouveau composant SVG natif)
- Heatmap zones A/B/C agrégée sur tous les tireurs (intensité proportionnelle)
- Donut chart répartition cartons blanc/jaune/rouge
- Histogramme durées de match (5 buckets)
- Bar chart top 8 tireurs (points touches Laser Sabre ou matchs joués)
- Bar chart cartons par motif (17 motifs FFE, triés par fréquence)
- Zéro dépendance externe — SVG pur

### AnalyticsDashboard — onglet "Graphiques"
- 3e onglet ajouté (Performance / Statistiques / **Graphiques**)
- Rechargement DB automatique à l'ouverture de l'onglet

### analyticsService — CSV fonctionnel
- `exportAnalytics(id, 'csv')` retournait `''` → génère CSV UTF-8 valide
- Export CSV complet depuis le bouton dans AnalyticsCharts

## ROADMAP.md — mis à jour
Plan détaillé P0→P3 :
- P0 fait (ce PR)
- P1 : ranking saisonnier Quest + interface équipes
- P2 : audit log UI + OBS overlay config
- P3 : PDF template editor visuel

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkGT3faaMdPmPrnu9zd64g)_