### PR TITLE
feat(training): kiosk live+historique, bouton paramètres, URL kiosk

### DIFF
--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -577,6 +577,7 @@ export class RemoteScoreServer {
         weapon: this.sessionWeapon,
         kioskViews: this.sessionKioskViews,
         orgNote: this.orgNote,
+        ...(this.isTrainingMode ? { competitionName: 'Entraînement', isTrainingMode: true } : {}),
       });
     });
 
@@ -1967,6 +1968,12 @@ export class RemoteScoreServer {
         console.error('[RemoteScoreServer] Erreur résultats:', error);
         res.status(500).json({ error: 'Erreur lors de la récupération des résultats' });
       }
+    });
+
+    // API : historique combats entraînement
+    this.app.get('/api/training/history', (req, res) => {
+      if (!this.isTrainingMode) return res.status(404).json({ error: 'Mode non entraînement' });
+      res.json({ history: this.trainingHistory });
     });
 
     // API : matchs à venir dans l'ordre de passage (kiosk vue suivants)
@@ -4659,7 +4666,7 @@ export class RemoteScoreServer {
     this.sessionShowPhotos = false;
     this.sessionCardAnnounce = false;
     this.sessionRefereeFeatureEnabled = false;
-    this.sessionKioskViews = { poules: false, classement: false, direct: false, suivants: false, tableau: false };
+    this.sessionKioskViews = { poules: false, classement: true, direct: true, suivants: false, tableau: false };
     this.sessionMatchScores.clear();
     this.poolFencersCache.clear();
     this.poolSignaturesCache.clear();

--- a/src/remote/kiosk.html
+++ b/src/remote/kiosk.html
@@ -1321,6 +1321,7 @@
         arenasData: [],
         upcomingData: [],
         overallRanking: [],
+        trainingHistory: [],
         lastUpdate: null,
         prevArenaScores: {},
         bracketData: null,
@@ -1637,18 +1638,27 @@
           }
           applyLocalViews();
 
