### PR TITLE
Fix head-to-head: stats côte à côte + indicateurs couleur

### DIFF
--- a/src/renderer/components/FencerComparison.tsx
+++ b/src/renderer/components/FencerComparison.tsx
@@ -240,85 +240,57 @@ const FencerComparison_: React.FC<FencerComparisonProps> = ({
               <div className="comparison__global-stats">
                 <h4>📊 Statistiques globales</h4>
                 <div className="comparison__stats-grid">
-                  <div className="comparison__stats-column">
-                    <h5>{comparison.fencer1.lastName}</h5>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Matchs joués:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer1GlobalStats.matchesPlayed}
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Victoires:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer1GlobalStats.victories}
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Taux de victoire:</span>
-                      <span className="comparison__stat-value">
-                        {(comparison.fencer1GlobalStats.victoryRatio * 100).toFixed(1)}%
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Touches données:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer1GlobalStats.touchesScored}
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Touches reçues:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer1GlobalStats.touchesReceived}
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Index:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer1GlobalStats.index}
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className="comparison__stats-column">
-                    <h5>{comparison.fencer2.lastName}</h5>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Matchs joués:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer2GlobalStats.matchesPlayed}
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Victoires:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer2GlobalStats.victories}
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Taux de victoire:</span>
-                      <span className="comparison__stat-value">
-                        {(comparison.fencer2GlobalStats.victoryRatio * 100).toFixed(1)}%
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Touches données:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer2GlobalStats.touchesScored}
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Touches reçues:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer2GlobalStats.touchesReceived}
-                      </span>
-                    </div>
-                    <div className="comparison__stat-row">
-                      <span className="comparison__stat-label">Index:</span>
-                      <span className="comparison__stat-value">
-                        {comparison.fencer2GlobalStats.index}
-                      </span>
-                    </div>
-                  </div>
+                  {(['fencer1GlobalStats', 'fencer2GlobalStats'] as const).map((key, idx) => {
+                    const stats = comparison[key];
+                    const otherStats = comparison[idx === 0 ? 'fencer2GlobalStats' : 'fencer1GlobalStats'];
+                    const fencer = idx === 0 ? comparison.fencer1 : comparison.fencer2;
+                    const cmp = (a: number, b: number, lowerIsBetter = false) => {
+                      if (a === b) return 'comparison__stat-value--equal';
+                      const better = lowerIsBetter ? a < b : a > b;
+                      return better ? 'comparison__stat-value--better' : 'comparison__stat-value--worse';
+                    };
+                    return (
+                      <div key={key} className="comparison__stats-column">
+                        <h5>{fencer.lastName}</h5>
+                        <div className="comparison__stat-row">
+                          <span className="comparison__stat-label">Matchs joués:</span>
+                          <span className={`comparison__stat-value ${cmp(stats.matchesPlayed, otherStats.matchesPlayed)}`}>
+                            {stats.matchesPlayed}
+                          </span>
+                        </div>
+                        <div className="comparison__stat-row">
+                          <span className="comparison__stat-label">Victoires:</span>
+                          <span className={`comparison__stat-value ${cmp(stats.victories, otherStats.victories)}`}>
+                            {stats.victories}
+                          </span>
+                        </div>
+                        <div className="comparison__stat-row">
+                          <span className="comparison__stat-label">Taux de victoire:</span>
+                          <span className={`comparison__stat-value ${cmp(stats.victoryRatio, otherStats.victoryRatio)}`}>
+                            {(stats.victoryRatio * 100).toFixed(1)}%
+                          </span>
+                        </div>
+                        <div className="comparison__stat-row">
+                          <span className="comparison__stat-label">Touches données:</span>
+                          <span className={`comparison__stat-value ${cmp(stats.touchesScored, otherStats.touchesScored)}`}>
+                            {stats.touchesScored}
+                          </span>
+                        </div>
+                        <div className="comparison__stat-row">
+                          <span className="comparison__stat-label">Touches reçues:</span>
+                          <span className={`comparison__stat-value ${cmp(stats.touchesReceived, otherStats.touchesReceived, true)}`}>
+                            {stats.touchesReceived}
+                          </span>
+                        </div>
+                        <div className="comparison__stat-row">
+                          <span className="comparison__stat-label">Index:</span>
+                          <span className={`comparison__stat-value ${cmp(stats.index, otherStats.index)}`}>
+                            {stats.index}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
 

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -1404,6 +1404,69 @@ body {
   letter-spacing: 0.05em;
 }
 
+.comparison__global-stats {
+  margin-bottom: 2rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+}
+
+.comparison__global-stats h4 {
+  margin-bottom: 1rem;
+  color: var(--color-text);
+}
+
+.comparison__stats-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.comparison__stats-column h5 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--color-text);
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--color-border);
+}
+
+.comparison__stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.comparison__stat-row:last-child {
+  border-bottom: none;
+}
+
+.comparison__stat-row .comparison__stat-label {
+  font-size: 0.875rem;
+  color: var(--color-text-light);
+}
+
+.comparison__stat-row .comparison__stat-value {
+  display: inline;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.comparison__stat-value--better {
+  color: var(--color-success) !important;
+}
+
+.comparison__stat-value--worse {
+  color: var(--color-danger) !important;
+}
+
+.comparison__stat-value--equal {
+  color: var(--color-warning, #f59e0b) !important;
+}
+
 /* ============================================================================
    ANALYTICS DASHBOARD
    ============================================================================ */


### PR DESCRIPTION
## Fix\n- Ajout CSS manquant `comparison__stats-grid` / `comparison__stats-column` → layout 2 colonnes côte à côte\n- Indicateurs couleur : vert (meilleur), rouge (moins bon), orange (égalité)\n- Touches reçues : logique inversée (moins = mieux → vert)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BizxgTcYvEZDvgNjFKM8e8)_