### PR TITLE
feat: saisie rapide souris dans les poules

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -139,6 +139,8 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const [competitionReferees, setCompetitionReferees] = useState<Referee[]>([]);
   const [isLoadingReferees, setIsLoadingReferees] = useState(false);
   const [assignedReferee, setAssignedReferee] = useState<Referee | null>(pool.referees?.[0] ?? null);
+  const [hoveredFencerIds, setHoveredFencerIds] = useState<Set<string>>(new Set());
+  const quickMouseScoring = localStorage.getItem('bellepoule-quick-mouse-scoring') === 'true';
 
   const defaultArena = (pool.strip != null && pool.strip > 0 ? pool.strip : pool.number) ?? 1;
 
@@ -425,6 +427,46 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     // Restaurer la victoire existante (ex: match déjà saisi par tirage au sort)
     setVictoryA(!inverted ? !!match.scoreA?.isVictory : !!match.scoreB?.isVictory);
     setVictoryB(!inverted ? !!match.scoreB?.isVictory : !!match.scoreA?.isVictory);
+  };
+
+  const handleHoverCell = (rowFencer: Fencer, colFencer: Fencer) => {
+    setHoveredFencerIds(new Set([rowFencer.id, colFencer.id]));
+  };
+
+  const handleHoverLeave = () => setHoveredFencerIds(new Set());
+
+  const handleWheelScore = (rowFencer: Fencer, colFencer: Fencer, shiftKey: boolean, delta: number) => {
+    if (isLocked) return;
+    const matchIndex = getMatchIndex(rowFencer, colFencer);
+    if (matchIndex === -1) return;
+    const match = pool.matches[matchIndex];
+    if (!match || match.status === MatchStatus.CANCELLED) return;
+    if (match.scoreA?.isAbstention || match.scoreA?.isExclusion || match.scoreA?.isForfait) return;
+
+    const inverted = match.fencerA?.id === colFencer.id;
+    const curA = match.scoreA?.value ?? 0;
+    const curB = match.scoreB?.value ?? 0;
+    let scoreLeft = inverted ? curB : curA;
+    let scoreRight = inverted ? curA : curB;
+
+    const effectiveMax = match.maxScore || maxScore || 5;
+    if (!shiftKey) {
+      scoreLeft = Math.max(0, Math.min(effectiveMax, scoreLeft + delta));
+    } else {
+      scoreRight = Math.max(0, Math.min(effectiveMax, scoreRight + delta));
+    }
+
+    const actualScoreA = inverted ? scoreRight : scoreLeft;
+    const actualScoreB = inverted ? scoreLeft : scoreRight;
+
+    if (actualScoreA === actualScoreB) {
+      if (isLaserSabre) {
+        openScoreModal(matchIndex, inverted);
+      }
+      return;
+    }
+
+    onScoreUpdate(matchIndex, actualScoreA, actualScoreB);
   };
 
   const handleCellClick = (rowFencer: Fencer, colFencer: Fencer) => {
@@ -1028,6 +1070,11 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           const matchIndex = getMatchIndex(rowFencer, colFencer);
           if (matchIndex !== -1) onMatchReset(matchIndex);
         } : undefined}
+        quickMouseScoring={quickMouseScoring}
+        highlightedFencerIds={hoveredFencerIds}
+        onHoverCell={quickMouseScoring ? handleHoverCell : undefined}
+        onHoverLeave={quickMouseScoring ? handleHoverLeave : undefined}
+        onWheelScore={quickMouseScoring ? handleWheelScore : undefined}
       />
       {orderedMatches.finished.length > 0 && (
         <div style={{ marginTop: '1rem' }}>

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -17,6 +17,7 @@ const LOGO_STORAGE_KEY = 'bellepoule-logo';
 const WEBHOOK_STORAGE_KEY = 'bellepoule-webhook-url';
 const AUDIT_LOG_KEY = 'bellepoule-audit-log-enabled';
 const TTS_CONFIG_KEY = 'bellepoule-tts-config';
+export const QUICK_MOUSE_KEY = 'bellepoule-quick-mouse-scoring';
 
 interface TtsConfig {
   voiceName: string | null;
@@ -124,6 +125,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
 
   const [auditLogEnabled, setAuditLogEnabled] = useState<boolean>(
     () => localStorage.getItem(AUDIT_LOG_KEY) === 'true'
+  );
+
+  const [quickMouseScoring, setQuickMouseScoring] = useState<boolean>(
+    () => localStorage.getItem(QUICK_MOUSE_KEY) === 'true'
   );
 
   const [webhookUrl, setWebhookUrl] = useState<string>(
@@ -292,6 +297,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
     localStorage.setItem(AUDIT_LOG_KEY, String(enabled));
   };
 
+  const handleQuickMouseScoringChange = (enabled: boolean) => {
+    setQuickMouseScoring(enabled);
+    localStorage.setItem(QUICK_MOUSE_KEY, String(enabled));
+  };
+
   const handleSave = () => {
     if (settings.language !== language) {
       changeLanguage(settings.language);
@@ -402,6 +412,24 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
             >
               {t('pdfTemplate.openButton')}
             </button>
+          </div>
+
+          {/* Saisie rapide souris */}
+          <div className="form-group" style={SECTION_DIVIDER}>
+            <label style={BOLD}>Saisie rapide souris</label>
+            <p style={HINT}>
+              Survol d'une cellule : met en évidence la cellule miroir et les noms.
+              Roulette : ±1 au score du tireur (ligne). Shift+roulette : score de l'adversaire (colonne).
+              Score nul en laser sabre → ouvre la modal de victoire.
+            </p>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={quickMouseScoring}
+                onChange={e => handleQuickMouseScoringChange(e.target.checked)}
+              />
+              <span style={{ fontSize: '0.875rem' }}>Activer la saisie rapide à la souris</span>
+            </label>
           </div>
 
           {/* Journal des scores */}

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -12,6 +12,11 @@ interface PoolScoreMatrixProps {
   onFencerChangePool?: (fencer: Fencer) => void;
   onMatchReset?: (rowFencer: Fencer, colFencer: Fencer) => void;
   isLocked?: boolean;
+  quickMouseScoring?: boolean;
+  highlightedFencerIds?: Set<string>;
+  onHoverCell?: (rowFencer: Fencer, colFencer: Fencer) => void;
+  onHoverLeave?: () => void;
+  onWheelScore?: (rowFencer: Fencer, colFencer: Fencer, shiftKey: boolean, delta: number) => void;
 }
 
 interface ScoreCellProps {
@@ -23,12 +28,18 @@ interface ScoreCellProps {
   isLocked: boolean;
   onCellClick: (rowFencer: Fencer, colFencer: Fencer) => void;
   onMatchReset?: (rowFencer: Fencer, colFencer: Fencer) => void;
+  isHighlighted?: boolean;
+  quickMouseScoring?: boolean;
+  onHoverIn?: () => void;
+  onHoverOut?: () => void;
+  onWheelScore?: (shiftKey: boolean, delta: number) => void;
 }
 
 // Cellule mémoïsée : seules les cellules dont le score/flash change re-rendent
 // (la grille est O(n²), un re-rendu global coûte cher sur les grandes poules).
 const ScoreCell = React.memo<ScoreCellProps>(
-  ({ rowFencer, colFencer, abandoned, score, isFlashing, isLocked, onCellClick, onMatchReset }) => {
+  ({ rowFencer, colFencer, abandoned, score, isFlashing, isLocked, onCellClick, onMatchReset,
+     isHighlighted, quickMouseScoring, onHoverIn, onHoverOut, onWheelScore }) => {
     if (abandoned) {
       return (
         <div
@@ -51,6 +62,10 @@ const ScoreCell = React.memo<ScoreCellProps>(
         : 'pool-cell-defeat'
       : 'pool-cell-editable';
 
+    const highlightStyle = isHighlighted
+      ? { outline: '2px solid rgba(59,130,246,0.55)', outlineOffset: '-2px', background: 'rgba(59,130,246,0.10)' }
+      : {};
+
     return (
       <div
         className={`pool-cell ${cellClass} ${isFlashing ? 'pool-cell-flash' : ''}`}
@@ -61,12 +76,20 @@ const ScoreCell = React.memo<ScoreCellProps>(
             onCellClick(rowFencer, colFencer);
           }
         }}
+        onMouseEnter={quickMouseScoring ? onHoverIn : undefined}
+        onMouseLeave={quickMouseScoring ? onHoverOut : undefined}
+        onWheel={quickMouseScoring && onWheelScore && !isLocked ? e => {
+          e.preventDefault();
+          e.stopPropagation();
+          const delta = e.deltaY > 0 ? -1 : 1;
+          onWheelScore(e.shiftKey, delta);
+        } : undefined}
         role="button"
         tabIndex={isLocked ? -1 : 0}
         aria-label={`${rowFencer.lastName} ${rowFencer.firstName} contre ${colFencer.lastName} ${colFencer.firstName}${
           score ? ` : ${score.isVictory ? 'victoire ' : 'défaite '}${score.value}` : ', saisir le score'
         }`}
-        style={{ cursor: isLocked ? 'default' : 'pointer', position: 'relative' }}
+        style={{ cursor: isLocked ? 'default' : 'pointer', position: 'relative', ...highlightStyle }}
       >
         {score ? (
           <>
@@ -123,6 +146,11 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
   onFencerChangePool,
   onMatchReset,
   isLocked = false,
+  quickMouseScoring = false,
+  highlightedFencerIds,
+  onHoverCell,
+  onHoverLeave,
+  onWheelScore,
 }) => {
   const fencers = pool.fencers;
   const [flashCell, setFlashCell] = useState<string | null>(null);
@@ -229,11 +257,18 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
     <div className="pool-grid">
       <div className="pool-row">
         <div className="pool-cell pool-cell-header pool-cell-name"></div>
-        {fencers.map((f, i) => (
-          <div key={f.id} className="pool-cell pool-cell-header">
-            {i + 1}
-          </div>
-        ))}
+        {fencers.map((f, i) => {
+          const colHighlighted = quickMouseScoring && !!highlightedFencerIds?.has(f.id);
+          return (
+            <div
+              key={f.id}
+              className="pool-cell pool-cell-header"
+              style={colHighlighted ? { background: 'rgba(59,130,246,0.15)', fontWeight: 700, color: 'var(--primary, #3b82f6)' } : undefined}
+            >
+              {i + 1}
+            </div>
+          );
+        })}
         {isVisible('victories') && (
           <div
             className="pool-cell pool-cell-header"
@@ -345,7 +380,12 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
             <div
               className="pool-cell pool-cell-header pool-cell-name"
               title={`${rowFencer.firstName} ${rowFencer.lastName}`}
-              style={{ display: 'flex', alignItems: 'center', gap: '0.375rem' }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '0.375rem',
+                ...(quickMouseScoring && highlightedFencerIds?.has(rowFencer.id)
+                  ? { background: 'rgba(59,130,246,0.12)', fontWeight: 700 }
+                  : {}),
+              }}
             >
               {(() => {
                 const avatarColor =
@@ -424,6 +464,10 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
               const cellKey = `${rowFencer.id}-${colFencer.id}`;
               const mirrorKey = `${colFencer.id}-${rowFencer.id}`;
 
+              const isHighlighted = quickMouseScoring
+                ? (!!highlightedFencerIds?.has(rowFencer.id) && !!highlightedFencerIds?.has(colFencer.id))
+                : false;
+
               return (
                 <ScoreCell
                   key={colFencer.id}
@@ -435,6 +479,11 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                   isLocked={isLocked}
                   onCellClick={onCellClick}
                   onMatchReset={onMatchReset}
+                  isHighlighted={isHighlighted}
+                  quickMouseScoring={quickMouseScoring}
+                  onHoverIn={onHoverCell ? () => onHoverCell(rowFencer, colFencer) : undefined}
+                  onHoverOut={onHoverLeave}
+                  onWheelScore={onWheelScore ? (shiftKey, delta) => onWheelScore(rowFencer, colFencer, shiftKey, delta) : undefined}
                 />
               );
             })}


### PR DESCRIPTION
## Résumé

- Option globale dans Paramètres : **Activer la saisie rapide à la souris**
- Survol d'une cellule → met en évidence la cellule miroir + noms (ligne et colonne en bleu)
- **Roulette** : ±1 au score du tireur de la ligne (fencerA du point de vue de la cellule)
- **Shift+roulette** : ±1 au score de l'adversaire (colonne)
- Score immédiatement enregistré sans ouvrir le modal
- Cellules abandon/forfait/exclusion ignorées
- Égalité laser sabre → ouvre automatiquement la modal de victoire

## Fichiers modifiés

- `src/renderer/components/SettingsModal.tsx` — section + clé localStorage `bellepoule-quick-mouse-scoring`
- `src/renderer/components/pool/PoolScoreMatrix.tsx` — highlight miroir, handlers hover/wheel
- `src/renderer/components/PoolView.tsx` — lecture du setting, handler wheel avec logique score

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLoGrBLJHhZGcNNR79BeQh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLoGrBLJHhZGcNNR79BeQh)_