### PR TITLE
fix: corrige TS error writeFileContent → writeContent

### DIFF
--- a/src/renderer/components/analytics/AnalyticsCharts.tsx
+++ b/src/renderer/components/analytics/AnalyticsCharts.tsx
@@ -295,7 +295,7 @@ async function exportCSV(competition: Competition, stats: FencerCompetitionStats
     defaultPath: `stats-${competition.title.replace(/\s+/g, '-')}.csv`,
   });
   if (result?.filePath) {
-    await window.electronAPI.file.writeFileContent(result.filePath, csv);
+    await window.electronAPI.file.writeContent(result.filePath, csv);
   }
 }
 


### PR DESCRIPTION
## Résumé

- `AnalyticsCharts.tsx:298` : `writeFileContent` n'existe pas sur `FileAPI` → renommé en `writeContent`

## Cause

CI fail sur `npm run type-check` avec `TS2551`.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoVu5nTzHqbvqGBGcXkirk)_