### PR TITLE
feat: thèmes par type d'écran (arena/kiosk/public/arbitre/poule)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1919,6 +1919,20 @@ ipcMain.handle(
   }
 );
 
+ipcMain.handle(
+  'remote:updateArenaScreenTheme',
+  async (_, competitionId: string, arenaId: string, targetType: string, customTheme?: any) => {
+    try {
+      const entry = remoteServers.get(competitionId);
+      if (!entry) return { success: false, error: 'Serveur non démarré' };
+      entry.server.updateArenaScreenTheme(arenaId, targetType as any, customTheme);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+    }
+  }
+);
+
 // ── Bibliothèque de thèmes (persistante dans userData) ──────────────────────
 
 function getThemesFilePath(): string {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -549,6 +549,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:updateArenaTheme', competitionId, arenaId, theme, customTheme),
     updateKioskTheme: (competitionId: string, variables: Record<string, string>) =>
       ipcRenderer.invoke('remote:updateKioskTheme', competitionId, variables),
+    updateArenaScreenTheme: (competitionId: string, arenaId: string, targetType: string, customTheme?: any) =>
+      ipcRenderer.invoke('remote:updateArenaScreenTheme', competitionId, arenaId, targetType, customTheme),
     setWebhookUrl: (url: string | null) => ipcRenderer.invoke('remote:setWebhookUrl', url),
     updateLogo: (logo: string | null) => ipcRenderer.invoke('remote:updateLogo', logo),
     setTtsConfig: (config: unknown) => ipcRenderer.invoke('remote:setTtsConfig', config),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -22,6 +22,7 @@ import {
   OrgNote,
   DisplayTheme,
   CustomTheme,
+  ThemeTargetType,
 } from '../shared/types/remote';
 import { Competition, Match, Fencer, MatchStatus, FencerStatus, Score } from '../shared/types';
 import { DatabaseManager } from '../database';
@@ -74,6 +75,7 @@ export class RemoteScoreServer {
   private sessionTheme: DisplayTheme = 'dark'; // Thème visuel de l'affichage distant (global)
   private arenaThemeOverrides: Map<string, { theme: DisplayTheme; customTheme?: CustomTheme }> =
     new Map();
+  private arenaScreenThemes: Map<string, Partial<Record<ThemeTargetType, CustomTheme>>> = new Map();
   private kioskThemeVariables: Record<string, string> | null = null; // Thème CSS vars pour le kiosk
   private orgNote: OrgNote | null = null; // Note d'organisation affichée sur le kiosk
   private sessionLogo: string | null = null; // Logo organisateur (base64) pour kiosk et affichages publics
@@ -2478,6 +2480,7 @@ export class RemoteScoreServer {
             cardAnnounce: this.sessionCardAnnounce,
             theme: override?.theme ?? this.sessionTheme,
             customTheme: override?.customTheme,
+            screenThemes: this.arenaScreenThemes.get(data.arenaId),
             fencerA: arena.currentMatch?.fencerA,
             fencerB: arena.currentMatch?.fencerB,
             refereeFeatureEnabled: this.sessionRefereeFeatureEnabled,
@@ -2493,6 +2496,10 @@ export class RemoteScoreServer {
 
       socket.on('join_pool', (data: { arenaId: string }) => {
         socket.join(`pool:${data.arenaId}`);
+        const poolTheme = this.arenaScreenThemes.get(data.arenaId)?.pool;
+        if (poolTheme) {
+          socket.emit('server:command', { type: 'pool:theme', variables: poolTheme.variables });
+        }
       });
 
       socket.on('dashboard:subscribe', () => {
@@ -2536,6 +2543,12 @@ export class RemoteScoreServer {
         });
         if (data.clientType === 'kiosk' && this.kioskThemeVariables) {
           socket.emit('server:command', { type: 'kiosk:theme', variables: this.kioskThemeVariables });
+        }
+        if (data.arenaId && (data.clientType === 'referee' || data.clientType === 'public')) {
+          const screenTheme = this.arenaScreenThemes.get(data.arenaId)?.[data.clientType];
+          if (screenTheme) {
+            socket.emit('server:command', { type: `${data.clientType}:theme`, variables: screenTheme.variables });
+          }
         }
         this.broadcastClientList();
       });
@@ -4091,6 +4104,7 @@ export class RemoteScoreServer {
       cardAnnounce: this.sessionCardAnnounce,
       theme: override?.theme ?? this.sessionTheme,
       customTheme: override?.customTheme,
+      screenThemes: this.arenaScreenThemes.get(arenaId),
       refereeFeatureEnabled: this.sessionRefereeFeatureEnabled,
       referees: this.session?.referees ?? [],
       timerDuration: isPoolMatch ? this.sessionPoolTimerSeconds : this.sessionTableTimerSeconds,
@@ -4721,6 +4735,39 @@ export class RemoteScoreServer {
         status: arena.status,
         fencerA: arena.currentMatch?.fencerA,
         fencerB: arena.currentMatch?.fencerB,
+      });
+    }
+  }
+
+  public updateArenaScreenTheme(arenaId: string, targetType: ThemeTargetType, customTheme?: CustomTheme): void {
+    if (!this.session) throw new Error('Aucune session active');
+    const fullId = arenaId.startsWith('arena') ? arenaId : `arena${arenaId}`;
+    const existing = this.arenaScreenThemes.get(fullId) ?? {};
+    if (customTheme) existing[targetType] = customTheme;
+    else delete existing[targetType];
+    this.arenaScreenThemes.set(fullId, existing);
+
+    if (targetType === 'arena') {
+      this.updateArenaTheme(arenaId, customTheme ? 'custom' : 'dark', customTheme);
+      return;
+    }
+
+    // Envoyer le thème immédiatement aux clients connectés du bon type
+    for (const [, client] of this.connectedClients) {
+      if (client.arenaId !== fullId) continue;
+      if (client.clientType === targetType) {
+        this.io.to(client.socketId).emit('server:command', {
+          type: `${targetType}:theme`,
+          variables: customTheme?.variables ?? null,
+        });
+      }
+    }
+
+    // Pour pool : diffuser aussi via la room pool
+    if (targetType === 'pool') {
+      this.io.to(`pool:${fullId}`).emit('server:command', {
+        type: 'pool:theme',
+        variables: customTheme?.variables ?? null,
       });
     }
   }

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -7,6 +7,17 @@
     <script src="/i18n.js"></script>
     <script src="/socket.io.min.js"></script>
     <style>
+      :root {
+        --pool-bg: #1a1a2e;
+        --pool-header-bg: rgba(0, 0, 0, 0.5);
+        --pool-accent: #6366f1;
+        --pool-accent2: #3b82f6;
+        --pool-text: #ffffff;
+        --pool-muted: #64748b;
+        --pool-card-bg: rgba(255, 255, 255, 0.04);
+        --pool-border: rgba(255, 255, 255, 0.08);
+      }
+
       * {
         margin: 0;
         padding: 0;
@@ -15,7 +26,7 @@
 
       body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        background: #1a1a2e;
+        background: var(--pool-bg);
         min-height: 100vh;
         color: #fff;
         display: flex;
@@ -24,13 +35,13 @@
 
       /* ── Header ── */
       .header {
-        background: rgba(0, 0, 0, 0.5);
+        background: var(--pool-header-bg);
         padding: 0.75rem 1.5rem;
         display: flex;
         justify-content: space-between;
         align-items: center;
         backdrop-filter: blur(8px);
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        border-bottom: 1px solid var(--pool-border);
         flex-shrink: 0;
       }
 
@@ -734,6 +745,18 @@
     </div>
 
     <script>
+      function applyScreenTheme(variables) {
+        if (!variables) {
+          const old = document.getElementById('screen-theme-style');
+          if (old) old.remove();
+          return;
+        }
+        let styleEl = document.getElementById('screen-theme-style');
+        if (!styleEl) { styleEl = document.createElement('style'); styleEl.id = 'screen-theme-style'; document.head.appendChild(styleEl); }
+        const vars = Object.entries(variables).map(([k, v]) => `  ${k}: ${v};`).join('\n');
+        styleEl.textContent = `:root {\n${vars}\n}`;
+      }
+
       window.initRemoteI18n().catch(() => {});
 
       // ── Extraction de l'arenaId depuis l'URL (/areneN/poule → "N") ──
@@ -780,6 +803,11 @@
         poolData = data;
         if (data.signatures) signaturesData = data.signatures;
         renderAll(data);
+      });
+
+      socket.on('server:command', cmd => {
+        if (cmd.type === 'pool:theme') { applyScreenTheme(cmd.variables); }
+        if (cmd.type === 'refresh') { location.reload(); }
       });
 
       // ── Chargement initial ──

