### PR TITLE
feat(training): règles personnalisées — durée, zones, mort subite

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2284,11 +2284,11 @@ ipcMain.handle('training:stopServer', async () => {
   }
 });
 
-ipcMain.handle('training:startSession', async (_event, strips: number, weapon: string) => {
+ipcMain.handle('training:startSession', async (_event, strips: number, weapon: string, customRules?: any) => {
   try {
     const entry = remoteServers.get(TRAINING_ID);
     if (!entry) return { success: false, error: 'Serveur entraînement non démarré' };
-    const session = await entry.server.startTrainingSession(strips, weapon);
+    const session = await entry.server.startTrainingSession(strips, weapon, customRules);
     return { success: true, session };
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : 'Erreur inconnue' };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -591,8 +591,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     startServer: (port?: number, host?: string, useHttps?: boolean) =>
       ipcRenderer.invoke('training:startServer', port, host, useHttps),
     stopServer: () => ipcRenderer.invoke('training:stopServer'),
-    startSession: (strips: number, weapon: string) =>
-      ipcRenderer.invoke('training:startSession', strips, weapon),
+    startSession: (strips: number, weapon: string, customRules?: any) =>
+      ipcRenderer.invoke('training:startSession', strips, weapon, customRules),
     stopSession: () => ipcRenderer.invoke('training:stopSession'),
     getHistory: () => ipcRenderer.invoke('training:getHistory'),
     getSession: () => ipcRenderer.invoke('training:getSession'),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -83,6 +83,7 @@ export class RemoteScoreServer {
     id: string; arenaId: string; arenaNumber: number; weapon: string;
     scoreA: number; scoreB: number; durationSec: number; finishedAt: string;
   }> = [];
+  private trainingCustomRules: { matchDurationSeconds: number; allowedZones: string[]; disableSuddenDeath: boolean } | null = null;
   private sessionLogo: string | null = null; // Logo organisateur (base64) pour kiosk et affichages publics
   private sessionWallpaper: string | null = null; // Fond d'écran (base64) affiché sur les arènes en attente
   // Config TTS (minuteur vocal) poussée aux tablettes d'arbitrage depuis les paramètres globaux
@@ -577,7 +578,7 @@ export class RemoteScoreServer {
         weapon: this.sessionWeapon,
         kioskViews: this.sessionKioskViews,
         orgNote: this.orgNote,
-        ...(this.isTrainingMode ? { competitionName: 'Entraînement', isTrainingMode: true } : {}),
+        ...(this.isTrainingMode ? { competitionName: 'Entraînement', isTrainingMode: true, trainingCustomRules: this.trainingCustomRules } : {}),
       });
     });
 
@@ -2499,6 +2500,7 @@ export class RemoteScoreServer {
             referees: this.session?.referees ?? [],
             refereeSelected: this.arenaRefereeSelected.get(data.arenaId) ?? false,
             timerDuration: isPoolMatch ? this.sessionPoolTimerSeconds : this.sessionTableTimerSeconds,
+            ...(this.isTrainingMode && this.trainingCustomRules ? { trainingCustomRules: this.trainingCustomRules } : {}),
             ...(arena.status === 'finished' && {
               nextMatch: this.peekNextMatch(data.arenaId),
             }),
@@ -2794,8 +2796,12 @@ export class RemoteScoreServer {
         const lastUpdate = this.scoreUpdateDebounce.get(debounceKey) ?? 0;
         if (Date.now() - lastUpdate < this.SCORE_UPDATE_DEBOUNCE_MS) break;
         this.scoreUpdateDebounce.set(debounceKey, Date.now());
-        if (data.suddenDeath !== undefined) {
-          this.arenaSuddenDeath.set(data.arenaId, data.suddenDeath);
+        // Supprimer la mort subite si désactivée en entraînement
+        const effectiveSuddenDeath = (this.isTrainingMode && this.trainingCustomRules?.disableSuddenDeath)
+          ? false
+          : data.suddenDeath;
+        if (effectiveSuddenDeath !== undefined) {
+          this.arenaSuddenDeath.set(data.arenaId, effectiveSuddenDeath);
         }
         if (data.overtimeType !== undefined) {
           this.arenaOvertimeType.set(data.arenaId, data.overtimeType);
@@ -2911,15 +2917,18 @@ export class RemoteScoreServer {
         break;
       case 'update_timer':
       case 'pause_timer':
-      case 'reset_timer':
-        if (data.suddenDeath !== undefined) {
-          this.arenaSuddenDeath.set(data.arenaId, data.suddenDeath);
+      case 'reset_timer': {
+        const timerSuddenDeath = (this.isTrainingMode && this.trainingCustomRules?.disableSuddenDeath)
+          ? false
+          : data.suddenDeath;
+        if (timerSuddenDeath !== undefined) {
+          this.arenaSuddenDeath.set(data.arenaId, timerSuddenDeath);
         }
         if (data.overtimeType !== undefined) {
           this.arenaOvertimeType.set(data.arenaId, data.overtimeType);
         }
         // Clear waiting state when sudden death actually starts
-        if (data.suddenDeath) {
+        if (timerSuddenDeath) {
           this.arenaWaitingOvertime.set(data.arenaId, false);
         }
         this.broadcastArenaUpdate(data.arenaId, {
@@ -2933,6 +2942,7 @@ export class RemoteScoreServer {
           status: arena.status,
         });
         break;
+      }
       case 'change_referee': {
         if (!data.matchId || !data.refereeId || !arena.currentMatch) break;
         if (arena.currentMatch.id !== data.matchId) break;
@@ -4642,6 +4652,7 @@ export class RemoteScoreServer {
 
   public stopSession(): void {
     this.isTrainingMode = false;
+    this.trainingCustomRules = null;
     this.session = null;
     this.sessionMatches = [];
     this.arenaMatchQueue.clear();
@@ -4655,14 +4666,20 @@ export class RemoteScoreServer {
     this.clearArenaCombatState();
   }
 
-  public async startTrainingSession(strips: number, weapon: string): Promise<RemoteSession> {
+  public async startTrainingSession(strips: number, weapon: string, customRules?: { matchDurationSeconds?: number; allowedZones?: string[]; disableSuddenDeath?: boolean }): Promise<RemoteSession> {
     if (this.session) throw new Error('Session déjà active');
     const effectiveStrips = Math.max(1, Math.min(strips, 20));
     this.isTrainingMode = true;
     this.trainingHistory = [];
     this.sessionWeapon = weapon;
-    this.sessionPoolTimerSeconds = 180;
-    this.sessionTableTimerSeconds = 180;
+    const duration = customRules?.matchDurationSeconds ?? 180;
+    this.sessionPoolTimerSeconds = duration;
+    this.sessionTableTimerSeconds = duration;
+    this.trainingCustomRules = {
+      matchDurationSeconds: duration,
+      allowedZones: customRules?.allowedZones ?? [],
+      disableSuddenDeath: customRules?.disableSuddenDeath ?? false,
+    };
     this.sessionShowPhotos = false;
     this.sessionCardAnnounce = false;
     this.sessionRefereeFeatureEnabled = false;

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1768,6 +1768,7 @@
           this.refereesList = []; // Liste des arbitres de la compétition
           this.swapped = false;
           this.pausedForModal = false;
+          this.trainingCustomRules = null; // { matchDurationSeconds, allowedZones, disableSuddenDeath }
           this.offlineQueue = new OfflineQueueInline();
           this.ttsEnabled = false;
           this._ttsAnnouncedSeconds = new Set();
@@ -1805,6 +1806,7 @@
               if (s) {
               this.isLaserSabre = s.weapon === 'L';
               this.isModernFencing = ['E', 'F', 'S'].includes(s.weapon);
+              if (s.trainingCustomRules) this.trainingCustomRules = s.trainingCustomRules;
               if (this.isModernFencing) {
                 const pisteLabel = window.T('remote.piste');
                 document.getElementById('arena-label').textContent = pisteLabel;
@@ -2295,6 +2297,19 @@
             return;
           }
 
+          // Restriction de zones en mode entraînement
+          const _zone = points === 1 ? 'A' : points === 3 ? 'B' : 'C';
+          if (
+            this.trainingCustomRules &&
+            this.trainingCustomRules.allowedZones &&
+            this.trainingCustomRules.allowedZones.length > 0 &&
+            !this.trainingCustomRules.allowedZones.includes(_zone)
+          ) {
+            const allowed = this.trainingCustomRules.allowedZones.join(', ');
+            this.showNotification(`Zone ${_zone} non autorisée (entraînement : ${allowed} uniquement)`);
+            return;
+          }
+
           this.pushHistory('score');
           if (navigator.vibrate) navigator.vibrate(points === 5 ? 120 : points === 3 ? 80 : 40);
 
@@ -2315,6 +2330,7 @@
           // Le déclenchement est autorisé hors mort subite ET pendant le temps supplémentaire
           if (
             this.isLaserSabre &&
+            !(this.trainingCustomRules && this.trainingCustomRules.disableSuddenDeath) &&
             (!this.isSuddenDeath || this.overtimeType === 'supplementary')
           ) {
             if (this.scoreA >= 10 && this.scoreB >= 10) {
@@ -2924,11 +2940,12 @@
               if (this.timerSeconds === 0) {
                 this.stopTimer();
                 if (navigator.vibrate) navigator.vibrate([300, 100, 300]);
-                if (this.scoreA === this.scoreB &&
+                const _sdDisabled = this.trainingCustomRules && this.trainingCustomRules.disableSuddenDeath;
+                if (!_sdDisabled && this.scoreA === this.scoreB &&
                     (!this.isSuddenDeath || this.overtimeType === 'challenger')) {
                   // Égalité : attente manuelle de l'arbitre pour lancer les 30s
                   this.prepareSuddenDeath();
-                } else if (this.isSuddenDeath && this.scoreA === this.scoreB) {
+                } else if (!_sdDisabled && this.isSuddenDeath && this.scoreA === this.scoreB) {
                   // Fin des 30s supplémentaires avec égalité → tirage au sort
                   this.triggerTiebreaker();
                 } else {
@@ -3569,6 +3586,10 @@
 
           if (data.timerDuration !== undefined && data.timerDuration > 0) {
             this.defaultTimerSeconds = data.timerDuration;
+          }
+
+          if (data.trainingCustomRules !== undefined) {
+            this.trainingCustomRules = data.trainingCustomRules;
           }
 
           if (data.cardAnnounce !== undefined) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -302,7 +302,7 @@ const AppContent: React.FC = () => {
     }
   }, [openCompetitions, activeTabId, confirm]);
 
-  const handleLaunchTraining = useCallback(async (weapon: string, strips: number) => {
+  const handleLaunchTraining = useCallback(async (weapon: string, strips: number, customRules?: any) => {
     if (!window.electronAPI?.training) return;
     setTrainingLaunching(true);
     try {
@@ -311,7 +311,7 @@ const AppContent: React.FC = () => {
         showToast(startRes.error ?? 'Impossible de démarrer le serveur', 'error');
         return;
       }
-      const sessionRes = await window.electronAPI.training.startSession(strips, weapon);
+      const sessionRes = await window.electronAPI.training.startSession(strips, weapon, customRules);
       if (!sessionRes.success) {
         await window.electronAPI.training.stopServer();
         showToast(sessionRes.error ?? 'Impossible de démarrer la session', 'error');

--- a/src/renderer/components/training/TrainingLauncherModal.tsx
+++ b/src/renderer/components/training/TrainingLauncherModal.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { X, Swords, Minus, Plus } from 'lucide-react';
-import { Weapon } from '../../../shared/types';
+import { X, Swords, Minus, Plus, Clock, Zap } from 'lucide-react';
+import { Weapon, TargetZone, ZONE_POINTS, ZONE_LABELS } from '../../../shared/types';
+import type { TrainingCustomRules } from '../../../shared/types/preload';
 
 interface Props {
   onClose: () => void;
-  onLaunch: (weapon: string, strips: number) => void;
+  onLaunch: (weapon: string, strips: number, customRules: TrainingCustomRules) => void;
   isLoading: boolean;
 }
 
@@ -15,14 +16,50 @@ const WEAPON_LABELS: Record<string, string> = {
   [Weapon.LASER]: 'Laser Sabre',
 };
 
+const ALL_ZONES: TargetZone[] = [TargetZone.ZONE_A, TargetZone.ZONE_B, TargetZone.ZONE_C];
+
+const DURATION_PRESETS = [
+  { label: '1 min', value: 60 },
+  { label: '2 min', value: 120 },
+  { label: '3 min', value: 180 },
+  { label: '5 min', value: 300 },
+];
+
 const TrainingLauncherModal: React.FC<Props> = ({ onClose, onLaunch, isLoading }) => {
   const [weapon, setWeapon] = useState<string>(Weapon.EPEE);
   const [strips, setStrips] = useState(1);
+  const [matchDuration, setMatchDuration] = useState(180);
+  const [allowedZones, setAllowedZones] = useState<TargetZone[]>([]);
+  const [disableSuddenDeath, setDisableSuddenDeath] = useState(false);
+
+  const isLaser = weapon === Weapon.LASER;
+
+  const toggleZone = (zone: TargetZone) => {
+    setAllowedZones(prev =>
+      prev.includes(zone) ? prev.filter(z => z !== zone) : [...prev, zone]
+    );
+  };
+
+  const handleWeaponChange = (w: string) => {
+    setWeapon(w);
+    if (w !== Weapon.LASER) {
+      setAllowedZones([]);
+      setDisableSuddenDeath(false);
+    }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onLaunch(weapon, strips);
+    onLaunch(weapon, strips, {
+      matchDurationSeconds: matchDuration,
+      allowedZones: allowedZones.map(z => z as string),
+      disableSuddenDeath,
+    });
   };
+
+  const durationMin = Math.floor(matchDuration / 60);
+  const durationSec = matchDuration % 60;
+  const durationLabel = durationSec === 0 ? `${durationMin} min` : `${durationMin}:${String(durationSec).padStart(2, '0')}`;
 
   return (
     <div
@@ -39,7 +76,9 @@ const TrainingLauncherModal: React.FC<Props> = ({ onClose, onLaunch, isLoading }
           border: '1px solid var(--color-border)',
           borderRadius: '12px',
           boxShadow: 'var(--shadow-xl)',
-          width: '420px',
+          width: '460px',
+          maxHeight: '90vh',
+          overflowY: 'auto',
           padding: '1.5rem',
           color: 'var(--color-text)',
         }}
@@ -52,6 +91,7 @@ const TrainingLauncherModal: React.FC<Props> = ({ onClose, onLaunch, isLoading }
         </div>
 
         <form onSubmit={handleSubmit}>
+          {/* Arme */}
           <div style={{ marginBottom: '1.25rem' }}>
             <label style={{ display: 'block', fontWeight: 500, marginBottom: '0.5rem', fontSize: '0.875rem' }}>
               Arme
@@ -61,7 +101,7 @@ const TrainingLauncherModal: React.FC<Props> = ({ onClose, onLaunch, isLoading }
                 <button
                   key={key}
                   type="button"
-                  onClick={() => setWeapon(key)}
+                  onClick={() => handleWeaponChange(key)}
                   style={{
                     padding: '0.625rem 0.75rem',
                     borderRadius: '8px',
@@ -80,7 +120,8 @@ const TrainingLauncherModal: React.FC<Props> = ({ onClose, onLaunch, isLoading }
             </div>
           </div>
 
-          <div style={{ marginBottom: '1.5rem' }}>
+          {/* Pistes */}
+          <div style={{ marginBottom: '1.25rem' }}>
             <label style={{ display: 'block', fontWeight: 500, marginBottom: '0.5rem', fontSize: '0.875rem' }}>
               Nombre de pistes
             </label>
@@ -109,6 +150,132 @@ const TrainingLauncherModal: React.FC<Props> = ({ onClose, onLaunch, isLoading }
               </span>
             </div>
           </div>
+
+          {/* Durée du combat */}
+          <div style={{ marginBottom: '1.25rem' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontWeight: 500, marginBottom: '0.5rem', fontSize: '0.875rem' }}>
+              <Clock size={14} /> Durée du combat — <strong>{durationLabel}</strong>
+            </label>
+            <input
+              type="range"
+              min={30}
+              max={600}
+              step={30}
+              value={matchDuration}
+              onChange={e => setMatchDuration(Number(e.target.value))}
+              style={{ width: '100%', accentColor: 'var(--color-primary)', cursor: 'pointer' }}
+            />
+            <div style={{ display: 'flex', gap: '0.4rem', marginTop: '0.5rem', flexWrap: 'wrap' }}>
+              {DURATION_PRESETS.map(p => (
+                <button
+                  key={p.value}
+                  type="button"
+                  onClick={() => setMatchDuration(p.value)}
+                  style={{
+                    padding: '0.25rem 0.6rem',
+                    borderRadius: '6px',
+                    border: matchDuration === p.value ? '2px solid var(--color-primary)' : '2px solid var(--color-border)',
+                    background: matchDuration === p.value ? 'var(--color-primary-soft, rgba(99,102,241,0.1))' : 'transparent',
+                    color: matchDuration === p.value ? 'var(--color-primary)' : 'var(--color-text-muted)',
+                    fontSize: '0.8125rem',
+                    fontWeight: matchDuration === p.value ? 600 : 400,
+                    cursor: 'pointer',
+                  }}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Options Laser Sabre uniquement */}
+          {isLaser && (
+            <>
+              {/* Zones autorisées */}
+              <div style={{ marginBottom: '1.25rem' }}>
+                <label style={{ display: 'block', fontWeight: 500, marginBottom: '0.5rem', fontSize: '0.875rem' }}>
+                  Zones autorisées{' '}
+                  <span style={{ fontWeight: 400, color: 'var(--color-text-muted)', fontSize: '0.8125rem' }}>
+                    (vide = toutes)
+                  </span>
+                </label>
+                <div style={{ display: 'flex', gap: '0.5rem' }}>
+                  {ALL_ZONES.map(zone => {
+                    const active = allowedZones.includes(zone);
+                    const pts = ZONE_POINTS[zone];
+                    const label = ZONE_LABELS[zone];
+                    const colors: Record<TargetZone, string> = {
+                      [TargetZone.ZONE_A]: '#60a5fa',
+                      [TargetZone.ZONE_B]: '#a78bfa',
+                      [TargetZone.ZONE_C]: '#f472b6',
+                    };
+                    return (
+                      <button
+                        key={zone}
+                        type="button"
+                        onClick={() => toggleZone(zone)}
+                        style={{
+                          flex: 1,
+                          padding: '0.5rem',
+                          borderRadius: '8px',
+                          border: `2px solid ${active ? colors[zone] : 'var(--color-border)'}`,
+                          background: active ? `${colors[zone]}22` : 'transparent',
+                          color: active ? colors[zone] : 'var(--color-text-muted)',
+                          fontWeight: active ? 600 : 400,
+                          cursor: 'pointer',
+                          fontSize: '0.8125rem',
+                          textAlign: 'center',
+                          transition: 'all 0.15s',
+                        }}
+                      >
+                        <div style={{ fontSize: '1rem', fontWeight: 700 }}>Zone {zone}</div>
+                        <div style={{ fontSize: '0.75rem' }}>{pts} pt{pts > 1 ? 's' : ''}</div>
+                        <div style={{ fontSize: '0.7rem', opacity: 0.8 }}>{label}</div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Mort subite */}
+              <div style={{ marginBottom: '1.25rem' }}>
+                <label
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '0.75rem',
+                    cursor: 'pointer', userSelect: 'none',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: '40px', height: '22px',
+                      borderRadius: '11px',
+                      background: disableSuddenDeath ? 'var(--color-danger, #ef4444)' : 'var(--color-border)',
+                      position: 'relative', transition: 'background 0.2s', cursor: 'pointer',
+                      flexShrink: 0,
+                    }}
+                    onClick={() => setDisableSuddenDeath(v => !v)}
+                  >
+                    <div style={{
+                      position: 'absolute', top: '3px',
+                      left: disableSuddenDeath ? '21px' : '3px',
+                      width: '16px', height: '16px',
+                      borderRadius: '50%', background: '#fff',
+                      transition: 'left 0.2s',
+                    }} />
+                  </div>
+                  <span style={{ fontSize: '0.875rem', fontWeight: 500, display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+                    <Zap size={14} />
+                    Désactiver la mort subite
+                  </span>
+                </label>
+                {disableSuddenDeath && (
+                  <p style={{ margin: '0.35rem 0 0 3.25rem', fontSize: '0.8rem', color: 'var(--color-text-muted)' }}>
+                    Égalité à temps → fin du match sans prolongation.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
 
           <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
             <button type="button" className="btn btn-secondary" onClick={onClose}>

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -561,6 +561,12 @@ export interface QuestPhaseConfig {
   opponentConstraint: 'none' | 'club' | 'region' | 'nation';
 }
 
+export interface TrainingCustomRules {
+  matchDurationSeconds: number;
+  allowedZones: TargetZone[];    // vide = toutes les zones autorisées
+  disableSuddenDeath: boolean;
+}
+
 export interface CompetitionSettings {
   defaultPoolMaxScore: number; // Score max en poules (défaut: 5)
   defaultTableMaxScore: number; // Score max en tableau (défaut: 10 ou 15)

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -862,6 +862,12 @@ export interface CryptoAPI {
   unprotect: (ciphertext: string) => Promise<string | null>;
 }
 
+export interface TrainingCustomRules {
+  matchDurationSeconds: number;
+  allowedZones: string[];
+  disableSuddenDeath: boolean;
+}
+
 export interface TrainingMatchRecord {
   id: string;
   arenaId: string;
@@ -876,7 +882,7 @@ export interface TrainingMatchRecord {
 export interface TrainingAPI {
   startServer: (port?: number, host?: string, useHttps?: boolean) => Promise<{ success: boolean; serverInfo?: { url: string; ip: string; port: number; useHttps: boolean; certFingerprint?: string }; error?: string }>;
   stopServer: () => Promise<{ success: boolean; error?: string }>;
-  startSession: (strips: number, weapon: string) => Promise<{ success: boolean; session?: any; error?: string }>;
+  startSession: (strips: number, weapon: string, customRules?: TrainingCustomRules) => Promise<{ success: boolean; session?: any; error?: string }>;
   stopSession: () => Promise<{ success: boolean; error?: string }>;
   getHistory: () => Promise<{ success: boolean; history: TrainingMatchRecord[]; error?: string }>;
   getSession: () => Promise<{ success: boolean; session: any | null; error?: string }>;


### PR DESCRIPTION
## Résumé

- **Durée du combat** : slider 30s–10min avec raccourcis 1/2/3/5 min (défaut 3 min)
- **Zones autorisées** (Laser Sabre uniquement) : sélecteur A/B/C — vide = toutes autorisées ; la tablette refuse les touches hors sélection avec notification
- **Mort subite** (Laser Sabre uniquement) : toggle pour la désactiver — ni le challenger (10-10) ni le temps supplémentaire ne se déclenchent ; égalité à temps = fin directe

## Fichiers modifiés

| Couche | Fichier | Changement |
|--------|---------|------------|
| Types | `src/shared/types/index.ts` | `TrainingCustomRules` interface |
| Types | `src/shared/types/preload.ts` | même + signature `startSession` |
| IPC | `src/main/preload.ts` | passe `customRules` à l'invoke |
| Main | `src/main/main.ts` | handler `training:startSession` reçoit les règles |
| Serveur | `src/main/remoteScoreServer.ts` | stocke les règles, applique la durée, filtre SD côté serveur, envoie `trainingCustomRules` à la tablette |
| Tablette | `src/remote/referee.html` | reçoit les règles, bloque zones interdites, supprime mort subite |
| UI | `src/renderer/components/training/TrainingLauncherModal.tsx` | nouveau formulaire |
| App | `src/renderer/App.tsx` | transmet `customRules` au `startSession` |

## Plan de test

- [ ] Lancer entraînement Épée — options zones/mort subite absentes de l'UI
- [ ] Lancer entraînement Laser Sabre durée 1 min → chrono tablette démarre à 01:00
- [ ] Sélectionner Zone A uniquement → toucher Zone B sur tablette → notification de refus
- [ ] Sélectionner Zone A + Zone C → Zone B refusée, A et C acceptées
- [ ] Activer "Désactiver mort subite" → amener 10-10 → pas de mort subite challenger
- [ ] Idem à temps écoulé à égalité → fin directe sans prolongation
- [ ] Vérifier que le mode normal (mort subite activée) fonctionne toujours

---
_Generated by [Claude Code](https://claude.ai/code/session_018BcWYKNghaoGpMQMSCgTaC)_