-          // 2. Données poules + classements
-          const poolsRes = await fetch('/api/competitions/' + competitionId + '/results-data');
-          if (poolsRes.ok) {
-            const data = await poolsRes.json();
-            state.poolsData = data.pools || [];
-            if (data.overallRanking && data.overallRanking.length > 0) {
-              state.overallRanking = data.overallRanking;
-            } else {
-              buildOverallRanking();
+          // 2. Données poules + classements (ou historique entraînement)
+          if (competitionId === '__training__') {
+            const histRes = await fetch('/api/training/history');
+            if (histRes.ok) {
+              const histData = await histRes.json();
+              state.trainingHistory = histData.history || [];
+              renderRanking();
             }
-            renderPools();
-            renderRanking();
+          } else {
+            const poolsRes = await fetch('/api/competitions/' + competitionId + '/results-data');
+            if (poolsRes.ok) {
+              const data = await poolsRes.json();
+              state.poolsData = data.pools || [];
+              if (data.overallRanking && data.overallRanking.length > 0) {
+                state.overallRanking = data.overallRanking;
+              } else {
+                buildOverallRanking();
+              }
+              renderPools();
+              renderRanking();
+            }
           }
 
           // 3. Arènes
@@ -1749,8 +1759,30 @@
       // ─── Rendu Classement ────────────────────────────────────────────────────
       function renderRanking() {
         const tbody = document.getElementById('ranking-body');
-        const ranking = state.overallRanking;
 
+        // Mode entraînement : afficher l'historique des combats
+        if (state.session?.competitionId === '__training__') {
+          const hist = (state.trainingHistory || []).slice().reverse();
+          document.getElementById('classement-badge').textContent = hist.length + ' combat' + (hist.length !== 1 ? 's' : '');
+          if (!hist.length) {
+            tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;color:#64748b;padding:3rem">Aucun combat terminé</td></tr>';
+            return;
+          }
+          tbody.innerHTML = hist.map(r => {
+            const dur = r.durationSec > 0 ? Math.floor(r.durationSec/60) + ':' + String(r.durationSec % 60).padStart(2,'0') : '—';
+            const t = new Date(r.finishedAt).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+            return `<tr>
+              <td style="color:#64748b;font-weight:700">P${r.arenaNumber}</td>
+              <td><div style="font-weight:600;font-size:1.1rem">${r.scoreA} — ${r.scoreB}</div></td>
+              <td style="color:#64748b;font-size:0.85rem">${dur}</td>
+              <td style="text-align:center;color:#94a3b8">${t}</td>
+              <td></td><td></td>
+            </tr>`;
+          }).join('');
+          return;
+        }
+
+        const ranking = state.overallRanking;
         document.getElementById('classement-badge').textContent = ranking.length + ' tireur' + (ranking.length > 1 ? 's' : '');
 
         if (!ranking || ranking.length === 0) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -801,6 +801,7 @@ const AppContent: React.FC = () => {
               weapon={trainingWeapon}
               onClose={() => setShowTrainingPanel(false)}
               onStop={handleStopTraining}
+              onOpenSettings={() => { setShowTrainingPanel(false); setShowSettingsModal(true); }}
             />
           </Suspense>
         )}

--- a/src/renderer/components/training/TrainingPanel.tsx
+++ b/src/renderer/components/training/TrainingPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { X, Swords, Clock, Trophy, Copy, QrCode, ChevronDown, ChevronUp, Check } from 'lucide-react';
+import { X, Swords, Clock, Trophy, Copy, QrCode, ChevronDown, ChevronUp, Check, Settings, Monitor } from 'lucide-react';
 import type { TrainingMatchRecord } from '../../../shared/types/preload';
 
 const WEAPON_LABELS: Record<string, string> = {
@@ -63,6 +63,51 @@ const UrlRow: React.FC<UrlRowProps> = ({ label, url, qrDataUrl }) => {
           </button>
         </div>
       </div>
+    </div>
+  );
+};
+
+// ── Bloc kiosk grand écran ───────────────────────────────────────────────────
+interface KioskBlockProps { kioskUrl: string; }
+const KioskBlock: React.FC<KioskBlockProps> = ({ kioskUrl }) => {
+  const [open, setOpen] = useState(false);
+  const [qr, setQr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const QRCode = (await import('qrcode')).default;
+      const r = await QRCode.toDataURL(kioskUrl, { width: 160, margin: 1 });
+      if (!cancelled) setQr(r);
+    })();
+    return () => { cancelled = true; };
+  }, [open, kioskUrl]);
+
+  return (
+    <div style={{ border: '1px solid var(--color-border)', borderRadius: '8px', overflow: 'hidden' }}>
+      <button
+        onClick={() => setOpen(v => !v)}
+        style={{
+          width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '0.5rem 0.75rem',
+          background: open ? 'var(--color-surface-raised, rgba(0,0,0,0.04))' : 'transparent',
+          border: 'none', cursor: 'pointer', color: 'var(--color-text)',
+        }}
+      >
+        <span style={{ fontWeight: 600, fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+          <Monitor size={13} /> Kiosk grand écran
+        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', color: 'var(--color-text-muted)', fontSize: '0.75rem' }}>
+          <QrCode size={13} />
+          {open ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+        </div>
+      </button>
+      {open && (
+        <div style={{ padding: '0.5rem 0.75rem', borderTop: '1px solid var(--color-border)' }}>
+          <UrlRow label="Kiosk" url={kioskUrl} qrDataUrl={qr} />
+        </div>
+      )}
     </div>
   );
 };
@@ -134,9 +179,10 @@ interface Props {
   weapon: string;
   onClose: () => void;
   onStop: () => void;
+  onOpenSettings: () => void;
 }
 
-const TrainingPanel: React.FC<Props> = ({ serverUrl, strips, weapon, onClose, onStop }) => {
+const TrainingPanel: React.FC<Props> = ({ serverUrl, strips, weapon, onClose, onStop, onOpenSettings }) => {
   const [history, setHistory] = useState<TrainingMatchRecord[]>([]);
 
   const refreshHistory = useCallback(async () => {
@@ -199,6 +245,9 @@ const TrainingPanel: React.FC<Props> = ({ serverUrl, strips, weapon, onClose, on
         </div>
 
         <div style={{ overflowY: 'auto', padding: '1.25rem 1.5rem', flex: 1, display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+          {/* Kiosk */}
+          <KioskBlock kioskUrl={`${serverUrl}/kiosk`} />
+
           {/* Pistes */}
           <div>
             <div style={{ fontSize: '0.8125rem', fontWeight: 600, color: 'var(--color-text-muted)', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
@@ -249,7 +298,10 @@ const TrainingPanel: React.FC<Props> = ({ serverUrl, strips, weapon, onClose, on
         </div>
 
         {/* Footer */}
-        <div style={{ padding: '1rem 1.5rem', borderTop: '1px solid var(--color-border)', display: 'flex', justifyContent: 'flex-end' }}>
+        <div style={{ padding: '1rem 1.5rem', borderTop: '1px solid var(--color-border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <button className="btn btn-secondary btn-icon-label" onClick={onOpenSettings} title="Paramètres">
+            <Settings size={14} /> Paramètres
+          </button>
           <button className="btn btn-danger" onClick={onStop}>Arrêter l'entraînement</button>
         </div>
       </div>


### PR DESCRIPTION
## Résumé

- **Kiosk en mode entraînement** : `sessionKioskViews` passe à `direct: true, classement: true` → les onglets "Matchs en direct" et "Historique" s'affichent automatiquement
- **`/api/training/history`** : nouvel endpoint qui expose l'historique en-mémoire au kiosk
- **`kiosk.html`** : `renderRanking()` détecte `competitionId === '__training__'` et affiche la liste des combats terminés (piste, score, durée, heure) à la place du classement
- **TrainingPanel** : nouveau bloc "Kiosk grand écran" avec QR + copier URL
- **TrainingPanel** : bouton "Paramètres" en pied de panneau → ferme le panneau et ouvre SettingsModal
- **`/api/session`** : ajoute `competitionName: 'Entraînement'` et `isTrainingMode: true` dans la réponse

## Test plan

- [ ] Lancer mode entraînement
- [ ] Ouvrir `/kiosk` → onglet "Matchs en direct" visible par défaut avec les arènes actives
- [ ] Terminer quelques combats → onglet "Historique" liste les résultats (piste, score, durée)
- [ ] Bloc "Kiosk grand écran" dans TrainingPanel → QR + copier URL fonctionnels
- [ ] Bouton "Paramètres" → ferme le panneau, ouvre SettingsModal, entraînement continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgPAZJPubksUntpHyRaM3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgPAZJPubksUntpHyRaM3v)_