### PR TITLE
feat: mode de saisie simplifiée dans les cases de poule

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -141,6 +141,10 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const [assignedReferee, setAssignedReferee] = useState<Referee | null>(pool.referees?.[0] ?? null);
   const [hoveredFencerIds, setHoveredFencerIds] = useState<Set<string>>(new Set());
   const quickMouseScoring = localStorage.getItem('bellepoule-quick-mouse-scoring') === 'true';
+  const simplifiedInputMode = localStorage.getItem('bellepoule-simplified-input-mode') === 'true';
+  const [inlineEditCell, setInlineEditCell] = useState<{ key: string; matchIndex: number; inverted: boolean } | null>(null);
+  const [inlineScoreLeft, setInlineScoreLeft] = useState('');
+  const [inlineScoreRight, setInlineScoreRight] = useState('');
 
   const defaultArena = (pool.strip != null && pool.strip > 0 ? pool.strip : pool.number) ?? 1;
 
@@ -475,9 +479,51 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     const matchIndex = getMatchIndex(rowFencer, colFencer);
     if (matchIndex === -1) return;
     const match = pool.matches[matchIndex];
-    // Inversion si le tireur de la ligne est fencerB (pour l'afficher à gauche)
     const inverted = match.fencerA?.id === colFencer.id;
+    if (simplifiedInputMode) {
+      const key = `${rowFencer.id}-${colFencer.id}`;
+      const curA = match.scoreA?.value ?? 0;
+      const curB = match.scoreB?.value ?? 0;
+      setInlineEditCell({ key, matchIndex, inverted });
+      setInlineScoreLeft(String(inverted ? curB : curA));
+      setInlineScoreRight(String(inverted ? curA : curB));
+      return;
+    }
     openScoreModal(matchIndex, inverted);
