### PR TITLE
feat: bibliothèque de thèmes persistante par section (arena/kiosk/public/lobby)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1919,6 +1919,54 @@ ipcMain.handle(
   }
 );
 
+// ── Bibliothèque de thèmes (persistante dans userData) ──────────────────────
+
+function getThemesFilePath(): string {
+  return path.join(app.getPath('userData'), 'themes.json');
+}
+
+function readThemesFile(): unknown[] {
+  try {
+    const raw = fs.readFileSync(getThemesFilePath(), 'utf-8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeThemesFile(themes: unknown[]): void {
+  fs.writeFileSync(getThemesFilePath(), JSON.stringify(themes, null, 2), 'utf-8');
+}
+
+ipcMain.handle('themes:list', () => {
+  return readThemesFile();
+});
+
+ipcMain.handle('themes:save', (_, theme: unknown) => {
+  try {
+    const themes = readThemesFile() as any[];
+    const t = theme as { id: string };
+    const idx = themes.findIndex((x: any) => x.id === t.id);
+    if (idx >= 0) themes[idx] = t;
+    else themes.push(t);
+    writeThemesFile(themes);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+  }
+});
+
+ipcMain.handle('themes:delete', (_, id: string) => {
+  try {
+    const themes = readThemesFile() as any[];
+    writeThemesFile(themes.filter((x: any) => x.id !== id));
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+  }
+});
+
 ipcMain.handle('remote:setArenaPassword', async (_, competitionId: string, arenaId: string, password: string) => {
   try {
     const entry = remoteServers.get(competitionId);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -639,6 +639,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('app:logoLoaded', handler);
   },
 
+  // Bibliothèque de thèmes persistante
+  themes: {
+    list: () => ipcRenderer.invoke('themes:list'),
+    save: (theme: unknown) => ipcRenderer.invoke('themes:save', theme),
+    delete: (id: string) => ipcRenderer.invoke('themes:delete', id),
+  },
+
   // Remove listeners
   removeAllListeners: (channel: string) => ipcRenderer.removeAllListeners(channel),
 

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -11,7 +11,7 @@ import { Competition, Pool } from '../../shared/types';
 import { logger, LogCategory } from '@shared/services/logger';
 import { TableauMatch, ConsolationBracket } from './tableau/tableauTypes';
 import { useToast } from './Toast';
-import ThemeEditor, { loadSavedThemes } from './ThemeEditor';
+import ThemeEditor from './ThemeEditor';
 import { OBSOverlayConfig } from './OBSOverlayConfig';
 import { CustomTheme, DisplayTheme } from '../../shared/types/remote';
 import { ConnectedClient, KioskScreenConfig } from '../../shared/types/preload';
@@ -155,8 +155,8 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   // Éditeur de thème kiosk
   const [kioskThemeEditorOpen, setKioskThemeEditorOpen] = useState(false);
   const [kioskTheme, setKioskTheme] = useState<CustomTheme | undefined>(undefined);
-  // Thèmes sauvegardés (rechargés depuis localStorage)
-  const [savedThemes, setSavedThemes] = useState<CustomTheme[]>(loadSavedThemes);
+  // Thèmes sauvegardés (depuis IPC)
+  const [savedThemes, setSavedThemes] = useState<CustomTheme[]>([]);
   // Sélecteur de thème global
   const [globalThemeSection, setGlobalThemeSection] = useState<'arenes' | 'kiosque'>('arenes');
   const [globalThemeId, setGlobalThemeId] = useState('');
@@ -499,8 +499,31 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     [session]
   );
 
-  // Recharger les thèmes sauvegardés quand l'éditeur se ferme
-  const refreshSavedThemes = useCallback(() => setSavedThemes(loadSavedThemes()), []);
+  // Charger tous les thèmes depuis l'app (+ migration one-shot depuis localStorage)
+  const refreshSavedThemes = useCallback(() => {
+    window.electronAPI.themes.list().then(setSavedThemes).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const MIGRATION_KEY = 'bp-themes-migrated-v1';
+    if (!localStorage.getItem(MIGRATION_KEY)) {
+      try {
+        const raw = localStorage.getItem('bellepoule-custom-themes');
+        if (raw) {
+          const old: CustomTheme[] = JSON.parse(raw);
+          Promise.all(
+            old.map(t => window.electronAPI.themes.save({ ...t, targetType: t.targetType ?? 'arena' }))
+          ).then(() => {
+            localStorage.setItem(MIGRATION_KEY, '1');
+            refreshSavedThemes();
+          }).catch(() => {});
+        } else {
+          localStorage.setItem(MIGRATION_KEY, '1');
+        }
+      } catch { localStorage.setItem(MIGRATION_KEY, '1'); }
+    }
+    refreshSavedThemes();
+  }, [refreshSavedThemes]);
 
   // Appliquer un thème sauvegardé à toutes les arènes ou au kiosque
   const handleGlobalThemeApply = useCallback(async () => {
@@ -1034,7 +1057,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                     >
                       ✏️
                     </button>
-                    {savedThemes.length > 0 && (
+                    {savedThemes.filter(t => (t.targetType ?? 'arena') === 'arena').length > 0 && (
                       <select
                         title="Appliquer un thème sauvegardé"
                         value=""
@@ -1050,7 +1073,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                         }}
                       >
                         <option value="">📦 Thèmes…</option>
-                        {savedThemes.map(t => (
+                        {savedThemes.filter(t => (t.targetType ?? 'arena') === 'arena').map(t => (
                           <option key={t.id} value={t.id}>{t.name}</option>
                         ))}
                       </select>
@@ -1237,41 +1260,46 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
         </div>
 
         {/* ── Thème global ── */}
-        {savedThemes.length > 0 && (
-          <div className="arena-url-card" style={RSM_STYLES.kioskCard}>
-            <div className="arena-url-header">
-              <strong>🎨 Thème global</strong>
+        {(() => {
+          const sectionType = globalThemeSection === 'arenes' ? 'arena' : 'kiosk';
+          const filteredForSection = savedThemes.filter(t => (t.targetType ?? 'arena') === sectionType);
+          if (savedThemes.length === 0) return null;
+          return (
+            <div className="arena-url-card" style={RSM_STYLES.kioskCard}>
+              <div className="arena-url-header">
+                <strong>🎨 Thème global</strong>
+              </div>
+              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap', marginTop: '0.25rem' }}>
+                <select
+                  value={globalThemeSection}
+                  onChange={e => { setGlobalThemeSection(e.target.value as 'arenes' | 'kiosque'); setGlobalThemeId(''); }}
+                  style={{ padding: '0.35rem 0.5rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#1e293b', color: '#e2e8f0', fontSize: '0.85rem' }}
+                >
+                  <option value="arenes">⚔️ Arènes</option>
+                  <option value="kiosque">🖥️ Kiosque</option>
+                </select>
+                <select
+                  value={globalThemeId}
+                  onChange={e => setGlobalThemeId(e.target.value)}
+                  style={{ flex: 1, minWidth: 120, padding: '0.35rem 0.5rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#1e293b', color: '#e2e8f0', fontSize: '0.85rem' }}
+                >
+                  <option value="">— Choisir un thème —</option>
+                  {filteredForSection.map(t => (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
+                <button
+                  className="btn btn-primary"
+                  disabled={!globalThemeId}
+                  onClick={() => void handleGlobalThemeApply()}
+                  style={{ whiteSpace: 'nowrap' }}
+                >
+                  Appliquer à tous
+                </button>
+              </div>
             </div>
-            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap', marginTop: '0.25rem' }}>
-              <select
-                value={globalThemeSection}
-                onChange={e => setGlobalThemeSection(e.target.value as 'arenes' | 'kiosque')}
-                style={{ padding: '0.35rem 0.5rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#1e293b', color: '#e2e8f0', fontSize: '0.85rem' }}
-              >
-                <option value="arenes">⚔️ Arènes</option>
-                <option value="kiosque">🖥️ Kiosque</option>
-              </select>
-              <select
-                value={globalThemeId}
-                onChange={e => setGlobalThemeId(e.target.value)}
-                style={{ flex: 1, minWidth: 120, padding: '0.35rem 0.5rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#1e293b', color: '#e2e8f0', fontSize: '0.85rem' }}
-              >
-                <option value="">— Choisir un thème —</option>
-                {savedThemes.map(t => (
-                  <option key={t.id} value={t.id}>{t.name}</option>
-                ))}
-              </select>
-              <button
-                className="btn btn-primary"
-                disabled={!globalThemeId}
-                onClick={() => void handleGlobalThemeApply()}
-                style={{ whiteSpace: 'nowrap' }}
-              >
-                Appliquer à tous
-              </button>
-            </div>
-          </div>
-        )}
+          );
+        })()}
 
         <div className="arena-url-card" style={RSM_STYLES.kioskCard}>
           <div className="arena-url-header">

--- a/src/renderer/components/ThemeEditor.tsx
+++ b/src/renderer/components/ThemeEditor.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef, useId } from 'react';
-import { CustomTheme } from '../../shared/types/remote';
+import { CustomTheme, ThemeTargetType } from '../../shared/types/remote';
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Valeurs par défaut (thème dark)
@@ -257,20 +257,10 @@ const KIOSK_OVERLAY_PRESET: Record<string, string> = {
 const VIRTUAL_W = 1280;
 const VIRTUAL_H = 720;
 
+// Compat shim : utilisé par RemoteScoreManager (migré vers IPC)
 const STORAGE_KEY = 'bellepoule-custom-themes';
-
-function loadSavedThemes(): CustomTheme[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch {
-    return [];
-  }
-}
-
-function saveSavedThemes(themes: CustomTheme[]): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(themes));
-}
+function loadSavedThemes(): CustomTheme[] { return []; }
+function saveSavedThemes(_themes: CustomTheme[]): void { /* no-op */ }
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Variables et defaults Kiosk
@@ -306,8 +296,8 @@ const KIOSK_VAR_GROUPS: VarGroup[] = [
 interface ThemeEditorProps {
   /** Arène cible (ex: 'arena1') ou 'all' pour toutes les arènes */
   targetArenaId: string;
-  /** 'arena' (défaut) ou 'kiosk' */
-  targetType?: 'arena' | 'kiosk';
+  /** Section cible : 'arena' (défaut), 'kiosk', 'public', 'lobby' */
+  targetType?: 'arena' | 'kiosk' | 'public' | 'lobby';
   /** Thème initial à éditer (undefined = nouveau thème depuis dark) */
   initialTheme?: CustomTheme;
   /** Callback quand l'utilisateur applique le thème */
@@ -329,14 +319,22 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({
   const isKiosk = targetType === 'kiosk';
   const activeDefaults = isKiosk ? KIOSK_DEFAULTS : DARK_DEFAULTS;
   const activeVarGroups = isKiosk ? KIOSK_VAR_GROUPS : VAR_GROUPS;
+  const effectiveType = (targetType ?? 'arena') as ThemeTargetType;
 
   const [themeName, setThemeName] = useState(initialTheme?.name ?? (isKiosk ? 'Thème kiosk' : 'Mon thème'));
   const [vars, setVars] = useState<Record<string, string>>(() => ({
     ...activeDefaults,
     ...(initialTheme?.variables ?? {}),
   }));
-  const [savedThemes, setSavedThemes] = useState<CustomTheme[]>(loadSavedThemes);
+  const [savedThemes, setSavedThemes] = useState<CustomTheme[]>([]);
   const [activeGroup, setActiveGroup] = useState(0);
+
+  // Charger les thèmes depuis l'app (filtrés par type)
+  useEffect(() => {
+    window.electronAPI.themes.list().then(all => {
+      setSavedThemes(all.filter(t => (t.targetType ?? 'arena') === effectiveType));
+    }).catch(() => {});
+  }, [effectiveType]);
   const [importError, setImportError] = useState('');
   const [overlayMode, setOverlayMode] = useState(initialTheme?.overlayMode ?? false);
   const previewStyleId = `theme-preview-${instanceId.replace(/:/g, '')}`;
@@ -434,22 +432,22 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({
     e.target.value = '';
   };
 
-  // ── Sauvegarde locale ──
+  // ── Sauvegarde dans l'app ──
   const handleSave = () => {
     const id = initialTheme?.id ?? `custom-${Date.now()}`;
-    const theme: CustomTheme = { id, name: themeName.trim() || 'Sans nom', variables: vars, overlayMode };
-    const existing = savedThemes.findIndex(t => t.id === id);
-    const updated = existing >= 0
-      ? savedThemes.map((t, i) => (i === existing ? theme : t))
-      : [...savedThemes, theme];
-    setSavedThemes(updated);
-    saveSavedThemes(updated);
+    const theme: CustomTheme = { id, name: themeName.trim() || 'Sans nom', targetType: effectiveType, variables: vars, overlayMode };
+    window.electronAPI.themes.save(theme).then(() => {
+      setSavedThemes(prev => {
+        const idx = prev.findIndex(t => t.id === id);
+        return idx >= 0 ? prev.map((t, i) => (i === idx ? theme : t)) : [...prev, theme];
+      });
+    }).catch(() => {});
   };
 
   const handleDeleteSaved = (id: string) => {
-    const updated = savedThemes.filter(t => t.id !== id);
-    setSavedThemes(updated);
-    saveSavedThemes(updated);
+    window.electronAPI.themes.delete(id).then(() => {
+      setSavedThemes(prev => prev.filter(t => t.id !== id));
+    }).catch(() => {});
   };
 
   const handleLoadSaved = (theme: CustomTheme) => {
@@ -463,6 +461,7 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({
     const theme: CustomTheme = {
       id: initialTheme?.id ?? `custom-${Date.now()}`,
       name: themeName.trim() || 'Mon thème',
+      targetType: effectiveType,
       variables: vars,
     };
     const json = JSON.stringify(theme, null, 2);
@@ -502,17 +501,18 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({
     const theme: CustomTheme = {
       id: initialTheme?.id ?? `custom-${Date.now()}`,
       name: themeName.trim() || 'Mon thème',
+      targetType: effectiveType,
       variables: vars,
       overlayMode,
     };
     onApply(targetArenaId, theme);
   };
 
-  const arenaLabel = isKiosk
-    ? 'Kiosk (affichage public)'
-    : targetArenaId === 'all'
-      ? 'Toutes les arènes'
-      : `Piste ${targetArenaId.replace('arena', '')}`;
+  const arenaLabel = effectiveType === 'kiosk' ? 'Kiosque'
+    : effectiveType === 'public' ? 'Affichage public'
+    : effectiveType === 'lobby' ? 'Lobby'
+    : targetArenaId === 'all' ? 'Toutes les pistes'
+    : `Piste ${targetArenaId.replace('arena', '')}`;
 
   return (
     <div className="theme-editor-overlay" onClick={onClose}>

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -876,4 +876,9 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   getLogo: () => Promise<string | null>;
   getTtsConfig: () => Promise<TtsConfig | null>;
   onLogoLoaded: (callback: (logo: string | null) => void) => () => void;
+  themes: {
+    list: () => Promise<import('../types/remote').CustomTheme[]>;
+    save: (theme: import('../types/remote').CustomTheme) => Promise<{ success: boolean; error?: string }>;
+    delete: (id: string) => Promise<{ success: boolean; error?: string }>;
+  };
 }

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -107,10 +107,14 @@ export interface Arena {
 
 export type DisplayTheme = 'dark' | 'light' | 'neon' | 'unicorn' | 'custom';
 
+export type ThemeTargetType = 'arena' | 'kiosk' | 'public' | 'lobby';
+
 /** Variables CSS personnalisées pour un thème d'arène */
 export interface CustomTheme {
   id: string;
   name: string;
+  /** Section cible : arena (piste), kiosk, public, lobby */
+  targetType: ThemeTargetType;
   /** Valeurs des variables CSS (ex: { '--bg': '#000', '--score-green': '#0f0' }) */
   variables: Record<string, string>;
   /** Mode overlay : image en fond, panneaux transparents, suppression des box-shadows */


### PR DESCRIPTION
## Résumé

- `CustomTheme.targetType` : `'arena' | 'kiosk' | 'public' | 'lobby'`
- Stockage persistent dans `userData/themes.json` via IPC (`themes:list/save/delete`) — plus de localStorage
- Migration one-shot des thèmes localStorage existants au premier lancement
- ThemeEditor filtre et sauvegarde les thèmes par `targetType`
- RemoteScoreManager : dropdown arènes n'affiche que les thèmes `arena`, section kiosk n'affiche que les thèmes `kiosk`
- Thème global : changer la section réinitialise la sélection

## Comportement

- Ouvrir l'éditeur depuis une piste → section `arena`, liste filtrée arènes uniquement
- Ouvrir l'éditeur depuis le kiosque → section `kiosk`, liste filtrée kiosque uniquement
- Dropdown rapide par arène → filtre `arena` uniquement
- Thème global Arènes → filtre `arena` ; Kiosque → filtre `kiosk`

## Plan de test

- [ ] Sauvegarder un thème depuis l'éditeur arène → apparaît dans les dropdowns arènes
- [ ] Sauvegarder un thème depuis l'éditeur kiosk → n'apparaît PAS dans les dropdowns arènes
- [ ] Fermer et rouvrir l'app → thèmes toujours présents (userData/themes.json)
- [ ] Migration : thèmes déjà en localStorage récupérés automatiquement

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHDwrhMuUJ39PX3Hc36euo)_