### PR TITLE
feat(remote): Piste vs Arène selon l'arme de la compétition

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1528,7 +1528,7 @@
             .then(r => (r.ok ? r.json() : null))
             .then(s => {
               if (s && ['E', 'F', 'S'].includes(s.weapon)) {
-                document.querySelectorAll('.arena-word-label').forEach(el => (el.textContent = 'Piste'));
+                document.querySelectorAll('.arena-word-label').forEach(el => (el.textContent = window.T('remote.piste')));
               }
             })
             .catch(() => {});

--- a/src/remote/i18n.js
+++ b/src/remote/i18n.js
@@ -14,6 +14,7 @@
       'login.error_connection': 'Erreur de connexion au serveur',
       /* commun */
       'remote.arena': 'Arène',
+      'remote.piste': 'Piste',
       'remote.connecting': 'Connexion...',
       'remote.syncing': '⟳ Sync...',
       'remote.connected': 'Connecté',
@@ -114,6 +115,7 @@
       'login.error_connection': 'Server connection error',
       /* commun */
       'remote.arena': 'Arena',
+      'remote.piste': 'Piste',
       'remote.connecting': 'Connecting...',
       'remote.syncing': '⟳ Sync...',
       'remote.connected': 'Connected',
@@ -214,6 +216,7 @@
       'login.error_connection': '伺服器連接錯誤',
       /* commun */
       'remote.arena': '場地',
+      'remote.piste': '場地',
       'remote.connecting': '連接中...',
       'remote.syncing': '⟳ 同步...',
       'remote.connected': '已連接',
@@ -330,12 +333,19 @@
     });
   }
 
+  let _remoteWeapon = null;
+
+  window.getArenaLabel = function () {
+    return _remoteWeapon === 'L' ? window.T('remote.arena') : window.T('remote.piste');
+  };
+
   window.initRemoteI18n = async function () {
     try {
       const resp = await fetch('/api/config');
       const cfg = await resp.json();
       const lang = cfg.lang || 'fr';
       _t = TRANSLATIONS[lang] || TRANSLATIONS.fr;
+      _remoteWeapon = cfg.weapon || null;
       if (document.documentElement) {
         document.documentElement.lang = lang === 'zh-HK' ? 'zh-HK' : lang;
       }

--- a/src/remote/login.html
+++ b/src/remote/login.html
@@ -143,8 +143,8 @@
 
         const arenaNum = arenaParam.replace(/^arena/, '');
         if (arenaNum) {
-          document.getElementById('subtitle').textContent = window.T('login.arena_prefix') + ' ' + arenaNum;
-          document.title = window.T('login.arena_prefix') + ' ' + arenaNum + ' – ' + window.T('login.title');
+          document.getElementById('subtitle').textContent = window.getArenaLabel() + ' ' + arenaNum;
+          document.title = window.getArenaLabel() + ' ' + arenaNum + ' – ' + window.T('login.title');
         } else {
           document.title = window.T('login.page_title');
         }

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -755,7 +755,7 @@
     <div class="header">
       <div class="arena-title">
         <span>⚔️</span>
-        <span>Arène <span id="arena-number">1</span></span>
+        <span><span id="arena-word-label">Arène</span> <span id="arena-number">1</span></span>
       </div>
       <div class="status-section">
         <div class="inversion-toggle">
@@ -890,6 +890,17 @@
           document.getElementById('arena-idle-number').textContent = this.arenaNumber;
           this.setupInversionToggle();
           this.setupSocketListeners();
+          fetch('/api/session')
+            .then(r => (r.ok ? r.json() : null))
+            .then(s => {
+              if (s && ['E', 'F', 'S'].includes(s.weapon)) {
+                const pisteLabel = window.T('remote.piste');
+                document.getElementById('arena-word-label').textContent = pisteLabel;
+                const idleLabel = document.querySelector('.arena-idle-label');
+                if (idleLabel) idleLabel.textContent = pisteLabel;
+              }
+            })
+            .catch(() => {});
         }
 
         setupInversionToggle() {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1466,7 +1466,7 @@
 
       <!-- Écran de sélection de match -->
       <div class="next-matches-screen" id="next-matches-screen">
-        <h2>📋 Matchs — Arène <span id="next-arena-number">1</span></h2>
+        <h2>📋 Matchs — <span id="next-arena-label">Arène</span> <span id="next-arena-number">1</span></h2>
         <input
           type="search"
           id="match-search"
@@ -1782,7 +1782,10 @@
               this.isLaserSabre = s.weapon === 'L';
               this.isModernFencing = ['E', 'F', 'S'].includes(s.weapon);
               if (this.isModernFencing) {
-                document.getElementById('arena-label').textContent = 'Piste';
+                const pisteLabel = window.T('remote.piste');
+                document.getElementById('arena-label').textContent = pisteLabel;
+                const nextLabel = document.getElementById('next-arena-label');
+                if (nextLabel) nextLabel.textContent = pisteLabel;
                 document.querySelectorAll('.btn-plus-3, .btn-plus-5').forEach(b => (b.style.display = 'none'));
               }
             }


### PR DESCRIPTION
## Résumé

- Arme conventionnelle (Épée/Fleuret/Sabre) → affiche **Piste N**
- Sabre Laser → affiche **Arène N**
- Traduit dans les 3 langues du remote (fr/en/zh-HK) via nouvelle clé `remote.piste`
- Pages mises à jour : `login.html`, `public.html`, `referee.html`, `arena.html`, `i18n.js`

## Détail technique

`initRemoteI18n()` stocke désormais l'arme (`window._remoteWeapon`) depuis `/api/config`. `window.getArenaLabel()` retourne le bon terme selon l'arme. Chaque page HTML détecte l'arme via `/api/session` (déjà fait pour arena/referee) ou via `getArenaLabel()` (login).

## Test

- [ ] Compétition Épée/Fleuret/Sabre → toutes les pages remote affichent "Piste N"
- [ ] Compétition Sabre Laser → toutes les pages remote affichent "Arène N"
- [ ] Vérifier en EN et zh-HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHrcnkpazP4WC6b4R6xxjz)_