--- a/src/remote/public.html
+++ b/src/remote/public.html
@@ -15,6 +15,17 @@
       font-display: block;
     }
 
+      :root {
+        --pub-bg: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+        --pub-header-bg: rgba(0, 0, 0, 0.4);
+        --pub-accent: #fbbf24;
+        --pub-accent2: #3b82f6;
+        --pub-text: #ffffff;
+        --pub-muted: rgba(255,255,255,0.6);
+        --pub-card-bg: rgba(255, 255, 255, 0.05);
+        --pub-border: rgba(255, 255, 255, 0.1);
+      }
+
           * {
         margin: 0;
         padding: 0;
@@ -23,10 +34,10 @@
 
       body {
         font-family: 'ArmadaBold', sans-serif;
-        background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+        background: var(--pub-bg);
         height: 100vh;
         overflow: hidden;
-        color: #fff;
+        color: var(--pub-text);
         display: flex;
         flex-direction: column;
       }
@@ -66,7 +77,7 @@
       }
 
       .header {
-        background: rgba(0, 0, 0, 0.4);
+        background: var(--pub-header-bg);
         padding: 0.4rem 1rem;
         display: flex;
         justify-content: space-between;
@@ -855,6 +866,18 @@
     </div>
 
     <script>
+      function applyScreenTheme(variables) {
+        if (!variables) {
+          const old = document.getElementById('screen-theme-style');
+          if (old) old.remove();
+          return;
+        }
+        let styleEl = document.getElementById('screen-theme-style');
+        if (!styleEl) { styleEl = document.createElement('style'); styleEl.id = 'screen-theme-style'; document.head.appendChild(styleEl); }
+        const vars = Object.entries(variables).map(([k, v]) => `  ${k}: ${v};`).join('\n');
+        styleEl.textContent = `:root {\n${vars}\n}`;
+      }
+
       class PublicDisplay {
         constructor() {
           this.socket = io({ reconnection: true, reconnectionDelay: 200, reconnectionDelayMax: 5000, randomizationFactor: 0.5 });
@@ -952,6 +975,7 @@
               b.textContent = cmd.text; b.style.opacity = '1';
               clearTimeout(b._t); b._t = setTimeout(() => { b.style.opacity = '0'; }, cmd.duration ?? 5000);
             }
+            if (cmd.type === 'public:theme') { applyScreenTheme(cmd.variables); }
           });
 
           setInterval(() => { if (this.socket.connected) this.socket.emit('client:pong'); }, 30000);
