### PR TITLE
feat(P2): OBS overlay config inline + onglet Journal analytiques

### DIFF
--- a/src/renderer/components/AnalyticsDashboard.tsx
+++ b/src/renderer/components/AnalyticsDashboard.tsx
@@ -4,12 +4,13 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useMemo, useCallback, memo} from 'react';
+import React, { useState, useEffect, useMemo, useCallback, memo, Suspense } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { Competition, Fencer, Pool, Match, MatchStatus, FencerCompetitionStats } from '../../shared/types';
 import { FencerStatsTable } from '../../features/analytics/components/FencerStatsTable';
 import { AnalyticsCharts } from './analytics/AnalyticsCharts';
 import { exportPostTournamentPDF } from '../../shared/utils/postTournamentReport';
+const MatchAuditLog = React.lazy(() => import('./MatchAuditLog').then(m => ({ default: m.MatchAuditLog })));
 
 interface AnalyticsData {
   totalFencers: number;
@@ -274,7 +275,7 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
   onClose,
 }) => {
   const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
-  const [activeTab, setActiveTab] = useState<'performance' | 'stats' | 'charts'>('performance');
+  const [activeTab, setActiveTab] = useState<'performance' | 'stats' | 'charts' | 'journal'>('performance');
   const [fencerStats, setFencerStats] = useState<FencerCompetitionStats[]>([]);
   const [selectedTimeframe, setSelectedTimeframe] = useState<'live' | 'last30min' | 'all'>('live');
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -384,10 +385,21 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
         >
           Graphiques
         </button>
+        <button
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${activeTab === 'journal' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'}`}
+          onClick={() => setActiveTab('journal')}
+        >
+          Journal
+        </button>
       </div>
 
       {activeTab === 'stats' && <FencerStatsTable competition={competition} />}
       {activeTab === 'charts' && <AnalyticsCharts competition={competition} stats={fencerStats} />}
+      {activeTab === 'journal' && (
+        <Suspense fallback={null}>
+          <MatchAuditLog competitionId={competition.id} competitionName={competition.title} />
+        </Suspense>
+      )}
 
       {activeTab === 'performance' && <>
       {/* Key Metrics */}

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -48,6 +48,7 @@ const MatchAuditLog = React.lazy(() => import('./MatchAuditLog').then(m => ({ de
 const AnalyticsDashboard = React.lazy(() => import('./AnalyticsDashboard').then(m => ({ default: m.AnalyticsDashboard })));
 const SeasonRankingView = React.lazy(() => import('./SeasonRankingView').then(m => ({ default: m.SeasonRankingView })));
 const TeamManagerView = React.lazy(() => import('./TeamManagerView').then(m => ({ default: m.TeamManagerView })));
+const FFEConnectModal = React.lazy(() => import('./FFEConnectModal'));
 const PresentationMode = React.lazy(() => import('./PresentationMode').then(m => ({ default: m.PresentationMode })));
 const QuestPhaseView = React.lazy(() => import('./QuestPhaseView'));
 
@@ -133,6 +134,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const [showAnalytics, setShowAnalytics] = useState(false);
   const [showSeasonRanking, setShowSeasonRanking] = useState(false);
   const [showTeamManager, setShowTeamManager] = useState(false);
+  const [showFFEConnect, setShowFFEConnect] = useState(false);
   const [showQRCode, setShowQRCode] = useState(false);
   const [showKiosk, setShowKiosk] = useState(false);
   const [showPresentation, setShowPresentation] = useState(false);
@@ -1188,6 +1190,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             onCheckInAll={checkInAll}
             onUncheckAll={uncheckAll}
             onImport={(type) => handleOpenImportDialog(type)}
+            onImportFFEConnect={() => setShowFFEConnect(true)}
             onFencersImported={loadFencers}
             onAppelStateChange={handleAppelStateChange}
             onSetFencerStatus={(id, status) => {
@@ -1667,6 +1670,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             competition={competition}
             fencers={fencers}
             onClose={() => setShowTeamManager(false)}
+          />
+        </Suspense>
+      )}
+
+      {showFFEConnect && (
+        <Suspense fallback={null}>
+          <FFEConnectModal
+            onImport={async (imported) => { await handleImportFencers(imported); setShowFFEConnect(false); }}
+            onClose={() => setShowFFEConnect(false)}
           />
         </Suspense>
       )}

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -39,6 +39,7 @@ interface FencerListProps {
   onUncheckAll?: () => void;
   onSetFencerStatus?: (id: string, status: FencerStatus) => void;
   onImport?: (type: 'xml' | 'fff' | 'ranking') => void;
+  onImportFFEConnect?: () => void;
   onFencersImported?: () => void;
   /** URL de la page d'inscription distante (ex: http://192.168.x.x:8066/register) */
   registerUrl?: string;
@@ -60,6 +61,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   onUncheckAll,
   onSetFencerStatus,
   onImport,
+  onImportFFEConnect,
   onFencersImported,
   registerUrl,
   onFencersChanged,
@@ -483,6 +485,15 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                   >
                     Importer classement FFE
                   </button>
+                  {onImportFFEConnect && (
+                    <button
+                      className="btn btn-ghost"
+                      style={MENU_ITEM}
+                      onClick={() => { onImportFFEConnect(); setImportMenuOpen(false); }}
+                    >
+                      🔗 Importer depuis FFE Connect
+                    </button>
+                  )}
                   {competitionId && (
                     <>
                       <button

--- a/src/renderer/components/OBSOverlayConfig.tsx
+++ b/src/renderer/components/OBSOverlayConfig.tsx
@@ -1,0 +1,213 @@
+/**
+ * BellePoule Modern - Configurateur OBS Overlay (inline Electron)
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+
+interface OBSOverlayConfigProps {
+  serverUrl: string;
+  arenaCount: number;
+}
+
+type OverlayTheme = 'transparent' | 'dark' | 'neon' | 'light';
+
+const THEMES: { value: OverlayTheme; label: string }[] = [
+  { value: 'transparent', label: 'Transparent (recommandé OBS)' },
+  { value: 'dark', label: 'Sombre' },
+  { value: 'neon', label: 'Néon' },
+  { value: 'light', label: 'Clair' },
+];
+
+const HIDE_OPTIONS: { key: string; label: string }[] = [
+  { key: 'timer', label: 'Chronomètre' },
+  { key: 'cards', label: 'Cartons' },
+  { key: 'club', label: 'Club' },
+  { key: 'phase', label: 'Phase / Piste' },
+];
+
+export const OBSOverlayConfig: React.FC<OBSOverlayConfigProps> = ({ serverUrl, arenaCount }) => {
+  const [arena, setArena] = useState(1);
+  const [theme, setTheme] = useState<OverlayTheme>('transparent');
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const [width, setWidth] = useState(1280);
+  const [height, setHeight] = useState(160);
+  const [copied, setCopied] = useState(false);
+  const [copiedJson, setCopiedJson] = useState(false);
+
+  const toggleHide = useCallback((key: string) => {
+    setHidden(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const overlayUrl = useMemo(() => {
+    const params = new URLSearchParams();
+    if (theme !== 'transparent') params.set('theme', theme);
+    if (hidden.size > 0) params.set('hide', [...hidden].join(','));
+    params.set('w', String(width));
+    params.set('h', String(height));
+    const qs = params.toString();
+    return `${serverUrl}/arene${arena}/overlay${qs ? '?' + qs : ''}`;
+  }, [serverUrl, arena, theme, hidden, width, height]);
+
+  const jsonUrl = `${serverUrl}/api/arenas/arene${arena}/obs-json`;
+
+  const copyUrl = useCallback(() => {
+    navigator.clipboard.writeText(overlayUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }, [overlayUrl]);
+
+  const copyJson = useCallback(() => {
+    navigator.clipboard.writeText(jsonUrl).then(() => {
+      setCopiedJson(true);
+      setTimeout(() => setCopiedJson(false), 1500);
+    });
+  }, [jsonUrl]);
+
+  const S = STYLES;
+
+  return (
+    <div style={S.root}>
+      {/* Arène */}
+      <div style={S.row}>
+        <label style={S.labelText}>Piste / Arène</label>
+        <select
+          style={S.select}
+          value={arena}
+          onChange={e => setArena(Number(e.target.value))}
+        >
+          {Array.from({ length: Math.max(arenaCount, 1) }, (_, i) => (
+            <option key={i + 1} value={i + 1}>Piste {i + 1}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Thème */}
+      <div style={S.row}>
+        <label style={S.labelText}>Thème</label>
+        <select style={S.select} value={theme} onChange={e => setTheme(e.target.value as OverlayTheme)}>
+          {THEMES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+        </select>
+      </div>
+
+      {/* Dimensions */}
+      <div style={S.row}>
+        <label style={S.labelText}>Dimensions (px)</label>
+        <div style={S.dimRow}>
+          <input
+            type="number" style={S.dimInput} value={width} min={200} max={3840}
+            onChange={e => setWidth(Number(e.target.value))}
+          />
+          <span style={S.dimSep}>×</span>
+          <input
+            type="number" style={S.dimInput} value={height} min={60} max={2160}
+            onChange={e => setHeight(Number(e.target.value))}
+          />
+          <button style={S.presetBtn} onClick={() => { setWidth(1280); setHeight(160); }} title="Bandeau 1280×160">1280×160</button>
+          <button style={S.presetBtn} onClick={() => { setWidth(1920); setHeight(80); }} title="Bandeau 1920×80">1920×80</button>
+          <button style={S.presetBtn} onClick={() => { setWidth(400); setHeight(200); }} title="Bloc coin 400×200">400×200</button>
+        </div>
+      </div>
+
+      {/* Masquer éléments */}
+      <div style={S.hideSection}>
+        <span style={S.labelText}>Masquer</span>
+        <div style={S.checkboxRow}>
+          {HIDE_OPTIONS.map(opt => (
+            <label key={opt.key} style={S.checkLabel}>
+              <input
+                type="checkbox"
+                checked={hidden.has(opt.key)}
+                onChange={() => toggleHide(opt.key)}
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* URL générée */}
+      <div style={S.urlBox}>
+        <div style={S.urlLabel}>URL OBS Browser Source</div>
+        <div style={S.urlRow}>
+          <code style={S.urlCode}>{overlayUrl}</code>
+          <button style={S.copyBtn} onClick={copyUrl}>{copied ? '✓' : '📋'}</button>
+          <button
+            style={S.openBtn}
+            onClick={() => window.open(overlayUrl, '_blank')}
+            title="Ouvrir dans le navigateur"
+          >↗</button>
+        </div>
+      </div>
+
+      {/* JSON API */}
+      <div style={S.urlBox}>
+        <div style={S.urlLabel}>Endpoint JSON (intégrations tierces)</div>
+        <div style={S.urlRow}>
+          <code style={S.urlCode}>{jsonUrl}</code>
+          <button style={S.copyBtn} onClick={copyJson}>{copiedJson ? '✓' : '📋'}</button>
+        </div>
+      </div>
+
+      <div style={S.hint}>
+        Dans OBS : Sources → + → Navigateur → coller l'URL · Largeur {width} · Hauteur {height}
+      </div>
+    </div>
+  );
+};
+
+// ─── Styles ────────────────────────────────────────────────────────────────────
+
+const STYLES: Record<string, React.CSSProperties> = {
+  root: {
+    display: 'flex', flexDirection: 'column', gap: '0.75rem',
+    padding: '0.75rem', background: '#1e293b', borderRadius: '0.5rem',
+    border: '1px solid #334155', marginTop: '0.5rem',
+  },
+  row: { display: 'flex', alignItems: 'center', gap: '0.75rem' },
+  labelText: { fontSize: '0.8rem', color: '#94a3b8', minWidth: '110px', flexShrink: 0 },
+  select: {
+    flex: 1, padding: '0.3rem 0.5rem', borderRadius: '0.3rem',
+    border: '1px solid #475569', background: '#0f172a', color: '#e2e8f0', fontSize: '0.85rem',
+  },
+  dimRow: { display: 'flex', alignItems: 'center', gap: '0.4rem', flex: 1, flexWrap: 'wrap' },
+  dimInput: {
+    width: '72px', padding: '0.3rem 0.4rem', borderRadius: '0.3rem',
+    border: '1px solid #475569', background: '#0f172a', color: '#e2e8f0',
+    fontSize: '0.85rem', textAlign: 'center',
+  },
+  dimSep: { color: '#64748b', fontSize: '0.9rem' },
+  presetBtn: {
+    padding: '0.2rem 0.5rem', fontSize: '0.75rem', borderRadius: '0.3rem',
+    border: '1px solid #475569', background: 'transparent', color: '#94a3b8', cursor: 'pointer',
+  },
+  hideSection: { display: 'flex', gap: '0.75rem', alignItems: 'flex-start' },
+  checkboxRow: { display: 'flex', gap: '0.75rem', flexWrap: 'wrap' },
+  checkLabel: { display: 'flex', alignItems: 'center', gap: '0.35rem', fontSize: '0.82rem', color: '#e2e8f0', cursor: 'pointer' },
+  urlBox: {
+    background: '#0f172a', borderRadius: '0.375rem',
+    border: '1px solid #334155', padding: '0.5rem 0.75rem',
+  },
+  urlLabel: { fontSize: '0.72rem', color: '#64748b', marginBottom: '0.3rem', textTransform: 'uppercase', letterSpacing: '0.05em' },
+  urlRow: { display: 'flex', alignItems: 'center', gap: '0.4rem' },
+  urlCode: {
+    flex: 1, fontSize: '0.78rem', color: '#4ade80', wordBreak: 'break-all',
+    fontFamily: 'ui-monospace, monospace',
+  },
+  copyBtn: {
+    padding: '0.2rem 0.4rem', fontSize: '0.8rem', background: 'transparent',
+    border: '1px solid #475569', borderRadius: '0.25rem', cursor: 'pointer', color: '#e2e8f0',
+    flexShrink: 0,
+  },
+  openBtn: {
+    padding: '0.2rem 0.4rem', fontSize: '0.8rem', background: 'transparent',
+    border: '1px solid #475569', borderRadius: '0.25rem', cursor: 'pointer', color: '#94a3b8',
+    flexShrink: 0,
+  },
+  hint: { fontSize: '0.75rem', color: '#475569', fontStyle: 'italic' },
+};

--- a/src/renderer/components/PdfTemplateEditor.tsx
+++ b/src/renderer/components/PdfTemplateEditor.tsx
@@ -1,9 +1,15 @@
 import React, { useState, useRef } from 'react';
 import { useTranslation } from '../hooks/useTranslation';
 import { SM, SUBHEAD, HIDDEN } from './pdfTemplateEditor.styles';
-import type { PdfTemplate, PdfElementConfig } from '../../shared/types/pdfTemplate.types';
+import type { PdfTemplate, PdfElementConfig, PdfColorScheme } from '../../shared/types/pdfTemplate.types';
 
 const LOGO_KEY = 'bellepoule-logo';
+
+const COLOR_PRESETS: { label: string; colors: PdfColorScheme }[] = [
+  { label: 'Classique', colors: { navy: '#1a2e4a', gold: '#c9a227', green: '#166534' } },
+  { label: '⚡ Sabre Laser', colors: { navy: '#1e0a5c', gold: '#6d28d9', green: '#2563eb' } },
+  { label: '🇫🇷 FFE Officielle', colors: { navy: '#990000', gold: '#e30613', green: '#003189' } },
+];
 
 interface Props {
   template: PdfTemplate;
@@ -157,6 +163,22 @@ const PdfTemplateEditor: React.FC<Props> = ({ template, onChange, onReset }) => 
       <div>
         <div style={SUBHEAD}>
           Couleurs
+        </div>
+        {/* Presets */}
+        <div style={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
+          {COLOR_PRESETS.map(preset => (
+            <button
+              key={preset.label}
+              className="btn btn-secondary"
+              style={{ ...SM, display: 'flex', alignItems: 'center', gap: '0.35rem' }}
+              onClick={() => onChange({ ...template, colors: { ...preset.colors }, updatedAt: new Date().toISOString() })}
+            >
+              {(['navy', 'gold', 'green'] as const).map(k => (
+                <span key={k} style={{ display: 'inline-block', width: 10, height: 10, borderRadius: 2, background: preset.colors[k], border: '1px solid rgba(0,0,0,0.2)' }} />
+              ))}
+              {preset.label}
+            </button>
+          ))}
         </div>
         <div style={{ display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
           {(['navy', 'gold', 'green'] as const).map(key => (

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -12,6 +12,7 @@ import { logger, LogCategory } from '@shared/services/logger';
 import { TableauMatch, ConsolationBracket } from './tableau/tableauTypes';
 import { useToast } from './Toast';
 import ThemeEditor from './ThemeEditor';
+import { OBSOverlayConfig } from './OBSOverlayConfig';
 import { CustomTheme, DisplayTheme } from '../../shared/types/remote';
 import { ConnectedClient, KioskScreenConfig } from '../../shared/types/preload';
 
@@ -1160,25 +1161,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           <div className="arena-url-header">
             <strong>🎥 Overlay streaming (OBS / vMix)</strong>
           </div>
-          <div className="arena-url-row">
-            <span className="arena-url-label" title="Configurateur visuel pour générer l'URL OBS">Configurateur</span>
-            <code className="arena-url-value">{serverUrl}/overlay-config</code>
-            <button
-              className="btn-copy"
-              onClick={() => copyToClipboard(`${serverUrl}/overlay-config`, 998)}
-              title="Copier l'URL du configurateur"
-            >
-              {copiedIndex === 998 ? '✓' : '📋'}
-            </button>
-            <button
-              className="btn-ghost"
-              style={{ fontSize: '13px', padding: '2px 8px', borderRadius: 4, border: '1px solid #ccc', cursor: 'pointer', background: 'transparent' }}
-              onClick={() => window.open(`${serverUrl}/overlay-config?arenas=${arenaCount}`, '_blank')}
-              title="Ouvrir le configurateur"
-            >
-              ↗
-            </button>
-          </div>
+          <OBSOverlayConfig serverUrl={serverUrl} arenaCount={arenaCount} />
         </div>
 
         <div className="arena-url-card" style={RSM_STYLES.kioskCard}>


### PR DESCRIPTION
## OBSOverlayConfig.tsx (nouveau composant React natif)

Remplace le lien vers `/overlay-config` web dans RemoteScoreManager :
- Sélecteur piste (1..N arènes actives)
- Thème : transparent / sombre / néon / clair
- Dimensions avec presets (1280×160, 1920×80, 400×200) + inputs libres
- Masquer : chronomètre, cartons, club, phase/piste
- URL overlay générée en temps réel → copie presse-papier + ouvrir ↗
- Endpoint JSON OBS (`/api/arenas/arene{N}/obs-json`) avec copie

## AnalyticsDashboard : onglet Journal

- 4e onglet **Journal** dans la modal analytiques
- Lazy-mount de `MatchAuditLog` filtré par compétition
- Filtre par type (score/touche/carton/sortie), vue par arbitre, export JSON inclus

## Test plan

- [ ] Activer le serveur distant → section "Overlay streaming" affiche le configurateur inline
- [ ] Changer arène / thème / masquer cartons → URL mise à jour immédiatement
- [ ] Copier URL → coller dans OBS > Sources > Navigateur
- [ ] Ouvrir l'overlay dans le navigateur → rendu correct
- [ ] Analytics > onglet Journal → liste les événements de la compétition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkGT3faaMdPmPrnu9zd64g

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkGT3faaMdPmPrnu9zd64g)_