### PR TITLE
fix: narrowing TypeScript TrainingMatchRecord | null (CI type-check)

### DIFF
--- a/src/renderer/components/training/TrainingPanel.tsx
+++ b/src/renderer/components/training/TrainingPanel.tsx
@@ -30,7 +30,8 @@ const TrainingPanel: React.FC<Props> = ({ serverUrl, strips, weapon, onStop }) =
   useEffect(() => {
     refreshHistory();
     const unsub = window.electronAPI?.onTrainingMatchFinished?.((data) => {
-      if (data?.record) setHistory(prev => [...prev, data.record]);
+      const record = data?.record;
+      if (record) setHistory(prev => [...prev, record]);
     });
     return () => { if (typeof unsub === 'function') unsub(); };
   }, [refreshHistory]);


### PR DESCRIPTION
## Fix

`TrainingPanel.tsx:33` — `data.record` était typé `TrainingMatchRecord | null`, TypeScript ne pouvait pas le narrower à l'intérieur du callback du spread.

```diff
- if (data?.record) setHistory(prev => [...prev, data.record]);
+ const record = data?.record;
+ if (record) setHistory(prev => [...prev, record]);
```

Corrige l'erreur CI :
```
error TS2345: Type 'null' is not assignable to type 'TrainingMatchRecord'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01QgPAZJPubksUntpHyRaM3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgPAZJPubksUntpHyRaM3v)_