### PR TITLE
feat: presets de taille de fenêtre pour l'affichage des poules

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1396,6 +1396,13 @@ ipcMain.handle('dialog:saveFile', async (_, options) => {
   return dialog.showSaveDialog(mainWindow!, options);
 });
 
+// Window resize handler
+ipcMain.handle('window:setSize', (_event, width: number, height: number) => {
+  if (mainWindow) {
+    mainWindow.setSize(Math.max(width, 800), Math.max(height, 600), true);
+  }
+});
+
 // Print handler
 ipcMain.handle('window:print', async () => {
   if (mainWindow) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -458,6 +458,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Utility functions
   print: () => ipcRenderer.invoke('window:print'),
+  setWindowSize: (width: number, height: number) => ipcRenderer.invoke('window:setSize', width, height),
   openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
   getVersionInfo: () => ipcRenderer.invoke('app:getVersionInfo'),
 

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -39,6 +39,7 @@ import { RefereeManagerComponent } from './RefereeManager';
 import CompetitionHeader from './competition/CompetitionHeader';
 import CompetitionNav from './competition/CompetitionNav';
 import GlobalPoolColumnsMenu from './pool/GlobalPoolColumnsMenu';
+import WindowSizePresets from './pool/WindowSizePresets';
 
 const PoolView = React.lazy(() => import('./PoolView'));
 const TableauView = React.lazy(() => import('./TableauView'));
@@ -1280,6 +1281,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                   }}
                 >
                   <GlobalPoolColumnsMenu isLaserSabre={isLaserSabre} />
+                  <WindowSizePresets />
                   {pools.length > 1 && (
                     <button className="btn btn-success" onClick={handleExportAllPoolsPDF}>
                       📄 Exporter toutes les poules en PDF

--- a/src/renderer/components/pool/WindowSizePresets.tsx
+++ b/src/renderer/components/pool/WindowSizePresets.tsx
@@ -1,0 +1,54 @@
+/**
+ * BellePoule Modern - Window Size Presets
+ * Boutons de redimensionnement de la fenêtre principale pour l'affichage des poules.
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'bellepoule-pool-window-size';
+
+const PRESETS = [
+  { label: 'Compact', width: 1024, height: 768 },
+  { label: 'Normal', width: 1400, height: 900 },
+  { label: 'Large', width: 1800, height: 1050 },
+  { label: 'XL', width: 2200, height: 1200 },
+] as const;
+
+type PresetLabel = (typeof PRESETS)[number]['label'];
+
+const WindowSizePresets: React.FC = () => {
+  const [active, setActive] = useState<PresetLabel>('Normal');
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY) as PresetLabel | null;
+    if (saved && PRESETS.some(p => p.label === saved)) {
+      setActive(saved);
+    }
+  }, []);
+
+  const apply = (preset: (typeof PRESETS)[number]) => {
+    setActive(preset.label);
+    localStorage.setItem(STORAGE_KEY, preset.label);
+    window.electronAPI?.setWindowSize(preset.width, preset.height);
+  };
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '0.375rem' }}>
+      <span style={{ fontSize: '0.75rem', color: '#6b7280', whiteSpace: 'nowrap' }}>Fenêtre :</span>
+      {PRESETS.map(preset => (
+        <button
+          key={preset.label}
+          className={`btn btn-sm ${active === preset.label ? 'btn-primary' : 'btn-secondary'}`}
+          onClick={() => apply(preset)}
+          title={`${preset.width}×${preset.height}`}
+          style={{ padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
+        >
+          {preset.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default WindowSizePresets;

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -774,6 +774,7 @@ export interface MenuAPI {
 
 export interface UtilityAPI {
   print: () => Promise<void>;
+  setWindowSize: (width: number, height: number) => Promise<void>;
   openExternal: (url: string) => Promise<void>;
   getVersionInfo: () => Promise<VersionInfo>;
   removeAllListeners: (channel: string) => void;


### PR DESCRIPTION
## Résumé

- Nouveau composant `WindowSizePresets` : 4 boutons (Compact 1024×768 / Normal 1400×900 / Large 1800×1050 / XL 2200×1200)
- Handler IPC `window:setSize` dans le process principal
- Persistance du preset choisi en `localStorage` (`bellepoule-pool-window-size`)
- Intégré dans la barre d'outils des poules, à côté du menu colonnes

## Test

- [ ] Ouvrir une compétition avec des poules
- [ ] Cliquer sur chaque preset → la fenêtre se redimensionne
- [ ] Fermer/rouvrir → le dernier preset est mémorisé (actif visuellement, mais resize ne se re-applique pas au démarrage — à valider si souhaité)

---
_Generated by [Claude Code](https://claude.ai/code/session_016fGWr6oMgLBkDri4wCXv1x)_