@@ -1060,6 +1084,8 @@
         }
 
         handleArenaUpdate(data) {
+          if (data.screenThemes?.public) { applyScreenTheme(data.screenThemes.public.variables); }
+
           if (data.showPhotos !== undefined) {
             this.showPhotos = data.showPhotos;
           }

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -10,6 +10,17 @@
     <script src="/i18n.js"></script>
     <script src="/socket.io.min.js"></script>
     <style>
+      :root {
+        --ref-bg: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+        --ref-header-bg: rgba(0, 0, 0, 0.3);
+        --ref-accent: #3b82f6;
+        --ref-accent2: #f59e0b;
+        --ref-text: #ffffff;
+        --ref-muted: rgba(255,255,255,0.6);
+        --ref-card-bg: rgba(255, 255, 255, 0.05);
+        --ref-border: rgba(255, 255, 255, 0.1);
+      }
+
       * {
         margin: 0;
         padding: 0;
@@ -21,14 +32,14 @@
         font-family:
           -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
           sans-serif;
-        background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+        background: var(--ref-bg);
         min-height: 100vh;
-        color: #fff;
+        color: var(--ref-text);
         overflow-x: hidden;
       }
 
       .header {
-        background: rgba(0, 0, 0, 0.3);
+        background: var(--ref-header-bg);
         padding: 1rem;
         display: flex;
         justify-content: space-between;
@@ -1546,6 +1557,19 @@
     <div class="notification" id="notification"></div>
 
     <script>
+      function applyScreenTheme(variables) {
+        if (!variables) {
+          document.documentElement.removeAttribute('data-screen-theme');
+          const old = document.getElementById('screen-theme-style');
+          if (old) old.remove();
+          return;
+        }
+        let styleEl = document.getElementById('screen-theme-style');
+        if (!styleEl) { styleEl = document.createElement('style'); styleEl.id = 'screen-theme-style'; document.head.appendChild(styleEl); }
+        const vars = Object.entries(variables).map(([k, v]) => `  ${k}: ${v};`).join('\n');
+        styleEl.textContent = `:root {\n${vars}\n}`;
+      }
+
       // ─── Utilitaire sécurité : encodage HTML pour éviter les XSS ───────────
       function escHtml(str) {
         if (str === null || str === undefined) return '';
@@ -2090,6 +2114,7 @@
               return;
             }
             if (cmd.type === 'message' && cmd.text) { this.showNotification(cmd.text); }
+            if (cmd.type === 'referee:theme') { applyScreenTheme(cmd.variables); }
           });
 
           setInterval(() => { if (this.socket.connected) this.socket.emit('client:pong'); }, 30000);
@@ -3537,6 +3562,8 @@
         }
 
         handleArenaUpdate(data) {
+          if (data.screenThemes?.referee) { applyScreenTheme(data.screenThemes.referee.variables); }
+
           if (data.timerDuration !== undefined && data.timerDuration > 0) {
             this.defaultTimerSeconds = data.timerDuration;
           }

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -146,19 +146,22 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   const [orgNoteTime, setOrgNoteTime] = useState('');
   const [orgNotePrefix, setOrgNotePrefix] = useState('Reprise');
   const [orgNoteActive, setOrgNoteActive] = useState(false);
-  // Thèmes par arène : arenaId → { theme, customTheme? }
+  // Thèmes par arène : arenaId → { theme, customTheme?, screenThemes }
   const [arenaThemes, setArenaThemes] = useState<
-    Record<string, { theme: DisplayTheme; customTheme?: CustomTheme }>
+    Record<string, { theme: DisplayTheme; customTheme?: CustomTheme; screenThemes: Partial<Record<'public' | 'referee' | 'pool', CustomTheme>> }>
   >({});
-  // Éditeur de thème arène
+  // Onglet de type d'écran sélectionné par arène
+  const [arenaScreenTab, setArenaScreenTab] = useState<Record<string, 'arena' | 'public' | 'referee' | 'pool'>>({});
+  // Éditeur de thème (arène + type d'écran)
   const [themeEditorTarget, setThemeEditorTarget] = useState<string | null>(null);
+  const [themeEditorScreenType, setThemeEditorScreenType] = useState<'arena' | 'public' | 'referee' | 'pool'>('arena');
   // Éditeur de thème kiosk
   const [kioskThemeEditorOpen, setKioskThemeEditorOpen] = useState(false);
   const [kioskTheme, setKioskTheme] = useState<CustomTheme | undefined>(undefined);
   // Thèmes sauvegardés (depuis IPC)
   const [savedThemes, setSavedThemes] = useState<CustomTheme[]>([]);
   // Sélecteur de thème global
-  const [globalThemeSection, setGlobalThemeSection] = useState<'arenes' | 'kiosque'>('arenes');
+  const [globalThemeSection, setGlobalThemeSection] = useState<'arena' | 'kiosk' | 'public' | 'referee' | 'pool'>('arena');
   const [globalThemeId, setGlobalThemeId] = useState('');
   // Lancement de la compétition
   const [isLaunched, setIsLaunched] = useState<boolean>(() => {
@@ -488,12 +491,26 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     }
   }, []);
 
