### PR TITLE
feat: boutons Annuler / Enregistrer / Enregistrer et ajouter dans AddFencerModal

### DIFF
--- a/src/renderer/components/AddFencerModal.tsx
+++ b/src/renderer/components/AddFencerModal.tsx
@@ -29,27 +29,49 @@ const AddFencerModalComponent: React.FC<AddFencerModalProps> = ({ onClose, onAdd
   const [nationality, setNationality] = useState('FRA');
   const [photo, setPhoto] = useState<string | undefined>();
 
+  const buildFencer = (): Partial<Fencer> => ({
+    lastName: lastName.trim().toUpperCase(),
+    firstName: firstName.trim(),
+    club: club.trim() || undefined,
+    region: region.trim() || undefined,
+    license: license.trim() || undefined,
+    ranking: ranking ? parseInt(ranking, 10) : undefined,
+    gender,
+    nationality,
+    status: FencerStatus.NOT_CHECKED_IN,
+    photo,
+  });
+
+  const resetForm = () => {
+    setLastName('');
+    setFirstName('');
+    setClub('');
+    setRegion('');
+    setLicense('');
+    setRanking('');
+    setGender(Gender.MALE);
+    setNationality('FRA');
+    setPhoto(undefined);
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-
     if (!lastName.trim() || !firstName.trim()) {
       showToast(t('messages.name_required'), 'warning');
       return;
     }
-
-    onAdd({
-      lastName: lastName.trim().toUpperCase(),
-      firstName: firstName.trim(),
-      club: club.trim() || undefined,
-      region: region.trim() || undefined,
-      license: license.trim() || undefined,
-      ranking: ranking ? parseInt(ranking, 10) : undefined,
-      gender,
-      nationality,
-      status: FencerStatus.NOT_CHECKED_IN,
-      photo,
-    });
+    onAdd(buildFencer());
     onClose();
+  };
+
+  const handleSaveAndAdd = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!lastName.trim() || !firstName.trim()) {
+      showToast(t('messages.name_required'), 'warning');
+      return;
+    }
+    onAdd(buildFencer());
+    resetForm();
   };
 
   return (
@@ -181,8 +203,11 @@ const AddFencerModalComponent: React.FC<AddFencerModalProps> = ({ onClose, onAdd
             <button type="button" className="btn btn-secondary" onClick={onClose}>
               {t('actions.cancel')}
             </button>
+            <button type="button" className="btn btn-secondary" onClick={handleSaveAndAdd}>
+              {t('actions.save_and_add')}
+            </button>
             <button type="submit" className="btn btn-primary">
-              {t('fencer.add')}
+              {t('actions.save')}
             </button>
           </div>
         </form>

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "app": {
     "title": "BellePoule Modern",
     "home": "Broadel",
@@ -209,7 +209,8 @@
     "check_in_all": "Boukañ pep tra",
     "uncheck_all": "Digoumanañ pep tra",
     "view": "Gwelet",
-    "default": "N'eus ket"
+    "default": "N'eus ket",
+    "save_and_add": "Enrollañ ha ouzhpennañ"
   },
   "messages": {
     "confirm_delete_fencer": "TODO(br): révision par un locuteur natif breton requise — Ha sur oc'h evid ? Fell eo an dilemelañ ar c'hoarzh ? An den dra zo diwezheg. VEOUS anv raoud bezañ.",

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "app": {
     "title": "BellePoule Modern",
     "home": "General",
@@ -209,7 +209,8 @@
     "check_in_all": "Registrar Tots",
     "uncheck_all": "Cancel·lar Tots",
     "view": "Veure",
-    "default": "No especificat"
+    "default": "No especificat",
+    "save_and_add": "Desar i afegir"
   },
   "messages": {
     "confirm_delete_fencer": "Esteu segur que voleu eliminar aquest tirador? Aquesta acció és irreversible.",

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -25,7 +25,8 @@
     "uncheck_all": "Alle Austragen",
     "validate": "Validieren",
     "view": "Anzeigen",
-    "yes": "Ja"
+    "yes": "Ja",
+    "save_and_add": "Speichern und hinzufügen"
   },
   "app": {
     "back_to_list": "Zurück zur Wettbewerbliste",

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -209,7 +209,8 @@
     "check_in_all": "Check in all",
     "uncheck_all": "Uncheck all",
     "view": "View",
-    "default": "Not specified"
+    "default": "Not specified",
+    "save_and_add": "Save and add"
   },
   "messages": {
     "confirm_delete_fencer": "Are you sure you want to delete this fencer? This action is irreversible.",

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "app": {
     "title": "BellePoule Modern",
     "home": "General",
@@ -209,7 +209,8 @@
     "check_in_all": "Registrar Todos",
     "uncheck_all": "Cancelar Todos",
     "view": "Ver",
-    "default": "No Especificado"
+    "default": "No Especificado",
+    "save_and_add": "Guardar y añadir"
   },
   "messages": {
     "confirm_delete_fencer": "¿Está seguro de que desea eliminar a este esgrimista? Esta acción es irreversible.",

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -209,7 +209,8 @@
     "check_in_all": "Tout pointer",
     "uncheck_all": "Tout dépointer",
     "view": "Voir",
-    "default": "Non spécifié"
+    "default": "Non spécifié",
+    "save_and_add": "Enregistrer et ajouter"
   },
   "messages": {
     "confirm_delete_fencer": "Êtes-vous sûr de vouloir supprimer ce tireur ? Cette action est irréversible.",

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "app": {
     "title": "BellePoule Modern",
     "home": "主頁",
@@ -209,7 +209,8 @@
     "check_in_all": "全部報到",
     "uncheck_all": "全部取消報到",
     "view": "查看",
-    "default": "未指定"
+    "default": "未指定",
+    "save_and_add": "儲存並新增"
   },
   "messages": {
     "confirm_delete_fencer": "確定要刪除此劍手嗎？此操作不可復原。",


### PR DESCRIPTION
## Changements\n\n- Remplace le bouton unique « Ajouter » par 3 boutons : **Annuler** / **Enregistrer et ajouter** / **Enregistrer**\n- « Enregistrer et ajouter » : sauvegarde le tireur et remet le formulaire à zéro pour en saisir un autre immédiatement\n- « Enregistrer » : sauvegarde et ferme la modale (comportement précédent)\n- Clé `actions.save_and_add` ajoutée dans les 7 locales (fr, en, de, es, br, ca, zh-HK)\n\nTravail terminé — valider et clore si OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjnmxEkVD8P8BcB2sEf736)_