### PR TITLE
Verrouille le genre du tireur selon le genre de la compétition

### DIFF
--- a/src/renderer/components/AddFencerModal.tsx
+++ b/src/renderer/components/AddFencerModal.tsx
@@ -13,9 +13,10 @@ import { useTranslation } from '../contexts/TranslationContext';
 interface AddFencerModalProps {
   onClose: () => void;
   onAdd: (fencer: Partial<Fencer>) => void;
+  competitionGender?: Gender;
 }
 
-const AddFencerModalComponent: React.FC<AddFencerModalProps> = ({ onClose, onAdd }) => {
+const AddFencerModalComponent: React.FC<AddFencerModalProps> = ({ onClose, onAdd, competitionGender }) => {
   const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
   const { showToast } = useToast();
   const { t } = useTranslation();
@@ -25,7 +26,8 @@ const AddFencerModalComponent: React.FC<AddFencerModalProps> = ({ onClose, onAdd
   const [region, setRegion] = useState('');
   const [license, setLicense] = useState('');
   const [ranking, setRanking] = useState('');
-  const [gender, setGender] = useState<Gender>(Gender.MALE);
+  const lockedGender = competitionGender === Gender.MALE || competitionGender === Gender.FEMALE ? competitionGender : null;
+  const [gender, setGender] = useState<Gender>(lockedGender ?? Gender.MALE);
   const [nationality, setNationality] = useState('FRA');
   const [photo, setPhoto] = useState<string | undefined>();
 
@@ -108,14 +110,24 @@ const AddFencerModalComponent: React.FC<AddFencerModalProps> = ({ onClose, onAdd
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
               <div className="form-group">
                 <label className="form-label">{t('fencer.gender')}</label>
-                <select
-                  className="form-input form-select"
-                  value={gender}
-                  onChange={e => setGender(e.target.value as Gender)}
-                >
-                  <option value={Gender.MALE}>{t('genders.male')}</option>
-                  <option value={Gender.FEMALE}>{t('genders.female')}</option>
-                </select>
+                {lockedGender ? (
+                  <input
+                    type="text"
+                    className="form-input"
+                    value={lockedGender === Gender.MALE ? t('genders.male') : t('genders.female')}
+                    readOnly
+                    style={{ background: 'var(--bg-secondary, #f5f5f5)', cursor: 'not-allowed' }}
+                  />
+                ) : (
+                  <select
+                    className="form-input form-select"
+                    value={gender}
+                    onChange={e => setGender(e.target.value as Gender)}
+                  >
+                    <option value={Gender.MALE}>{t('genders.male')}</option>
+                    <option value={Gender.FEMALE}>{t('genders.female')}</option>
+                  </select>
+                )}
               </div>
               <div className="form-group">
                 <label className="form-label">{t('fencer.nationality')}</label>

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -1612,6 +1612,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         <AddFencerModal
           onClose={() => setShowAddFencerModal(false)}
           onAdd={fencer => addFencer(fencer as any)}
+          competitionGender={competition.gender}
         />
       )}
 


### PR DESCRIPTION
## Résumé

- `AddFencerModal` accepte un prop `competitionGender`
- Si compétition H ou F → champ genre verrouillé (lecture seule), valeur forcée
- Si compétition mixte → comportement inchangé (sélecteur H/F libre)
- `CompetitionView` passe `competition.gender` au modal

## Test

1. Créer compétition féminine → ajouter tireur → champ genre = "Femme" grisé
2. Créer compétition masculine → idem forcé "Homme"
3. Compétition mixte → sélecteur normal

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bxv5mkr2S5D7kbahWt1H5)_