### PR TITLE
feat: HTTPS optionnel pour le serveur de scoring distant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "bellepoule-modern",
-  "version": "1.0.3-build.1167",
+  "version": "1.0.3-build.1230",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bellepoule-modern",
-      "version": "1.0.3-build.1167",
+      "version": "1.0.3-build.1230",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
-        "lucide-react": "^1.17.0"
+        "lucide-react": "^1.17.0",
+        "selfsigned": "^2.4.1"
       },
       "devDependencies": {
         "@electron/rebuild": "^4.0.4",
@@ -1883,6 +1884,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -1891,128 +1893,148 @@
       }
     },
     "node_modules/@peculiar/asn1-cms": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
-      "integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "@peculiar/asn1-x509-attr": "^2.6.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-csr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.0.tgz",
-      "integrity": "sha512-BeWIu5VpTIhfRysfEp73SGbwjjoLL/JWXhJ/9mo4vXnz3tRGm+NGm3KNcRzQ9VMVqwYS2RHlolz21svzRXIHPQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.0.tgz",
-      "integrity": "sha512-FF3LMGq6SfAOwUG2sKpPXblibn6XnEIKa+SryvUl5Pik+WR9rmRA3OCiwz8R3lVXnYnyRkSZsSLdml8H3UiOcw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.0.tgz",
-      "integrity": "sha512-rtUvtf+tyKGgokHHmZzeUojRZJYPxoD/jaN1+VAB4kKR7tXrnDCA/RAWXAIhMJJC+7W27IIRGe9djvxKgsldCQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.0",
-        "@peculiar/asn1-pkcs8": "^2.6.0",
-        "@peculiar/asn1-rsa": "^2.6.0",
-        "@peculiar/asn1-schema": "^2.6.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.0.tgz",
-      "integrity": "sha512-KyQ4D8G/NrS7Fw3XCJrngxmjwO/3htnA0lL9gDICvEQ+GJ+EPFqldcJQTwPIdvx98Tua+WjkdKHSC0/Km7T+lA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.0.tgz",
-      "integrity": "sha512-b78OQ6OciW0aqZxdzliXGYHASeCvvw5caqidbpQRYW2mBtXIX2WhofNXTEe7NyxTb0P6J62kAAWLwn0HuMF1Fw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.0",
-        "@peculiar/asn1-pfx": "^2.6.0",
-        "@peculiar/asn1-pkcs8": "^2.6.0",
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "@peculiar/asn1-x509-attr": "^2.6.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.0.tgz",
-      "integrity": "sha512-Nu4C19tsrTsCp9fDrH+sdcOKoVfdfoQQ7S3VqjJU6vedR7tY3RLkQ5oguOIB3zFW33USDUuYZnPEQYySlgha4w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
-      "integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
-      "integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "tslib": "^2.8.1"
       }
     },
@@ -2021,6 +2043,7 @@
       "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
       "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-cms": "^2.6.0",
         "@peculiar/asn1-csr": "^2.6.0",
@@ -2781,9 +2804,17 @@
       "version": "22.19.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
       "integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pako": {
@@ -4107,13 +4138,14 @@
       }
     },
     "node_modules/asn1js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
+        "pvutils": "^1.1.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -4554,6 +4586,7 @@
       "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
       "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -9530,6 +9563,15 @@
         "semver": "^7.3.5"
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
@@ -10146,10 +10188,11 @@
       }
     },
     "node_modules/pkijs": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.3.3.tgz",
-      "integrity": "sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@noble/hashes": "1.4.0",
         "asn1js": "^3.0.6",
@@ -10597,6 +10640,7 @@
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
       "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
       }
@@ -10606,6 +10650,7 @@
       "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
       "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -10943,7 +10988,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -11418,16 +11464,16 @@
       "dev": true
     },
     "node_modules/selfsigned": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
-      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
-      "dev": true,
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "license": "MIT",
       "dependencies": {
-        "@peculiar/x509": "^1.14.2",
-        "pkijs": "^3.3.3"
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/semver": {
@@ -12857,6 +12903,7 @@
       "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
       "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^1.9.3"
       },
@@ -12868,7 +12915,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -13051,8 +13099,7 @@
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -14012,6 +14059,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/webpack-dev-server/node_modules/send": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.10.0",
-    "lucide-react": "^1.17.0"
+    "lucide-react": "^1.17.0",
+    "selfsigned": "^2.4.1"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.4",

--- a/src/main/certManager.ts
+++ b/src/main/certManager.ts
@@ -1,0 +1,65 @@
+/**
+ * BellePoule Modern - TLS Certificate Manager
+ * Generates and persists a self-signed certificate for the HTTPS remote score server.
+ * Licensed under GPL-3.0
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import selfsigned from 'selfsigned';
+
+export interface CertBundle {
+  cert: string;
+  key: string;
+  /** SHA-256 fingerprint in XX:XX:... format */
+  fingerprint: string;
+}
+
+function computeFingerprint(certPem: string): string {
+  const der = crypto
+    .createHash('sha256')
+    .update(
+      Buffer.from(
+        certPem
+          .replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\n|\r/g, ''),
+        'base64'
+      )
+    )
+    .digest('hex')
+    .toUpperCase();
+  return der.match(/.{2}/g)!.join(':');
+}
+
+export async function ensureCert(userDataPath: string): Promise<CertBundle> {
+  const certsDir = path.join(userDataPath, 'certs');
+  const certPath = path.join(certsDir, 'server.pem');
+  const keyPath = path.join(certsDir, 'server.key');
+
+  if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
+    const cert = fs.readFileSync(certPath, 'utf-8');
+    const key = fs.readFileSync(keyPath, 'utf-8');
+    return { cert, key, fingerprint: computeFingerprint(cert) };
+  }
+
+  fs.mkdirSync(certsDir, { recursive: true });
+
+  const attrs = [{ name: 'commonName', value: 'BellePoule-LAN' }];
+  const generated = selfsigned.generate(attrs, {
+    days: 3650,
+    keySize: 2048,
+    algorithm: 'sha256',
+    extensions: [
+      { name: 'subjectAltName', altNames: [{ type: 7, ip: '0.0.0.0' }] },
+    ],
+  });
+
+  fs.writeFileSync(certPath, generated.cert, { mode: 0o600 });
+  fs.writeFileSync(keyPath, generated.private, { mode: 0o600 });
+
+  return {
+    cert: generated.cert,
+    key: generated.private,
+    fingerprint: computeFingerprint(generated.cert),
+  };
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import JSZip from 'jszip';
 import { DatabaseManager } from '../database';
 import { RemoteScoreServer } from './remoteScoreServer';
+import { ensureCert } from './certManager';
 import { AutoUpdater } from './autoUpdater';
 import { Competition, Fencer, FencerStatus, Match, MatchStatus, Pool } from '../shared/types';
 
@@ -17,7 +18,7 @@ import { Competition, Fencer, FencerStatus, Match, MatchStatus, Pool } from '../
 const db = new DatabaseManager();
 
 // Remote score servers — one per competition (key = competitionId)
-const remoteServers = new Map<string, { server: RemoteScoreServer; port: number; host: string }>();
+const remoteServers = new Map<string, { server: RemoteScoreServer; port: number; host: string; useHttps: boolean; certFingerprint?: string }>();
 const usedPorts = new Set<number>();
 const BASE_REMOTE_PORT = 8066;
 
@@ -1542,7 +1543,7 @@ ipcMain.handle('remote:getNetworkInterfaces', async () => {
   return { success: true, interfaces: result };
 });
 
