### PR TITLE
feat: bouton déverrouillage thème par piste (saisie distante)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1886,6 +1886,20 @@ ipcMain.handle(
 );
 
 ipcMain.handle(
+  'remote:clearArenaThemeOverride',
+  async (_, competitionId: string, arenaId: string) => {
+    try {
+      const entry = remoteServers.get(competitionId);
+      if (!entry) return { success: false, error: 'Le serveur distant n est pas démarré pour cette compétition' };
+      entry.server.clearArenaThemeOverride(arenaId);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+    }
+  }
+);
+
+ipcMain.handle(
   'remote:updateKioskViews',
   async (_, competitionId: string, views: { poules: boolean; classement: boolean; direct: boolean; suivants: boolean }) => {
     try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -547,6 +547,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     clearOrgNote: (competitionId: string) => ipcRenderer.invoke('remote:clearOrgNote', competitionId),
     updateArenaTheme: (competitionId: string, arenaId: string, theme: string, customTheme?: any) =>
       ipcRenderer.invoke('remote:updateArenaTheme', competitionId, arenaId, theme, customTheme),
+    clearArenaThemeOverride: (competitionId: string, arenaId: string) =>
+      ipcRenderer.invoke('remote:clearArenaThemeOverride', competitionId, arenaId),
     updateKioskTheme: (competitionId: string, variables: Record<string, string>) =>
       ipcRenderer.invoke('remote:updateKioskTheme', competitionId, variables),
     updateArenaScreenTheme: (competitionId: string, arenaId: string, targetType: string, customTheme?: any) =>

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -4739,6 +4739,24 @@ export class RemoteScoreServer {
     }
   }
 
+  public clearArenaThemeOverride(arenaId: string): void {
+    if (!this.session) throw new Error('Aucune session active');
+    const fullId = arenaId.startsWith('arena') ? arenaId : `arena${arenaId}`;
+    this.arenaThemeOverrides.delete(fullId);
+    const arena = this.arenas.get(fullId);
+    if (arena) {
+      this.broadcastArenaUpdate(fullId, {
+        arenaId: fullId,
+        match: arena.currentMatch,
+        scoreA: arena.currentMatch?.scoreA,
+        scoreB: arena.currentMatch?.scoreB,
+        status: arena.status,
+        fencerA: arena.currentMatch?.fencerA,
+        fencerB: arena.currentMatch?.fencerB,
+      });
+    }
+  }
+
   public updateArenaScreenTheme(arenaId: string, targetType: ThemeTargetType, customTheme?: CustomTheme): void {
     if (!this.session) throw new Error('Aucune session active');
     const fullId = arenaId.startsWith('arena') ? arenaId : `arena${arenaId}`;

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -516,6 +516,29 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     [session]
   );
 
+  // Supprimer le verrou de thème d'une arène (retour au thème global)
+  const handleClearArenaThemeOverride = useCallback(
+    async (arenaId: string) => {
+      setArenaThemes(prev => {
+        const next = { ...prev };
+        delete next[arenaId];
+        return next;
+      });
+      if (session) {
+        await window.electronAPI.remote.clearArenaThemeOverride(competition.id, arenaId);
+      }
+    },
+    [session, competition.id]
+  );
+
+  // Supprimer le verrou de thème d'écran d'une arène
+  const handleClearArenaScreenTheme = useCallback(
+    async (arenaId: string, screenType: 'public' | 'referee' | 'pool') => {
+      await handleArenaScreenThemeChange(arenaId, screenType, undefined);
+    },
+    [handleArenaScreenThemeChange]
+  );
+
   // Charger tous les thèmes depuis l'app (+ migration one-shot depuis localStorage)
   const refreshSavedThemes = useCallback(() => {
     window.electronAPI.themes.list().then(setSavedThemes).catch(() => {});
@@ -1110,15 +1133,37 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                       >
                         ✏️
                       </button>
+                      {arenaThemes[arenaId] && (
+                        <button
+                          title="Déverrouiller — suivre le thème global"
+                          className="arena-theme-btn"
+                          style={{ color: '#f59e0b', borderColor: '#f59e0b' }}
+                          onClick={() => void handleClearArenaThemeOverride(arenaId)}
+                        >
+                          🔓
+                        </button>
+                      )}
                     </>
                   ) : (
-                    <button
-                      title={`Personnaliser ${screenTab}`}
-                      className={`arena-theme-btn ${arenaTheme?.screenThemes?.[screenTab] ? 'active' : ''}`}
-                      onClick={() => { setThemeEditorScreenType(screenTab); setThemeEditorTarget(arenaId); }}
-                    >
-                      ✏️ {arenaTheme?.screenThemes?.[screenTab] ? '●' : ''}
-                    </button>
+                    <>
+                      <button
+                        title={`Personnaliser ${screenTab}`}
+                        className={`arena-theme-btn ${arenaTheme?.screenThemes?.[screenTab] ? 'active' : ''}`}
+                        onClick={() => { setThemeEditorScreenType(screenTab); setThemeEditorTarget(arenaId); }}
+                      >
+                        ✏️ {arenaTheme?.screenThemes?.[screenTab] ? '●' : ''}
+                      </button>
+                      {arenaTheme?.screenThemes?.[screenTab] && (
+                        <button
+                          title="Déverrouiller — suivre le thème global"
+                          className="arena-theme-btn"
+                          style={{ color: '#f59e0b', borderColor: '#f59e0b' }}
+                          onClick={() => void handleClearArenaScreenTheme(arenaId, screenTab)}
+                        >
+                          🔓
+                        </button>
+                      )}
+                    </>
                   )}
                   {filteredForScreen.length > 0 && (
                     <select

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -445,6 +445,10 @@ export interface RemoteServerAPI {
     theme: import('../types/remote').DisplayTheme,
     customTheme?: import('../types/remote').CustomTheme
   ) => Promise<{ success: boolean; error?: string }>;
+  clearArenaThemeOverride: (
+    competitionId: string,
+    arenaId: string
+  ) => Promise<{ success: boolean; error?: string }>;
   updateKioskTheme: (
     competitionId: string,
     variables: Record<string, string>


### PR DESCRIPTION
## Problème

Quand on applique un thème global après avoir posé un thème custom sur une piste, la piste garde son override et ignore le thème global.

## Solution

Bouton 🔓 (orange) par piste et par type d'écran. Visible uniquement quand un override local existe. Cliquer dessus supprime le verrou → la piste retombe sur le thème global.

## Changements

- `remoteScoreServer.ts` : méthode `clearArenaThemeOverride()` — supprime l'entrée de `arenaThemeOverrides` et rediffuse (avec fallback `sessionTheme`)
- `main.ts` : handler IPC `remote:clearArenaThemeOverride`
- `preload.ts` + `shared/types/preload.ts` : exposition API `clearArenaThemeOverride`
- `RemoteScoreManager.tsx` : callback `handleClearArenaThemeOverride` + `handleClearArenaScreenTheme` + bouton 🔓 dans l'UI (onglet Affichage et onglets Public/Arbitre/Poule)

Travail terminé — PR créée. Valider et clore si OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6gr8ShgPsehkbWj8nDEar)_