-  // Appliquer un thème (prédéfini ou custom) à une arène
+  // Appliquer un thème (prédéfini ou custom) à une arène — affichage principal
   const handleArenaThemeChange = useCallback(
     async (arenaId: string, theme: DisplayTheme, customTheme?: CustomTheme) => {
-      setArenaThemes(prev => ({ ...prev, [arenaId]: { theme, customTheme } }));
+      setArenaThemes(prev => ({ ...prev, [arenaId]: { ...(prev[arenaId] ?? { screenThemes: {} }), theme, customTheme } }));
       if (session) {
         await window.electronAPI.remote.updateArenaTheme(competition.id, arenaId, theme, customTheme);
+      }
+    },
+    [session]
+  );
+
+  // Appliquer un thème custom à un type d'écran spécifique d'une arène
+  const handleArenaScreenThemeChange = useCallback(
+    async (arenaId: string, screenType: 'public' | 'referee' | 'pool', customTheme?: CustomTheme) => {
+      setArenaThemes(prev => {
+        const existing = prev[arenaId] ?? { theme: 'dark' as DisplayTheme, screenThemes: {} };
+        return { ...prev, [arenaId]: { ...existing, screenThemes: { ...existing.screenThemes, [screenType]: customTheme } } };
+      });
+      if (session) {
+        await window.electronAPI.remote.updateArenaScreenTheme(competition.id, arenaId, screenType, customTheme);
       }
     },
     [session]
@@ -525,21 +542,28 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     refreshSavedThemes();
   }, [refreshSavedThemes]);
 
-  // Appliquer un thème sauvegardé à toutes les arènes ou au kiosque
+  // Appliquer un thème sauvegardé globalement (toutes les arènes, un type d'écran)
   const handleGlobalThemeApply = useCallback(async () => {
     const theme = savedThemes.find(t => t.id === globalThemeId);
     if (!theme) return;
-    if (globalThemeSection === 'arenes') {
+    if (globalThemeSection === 'arena') {
       await handleArenaThemeChange('all', 'custom', theme);
-      showToast(`Thème "${theme.name}" appliqué à toutes les arènes`, 'success');
-    } else {
+      showToast(`Thème "${theme.name}" appliqué à toutes les pistes`, 'success');
+    } else if (globalThemeSection === 'kiosk') {
       const result = await window.electronAPI.remote.updateKioskTheme(competition.id, theme.variables);
       setKioskTheme(theme);
       if (result?.success) showToast(`Thème "${theme.name}" appliqué au kiosque`, 'success');
       else showToast(result?.error ?? 'Erreur', 'error');
+    } else {
+      // public / referee / pool → appliquer à toutes les arènes pour ce type d'écran
+      const count = session ? session.strips.length : effectiveCommitted;
+      for (let i = 1; i <= count; i++) {
+        await window.electronAPI.remote.updateArenaScreenTheme(competition.id, `arena${i}`, globalThemeSection, theme);
+      }
+      showToast(`Thème "${theme.name}" appliqué (${globalThemeSection}) à toutes les pistes`, 'success');
     }
     setGlobalThemeId('');
-  }, [savedThemes, globalThemeId, globalThemeSection, handleArenaThemeChange, competition.id]);
+  }, [savedThemes, globalThemeId, globalThemeSection, handleArenaThemeChange, competition.id, session, effectiveCommitted]);
 
   // La grille d'URLs reflète l'état réel du serveur (committedCount) ou la session active
   const arenaCount = session ? session.strips.length : effectiveCommitted;
