### PR TITLE
feat: webhook notifications, zone heatmap, journal nav, teams CSV export

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } fr
 import { Competition, Fencer, FencerStatus, Match, MatchStatus, Weapon, QuestPhaseConfig, Referee, Gender } from '../../shared/types';
 import { Arena } from '../../shared/types/remote';
 import { logger, LogCategory } from '@shared/services/logger';
+import { NotificationService } from '../../shared/services/notificationService';
 import { RankingImportResult } from '../../shared/utils/fileParser';
 import FencerList from './FencerList';
 import { TableauMatch, FinalResult, propagateWinners, ConsolationBracket } from './tableau/tableauTypes';
@@ -468,6 +469,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     return () => unlisten?.();
   }, [isRemoteActive, competition.id]);
 
+  const fireWebhookNotif = useCallback((title: string, body: string) => {
+    try {
+      const webhookUrl = localStorage.getItem('bellepoule-webhook-url');
+      if (!webhookUrl) return;
+      const svc = new NotificationService({ browser: false, webhook: { url: webhookUrl }, events: { matchCompleted: true, matchStarting: false, competitionStarted: false, competitionEnded: false, fencerLate: false } });
+      svc.notify({ title, body }).catch(() => {});
+    } catch { /* non bloquant */ }
+  }, []);
+
   // Écouter les mises à jour des matches distants
   // Note: pas de garde sur currentPhase car la phase 'remote' affiche le panel de saisie distante
   // mais les mises à jour doivent quand même être appliquées aux pools
@@ -487,6 +497,10 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         `[CompetitionView] match:finished REÇU matchId=${matchId} score=${scoreA}-${scoreB} tableau=${!!isTableau}`
       );
       applyRemoteScore(matchId, scoreA, scoreB, true, winnerOverride);
+      fireWebhookNotif(
+        `✅ Match terminé — ${competition.title}`,
+        `Score : ${scoreA} – ${scoreB}${isTableau ? ' (tableau)' : ''}`
+      );
     };
 
     const offMatchFinished = window.electronAPI.onRemoteMatchFinished(handleMatchFinished);
@@ -501,7 +515,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       offMatchFinished?.();
       offExcluded?.();
     };
-  }, [applyRemoteScore, updateFencer]);
+  }, [applyRemoteScore, updateFencer, fireWebhookNotif, competition.title]);
 
   // Sync scores/statuts des matches de poule vers la DB quand ils changent
   const prevPoolsRef = useRef(pools);