+  };
+
+  const handleInlineSubmit = () => {
+    if (!inlineEditCell) return;
+    const { matchIndex, inverted } = inlineEditCell;
+    const scoreLeft = parseInt(inlineScoreLeft, 10);
+    const scoreRight = parseInt(inlineScoreRight, 10);
+    if (isNaN(scoreLeft) || isNaN(scoreRight)) return;
+    const effectiveMax = pool.matches[matchIndex]?.maxScore || maxScore || 0;
+    if (effectiveMax > 0 && (scoreLeft > effectiveMax || scoreRight > effectiveMax)) {
+      showToast(`Score maximum : ${effectiveMax}`, 'error');
+      return;
+    }
+    const actualScoreA = inverted ? scoreRight : scoreLeft;
+    const actualScoreB = inverted ? scoreLeft : scoreRight;
+    if (actualScoreA === actualScoreB) {
+      if (isLaserSabre) {
+        setInlineEditCell(null);
+        openScoreModal(matchIndex, inverted);
+      } else {
+        showToast("Match nul impossible ! En match en direct, la mort subite de 30s s'applique automatiquement", 'error');
+      }
+      return;
+    }
+    onScoreUpdate(matchIndex, actualScoreA, actualScoreB);
+    setInlineEditCell(null);
+    setInlineScoreLeft('');
+    setInlineScoreRight('');
+  };
+
+  const handleInlineCancel = () => {
+    setInlineEditCell(null);
+    setInlineScoreLeft('');
+    setInlineScoreRight('');
   };
 
   const handleScoreSubmit = () => {
@@ -1075,6 +1121,13 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         onHoverCell={quickMouseScoring ? handleHoverCell : undefined}
         onHoverLeave={quickMouseScoring ? handleHoverLeave : undefined}
         onWheelScore={quickMouseScoring ? handleWheelScore : undefined}
+        simplifiedInputMode={simplifiedInputMode}
+        inlineEditKey={inlineEditCell?.key ?? null}
+        inlineScoreLeft={inlineScoreLeft}
+        inlineScoreRight={inlineScoreRight}
+        onInlineScoreChange={(left, right) => { setInlineScoreLeft(left); setInlineScoreRight(right); }}
+        onInlineSubmit={handleInlineSubmit}
+        onInlineCancel={handleInlineCancel}
       />
       {orderedMatches.finished.length > 0 && (
         <div style={{ marginTop: '1rem' }}>

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -18,6 +18,7 @@ const WEBHOOK_STORAGE_KEY = 'bellepoule-webhook-url';
 const AUDIT_LOG_KEY = 'bellepoule-audit-log-enabled';
 const TTS_CONFIG_KEY = 'bellepoule-tts-config';
 export const QUICK_MOUSE_KEY = 'bellepoule-quick-mouse-scoring';
+export const SIMPLIFIED_INPUT_KEY = 'bellepoule-simplified-input-mode';
 
 interface TtsConfig {
   voiceName: string | null;
@@ -129,6 +130,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
 
   const [quickMouseScoring, setQuickMouseScoring] = useState<boolean>(
     () => localStorage.getItem(QUICK_MOUSE_KEY) === 'true'
+  );
+
+  const [simplifiedInputMode, setSimplifiedInputMode] = useState<boolean>(
+    () => localStorage.getItem(SIMPLIFIED_INPUT_KEY) === 'true'
   );
 
   const [webhookUrl, setWebhookUrl] = useState<string>(
@@ -302,6 +307,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
     localStorage.setItem(QUICK_MOUSE_KEY, String(enabled));
   };
 
+  const handleSimplifiedInputModeChange = (enabled: boolean) => {
+    setSimplifiedInputMode(enabled);
+    localStorage.setItem(SIMPLIFIED_INPUT_KEY, String(enabled));
+  };
+
   const handleSave = () => {
     if (settings.language !== language) {
       changeLanguage(settings.language);
@@ -429,6 +439,23 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
                 onChange={e => handleQuickMouseScoringChange(e.target.checked)}
               />
               <span style={{ fontSize: '0.875rem' }}>Activer la saisie rapide à la souris</span>
+            </label>
+          </div>
+
+          {/* Mode de saisie simplifiée */}
+          <div className="form-group" style={SECTION_DIVIDER}>
+            <label style={BOLD}>Mode de saisie simplifiée</label>
+            <p style={HINT}>
+              Clic sur une cellule de poule : saisie directe des scores dans la case, sans ouverture de modal.
+              Score nul en laser sabre → ouvre tout de même la modal de victoire.
+            </p>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={simplifiedInputMode}
+                onChange={e => handleSimplifiedInputModeChange(e.target.checked)}
+              />
+              <span style={{ fontSize: '0.875rem' }}>Activer la saisie simplifiée dans les cases</span>
             </label>
           </div>
 

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -17,6 +17,13 @@ interface PoolScoreMatrixProps {
   onHoverCell?: (rowFencer: Fencer, colFencer: Fencer) => void;
   onHoverLeave?: () => void;
   onWheelScore?: (rowFencer: Fencer, colFencer: Fencer, shiftKey: boolean, delta: number) => void;
+  simplifiedInputMode?: boolean;
+  inlineEditKey?: string | null;
+  inlineScoreLeft?: string;
+  inlineScoreRight?: string;
+  onInlineScoreChange?: (left: string, right: string) => void;
+  onInlineSubmit?: () => void;
+  onInlineCancel?: () => void;
 }
 
 interface ScoreCellProps {
@@ -33,13 +40,26 @@ interface ScoreCellProps {
   onHoverIn?: () => void;
   onHoverOut?: () => void;
   onWheelScore?: (shiftKey: boolean, delta: number) => void;
+  isInlineEditing?: boolean;
+  inlineScoreLeft?: string;
+  inlineScoreRight?: string;
+  onInlineScoreChange?: (left: string, right: string) => void;
+  onInlineSubmit?: () => void;
+  onInlineCancel?: () => void;
 }
 
 // Cellule mémoïsée : seules les cellules dont le score/flash change re-rendent
 // (la grille est O(n²), un re-rendu global coûte cher sur les grandes poules).
 const ScoreCell = React.memo<ScoreCellProps>(
   ({ rowFencer, colFencer, abandoned, score, isFlashing, isLocked, onCellClick, onMatchReset,
-     isHighlighted, quickMouseScoring, onHoverIn, onHoverOut, onWheelScore }) => {
+     isHighlighted, quickMouseScoring, onHoverIn, onHoverOut, onWheelScore,
+     isInlineEditing, inlineScoreLeft, inlineScoreRight, onInlineScoreChange, onInlineSubmit, onInlineCancel }) => {
+    const leftInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+      if (isInlineEditing) leftInputRef.current?.focus();
+    }, [isInlineEditing]);
+
     if (abandoned) {
       return (
         <div
@@ -65,6 +85,57 @@ const ScoreCell = React.memo<ScoreCellProps>(
     const highlightStyle = isHighlighted
       ? { outline: '2px solid rgba(59,130,246,0.55)', outlineOffset: '-2px', background: 'rgba(59,130,246,0.10)' }
       : {};
+
+    const inlineInputStyle: React.CSSProperties = {
+      width: '26px',
+      textAlign: 'center',
+      fontSize: '0.7rem',
+      padding: '1px 2px',
+      border: '1px solid #3b82f6',
+      borderRadius: '2px',
+      outline: 'none',
+      background: 'white',
+      color: '#111',
+      MozAppearance: 'textfield',
+    };
+
+    if (isInlineEditing) {
+      return (
+        <div
+          className={`pool-cell pool-cell-editable pool-cell-inline-editing`}
+          style={{ cursor: 'default', position: 'relative', padding: '2px', background: 'rgba(59,130,246,0.08)', outline: '2px solid #3b82f6', outlineOffset: '-2px' }}
+          onClick={e => e.stopPropagation()}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
+            <input
+              ref={leftInputRef}
+              type="number"
+              min={0}
+              value={inlineScoreLeft ?? ''}
+              onChange={e => onInlineScoreChange?.(e.target.value, inlineScoreRight ?? '')}
+              onKeyDown={e => {
+                if (e.key === 'Enter') { e.preventDefault(); onInlineSubmit?.(); }
+                if (e.key === 'Escape') { e.preventDefault(); onInlineCancel?.(); }
+              }}
+              style={inlineInputStyle}
+            />
+            <span style={{ fontSize: '0.6rem', color: '#6b7280' }}>:</span>
+            <input
+              type="number"
+              min={0}
+              value={inlineScoreRight ?? ''}
+              onChange={e => onInlineScoreChange?.(inlineScoreLeft ?? '', e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') { e.preventDefault(); onInlineSubmit?.(); }
+                if (e.key === 'Escape') { e.preventDefault(); onInlineCancel?.(); }
+                if (e.key === 'Tab') { e.preventDefault(); onInlineSubmit?.(); }
+              }}
+              style={inlineInputStyle}
+            />
+          </div>
+        </div>
+      );
+    }
 
     return (
       <div
@@ -151,6 +222,13 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
   onHoverCell,
   onHoverLeave,
   onWheelScore,
+  simplifiedInputMode = false,
+  inlineEditKey,
+  inlineScoreLeft,
+  inlineScoreRight,
+  onInlineScoreChange,
+  onInlineSubmit,
+  onInlineCancel,
 }) => {
   const fencers = pool.fencers;
   const [flashCell, setFlashCell] = useState<string | null>(null);
@@ -484,6 +562,12 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                   onHoverIn={onHoverCell ? () => onHoverCell(rowFencer, colFencer) : undefined}
                   onHoverOut={onHoverLeave}
                   onWheelScore={onWheelScore ? (shiftKey, delta) => onWheelScore(rowFencer, colFencer, shiftKey, delta) : undefined}
+                  isInlineEditing={simplifiedInputMode && inlineEditKey === cellKey}
+                  inlineScoreLeft={inlineScoreLeft}
+                  inlineScoreRight={inlineScoreRight}
+                  onInlineScoreChange={onInlineScoreChange}
+                  onInlineSubmit={onInlineSubmit}
+                  onInlineCancel={onInlineCancel}
                 />
               );
             })}


### PR DESCRIPTION
## Résumé

- Nouvelle option **"Mode de saisie simplifiée"** dans SettingsModal, à côté de "Saisie rapide souris"
- Quand activée : clic sur une case de poule → deux inputs inline directement dans la cellule (pas de modal)
- Quand désactivée : comportement normal (ouverture de la modal habituelle)
- Score nul en laser sabre → repli automatique sur la modal de victoire pour désigner le vainqueur
- Entrée validée par `Enter` ou `Tab` (deuxième champ), annulée par `Escape`

## Fichiers modifiés

- `SettingsModal.tsx` — ajout constante `SIMPLIFIED_INPUT_KEY`, état, handler et bloc UI
- `PoolScoreMatrix.tsx` — nouveaux props inline edit sur `ScoreCell` et `PoolScoreMatrix`, rendu conditionnel des inputs
- `PoolView.tsx` — lecture du setting, états `inlineEditCell`/`inlineScoreLeft`/`inlineScoreRight`, handlers `handleInlineSubmit`/`handleInlineCancel`, branchement dans `handleCellClick`

## Test

- [ ] Activer l'option dans Paramètres → clic cellule → inputs inline apparaissent
- [ ] Saisir 5 et 3, Enter → score soumis, cellule mise à jour
- [ ] Escape → annulation, retour état précédent
- [ ] Désactiver → modal s'ouvre normalement
- [ ] Laser sabre score nul → modal de victoire s'ouvre

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoPc8u9VqHh449Xnaae2xk

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoPc8u9VqHh449Xnaae2xk)_