### PR TITLE
fix: bugs remote #729 #633 #629 + arbitre poule #588

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -787,19 +787,19 @@ export class DatabaseManager {
   public getCompetitionPools(competitionId: string): { id: string; name: string }[] {
     if (!this.db) throw new Error('Database not open');
     try {
-      const pools = this.queryAll<{ id: string; name: string }>(
-        'SELECT DISTINCT p.id, p.name FROM pools p INNER JOIN pool_fencers pf ON p.id = pf.pool_id INNER JOIN fencers f ON pf.fencer_id = f.id WHERE f.competition_id = ? ORDER BY p.name',
+      const pools = this.queryAll<{ id: string; number: number }>(
+        'SELECT DISTINCT p.id, p.number FROM pools p INNER JOIN pool_fencers pf ON p.id = pf.pool_id INNER JOIN fencers f ON pf.fencer_id = f.id WHERE f.competition_id = ? ORDER BY p.number',
         [competitionId]
       );
-      if (pools.length > 0) return pools;
+      if (pools.length > 0) return pools.map(p => ({ id: p.id, name: 'Poule ' + p.number }));
     } catch (e) {
       console.warn('[Database] Error getting pools:', e);
     }
     try {
-      return this.queryAll<{ id: string; name: string }>(
-        'SELECT p.id, p.name FROM pools p INNER JOIN phases ph ON p.phase_id = ph.id WHERE ph.competition_id = ? ORDER BY p.name',
+      return this.queryAll<{ id: string; number: number }>(
+        'SELECT p.id, p.number FROM pools p INNER JOIN phases ph ON p.phase_id = ph.id WHERE ph.competition_id = ? ORDER BY p.number',
         [competitionId]
-      );
+      ).map(p => ({ id: p.id, name: 'Poule ' + p.number }));
     } catch (e) {
       console.warn('[Database] Error getting pools via phases:', e);
     }

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -2156,8 +2156,8 @@ export class RemoteScoreServer {
             fencerB: m.fencerB
               ? { lastName: m.fencerB.lastName, firstName: m.fencerB.firstName, club: m.fencerB.club ?? '', id: m.fencerB.id }
               : null,
-            scoreA: (() => { const s = live?.scoreA ?? m.scoreA; return s != null ? ((s as any).value ?? s) : null; })(),
-            scoreB: (() => { const s = live?.scoreB ?? m.scoreB; return s != null ? ((s as any).value ?? s) : null; })(),
+            scoreA: (() => { const s = live?.scoreA ?? m.scoreA; if (s == null) return null; return typeof s === 'number' ? s : (s as any)?.value ?? null; })(),
+            scoreB: (() => { const s = live?.scoreB ?? m.scoreB; if (s == null) return null; return typeof s === 'number' ? s : (s as any)?.value ?? null; })(),
             winnerId: m.winner?.id ?? null,
             status: isFinished ? 'finished' : isLive ? 'live' : 'pending',
             isBye: !!m.isBye,
@@ -2471,6 +2471,7 @@ export class RemoteScoreServer {
             fencerB: arena.currentMatch?.fencerB,
             refereeFeatureEnabled: this.sessionRefereeFeatureEnabled,
             referees: this.session?.referees ?? [],
+            refereeSelected: this.arenaRefereeSelected.get(data.arenaId) ?? false,
             timerDuration: isPoolMatch ? this.sessionPoolTimerSeconds : this.sessionTableTimerSeconds,
             ...(arena.status === 'finished' && {
               nextMatch: this.peekNextMatch(data.arenaId),

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1370,6 +1370,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                             fencerB ?? undefined
                           ).catch(() => {});
                         }}
+                        onRefereeAssigned={(poolId, referee) => {
+                          setPools(prev => prev.map(p =>
+                            p.id === poolId
+                              ? { ...p, referees: referee ? [referee] : [] }
+                              : p
+                          ));
+                        }}
                       />
                     </div>
                   ))}

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -90,6 +90,7 @@ interface PoolViewProps {
     fencerA?: Fencer | null,
     fencerB?: Fencer | null
   ) => void;
+  onRefereeAssigned?: (poolId: string, referee: Referee | null) => void;
 }
 
 type ViewMode = 'grid' | 'matches';
@@ -111,6 +112,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   isRemoteActive,
   remoteServerUrl,
   onMatchArenaChange,
+  onRefereeAssigned,
 }) => {
   const { showToast } = useToast();
   const { confirm } = useConfirm();
@@ -177,7 +179,8 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     window.electronAPI.db.updatePoolReferee(pool.id, referee?.id ?? null);
     setAssignedReferee(referee);
     setShowRefereeModal(false);
-  }, [pool.id]);
+    onRefereeAssigned?.(pool.id, referee);
+  }, [pool.id, onRefereeAssigned]);
 
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
   const [showPoolConfetti, setShowPoolConfetti] = useState(false);


### PR DESCRIPTION
## Corrections

- **#729** `remoteScoreServer.ts` `/api/bracket` — extrait `.value` des objets `Score` au lieu d'envoyer `[object Object]` au kiosque
- **#633** `remoteScoreServer.ts` `join_arena` — inclut maintenant `refereeSelected` dans l'état initial envoyé au client public (fix affichage prématuré)
- **#629** `database/index.ts` `getCompetitionPools` — utilisait `p.name` (colonne inexistante) → remplacé par `'Poule ' + p.number` (fix nom de poule affiché dans l'interface tablette)
- **#588** `PoolView.tsx` + `CompetitionView.tsx` — l'arbitre assigné à une poule est maintenant remonté au state parent via `onRefereeAssigned` → persisté entre changements d'onglet et affiché dans le PDF

## Test plan
- [ ] #729 : Saisir un score tableau depuis tablette arbitre → kiosque affiche le score (pas `[object Object]`)
- [ ] #633 : Assigner une piste sans que l'arbitre sélectionne → vue public ne montre pas le match
- [ ] #629 : Interface tablette `/poule` affiche "Poule 1", "Poule 2" (pas "Poule undefined")
- [ ] #588 : Assigner un arbitre à une poule → changer d'onglet → revenir → arbitre toujours affiché + apparaît sur PDF imprimé

Travail terminé — PR draft créée. Valider et clore les issues si OK.

https://claude.ai/code/session_01FkGT3faaMdPmPrnu9zd64g

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkGT3faaMdPmPrnu9zd64g)_