@@ -1292,6 +1306,15 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                         competitionId={competition.id}
                         onScoreUpdate={(matchIndex, scoreA, scoreB, winner, specialStatus) => {
                           updateScore(poolIndex, matchIndex, scoreA, scoreB, winner, specialStatus);
+                          if (winner) {
+                            const m = pool.matches[matchIndex];
+                            const nameA = m?.fencerA ? `${m.fencerA.lastName}` : 'A';
+                            const nameB = m?.fencerB ? `${m.fencerB.lastName}` : 'B';
+                            fireWebhookNotif(
+                              `✅ Match terminé — ${competition.title}`,
+                              `${nameA} ${scoreA} – ${scoreB} ${nameB} (Poule ${pool.number})`
+                            );
+                          }
                           if (isRemoteActive && competition?.id) {
                             const match = pool.matches[matchIndex];
                             if (match) {

--- a/src/renderer/components/MatchAuditLog.tsx
+++ b/src/renderer/components/MatchAuditLog.tsx
@@ -3,7 +3,7 @@
  * Licensed under GPL-3.0
  */
 
-import React, { useState, useEffect, useCallback, memo } from 'react';
+import React, { useState, useEffect, useCallback, memo, useMemo } from 'react';
 import type { MatchEventEntry, MatchEventType } from '../../shared/types';
 import { useMatchAuditStore } from '../../features/matchAuditLog/hooks/useMatchAuditStore';
 import { useToast } from './Toast';
@@ -92,6 +92,19 @@ const MatchAuditLogComponent: React.FC<MatchAuditLogProps> = ({
   const baseTs = entries.length > 0 ? entries[0].timestamp : null;
   const refereeLastActions = buildRefereeLastActions(entries);
 
+  const zoneStats = useMemo(() => {
+    type ZoneSide = { A: number; B: number; C: number };
+    const stats: Record<'A' | 'B', ZoneSide> = { A: { A: 0, B: 0, C: 0 }, B: { A: 0, B: 0, C: 0 } };
+    for (const e of entries) {
+      if (e.eventType === 'touch' && e.zone && (e.fencerSide === 'A' || e.fencerSide === 'B')) {
+        const z = e.zone as 'A' | 'B' | 'C';
+        if (z === 'A' || z === 'B' || z === 'C') stats[e.fencerSide][z]++;
+      }
+    }
+    const hasZones = Object.values(stats).some(s => s.A + s.B + s.C > 0);
+    return hasZones ? stats : null;
+  }, [entries]);
+
   const filtered =
     filterTypes.length === 0 ? entries : entries.filter(e => filterTypes.includes(e.eventType));
 
@@ -126,6 +139,41 @@ const MatchAuditLogComponent: React.FC<MatchAuditLogProps> = ({
 
   const content = (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', gap: '1rem' }}>
+
+      {/* Heatmap zones Laser Sabre (visible quand matchId et données disponibles) */}
+      {matchId && zoneStats && (
+        <div style={{ display: 'flex', gap: '1rem', padding: '0.75rem', background: '#1e1b4b', borderRadius: '0.5rem', border: '1px solid #3730a3' }}>
+          {(['A', 'B'] as const).map(side => {
+            const s = zoneStats[side];
+            const total = s.A + s.B + s.C;
+            const ZONE_COLORS: Record<string, string> = { A: '#22c55e', B: '#f59e0b', C: '#ef4444' };
+            const ZONE_PTS: Record<string, string> = { A: '1pt', B: '3pt', C: '5pt' };
+            return (
+              <div key={side} style={{ flex: 1 }}>
+                <div style={{ fontSize: '0.7rem', fontWeight: 700, color: side === 'A' ? '#60a5fa' : '#f87171', textTransform: 'uppercase', marginBottom: '0.4rem' }}>
+                  Côté {side}
+                </div>
+                {(['A', 'B', 'C'] as const).map(z => {
+                  const count = s[z];
+                  const pct = total > 0 ? (count / total) * 100 : 0;
+                  return (
+                    <div key={z} style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', marginBottom: '0.25rem' }}>
+                      <span style={{ width: '28px', fontSize: '0.72rem', color: ZONE_COLORS[z], fontWeight: 700 }}>
+                        {z} <span style={{ fontSize: '0.6rem', opacity: 0.7 }}>{ZONE_PTS[z]}</span>
+                      </span>
+                      <div style={{ flex: 1, height: '8px', background: '#312e81', borderRadius: '4px', overflow: 'hidden' }}>
+                        <div style={{ width: `${pct}%`, height: '100%', background: ZONE_COLORS[z], borderRadius: '4px', transition: 'width 0.3s' }} />
+                      </div>
+                      <span style={{ width: '20px', fontSize: '0.72rem', color: '#c7d2fe', textAlign: 'right' }}>{count}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
       {/* Filtres */}
       <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
         <span style={{ fontSize: '0.8rem', color: '#6b7280', marginRight: '0.25rem' }}>Filtrer :</span>

--- a/src/renderer/components/TeamManagerView.tsx
+++ b/src/renderer/components/TeamManagerView.tsx
@@ -532,6 +532,40 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
           {/* ── Vue CLASSEMENT ── */}
           {view === 'ranking' && (
             <div>
+              {rankings.length > 0 && (
+                <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '0.5rem' }}>
+                  <button
+                    className="btn btn-secondary"
+                    style={{ fontSize: '0.8rem', padding: '0.3rem 0.7rem' }}
+                    onClick={() => {
+                      const header = 'Rang,Équipe,Club,V,D,Assauts+,Assauts-,Ind.,Pts+,Pts-\n';
+                      const rows = rankings.map((r, i) =>
+                        [
+                          i + 1,
+                          `"${r.team.name}"`,
+                          `"${r.team.club ?? ''}"`,
+                          r.victories,
+                          r.defeats,
+                          r.boutsWon,
+                          r.boutsLost,
+                          r.boutsWon - r.boutsLost,
+                          r.pointsFor,
+                          r.pointsAgainst,
+                        ].join(',')
+                      ).join('\n');
+                      const blob = new Blob([header + rows], { type: 'text/csv;charset=utf-8;' });
+                      const url = URL.createObjectURL(blob);
+                      const a = document.createElement('a');
+                      a.href = url;
+                      a.download = 'classement-equipes.csv';
+                      a.click();
+                      URL.revokeObjectURL(url);
+                    }}
+                  >
+                    ↓ Exporter CSV
+                  </button>
+                </div>
+              )}
               {rankings.length === 0 ? (
                 <div className="text-center text-gray-400 py-10">Aucun match joué.</div>
               ) : (

--- a/src/renderer/components/competition/CompetitionNav.tsx
+++ b/src/renderer/components/competition/CompetitionNav.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { ChevronLeft, ChevronRight, Swords, Target, Zap, Trophy } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Swords, Target, Zap, Trophy, ScrollText } from 'lucide-react';
 import { Competition, MatchStatus, QuestPhaseConfig, Fencer } from '../../../shared/types';
 import { Phase } from '../../hooks/useCompetitionSession';
 import CoachMark from '../CoachMark';
@@ -139,6 +139,14 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
             {poolsNextAction.label}
           </button>
         )}
+        <button
+          className={`btn btn-secondary btn-icon-label${currentPhase === 'logs' ? ' btn-active' : ''}`}
+          onClick={() => setCurrentPhase(currentPhase === 'logs' ? 'checkin' : 'logs')}
+          title="Journal des événements de match"
+          style={{ fontSize: '0.8rem', padding: '0.3rem 0.6rem' }}
+        >
+          <ScrollText size={14} /> Journal
+        </button>
 
       </div>
     </div>


### PR DESCRIPTION
## Résumé

- **Notifications webhook** (Discord/Slack) déclenchées automatiquement à la fin de chaque match (remote + poule locale)
- **Heatmap zones A/B/C** par côté tireur dans le journal de match (Laser Sabre)
- **Bouton Journal** dans CompetitionNav — accès direct depuis n'importe quelle phase
- **Export CSV classement équipes** — bouton dans l'onglet Classement de TeamManagerView

## Fichiers modifiés

- `src/renderer/components/CompetitionView.tsx` — `fireWebhookNotif` + appels sur fin de match
- `src/renderer/components/MatchAuditLog.tsx` — `zoneStats` useMemo + heatmap JSX
- `src/renderer/components/competition/CompetitionNav.tsx` — bouton Journal (ScrollText)
- `src/renderer/components/TeamManagerView.tsx` — export CSV classement

## Test plan
- [ ] Configurer un webhook Discord dans les paramètres → finir un match → notification reçue
- [ ] Ouvrir un match Laser Sabre avec touches → onglet Journal → heatmap A/B/C visible
- [ ] Cliquer "Journal" dans la nav → passe en phase `logs` → reclic → retour
- [ ] TeamManagerView onglet Classement → bouton "↓ Exporter CSV" → fichier téléchargé

Travail terminé — PR draft créée. Valider et clore si OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkGT3faaMdPmPrnu9zd64g)_