-ipcMain.handle('remote:startServer', async (_event, competitionId: string, port?: number, host?: string) => {
+ipcMain.handle('remote:startServer', async (_event, competitionId: string, port?: number, host?: string, useHttps?: boolean) => {
   try {
     if (remoteServers.has(competitionId)) {
       return { success: false, error: 'Le serveur est déjà démarré pour cette compétition' };
@@ -1550,14 +1551,28 @@ ipcMain.handle('remote:startServer', async (_event, competitionId: string, port?
 
     const effectivePort = findAvailablePort(port);
     const effectiveHost = host ?? '0.0.0.0';
-    const server = new RemoteScoreServer(db, effectivePort, effectiveHost);
+
+    let tlsOptions: { cert: string; key: string } | undefined;
+    let certFingerprint: string | undefined;
+    if (useHttps) {
+      try {
+        const bundle = await ensureCert(app.getPath('userData'));
+        tlsOptions = { cert: bundle.cert, key: bundle.key };
+        certFingerprint = bundle.fingerprint;
+      } catch (certError) {
+        console.error('Erreur génération certificat TLS:', certError);
+        return { success: false, error: 'Impossible de générer le certificat TLS' };
+      }
+    }
+
+    const server = new RemoteScoreServer(db, effectivePort, effectiveHost, tlsOptions);
     try {
       await server.start();
     } catch (startError: any) {
       console.error('Error binding remote server port:', startError);
       return { success: false, error: startError?.message ?? 'Port indisponible' };
     }
-    remoteServers.set(competitionId, { server, port: effectivePort, host: effectiveHost });
+    remoteServers.set(competitionId, { server, port: effectivePort, host: effectiveHost, useHttps: !!useHttps, certFingerprint });
     usedPorts.add(effectivePort);
 
     // Appliquer la config TTS persistée aux tablettes de ce nouveau serveur
@@ -1576,6 +1591,8 @@ ipcMain.handle('remote:startServer', async (_event, competitionId: string, port?
         url: server.getServerUrl(),
         ip: server.getLocalIPAddress(),
         port: effectivePort,
+        useHttps: !!useHttps,
+        certFingerprint,
       },
     };
   } catch (error) {
@@ -1614,8 +1631,19 @@ ipcMain.handle('remote:getServerInfo', async (_event, competitionId: string) => 
       url: entry.server.getServerUrl(),
       ip: entry.server.getLocalIPAddress(),
       port: entry.port,
+      useHttps: entry.useHttps,
+      certFingerprint: entry.certFingerprint,
     },
   };
+});
+
+ipcMain.handle('remote:getCertFingerprint', async () => {
+  try {
+    const bundle = await ensureCert(app.getPath('userData'));
+    return { success: true, fingerprint: bundle.fingerprint };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
 });
 
 // Remote session handlers
@@ -1982,12 +2010,21 @@ ipcMain.handle('remote:changePort', async (_, competitionId: string, newPort: nu
     if (usedPorts.has(newPort) && newPort !== entry.port) {
       return { success: false, error: `Le port ${newPort} est déjà utilisé` };
     }
-    const host = entry.host;
+    const { host, useHttps, certFingerprint } = entry;
+    let tlsOptions: { cert: string; key: string } | undefined;
+    if (useHttps && certFingerprint) {
+      try {
+        const bundle = await ensureCert(app.getPath('userData'));
+        tlsOptions = { cert: bundle.cert, key: bundle.key };
+      } catch {
+        /* ignore — redémarre en HTTP si cert inaccessible */
+      }
+    }
     entry.server.stop();
     usedPorts.delete(entry.port);
-    const server = new RemoteScoreServer(db, newPort, host);
+    const server = new RemoteScoreServer(db, newPort, host, tlsOptions);
     server.start();
-    remoteServers.set(competitionId, { server, port: newPort, host });
+    remoteServers.set(competitionId, { server, port: newPort, host, useHttps: !!tlsOptions, certFingerprint });
     usedPorts.add(newPort);
     return {
       success: true,
@@ -1995,6 +2032,8 @@ ipcMain.handle('remote:changePort', async (_, competitionId: string, newPort: nu
         url: server.getServerUrl(),
         ip: server.getLocalIPAddress(),
         port: newPort,
+        useHttps: !!tlsOptions,
+        certFingerprint,
       },
     };
   } catch (error) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -492,8 +492,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Remote score server functions
   remote: {
     getNetworkInterfaces: () => ipcRenderer.invoke('remote:getNetworkInterfaces'),
-    startServer: (competitionId: string, port?: number, host?: string) =>
-      ipcRenderer.invoke('remote:startServer', competitionId, port, host),
+    startServer: (competitionId: string, port?: number, host?: string, useHttps?: boolean) =>
+      ipcRenderer.invoke('remote:startServer', competitionId, port, host, useHttps),
+    getCertFingerprint: () => ipcRenderer.invoke('remote:getCertFingerprint'),
     stopServer: (competitionId: string) => ipcRenderer.invoke('remote:stopServer', competitionId),
     getServerInfo: (competitionId: string) => ipcRenderer.invoke('remote:getServerInfo', competitionId),
     startSession: (

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -6,7 +6,8 @@
 
 import express from 'express';
 import { Server as SocketIOServer } from 'socket.io';
-import { createServer } from 'http';
+import { createServer as createHttpServer } from 'http';
+import { createServer as createHttpsServer } from 'https';
 import path from 'path';
 import os from 'os';
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
@@ -53,6 +54,7 @@ export class RemoteScoreServer {
   private io: SocketIOServer;
   private port: number;
   private host: string;
+  private useHttps: boolean = false;
   private db: DatabaseManager;
   private session: RemoteSession | null = null;
   private arenas: Map<string, Arena> = new Map();
@@ -147,13 +149,21 @@ export class RemoteScoreServer {
   // Labels persistants par screenId (survivent aux reconnexions)
   private screenLabels: Map<string, string> = new Map();
 
-  constructor(db: DatabaseManager, port: number = 8066, host: string = '0.0.0.0') {
+  constructor(
+    db: DatabaseManager,
+    port: number = 8066,
+    host: string = '0.0.0.0',
+    tlsOptions?: { cert: string; key: string }
+  ) {
     console.log('[RemoteScoreServer] Initialisation du serveur de saisie distante...');
     this.db = db;
     this.port = port;
     this.host = host;
+    this.useHttps = !!tlsOptions;
     this.app = express();
-    this.server = createServer(this.app);
+    this.server = tlsOptions
+      ? createHttpsServer({ cert: tlsOptions.cert, key: tlsOptions.key }, this.app)
+      : createHttpServer(this.app);
     // Limiter CORS au réseau local (localhost + LAN) pour la sécurité
     this.io = new SocketIOServer(this.server, {
       cors: {
@@ -4198,14 +4208,15 @@ export class RemoteScoreServer {
 
   public getServerUrl(): string {
     const ip = this.host !== '0.0.0.0' ? this.host : this.getLocalIPAddress();
-    return `http://${ip}:${this.port}`;
+    const protocol = this.useHttps ? 'https' : 'http';
+    return `${protocol}://${ip}:${this.port}`;
   }
 
   public start(): Promise<void> {
     console.log('[RemoteScoreServer] Démarrage du serveur...');
     console.log(`[RemoteScoreServer] Port: ${this.port}`);
     console.log(`[RemoteScoreServer] Interface: ${this.host}`);
-    console.log(`[RemoteScoreServer] URL locale: http://localhost:${this.port}`);
+    console.log(`[RemoteScoreServer] URL locale: ${this.useHttps ? 'https' : 'http'}://localhost:${this.port}`);
     console.log(`[RemoteScoreServer] URL réseau: ${this.getServerUrl()}`);
 
     return new Promise((resolve, reject) => {

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -108,6 +108,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const [session, setSession] = useState<RemoteSession | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [serverUrl, setServerUrl] = useState<string>('');
+  const [useHttps, setUseHttps] = useState<boolean>(() => {
+    return localStorage.getItem('bellepoule-remote-https') === 'true';
+  });
+  const [certFingerprint, setCertFingerprint] = useState<string | null>(null);
   const [remotePort, setRemotePort] = useState<number>(() => {
     const saved = localStorage.getItem(`bellepoule-remote-port-${competition.id}`);
     return saved ? parseInt(saved, 10) : 8066;
@@ -286,7 +290,10 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       if (result.success && result.session) {
         // Récupérer l'IP réseau réelle (éviter localhost)
         const info = await window.electronAPI.remote.getServerInfo(competition.id);
-        if (info.success && info.serverInfo) setServerUrl(info.serverInfo.url);
+        if (info.success && info.serverInfo) {
+          setServerUrl(info.serverInfo.url);
+          setCertFingerprint(info.serverInfo.certFingerprint ?? null);
+        }
         setSession(result.session);
         const existingCount = result.session.strips.length;
         setPendingCount(existingCount);
@@ -300,7 +307,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const startRemoteServer = async () => {
     try {
       setIsLoading(true);
-      const result = await window.electronAPI.remote.startServer(competition.id, remotePort, selectedInterface);
+      const result = await window.electronAPI.remote.startServer(competition.id, remotePort, selectedInterface, useHttps);
 
       if (result.success && result.serverInfo) {
         if (result.serverInfo.port !== remotePort) {
@@ -308,6 +315,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           localStorage.setItem(`bellepoule-remote-port-${competition.id}`, String(result.serverInfo.port));
         }
         setServerUrl(result.serverInfo.url);
+        setCertFingerprint(result.serverInfo.certFingerprint ?? null);
         await startSession(result.serverInfo.url, effectivePending);
       } else {
         showToast(`Erreur: ${result.error || 'Impossible de démarrer le serveur'}`, 'error');
@@ -539,7 +547,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     const previewHost = selectedInterface === '0.0.0.0'
       ? (networkInterfaces.find(i => i.address !== '0.0.0.0')?.address ?? 'localhost')
       : selectedInterface;
-    const networkPreview = `http://${previewHost}:${remotePort}`;
+    const networkPreview = `${useHttps ? 'https' : 'http'}://${previewHost}:${remotePort}`;
 
     const kioskPills = (
       [
@@ -641,6 +649,23 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               {!portValid && (
                 <div className="rsm-port-error">Port invalide (1–65535)</div>
               )}
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem', cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={useHttps}
+                  onChange={e => {
+                    setUseHttps(e.target.checked);
+                    localStorage.setItem('bellepoule-remote-https', String(e.target.checked));
+                  }}
+                  disabled={isLoading}
+                />
+                🔒 Activer HTTPS (connexion chiffrée)
+              </label>
+              {useHttps && (
+                <div style={{ fontSize: '0.78rem', color: '#94a3b8', marginTop: '0.25rem', lineHeight: 1.4 }}>
+                  Certificat auto-signé — les tablettes devront accepter l&apos;avertissement de sécurité du navigateur une seule fois.
+                </div>
+              )}
               <span className="rsm-network-preview">{networkPreview}</span>
             </div>
           </div>
@@ -669,6 +694,11 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           <p>
             Serveur: <strong>{serverUrl}</strong>
           </p>
+          {certFingerprint && (
+            <p style={{ fontSize: '0.75rem', color: '#94a3b8', margin: '0.25rem 0 0', wordBreak: 'break-all' }}>
+              🔒 Empreinte cert. SHA-256 : <code style={{ fontSize: '0.7rem' }}>{certFingerprint}</code>
+            </p>
+          )}
           <div style={RSM_STYLES.portActiveRow}>
             <label htmlFor={`remote-port-active-${competition.id}`} style={RSM_STYLES.portActiveLabel}>
               Port :

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -340,6 +340,8 @@ export interface RemoteServerInfo {
   url: string;
   ip: string;
   port: number;
+  useHttps?: boolean;
+  certFingerprint?: string;
 }
 
 export interface ConnectedClient {
@@ -381,10 +383,12 @@ export interface RemoteServerAPI {
   startServer: (
     competitionId: string,
     port?: number,
-    host?: string
+    host?: string,
+    useHttps?: boolean
   ) => Promise<{ success: boolean; serverInfo?: RemoteServerInfo; error?: string }>;
   stopServer: (competitionId: string) => Promise<{ success: boolean; error?: string }>;
   getServerInfo: (competitionId: string) => Promise<{ success: boolean; serverInfo?: RemoteServerInfo; error?: string }>;
+  getCertFingerprint: () => Promise<{ success: boolean; fingerprint?: string; error?: string }>;
   startSession: (
     competitionId: string,
     strips: number,


### PR DESCRIPTION
## Résumé

- Nouveau `certManager.ts` : génère et persiste un certificat auto-signé (RSA-2048, SHA-256, 10 ans) dans `userData/certs/` via le package `selfsigned`
- `remoteScoreServer.ts` : accepte des `tlsOptions` optionnels → bascule entre `http.createServer` et `https.createServer`; `getServerUrl()` retourne `https://` si TLS actif
- `main.ts` : `remote:startServer` accepte `useHttps?`; charge le cert via `ensureCert()`; `remote:changePort` propage le mode HTTPS; nouveau handler `remote:getCertFingerprint`
- Preload + types : `startServer` expose `useHttps`, nouveau `getCertFingerprint`, `RemoteServerInfo` inclut `useHttps` et `certFingerprint`
- `RemoteScoreManager.tsx` : toggle « 🔒 Activer HTTPS » dans la section Réseau (persisté localStorage); `networkPreview` adapte le protocole; empreinte SHA-256 affichée quand le serveur HTTPS est actif

## Notes de déploiement

Les tablettes verront un avertissement de sécurité du navigateur (certificat auto-signé) — elles devront cliquer « Avancé → Continuer » **une seule fois**. Après acceptation, la connexion est chiffrée (HTTPS + WSS).

## Test plan

- [ ] Démarrer un serveur avec HTTPS désactivé → `http://` dans l'URL, comportement inchangé
- [ ] Activer le toggle HTTPS → `https://` dans la prévisualisation réseau et dans l'URL active
- [ ] Sur tablette : scanner le QR → accepter l'avertissement cert → page arbitre accessible
- [ ] Vérifier cadenas dans la barre d'adresse de la tablette
- [ ] Vérifier que Socket.IO se connecte en `wss://` (DevTools tablette → onglet Network)
- [ ] Redémarrer l'appli → cert réutilisé (pas régénéré), fingerprint identique
- [ ] `npm run test:run` → 963 tests verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxYYcybbHiwPgMZPtjmaVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxYYcybbHiwPgMZPtjmaVX)_