@@ -1030,55 +1054,98 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           {arenaUrls.map(arena => {
             const arenaId = `arena${arena.number}`;
             const arenaTheme = arenaThemes[arenaId];
+            const screenTab = arenaScreenTab[arenaId] ?? 'arena';
+            const screenThemeTypes = [
+              { value: 'arena' as const,   label: 'Affichage' },
+              { value: 'public' as const,  label: 'Public' },
+              { value: 'referee' as const, label: 'Arbitre' },
+              { value: 'pool' as const,    label: 'Poule' },
+            ] as const;
+            const filteredForScreen = savedThemes.filter(t => (t.targetType ?? 'arena') === screenTab);
             return (
               <div key={arena.number} className="arena-url-card">
                 <div className="arena-url-header">
                   <strong>Piste {arena.number}</strong>
-                  {/* Sélecteur de thème par arène */}
-                  <div className="arena-theme-picker">
-                    {[
-                      { value: 'dark' as const, icon: '🌙', title: 'Sombre' },
-                      { value: 'light' as const, icon: '☀️', title: 'Clair' },
-                      { value: 'neon' as const, icon: '⚡', title: 'Néon' },
-                    ].map(({ value, icon, title }) => (
-                      <button
-                        key={value}
-                        title={title}
-                        className={`arena-theme-btn ${arenaTheme?.theme === value ? 'active' : ''}`}
-                        onClick={() => handleArenaThemeChange(arenaId, value)}
-                      >
-                        {icon}
-                      </button>
-                    ))}
+                </div>
+                {/* Onglets type d'écran */}
+                <div style={{ display: 'flex', gap: '0.25rem', margin: '0.4rem 0 0.25rem' }}>
+                  {screenThemeTypes.map(({ value, label }) => (
                     <button
-                      title="Thème personnalisé"
-                      className={`arena-theme-btn ${arenaTheme?.theme === 'custom' ? 'active' : ''}`}
-                      onClick={() => setThemeEditorTarget(arenaId)}
+                      key={value}
+                      onClick={() => setArenaScreenTab(prev => ({ ...prev, [arenaId]: value }))}
+                      style={{
+                        padding: '0.15rem 0.45rem', fontSize: '0.7rem', borderRadius: '0.25rem',
+                        border: `1px solid ${screenTab === value ? '#3b82f6' : '#475569'}`,
+                        background: screenTab === value ? '#1d4ed8' : 'transparent',
+                        color: screenTab === value ? '#fff' : '#94a3b8',
+                        cursor: 'pointer', fontWeight: screenTab === value ? 700 : 400,
+                      }}
                     >
-                      ✏️
+                      {label}
                     </button>
-                    {savedThemes.filter(t => (t.targetType ?? 'arena') === 'arena').length > 0 && (
-                      <select
-                        title="Appliquer un thème sauvegardé"
-                        value=""
-                        onChange={async e => {
-                          const t = savedThemes.find(x => x.id === e.target.value);
-                          if (t) await handleArenaThemeChange(arenaId, 'custom', t);
-                          e.currentTarget.value = '';
-                        }}
-                        style={{
-                          padding: '0.2rem 0.4rem', borderRadius: '0.3rem',
-                          border: '1px solid #475569', background: '#1e293b', color: '#e2e8f0',
-                          fontSize: '0.75rem', cursor: 'pointer', maxWidth: 110,
-                        }}
+                  ))}
+                </div>
+                {/* Sélecteur de thème selon l'onglet */}
+                <div className="arena-theme-picker">
+                  {screenTab === 'arena' ? (
+                    <>
+                      {[
+                        { value: 'dark' as const, icon: '🌙', title: 'Sombre' },
+                        { value: 'light' as const, icon: '☀️', title: 'Clair' },
+                        { value: 'neon' as const, icon: '⚡', title: 'Néon' },
+                      ].map(({ value, icon, title }) => (
+                        <button
+                          key={value}
+                          title={title}
+                          className={`arena-theme-btn ${arenaTheme?.theme === value ? 'active' : ''}`}
+                          onClick={() => handleArenaThemeChange(arenaId, value)}
+                        >
+                          {icon}
+                        </button>
+                      ))}
+                      <button
+                        title="Thème personnalisé"
+                        className={`arena-theme-btn ${arenaTheme?.theme === 'custom' ? 'active' : ''}`}
+                        onClick={() => { setThemeEditorScreenType('arena'); setThemeEditorTarget(arenaId); }}
                       >
-                        <option value="">📦 Thèmes…</option>
-                        {savedThemes.filter(t => (t.targetType ?? 'arena') === 'arena').map(t => (
-                          <option key={t.id} value={t.id}>{t.name}</option>
-                        ))}
-                      </select>
-                    )}
-                  </div>
+                        ✏️
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      title={`Personnaliser ${screenTab}`}
+                      className={`arena-theme-btn ${arenaTheme?.screenThemes?.[screenTab] ? 'active' : ''}`}
+                      onClick={() => { setThemeEditorScreenType(screenTab); setThemeEditorTarget(arenaId); }}
+                    >
+                      ✏️ {arenaTheme?.screenThemes?.[screenTab] ? '●' : ''}
+                    </button>
+                  )}
+                  {filteredForScreen.length > 0 && (
+                    <select
+                      title="Appliquer un thème sauvegardé"
+                      value=""
+                      onChange={async e => {
+                        const t = savedThemes.find(x => x.id === e.target.value);
+                        if (!t) return;
+                        if (screenTab === 'arena') {
+                          await handleArenaThemeChange(arenaId, 'custom', t);
+                        } else {
+                          await handleArenaScreenThemeChange(arenaId, screenTab, t);
+                        }
+                        e.currentTarget.value = '';
+                      }}
+                      style={{
+                        padding: '0.2rem 0.4rem', borderRadius: '0.3rem',
+                        border: '1px solid #475569', background: '#1e293b', color: '#e2e8f0',
+                        fontSize: '0.75rem', cursor: 'pointer', maxWidth: 110,
+                      }}
+                    >
+                      <option value="">📦 Thèmes…</option>
+                      {filteredForScreen.map(t => (
+                        <option key={t.id} value={t.id}>{t.name}</option>
+                      ))}
+                    </select>
+                  )}
                 </div>
                 <div className="arena-url-row">
                   <span className="arena-url-label">Arbitre</span>
@@ -1261,8 +1328,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
 
         {/* ── Thème global ── */}
         {(() => {
-          const sectionType = globalThemeSection === 'arenes' ? 'arena' : 'kiosk';
-          const filteredForSection = savedThemes.filter(t => (t.targetType ?? 'arena') === sectionType);
+          const filteredForSection = savedThemes.filter(t => (t.targetType ?? 'arena') === globalThemeSection);
           if (savedThemes.length === 0) return null;
           return (
             <div className="arena-url-card" style={RSM_STYLES.kioskCard}>
@@ -1272,11 +1338,14 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
               <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap', marginTop: '0.25rem' }}>
                 <select
                   value={globalThemeSection}
-                  onChange={e => { setGlobalThemeSection(e.target.value as 'arenes' | 'kiosque'); setGlobalThemeId(''); }}
+                  onChange={e => { setGlobalThemeSection(e.target.value as typeof globalThemeSection); setGlobalThemeId(''); }}
                   style={{ padding: '0.35rem 0.5rem', borderRadius: '0.3rem', border: '1px solid #475569', background: '#1e293b', color: '#e2e8f0', fontSize: '0.85rem' }}
                 >
-                  <option value="arenes">⚔️ Arènes</option>
-                  <option value="kiosque">🖥️ Kiosque</option>
+                  <option value="arena">⚔️ Affichage piste</option>
+                  <option value="kiosk">🖥️ Kiosque</option>
+                  <option value="public">👥 Public</option>
+                  <option value="referee">🤝 Arbitre</option>
+                  <option value="pool">📋 Poule</option>
                 </select>
                 <select
                   value={globalThemeId}
@@ -1510,10 +1579,18 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
       {themeEditorTarget && (
         <ThemeEditor
           targetArenaId={themeEditorTarget}
-          targetType="arena"
-          initialTheme={arenaThemes[themeEditorTarget]?.customTheme}
+          targetType={themeEditorScreenType}
+          initialTheme={
+            themeEditorScreenType === 'arena'
+              ? arenaThemes[themeEditorTarget]?.customTheme
+              : arenaThemes[themeEditorTarget]?.screenThemes?.[themeEditorScreenType as 'public' | 'referee' | 'pool']
+          }
           onApply={async (arenaId, theme) => {
-            await handleArenaThemeChange(arenaId, 'custom', theme);
+            if (themeEditorScreenType === 'arena') {
+              await handleArenaThemeChange(arenaId, 'custom', theme);
+            } else {
+              await handleArenaScreenThemeChange(arenaId, themeEditorScreenType as 'public' | 'referee' | 'pool', theme);
+            }
             setThemeEditorTarget(null);
             showToast('Thème personnalisé appliqué', 'success');
           }}

--- a/src/renderer/components/ThemeEditor.tsx
+++ b/src/renderer/components/ThemeEditor.tsx
@@ -263,6 +263,126 @@ function loadSavedThemes(): CustomTheme[] { return []; }
 function saveSavedThemes(_themes: CustomTheme[]): void { /* no-op */ }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// Variables et defaults Arbitre (tablette)
+// ──────────────────────────────────────────────────────────────────────────────
+const REFEREE_DEFAULTS: Record<string, string> = {
+  '--ref-bg':         'linear-gradient(135deg, #1e3c72 0%, #2a5298 100%)',
+  '--ref-header-bg':  'rgba(0, 0, 0, 0.3)',
+  '--ref-accent':     '#3b82f6',
+  '--ref-accent2':    '#f59e0b',
+  '--ref-text':       '#ffffff',
+  '--ref-muted':      'rgba(255,255,255,0.6)',
+  '--ref-card-bg':    'rgba(255, 255, 255, 0.05)',
+  '--ref-border':     'rgba(255, 255, 255, 0.1)',
+};
+
+const REFEREE_VAR_GROUPS: VarGroup[] = [
+  {
+    label: 'Arbitre – Arrière-plan',
+    vars: [
+      { key: '--ref-bg',        label: 'Fond page',         type: 'text'  },
+      { key: '--ref-header-bg', label: 'Fond en-tête',      type: 'text'  },
+    ],
+  },
+  {
+    label: 'Arbitre – Couleurs',
+    vars: [
+      { key: '--ref-accent',  label: 'Couleur accent 1',  type: 'color' },
+      { key: '--ref-accent2', label: 'Couleur accent 2',  type: 'color' },
+      { key: '--ref-text',    label: 'Texte principal',   type: 'color' },
+      { key: '--ref-muted',   label: 'Texte discret',     type: 'color' },
+    ],
+  },
+  {
+    label: 'Arbitre – Cartes',
+    vars: [
+      { key: '--ref-card-bg', label: 'Fond cartes',  type: 'text'  },
+      { key: '--ref-border',  label: 'Bordures',     type: 'text'  },
+    ],
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Variables et defaults Affichage poule
+// ──────────────────────────────────────────────────────────────────────────────
+const POOL_DEFAULTS: Record<string, string> = {
+  '--pool-bg':         '#1a1a2e',
+  '--pool-header-bg':  'rgba(0, 0, 0, 0.5)',
+  '--pool-accent':     '#6366f1',
+  '--pool-accent2':    '#3b82f6',
+  '--pool-text':       '#ffffff',
+  '--pool-muted':      '#64748b',
+  '--pool-card-bg':    'rgba(255, 255, 255, 0.04)',
+  '--pool-border':     'rgba(255, 255, 255, 0.08)',
+};
+
+const POOL_VAR_GROUPS: VarGroup[] = [
+  {
+    label: 'Poule – Arrière-plan',
+    vars: [
+      { key: '--pool-bg',        label: 'Fond page',     type: 'text'  },
+      { key: '--pool-header-bg', label: 'Fond en-tête',  type: 'text'  },
+    ],
+  },
+  {
+    label: 'Poule – Couleurs',
+    vars: [
+      { key: '--pool-accent',  label: 'Couleur accent 1',  type: 'color' },
+      { key: '--pool-accent2', label: 'Couleur accent 2',  type: 'color' },
+      { key: '--pool-text',    label: 'Texte principal',   type: 'color' },
+      { key: '--pool-muted',   label: 'Texte discret',     type: 'color' },
+    ],
+  },
+  {
+    label: 'Poule – Cartes',
+    vars: [
+      { key: '--pool-card-bg', label: 'Fond cartes',  type: 'text'  },
+      { key: '--pool-border',  label: 'Bordures',     type: 'text'  },
+    ],
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Variables et defaults Public
+// ──────────────────────────────────────────────────────────────────────────────
+const PUBLIC_DEFAULTS: Record<string, string> = {
+  '--pub-bg':         'linear-gradient(135deg, #1e3c72 0%, #2a5298 100%)',
+  '--pub-header-bg':  'rgba(0, 0, 0, 0.4)',
+  '--pub-accent':     '#fbbf24',
+  '--pub-accent2':    '#3b82f6',
+  '--pub-text':       '#ffffff',
+  '--pub-muted':      'rgba(255,255,255,0.6)',
+  '--pub-card-bg':    'rgba(255, 255, 255, 0.05)',
+  '--pub-border':     'rgba(255, 255, 255, 0.1)',
+};
+
+const PUBLIC_VAR_GROUPS: VarGroup[] = [
+  {
+    label: 'Public – Arrière-plan',
+    vars: [
+      { key: '--pub-bg',        label: 'Fond page',     type: 'text'  },
+      { key: '--pub-header-bg', label: 'Fond en-tête',  type: 'text'  },
+    ],
+  },
+  {
+    label: 'Public – Couleurs',
+    vars: [
+      { key: '--pub-accent',  label: 'Couleur accent 1',  type: 'color' },
+      { key: '--pub-accent2', label: 'Couleur accent 2',  type: 'color' },
+      { key: '--pub-text',    label: 'Texte principal',   type: 'color' },
+      { key: '--pub-muted',   label: 'Texte discret',     type: 'color' },
+    ],
+  },
+  {
+    label: 'Public – Cartes',
+    vars: [
+      { key: '--pub-card-bg', label: 'Fond cartes',  type: 'text'  },
+      { key: '--pub-border',  label: 'Bordures',     type: 'text'  },
+    ],
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────────────
 // Variables et defaults Kiosk
 // ──────────────────────────────────────────────────────────────────────────────
 const KIOSK_DEFAULTS: Record<string, string> = {
@@ -296,8 +416,8 @@ const KIOSK_VAR_GROUPS: VarGroup[] = [
 interface ThemeEditorProps {
   /** Arène cible (ex: 'arena1') ou 'all' pour toutes les arènes */
   targetArenaId: string;
-  /** Section cible : 'arena' (défaut), 'kiosk', 'public', 'lobby' */
-  targetType?: 'arena' | 'kiosk' | 'public' | 'lobby';
+  /** Section cible : 'arena' (défaut), 'kiosk', 'public', 'referee', 'pool' */
+  targetType?: ThemeTargetType;
   /** Thème initial à éditer (undefined = nouveau thème depuis dark) */
   initialTheme?: CustomTheme;
   /** Callback quand l'utilisateur applique le thème */
@@ -316,12 +436,28 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({
   onClose,
 }) => {
   const instanceId = useId();
-  const isKiosk = targetType === 'kiosk';
-  const activeDefaults = isKiosk ? KIOSK_DEFAULTS : DARK_DEFAULTS;
-  const activeVarGroups = isKiosk ? KIOSK_VAR_GROUPS : VAR_GROUPS;
   const effectiveType = (targetType ?? 'arena') as ThemeTargetType;
+  const isKiosk = effectiveType === 'kiosk';
+  const activeDefaults =
+    effectiveType === 'kiosk'    ? KIOSK_DEFAULTS :
+    effectiveType === 'referee'  ? REFEREE_DEFAULTS :
+    effectiveType === 'pool'     ? POOL_DEFAULTS :
+    effectiveType === 'public'   ? PUBLIC_DEFAULTS :
+    DARK_DEFAULTS;
+  const activeVarGroups =
+    effectiveType === 'kiosk'    ? KIOSK_VAR_GROUPS :
+    effectiveType === 'referee'  ? REFEREE_VAR_GROUPS :
+    effectiveType === 'pool'     ? POOL_VAR_GROUPS :
+    effectiveType === 'public'   ? PUBLIC_VAR_GROUPS :
+    VAR_GROUPS;
+  const defaultName =
+    effectiveType === 'kiosk'   ? 'Thème kiosk' :
+    effectiveType === 'referee' ? 'Thème arbitre' :
+    effectiveType === 'pool'    ? 'Thème poule' :
+    effectiveType === 'public'  ? 'Thème public' :
+    'Mon thème';
 
-  const [themeName, setThemeName] = useState(initialTheme?.name ?? (isKiosk ? 'Thème kiosk' : 'Mon thème'));
+  const [themeName, setThemeName] = useState(initialTheme?.name ?? defaultName);
   const [vars, setVars] = useState<Record<string, string>>(() => ({
     ...activeDefaults,
     ...(initialTheme?.variables ?? {}),
@@ -508,9 +644,10 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({
     onApply(targetArenaId, theme);
   };
 
-  const arenaLabel = effectiveType === 'kiosk' ? 'Kiosque'
-    : effectiveType === 'public' ? 'Affichage public'
-    : effectiveType === 'lobby' ? 'Lobby'
+  const arenaLabel = effectiveType === 'kiosk'   ? 'Kiosque'
+    : effectiveType === 'public'   ? 'Affichage public'
+    : effectiveType === 'referee'  ? 'Tablette arbitre'
+    : effectiveType === 'pool'     ? 'Affichage poule'
     : targetArenaId === 'all' ? 'Toutes les pistes'
     : `Piste ${targetArenaId.replace('arena', '')}`;
 

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -449,6 +449,12 @@ export interface RemoteServerAPI {
     competitionId: string,
     variables: Record<string, string>
   ) => Promise<{ success: boolean; error?: string }>;
+  updateArenaScreenTheme: (
+    competitionId: string,
+    arenaId: string,
+    targetType: import('../types/remote').ThemeTargetType,
+    customTheme?: import('../types/remote').CustomTheme
+  ) => Promise<{ success: boolean; error?: string }>;
   setWebhookUrl: (url: string | null) => Promise<{ success: boolean; error?: string }>;
   updateLogo: (logo: string | null) => Promise<{ success: boolean; error?: string }>;
   setTtsConfig: (config: TtsConfig) => Promise<{ success: boolean; error?: string }>;

--- a/src/shared/types/remote.ts
+++ b/src/shared/types/remote.ts
@@ -107,13 +107,13 @@ export interface Arena {
 
 export type DisplayTheme = 'dark' | 'light' | 'neon' | 'unicorn' | 'custom';
 
-export type ThemeTargetType = 'arena' | 'kiosk' | 'public' | 'lobby';
+export type ThemeTargetType = 'arena' | 'kiosk' | 'public' | 'referee' | 'pool';
 
 /** Variables CSS personnalisées pour un thème d'arène */
 export interface CustomTheme {
   id: string;
   name: string;
-  /** Section cible : arena (piste), kiosk, public, lobby */
+  /** Section cible : arena (piste), kiosk, public, referee (tablette arbitre), pool (poule) */
   targetType: ThemeTargetType;
   /** Valeurs des variables CSS (ex: { '--bg': '#000', '--score-green': '#0f0' }) */
   variables: Record<string, string>;
@@ -129,6 +129,8 @@ export interface ArenaSettings {
   cardAnnounce?: boolean; // annoncer les cartons avec raison sur les affichages
   theme?: DisplayTheme; // thème visuel de l'affichage distant
   customTheme?: CustomTheme; // thème personnalisé (si theme === 'custom')
+  /** Thèmes par type d'écran (public, referee, pool) — indépendants du thème arena */
+  screenThemes?: Partial<Record<ThemeTargetType, CustomTheme>>;
 }
 
 export interface ArenaMatch {
@@ -165,6 +167,8 @@ export interface ArenaUpdate {
   cardAnnounce?: boolean; // annoncer les cartons avec raison sur les affichages
   theme?: DisplayTheme; // thème visuel de l'affichage distant
   customTheme?: CustomTheme; // thème personnalisé (si theme === 'custom')
+  /** Thèmes par type d'écran (public, referee, pool) — indépendants du thème arena */
+  screenThemes?: Partial<Record<ThemeTargetType, CustomTheme>>;
   nextMatch?: ArenaMatch | null; // prochain combat (affiché quand status=finished)
   swapped?: boolean;
   refereeFeatureEnabled?: boolean; // fonctionnalité arbitres activée


### PR DESCRIPTION
## Résumé

- `ThemeTargetType` étendu : `'arena' | 'kiosk' | 'public' | 'referee' | 'pool'`
- Stockage par piste × type d'écran (`arenaScreenThemes` Map dans le serveur)
- `referee.html`, `public.html`, `pool.html` : CSS vars + listener `applyScreenTheme`
- ThemeEditor : groupes de variables dédiés pour chaque type d'écran
- RemoteScoreManager : onglets par type (Affichage / Public / Arbitre / Poule) + sélecteur thème global pour les 5 types
- Nouveau IPC `remote:updateArenaScreenTheme` + préload correspondant

## Plan de test

- [ ] Démarrer un serveur remote, ouvrir referee.html → appliquer thème arbitre → vérifier CSS vars
- [ ] Même test pour public.html et pool.html
- [ ] Vérifier que piste 1 et piste 2 peuvent avoir des thèmes indépendants par type
- [ ] Kiosque reste global (non par piste)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHDwrhMuUJ39PX3Hc36euo)_