### PR TITLE
feat: mode entraînement (saisie distante sans compétition)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2222,6 +2222,139 @@ ipcMain.handle('remote:setTtsConfig', async (_, config: unknown) => {
   }
 });
 
+// Training mode handlers
+const TRAINING_ID = '__training__';
+
+ipcMain.handle('training:startServer', async (_event, port?: number, host?: string, useHttps?: boolean) => {
+  try {
+    if (remoteServers.has(TRAINING_ID)) {
+      return { success: false, error: 'Serveur entraînement déjà démarré' };
+    }
+    const effectivePort = findAvailablePort(port);
+    const effectiveHost = host ?? '0.0.0.0';
+    let tlsOptions: { cert: string; key: string } | undefined;
+    let certFingerprint: string | undefined;
+    if (useHttps) {
+      try {
+        const bundle = await ensureCert(app.getPath('userData'));
+        tlsOptions = { cert: bundle.cert, key: bundle.key };
+        certFingerprint = bundle.fingerprint;
+      } catch (certError) {
+        return { success: false, error: 'Impossible de générer le certificat TLS' };
+      }
+    }
+    const server = new RemoteScoreServer(db, effectivePort, effectiveHost, tlsOptions);
+    try {
+      await server.start();
+    } catch (startError: any) {
+      return { success: false, error: startError?.message ?? 'Port indisponible' };
+    }
+    remoteServers.set(TRAINING_ID, { server, port: effectivePort, host: effectiveHost, useHttps: !!useHttps, certFingerprint });
+    usedPorts.add(effectivePort);
+    try {
+      const ttsPath = path.join(app.getPath('userData'), 'tts-config.json');
+      server.setTtsConfig(JSON.parse(await fs.promises.readFile(ttsPath, 'utf-8')));
+    } catch { /* optionnel */ }
+    (global as any).mainWindow = mainWindow;
+    return {
+      success: true,
+      serverInfo: {
+        url: server.getServerUrl(),
+        ip: server.getLocalIPAddress(),
+        port: effectivePort,
+        useHttps: !!useHttps,
+        certFingerprint,
+      },
+    };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('training:stopServer', async () => {
+  try {
+    const entry = remoteServers.get(TRAINING_ID);
+    if (!entry) return { success: false, error: 'Serveur entraînement non démarré' };
+    entry.server.stop();
+    usedPorts.delete(entry.port);
+    remoteServers.delete(TRAINING_ID);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('training:startSession', async (_event, strips: number, weapon: string) => {
+  try {
+    const entry = remoteServers.get(TRAINING_ID);
+    if (!entry) return { success: false, error: 'Serveur entraînement non démarré' };
+    const session = await entry.server.startTrainingSession(strips, weapon);
+    return { success: true, session };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('training:stopSession', async () => {
+  try {
+    const entry = remoteServers.get(TRAINING_ID);
+    if (!entry) return { success: false, error: 'Serveur entraînement non démarré' };
+    entry.server.stopTrainingSession();
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('training:getHistory', async () => {
+  try {
+    const entry = remoteServers.get(TRAINING_ID);
+    if (!entry) return { success: true, history: [] };
+    return { success: true, history: entry.server.getTrainingHistory() };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('training:getSession', async () => {
+  try {
+    const entry = remoteServers.get(TRAINING_ID);
+    if (!entry) return { success: true, session: null };
+    return { success: true, session: entry.server.getSession() };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('training:getArenas', async () => {
+  try {
+    const entry = remoteServers.get(TRAINING_ID);
+    if (!entry) return { success: true, arenas: [] };
+    return { success: true, arenas: entry.server.getAllArenas() };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
+ipcMain.handle('training:getServerInfo', async () => {
+  try {
+    const entry = remoteServers.get(TRAINING_ID);
+    if (!entry) return { success: false, error: 'Serveur non démarré' };
+    return {
+      success: true,
+      serverInfo: {
+        url: entry.server.getServerUrl(),
+        ip: entry.server.getLocalIPAddress(),
+        port: entry.port,
+        useHttps: entry.useHttps,
+        certFingerprint: entry.certFingerprint,
+      },
+    };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };
+  }
+});
+
 ipcMain.handle('app:getTtsConfig', async () => {
   const ttsPath = path.join(app.getPath('userData'), 'tts-config.json');
   try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -587,6 +587,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:setClientKioskMode', competitionId, socketId, config),
   },
 
+  training: {
+    startServer: (port?: number, host?: string, useHttps?: boolean) =>
+      ipcRenderer.invoke('training:startServer', port, host, useHttps),
+    stopServer: () => ipcRenderer.invoke('training:stopServer'),
+    startSession: (strips: number, weapon: string) =>
+      ipcRenderer.invoke('training:startSession', strips, weapon),
+    stopSession: () => ipcRenderer.invoke('training:stopSession'),
+    getHistory: () => ipcRenderer.invoke('training:getHistory'),
+    getSession: () => ipcRenderer.invoke('training:getSession'),
+    getArenas: () => ipcRenderer.invoke('training:getArenas'),
+    getServerInfo: () => ipcRenderer.invoke('training:getServerInfo'),
+  },
+
   // Remote event listeners (for real-time updates)
   onRemoteArenaUpdate: (callback: (data: any) => void) => {
     const handler = (_: any, data: any) => callback(data);
@@ -601,6 +614,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     };
     ipcRenderer.on('match:finished', handler);
     return () => ipcRenderer.removeListener('match:finished', handler);
+  },
+  onTrainingMatchFinished: (callback: (data: any) => void) => {
+    const handler = (_: any, data: any) => callback(data);
+    ipcRenderer.on('training:match_finished', handler);
+    return () => ipcRenderer.removeListener('training:match_finished', handler);
   },
   onRemoteFencerExcluded: (callback: (data: { fencerId: string; matchId: string }) => void) => {
     const handler = (_: any, data: any) => callback(data);

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -78,6 +78,11 @@ export class RemoteScoreServer {
   private arenaScreenThemes: Map<string, Partial<Record<ThemeTargetType, CustomTheme>>> = new Map();
   private kioskThemeVariables: Record<string, string> | null = null; // Thème CSS vars pour le kiosk
   private orgNote: OrgNote | null = null; // Note d'organisation affichée sur le kiosk
+  private isTrainingMode: boolean = false;
+  private trainingHistory: Array<{
+    id: string; arenaId: string; arenaNumber: number; weapon: string;
+    scoreA: number; scoreB: number; durationSec: number; finishedAt: string;
+  }> = [];
   private sessionLogo: string | null = null; // Logo organisateur (base64) pour kiosk et affichages publics
   private sessionWallpaper: string | null = null; // Fond d'écran (base64) affiché sur les arènes en attente
   // Config TTS (minuteur vocal) poussée aux tablettes d'arbitrage depuis les paramètres globaux
@@ -3572,7 +3577,7 @@ export class RemoteScoreServer {
     // (stocké en composite). Une éventuelle exception (ex: contrainte FK) NE DOIT PAS
     // empêcher l'émission de match:finished vers le renderer (sinon : vainqueur jamais
     // remonté, pas de passage au tour suivant). On isole donc tout ce bloc.
-    try {
+    if (!this.isTrainingMode) try {
       // Persister le timing en DB
       if (arena.currentMatch.id && arena.startTime) {
         const durationSec = arena.currentMatch.duration ?? 0;
@@ -3651,6 +3656,23 @@ export class RemoteScoreServer {
       console.warn('[RemoteScoreServer] Persistance secondaire (timing/cartons/touches) échouée:', e);
     }
 
+    // Enregistrement mode entraînement (pas de DB)
+    if (this.isTrainingMode) {
+      this.trainingHistory.push({
+        id: finishedMatch.id,
+        arenaId,
+        arenaNumber: arena.number,
+        weapon: this.sessionWeapon ?? '',
+        scoreA: finishedMatch.scoreA,
+        scoreB: finishedMatch.scoreB,
+        durationSec: finishedMatch.duration ?? 0,
+        finishedAt: new Date().toISOString(),
+      });
+      // Pré-charger le prochain match entraînement dans la file
+      const queue = this.arenaMatchQueue.get(arenaId) ?? [];
+      this.arenaMatchQueue.set(arenaId, [...queue, this.createTrainingMatch()]);
+    }
+
     const nextMatch = this.peekNextMatch(arenaId);
 
     // Mettre à jour l'état en mémoire sans broadcaster (on fait le broadcast manuellement
@@ -3690,8 +3712,8 @@ export class RemoteScoreServer {
       text: `Match terminé — ${finishedMatch.fencerA ? `${finishedMatch.fencerA.lastName} ${finishedMatch.fencerA.firstName}` : '?'} ${finishedMatch.scoreA} – ${finishedMatch.scoreB} ${finishedMatch.fencerB ? `${finishedMatch.fencerB.lastName} ${finishedMatch.fencerB.firstName}` : '?'}`,
     });
 
-    // Persister le score final dans la DB et dans l'audit log
-    try {
+    // Persister le score final dans la DB et dans l'audit log (pas en mode entraînement)
+    if (!this.isTrainingMode) try {
       const finalMatchId = finishedMatch.id;
       const dbMatch = this.db.getMatch(finalMatchId);
       // Pour les matchs TED, l'ID en base est "${competitionId}-${matchId}"
@@ -3750,7 +3772,7 @@ export class RemoteScoreServer {
 
     // Émettre l'event pour le renderer (pour sauvegarder le score dans les pools)
     const mainWindow = (global as any).mainWindow;
-    if (mainWindow) {
+    if (mainWindow && !this.isTrainingMode) {
       // Dériver le vainqueur depuis la DB pour gérer le cas tirage au sort (scores égaux)
       let winnerForRenderer: 'A' | 'B' | null =
         finishedMatch.scoreA > finishedMatch.scoreB ? 'A' :
@@ -3781,6 +3803,11 @@ export class RemoteScoreServer {
       console.log(
         `[RemoteScoreServer] Émission match:finished pour ${finishedMatch.id}: ${finishedMatch.scoreA}-${finishedMatch.scoreB}`
       );
+    }
+    if (mainWindow && this.isTrainingMode) {
+      mainWindow.webContents.send('training:match_finished', {
+        record: this.trainingHistory[this.trainingHistory.length - 1] ?? null,
+      });
     }
 
     this.persistArenaState(arenaId);
@@ -3881,8 +3908,8 @@ export class RemoteScoreServer {
       `[RemoteScoreServer] loadNextMatch: arena=${arenaId}, pool=${currentPoolId}, total=${this.sessionMatches.length}`
     );
 
-    // Si pas de matches en mémoire, essayer la DB
-    if (this.sessionMatches.length === 0) {
+    // Si pas de matches en mémoire, essayer la DB (sauf mode entraînement)
+    if (this.sessionMatches.length === 0 && !this.isTrainingMode) {
       console.log('[RemoteScoreServer] Pas de matches en mémoire, recherche dans la DB...');
       const pendingMatches = this.db.getPendingMatches(this.session.competitionId);
       if (pendingMatches.length === 0) {
@@ -3953,7 +3980,7 @@ export class RemoteScoreServer {
       );
 
       // Vérifier si la poule est entièrement terminée (tous matchs FINISHED en DB)
-      try {
+      if (!this.isTrainingMode) try {
         const allPoolMatches = this.db.getMatchesByPool(currentPoolId);
         if (
           allPoolMatches.length > 0 &&
@@ -3996,6 +4023,7 @@ export class RemoteScoreServer {
 
   private buildDashboardSnapshot(): { rankings: any[]; pools: any[]; liveMatches: any[] } | null {
     if (!this.session) return null;
+    if (this.isTrainingMode) return { rankings: [], pools: [], liveMatches: [] };
     const { competitionId } = this.session;
 
     // Classement global (depuis les poules terminées)
@@ -4606,6 +4634,7 @@ export class RemoteScoreServer {
   }
 
   public stopSession(): void {
+    this.isTrainingMode = false;
     this.session = null;
     this.sessionMatches = [];
     this.arenaMatchQueue.clear();
@@ -4617,6 +4646,60 @@ export class RemoteScoreServer {
     this.arenaTokens.clear();
     this.arenaEventBuffer.clear();
     this.clearArenaCombatState();
+  }
+
+  public async startTrainingSession(strips: number, weapon: string): Promise<RemoteSession> {
+    if (this.session) throw new Error('Session déjà active');
+    const effectiveStrips = Math.max(1, Math.min(strips, 20));
+    this.isTrainingMode = true;
+    this.trainingHistory = [];
+    this.sessionWeapon = weapon;
+    this.sessionPoolTimerSeconds = 180;
+    this.sessionTableTimerSeconds = 180;
+    this.sessionShowPhotos = false;
+    this.sessionCardAnnounce = false;
+    this.sessionRefereeFeatureEnabled = false;
+    this.sessionKioskViews = { poules: false, classement: false, direct: false, suivants: false, tableau: false };
+    this.sessionMatchScores.clear();
+    this.poolFencersCache.clear();
+    this.poolSignaturesCache.clear();
+    this.setArenaCount(effectiveStrips);
+    this.sessionMatches = [];
+    this.session = {
+      competitionId: '__training__',
+      strips: Array.from({ length: effectiveStrips }, (_, i) => ({ number: i + 1, status: 'available' as const })),
+      referees: [],
+      activeMatches: [],
+      isRunning: true,
+      startTime: new Date(),
+    };
+    for (let i = 1; i <= effectiveStrips; i++) {
+      this.assignMatchToArena(`arena${i}`, this.createTrainingMatch());
+    }
+    console.log(`[RemoteScoreServer] Session entraînement démarrée: ${effectiveStrips} pistes, arme=${weapon}`);
+    return this.session;
+  }
+
+  private createTrainingMatch(): ArenaMatch {
+    return {
+      id: `training-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      poolId: '__training__',
+      fencerA: { id: 'training-A', firstName: '', lastName: 'Tireur A', club: '', ref: 0 } as any,
+      fencerB: { id: 'training-B', firstName: '', lastName: 'Tireur B', club: '', ref: 0 } as any,
+      scoreA: 0,
+      scoreB: 0,
+      status: 'not_started',
+      startTime: null,
+      endTime: null,
+    };
+  }
+
+  public getTrainingHistory() {
+    return [...this.trainingHistory];
+  }
+
+  public stopTrainingSession(): void {
+    this.stopSession();
   }
 
   public updateStripCount(newCount: number): RemoteSession | null {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -21,6 +21,8 @@ const KeyboardShortcutsHelp = React.lazy(() => import('./components/KeyboardShor
 const WikiModal = React.lazy(() => import('./components/WikiModal'));
 const WifiQRModal = React.lazy(() => import('./components/WifiQRModal').then(m => ({ default: m.WifiQRModal })));
 const XiaomiRemotePanel = React.lazy(() => import('./components/XiaomiRemotePanel').then(m => ({ default: m.XiaomiRemotePanel })));
+const TrainingLauncherModal = React.lazy(() => import('./components/training/TrainingLauncherModal'));
+const TrainingPanel = React.lazy(() => import('./components/training/TrainingPanel'));
 import { ToastProvider, useToast } from './components/Toast';
 import { ConfirmProvider, useConfirm } from './components/ConfirmDialog';
 import { TranslationProvider, useTranslation, Theme } from './contexts/TranslationContext';
@@ -55,6 +57,12 @@ const AppContent: React.FC = () => {
   const [showTVRemote, setShowTVRemote] = useState(false);
   const [remoteServerUrl, setRemoteServerUrl] = useState<string | null>(null);
   const [remoteArenaCount, setRemoteArenaCount] = useState<number>(1);
+  const [showTrainingModal, setShowTrainingModal] = useState(false);
+  const [trainingActive, setTrainingActive] = useState(false);
+  const [trainingServerUrl, setTrainingServerUrl] = useState('');
+  const [trainingStrips, setTrainingStrips] = useState(1);
+  const [trainingWeapon, setTrainingWeapon] = useState('');
+  const [trainingLaunching, setTrainingLaunching] = useState(false);
   const toolsMenuRef = useRef<HTMLDivElement>(null);
   const toolsBtnRef = useRef<HTMLButtonElement>(null);
   const [toolsMenuPos, setToolsMenuPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
@@ -293,6 +301,45 @@ const AppContent: React.FC = () => {
     }
   }, [openCompetitions, activeTabId, confirm]);
 
+  const handleLaunchTraining = useCallback(async (weapon: string, strips: number) => {
+    if (!window.electronAPI?.training) return;
+    setTrainingLaunching(true);
+    try {
+      const startRes = await window.electronAPI.training.startServer();
+      if (!startRes.success || !startRes.serverInfo) {
+        showToast(startRes.error ?? 'Impossible de démarrer le serveur', 'error');
+        return;
+      }
+      const sessionRes = await window.electronAPI.training.startSession(strips, weapon);
+      if (!sessionRes.success) {
+        await window.electronAPI.training.stopServer();
+        showToast(sessionRes.error ?? 'Impossible de démarrer la session', 'error');
+        return;
+      }
+      setTrainingServerUrl(startRes.serverInfo.url);
+      setTrainingStrips(strips);
+      setTrainingWeapon(weapon);
+      setTrainingActive(true);
+      setShowTrainingModal(false);
+    } catch (err) {
+      showToast('Erreur lors du lancement de l\'entraînement', 'error');
+    } finally {
+      setTrainingLaunching(false);
+    }
+  }, [showToast]);
+
+  const handleStopTraining = useCallback(async () => {
+    if (!window.electronAPI?.training) return;
+    try {
+      await window.electronAPI.training.stopSession();
+      await window.electronAPI.training.stopServer();
+    } catch { /* ignore */ }
+    setTrainingActive(false);
+    setTrainingServerUrl('');
+    setTrainingStrips(1);
+    setTrainingWeapon('');
+  }, []);
+
   const handleDeleteCompetition = useCallback(async (id: string) => {
     try {
       if (window.electronAPI) {
@@ -364,6 +411,14 @@ const AppContent: React.FC = () => {
             <button className="btn btn-primary btn-icon-label" onClick={() => setShowNewCompetitionModal(true)}>
               <Plus size={15} />
               {t('menu.new_competition')}
+            </button>
+            <button
+              className={`btn btn-icon-label ${trainingActive ? 'btn-danger' : 'btn-secondary'}`}
+              onClick={() => trainingActive ? handleStopTraining() : setShowTrainingModal(true)}
+              title={trainingActive ? "Arrêter l'entraînement" : "Mode entraînement"}
+            >
+              <Swords size={15} />
+              {trainingActive ? 'Entraînement' : 'Entraînement'}
             </button>
             {view === 'competition' && currentCompetition && (
               <button
@@ -721,6 +776,27 @@ const AppContent: React.FC = () => {
         <Suspense fallback={null}>
           <KeyboardShortcutsHelp />
         </Suspense>
+
+        {showTrainingModal && (
+          <Suspense fallback={null}>
+            <TrainingLauncherModal
+              onClose={() => setShowTrainingModal(false)}
+              onLaunch={handleLaunchTraining}
+              isLoading={trainingLaunching}
+            />
+          </Suspense>
+        )}
+
+        {trainingActive && (
+          <Suspense fallback={null}>
+            <TrainingPanel
+              serverUrl={trainingServerUrl}
+              strips={trainingStrips}
+              weapon={trainingWeapon}
+              onStop={handleStopTraining}
+            />
+          </Suspense>
+        )}
       </div>
     </>
   );

--- a/src/renderer/components/training/TrainingLauncherModal.tsx
+++ b/src/renderer/components/training/TrainingLauncherModal.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { X, Swords, Minus, Plus } from 'lucide-react';
+import { Weapon } from '../../../shared/types';
+
+interface Props {
+  onClose: () => void;
+  onLaunch: (weapon: string, strips: number) => void;
+  isLoading: boolean;
+}
+
+const WEAPON_LABELS: Record<string, string> = {
+  [Weapon.EPEE]: 'Épée',
+  [Weapon.FOIL]: 'Fleuret',
+  [Weapon.SABRE]: 'Sabre',
+  [Weapon.LASER]: 'Laser Sabre',
+};
+
+const TrainingLauncherModal: React.FC<Props> = ({ onClose, onLaunch, isLoading }) => {
+  const [weapon, setWeapon] = useState<string>(Weapon.EPEE);
+  const [strips, setStrips] = useState(1);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onLaunch(weapon, strips);
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 2000,
+      }}
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        style={{
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-border)',
+          borderRadius: '12px',
+          boxShadow: 'var(--shadow-xl)',
+          width: '420px',
+          padding: '1.5rem',
+          color: 'var(--color-text)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1.25rem' }}>
+          <h2 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Swords size={18} /> Mode Entraînement
+          </h2>
+          <button className="btn btn-icon" onClick={onClose} title="Fermer"><X size={16} /></button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '1.25rem' }}>
+            <label style={{ display: 'block', fontWeight: 500, marginBottom: '0.5rem', fontSize: '0.875rem' }}>
+              Arme
+            </label>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem' }}>
+              {Object.entries(WEAPON_LABELS).map(([key, label]) => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setWeapon(key)}
+                  style={{
+                    padding: '0.625rem 0.75rem',
+                    borderRadius: '8px',
+                    border: weapon === key ? '2px solid var(--color-primary)' : '2px solid var(--color-border)',
+                    background: weapon === key ? 'var(--color-primary-soft, rgba(99,102,241,0.1))' : 'transparent',
+                    color: weapon === key ? 'var(--color-primary)' : 'var(--color-text)',
+                    fontWeight: weapon === key ? 600 : 400,
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                    transition: 'all 0.15s',
+                  }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ marginBottom: '1.5rem' }}>
+            <label style={{ display: 'block', fontWeight: 500, marginBottom: '0.5rem', fontSize: '0.875rem' }}>
+              Nombre de pistes
+            </label>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+              <button
+                type="button"
+                className="btn btn-secondary btn-icon"
+                onClick={() => setStrips(s => Math.max(1, s - 1))}
+                disabled={strips <= 1}
+              >
+                <Minus size={14} />
+              </button>
+              <span style={{ fontSize: '1.5rem', fontWeight: 700, minWidth: '2rem', textAlign: 'center' }}>
+                {strips}
+              </span>
+              <button
+                type="button"
+                className="btn btn-secondary btn-icon"
+                onClick={() => setStrips(s => Math.min(20, s + 1))}
+                disabled={strips >= 20}
+              >
+                <Plus size={14} />
+              </button>
+              <span style={{ fontSize: '0.8125rem', color: 'var(--color-text-muted)', marginLeft: '0.25rem' }}>
+                piste{strips > 1 ? 's' : ''}
+              </span>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
+            <button type="button" className="btn btn-secondary" onClick={onClose}>
+              Annuler
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={isLoading}>
+              {isLoading ? 'Démarrage…' : 'Lancer'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default TrainingLauncherModal;

--- a/src/renderer/components/training/TrainingPanel.tsx
+++ b/src/renderer/components/training/TrainingPanel.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { X, Swords, Wifi, Clock, Trophy } from 'lucide-react';
+import type { TrainingMatchRecord } from '../../../shared/types/preload';
+
+const WEAPON_LABELS: Record<string, string> = {
+  E: 'Épée', F: 'Fleuret', S: 'Sabre', L: 'Laser', C: 'Custom',
+};
+
+function formatDuration(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+interface Props {
+  serverUrl: string;
+  strips: number;
+  weapon: string;
+  onStop: () => void;
+}
+
+const TrainingPanel: React.FC<Props> = ({ serverUrl, strips, weapon, onStop }) => {
+  const [history, setHistory] = useState<TrainingMatchRecord[]>([]);
+
+  const refreshHistory = useCallback(async () => {
+    const result = await window.electronAPI?.training?.getHistory();
+    if (result?.success) setHistory(result.history ?? []);
+  }, []);
+
+  useEffect(() => {
+    refreshHistory();
+    const unsub = window.electronAPI?.onTrainingMatchFinished?.((data) => {
+      if (data?.record) setHistory(prev => [...prev, data.record]);
+    });
+    return () => { if (typeof unsub === 'function') unsub(); };
+  }, [refreshHistory]);
+
+  const arenaUrls = Array.from({ length: strips }, (_, i) => ({
+    number: i + 1,
+    referee: `${serverUrl}/arene${i + 1}/arbitre`,
+    display: `${serverUrl}/arene${i + 1}`,
+  }));
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 2000,
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-border)',
+          borderRadius: '12px',
+          boxShadow: 'var(--shadow-xl)',
+          width: '580px',
+          maxHeight: '80vh',
+          display: 'flex',
+          flexDirection: 'column',
+          color: 'var(--color-text)',
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '1.25rem 1.5rem',
+          borderBottom: '1px solid var(--color-border)',
+        }}>
+          <h2 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Swords size={18} />
+            Entraînement — {WEAPON_LABELS[weapon] ?? weapon}
+            <span style={{
+              display: 'inline-flex', alignItems: 'center', gap: '0.25rem',
+              background: '#22c55e20', color: '#16a34a',
+              padding: '0.125rem 0.5rem', borderRadius: '999px',
+              fontSize: '0.75rem', fontWeight: 600, marginLeft: '0.25rem',
+            }}>
+              <span style={{ width: 6, height: 6, borderRadius: '50%', background: '#16a34a', display: 'inline-block' }} />
+              EN COURS
+            </span>
+          </h2>
+          <button className="btn btn-icon" onClick={onStop} title="Arrêter l'entraînement"><X size={16} /></button>
+        </div>
+
+        <div style={{ overflowY: 'auto', padding: '1.25rem 1.5rem', flex: 1, display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+          {/* Pistes */}
+          <div>
+            <div style={{ fontSize: '0.8125rem', fontWeight: 600, color: 'var(--color-text-muted)', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+              <Wifi size={13} style={{ verticalAlign: 'middle', marginRight: '0.25rem' }} />
+              Pistes — {strips} piste{strips > 1 ? 's' : ''}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
+              {arenaUrls.map(({ number, referee, display }) => (
+                <div key={number} style={{
+                  background: 'var(--color-surface-raised, rgba(0,0,0,0.04))',
+                  border: '1px solid var(--color-border)',
+                  borderRadius: '8px',
+                  padding: '0.5rem 0.75rem',
+                  display: 'flex', alignItems: 'center', gap: '0.75rem',
+                }}>
+                  <span style={{ fontWeight: 600, fontSize: '0.875rem', minWidth: '5rem' }}>Piste {number}</span>
+                  <span style={{ fontSize: '0.8125rem', color: 'var(--color-text-muted)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    Arbitre : <code style={{ fontSize: '0.75rem' }}>{referee}</code>
+                  </span>
+                  <a
+                    href={display}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ fontSize: '0.75rem', color: 'var(--color-primary)', textDecoration: 'none', whiteSpace: 'nowrap' }}
+                  >
+                    Affichage ↗
+                  </a>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Historique */}
+          <div>
+            <div style={{ fontSize: '0.8125rem', fontWeight: 600, color: 'var(--color-text-muted)', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+              <Trophy size={13} style={{ verticalAlign: 'middle', marginRight: '0.25rem' }} />
+              Historique session ({history.length} combat{history.length !== 1 ? 's' : ''})
+            </div>
+            {history.length === 0 ? (
+              <div style={{ fontSize: '0.875rem', color: 'var(--color-text-muted)', padding: '0.75rem', textAlign: 'center', background: 'var(--color-surface-raised, rgba(0,0,0,0.04))', borderRadius: '8px' }}>
+                Aucun combat terminé
+              </div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', maxHeight: '220px', overflowY: 'auto' }}>
+                {[...history].reverse().map((rec, idx) => (
+                  <div key={rec.id} style={{
+                    display: 'flex', alignItems: 'center', gap: '0.75rem',
+                    padding: '0.375rem 0.75rem',
+                    background: idx % 2 === 0 ? 'var(--color-surface-raised, rgba(0,0,0,0.03))' : 'transparent',
+                    borderRadius: '6px',
+                    fontSize: '0.875rem',
+                  }}>
+                    <span style={{ minWidth: '4rem', color: 'var(--color-text-muted)', fontSize: '0.75rem' }}>
+                      Piste {rec.arenaNumber}
+                    </span>
+                    <span style={{ flex: 1, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
+                      {rec.scoreA} — {rec.scoreB}
+                    </span>
+                    {rec.durationSec > 0 && (
+                      <span style={{ color: 'var(--color-text-muted)', fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                        <Clock size={11} /> {formatDuration(rec.durationSec)}
+                      </span>
+                    )}
+                    <span style={{ color: 'var(--color-text-muted)', fontSize: '0.75rem' }}>
+                      {new Date(rec.finishedAt).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding: '1rem 1.5rem',
+          borderTop: '1px solid var(--color-border)',
+          display: 'flex', justifyContent: 'flex-end',
+        }}>
+          <button className="btn btn-danger" onClick={onStop}>
+            Arrêter l'entraînement
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TrainingPanel;

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -862,6 +862,28 @@ export interface CryptoAPI {
   unprotect: (ciphertext: string) => Promise<string | null>;
 }
 
+export interface TrainingMatchRecord {
+  id: string;
+  arenaId: string;
+  arenaNumber: number;
+  weapon: string;
+  scoreA: number;
+  scoreB: number;
+  durationSec: number;
+  finishedAt: string;
+}
+
+export interface TrainingAPI {
+  startServer: (port?: number, host?: string, useHttps?: boolean) => Promise<{ success: boolean; serverInfo?: { url: string; ip: string; port: number; useHttps: boolean; certFingerprint?: string }; error?: string }>;
+  stopServer: () => Promise<{ success: boolean; error?: string }>;
+  startSession: (strips: number, weapon: string) => Promise<{ success: boolean; session?: any; error?: string }>;
+  stopSession: () => Promise<{ success: boolean; error?: string }>;
+  getHistory: () => Promise<{ success: boolean; history: TrainingMatchRecord[]; error?: string }>;
+  getSession: () => Promise<{ success: boolean; session: any | null; error?: string }>;
+  getArenas: () => Promise<{ success: boolean; arenas: any[]; error?: string }>;
+  getServerInfo: () => Promise<{ success: boolean; serverInfo?: { url: string; ip: string; port: number; useHttps: boolean; certFingerprint?: string }; error?: string }>;
+}
+
 export interface ElectronAPI extends MenuAPI, UtilityAPI {
   db: DatabaseAPI;
   file: FileAPI;
@@ -869,8 +891,10 @@ export interface ElectronAPI extends MenuAPI, UtilityAPI {
   updater: UpdaterAPI;
   crypto: CryptoAPI;
   remote: RemoteServerAPI;
+  training: TrainingAPI;
   onRemoteArenaUpdate: (callback: (data: any) => void) => () => void;
   onRemoteMatchFinished: (callback: (data: any) => void) => () => void;
+  onTrainingMatchFinished: (callback: (data: { record: TrainingMatchRecord | null }) => void) => () => void;
   onRemoteFencerExcluded: (callback: (data: { fencerId: string; matchId: string }) => void) => (() => void);
   onKioskNoteUpdate: (
     callback: (note: import('../types/remote').OrgNote | null) => void


### PR DESCRIPTION
## Résumé

- Bouton **Entraînement** dans la barre d'en-tête (à côté de "Nouvelle Compétition")
- Modal de lancement : choix de l'arme (Épée/Fleuret/Sabre/Laser) + nb de pistes (1–20)
- Démarre le serveur Socket.IO en mode training (`__training__`) sans créer de compétition ni toucher la DB
- Interface arbitre standard (`referee.html`) réutilisée — règles/timer selon l'arme
- Après chaque combat, un nouveau match vierge est automatiquement mis en file
- Historique léger en mémoire (score, durée, piste, heure) — perdu à l'arrêt

## Technique

- `remoteScoreServer.ts` : flag `isTrainingMode`, méthode `startTrainingSession()`, skip de toutes les écritures DB dans `finishArenaMatch()` et `loadNextMatch()`
- `main.ts` : handlers IPC `training:startServer/stopServer/startSession/stopSession/getHistory/getSession/getArenas/getServerInfo`
- `preload.ts` : API `window.electronAPI.training.*` + event `onTrainingMatchFinished`
- `shared/types/preload.ts` : `TrainingMatchRecord`, `TrainingAPI`, mise à jour `ElectronAPI`
- `TrainingLauncherModal.tsx` : sélection arme + pistes
- `TrainingPanel.tsx` : URL pistes + historique session en temps réel

## Plan de test

- [ ] Cliquer "Entraînement" → modal s'ouvre
- [ ] Choisir Épée, 2 pistes → lancer
- [ ] Ouvrir `http://[IP]:8066/arene1/arbitre` sur une tablette
- [ ] Jouer un combat jusqu'à la fin
- [ ] Vérifier que le score apparaît dans l'historique du panel
- [ ] Vérifier qu'aucune compétition n'a été créée en DB
- [ ] Arrêter → serveur coupé proprement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgPAZJPubksUntpHyRaM3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgPAZJPubksUntpHyRaM3v)_