### PR TITLE
Saisie rapide cellule par cellule + fix "Sabre Laser"

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -142,9 +142,9 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   const [hoveredFencerIds, setHoveredFencerIds] = useState<Set<string>>(new Set());
   const quickMouseScoring = localStorage.getItem('bellepoule-quick-mouse-scoring') === 'true';
   const simplifiedInputMode = localStorage.getItem('bellepoule-simplified-input-mode') === 'true';
-  const [inlineEditCell, setInlineEditCell] = useState<{ key: string; matchIndex: number; inverted: boolean } | null>(null);
-  const [inlineScoreLeft, setInlineScoreLeft] = useState('');
-  const [inlineScoreRight, setInlineScoreRight] = useState('');
+  const [inlineEditCell, setInlineEditCell] = useState<{ key: string; rowId: string; colId: string; matchIndex: number; inverted: boolean } | null>(null);
+  const [inlineSingleScore, setInlineSingleScore] = useState('');
+  const [cellScoreBuffer, setCellScoreBuffer] = useState<Record<string, number>>({});
 
   const defaultArena = (pool.strip != null && pool.strip > 0 ? pool.strip : pool.number) ?? 1;
 
@@ -473,6 +473,39 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     onScoreUpdate(matchIndex, actualScoreA, actualScoreB);
   };
 
+  const getOrderedCells = () => {
+    const cells: Array<{ rowFencer: Fencer; colFencer: Fencer; key: string; matchIndex: number; inverted: boolean }> = [];
+    for (const rowFencer of fencers) {
+      for (const colFencer of fencers) {
+        if (rowFencer.id === colFencer.id) continue;
+        const isAbandoned =
+          rowFencer.status === FencerStatus.ABANDONED || rowFencer.status === FencerStatus.FORFAIT || rowFencer.status === FencerStatus.EXCLUDED ||
+          colFencer.status === FencerStatus.ABANDONED || colFencer.status === FencerStatus.FORFAIT || colFencer.status === FencerStatus.EXCLUDED;
+        if (isAbandoned) continue;
+        const matchIndex = getMatchIndex(rowFencer, colFencer);
+        if (matchIndex === -1) continue;
+        const match = pool.matches[matchIndex];
+        if (match.status === MatchStatus.FINISHED || match.status === MatchStatus.CANCELLED) continue;
+        const inverted = match.fencerA?.id === colFencer.id;
+        cells.push({ rowFencer, colFencer, key: `${rowFencer.id}-${colFencer.id}`, matchIndex, inverted });
+      }
+    }
+    return cells;
+  };
+
+  const openNextCell = (currentKey: string, skipKeys: Set<string>, buffer: Record<string, number>) => {
+    const cells = getOrderedCells().filter(c => !skipKeys.has(c.key));
+    const currentIndex = cells.findIndex(c => c.key === currentKey);
+    const next = currentIndex === -1 ? cells[0] : cells[currentIndex + 1];
+    if (!next) {
+      setInlineEditCell(null);
+      setInlineSingleScore('');
+      return;
+    }
+    setInlineEditCell({ key: next.key, rowId: next.rowFencer.id, colId: next.colFencer.id, matchIndex: next.matchIndex, inverted: next.inverted });
+    setInlineSingleScore(buffer[next.key] !== undefined ? String(buffer[next.key]) : '');
+  };
+
   const handleCellClick = (rowFencer: Fencer, colFencer: Fencer) => {
     if (isLocked) return;
     if (rowFencer.id === colFencer.id) return;
@@ -482,11 +515,8 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     const inverted = match.fencerA?.id === colFencer.id;
     if (simplifiedInputMode) {
       const key = `${rowFencer.id}-${colFencer.id}`;
-      const curA = match.scoreA?.value ?? 0;
-      const curB = match.scoreB?.value ?? 0;
-      setInlineEditCell({ key, matchIndex, inverted });
-      setInlineScoreLeft(String(inverted ? curB : curA));
-      setInlineScoreRight(String(inverted ? curA : curB));
+      setInlineEditCell({ key, rowId: rowFencer.id, colId: colFencer.id, matchIndex, inverted });
+      setInlineSingleScore(cellScoreBuffer[key] !== undefined ? String(cellScoreBuffer[key]) : '');
       return;
     }
     openScoreModal(matchIndex, inverted);
@@ -494,36 +524,45 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
 
   const handleInlineSubmit = () => {
     if (!inlineEditCell) return;
-    const { matchIndex, inverted } = inlineEditCell;
-    const scoreLeft = parseInt(inlineScoreLeft, 10);
-    const scoreRight = parseInt(inlineScoreRight, 10);
-    if (isNaN(scoreLeft) || isNaN(scoreRight)) return;
-    const effectiveMax = pool.matches[matchIndex]?.maxScore || maxScore || 0;
-    if (effectiveMax > 0 && (scoreLeft > effectiveMax || scoreRight > effectiveMax)) {
-      showToast(`Score maximum : ${effectiveMax}`, 'error');
+    const { key, rowId, colId, matchIndex, inverted } = inlineEditCell;
+    const score = parseInt(inlineSingleScore, 10);
+
+    if (isNaN(score) || score < 0) {
+      openNextCell(key, new Set(), cellScoreBuffer);
       return;
     }
-    const actualScoreA = inverted ? scoreRight : scoreLeft;
-    const actualScoreB = inverted ? scoreLeft : scoreRight;
-    if (actualScoreA === actualScoreB) {
-      if (isLaserSabre) {
-        setInlineEditCell(null);
-        openScoreModal(matchIndex, inverted);
-      } else {
-        showToast("Match nul impossible ! En match en direct, la mort subite de 30s s'applique automatiquement", 'error');
+
+    const mirrorKey = `${colId}-${rowId}`;
+    const newBuffer = { ...cellScoreBuffer, [key]: score };
+
+    if (newBuffer[mirrorKey] !== undefined) {
+      const mirrorScore = newBuffer[mirrorKey];
+      const actualScoreA = inverted ? mirrorScore : score;
+      const actualScoreB = inverted ? score : mirrorScore;
+
+      const effectiveMax = pool.matches[matchIndex]?.maxScore || maxScore || 0;
+      if (effectiveMax > 0 && (actualScoreA > effectiveMax || actualScoreB > effectiveMax)) {
+        showToast(`Score maximum : ${effectiveMax}`, 'error');
+        return;
       }
-      return;
+      if (actualScoreA === actualScoreB && !isLaserSabre) {
+        showToast("Match nul impossible !", 'error');
+        return;
+      }
+
+      const { [key]: _a, [mirrorKey]: _b, ...restBuffer } = newBuffer;
+      setCellScoreBuffer(restBuffer);
+      onScoreUpdate(matchIndex, actualScoreA, actualScoreB);
+      openNextCell(key, new Set([key, mirrorKey]), restBuffer);
+    } else {
+      setCellScoreBuffer(newBuffer);
+      openNextCell(key, new Set(), newBuffer);
     }
-    onScoreUpdate(matchIndex, actualScoreA, actualScoreB);
-    setInlineEditCell(null);
-    setInlineScoreLeft('');
-    setInlineScoreRight('');
   };
 
   const handleInlineCancel = () => {
     setInlineEditCell(null);
-    setInlineScoreLeft('');
-    setInlineScoreRight('');
+    setInlineSingleScore('');
   };
 
   const handleScoreSubmit = () => {
@@ -1124,9 +1163,9 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         onWheelScore={quickMouseScoring ? handleWheelScore : undefined}
         simplifiedInputMode={simplifiedInputMode}
         inlineEditKey={inlineEditCell?.key ?? null}
-        inlineScoreLeft={inlineScoreLeft}
-        inlineScoreRight={inlineScoreRight}
-        onInlineScoreChange={(left, right) => { setInlineScoreLeft(left); setInlineScoreRight(right); }}
+        inlineSingleScore={inlineSingleScore}
+        cellScoreBuffer={cellScoreBuffer}
+        onInlineSingleScoreChange={setInlineSingleScore}
         onInlineSubmit={handleInlineSubmit}
         onInlineCancel={handleInlineCancel}
       />

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -19,9 +19,9 @@ interface PoolScoreMatrixProps {
   onWheelScore?: (rowFencer: Fencer, colFencer: Fencer, shiftKey: boolean, delta: number) => void;
   simplifiedInputMode?: boolean;
   inlineEditKey?: string | null;
-  inlineScoreLeft?: string;
-  inlineScoreRight?: string;
-  onInlineScoreChange?: (left: string, right: string) => void;
+  inlineSingleScore?: string;
+  cellScoreBuffer?: Record<string, number>;
+  onInlineSingleScoreChange?: (value: string) => void;
   onInlineSubmit?: () => void;
   onInlineCancel?: () => void;
 }
@@ -41,9 +41,9 @@ interface ScoreCellProps {
   onHoverOut?: () => void;
   onWheelScore?: (shiftKey: boolean, delta: number) => void;
   isInlineEditing?: boolean;
-  inlineScoreLeft?: string;
-  inlineScoreRight?: string;
-  onInlineScoreChange?: (left: string, right: string) => void;
+  inlineSingleScore?: string;
+  bufferedScore?: number;
+  onInlineSingleScoreChange?: (value: string) => void;
   onInlineSubmit?: () => void;
   onInlineCancel?: () => void;
 }
@@ -53,11 +53,14 @@ interface ScoreCellProps {
 const ScoreCell = React.memo<ScoreCellProps>(
   ({ rowFencer, colFencer, abandoned, score, isFlashing, isLocked, onCellClick, onMatchReset,
      isHighlighted, quickMouseScoring, onHoverIn, onHoverOut, onWheelScore,
-     isInlineEditing, inlineScoreLeft, inlineScoreRight, onInlineScoreChange, onInlineSubmit, onInlineCancel }) => {
-    const leftInputRef = useRef<HTMLInputElement>(null);
+     isInlineEditing, inlineSingleScore, bufferedScore, onInlineSingleScoreChange, onInlineSubmit, onInlineCancel }) => {
+    const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
-      if (isInlineEditing) leftInputRef.current?.focus();
+      if (isInlineEditing) {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
     }, [isInlineEditing]);
 
     if (abandoned) {
@@ -106,33 +109,18 @@ const ScoreCell = React.memo<ScoreCellProps>(
           style={{ cursor: 'default', position: 'relative', padding: '2px', background: 'rgba(59,130,246,0.08)', outline: '2px solid #3b82f6', outlineOffset: '-2px' }}
           onClick={e => e.stopPropagation()}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
-            <input
-              ref={leftInputRef}
-              type="number"
-              min={0}
-              value={inlineScoreLeft ?? ''}
-              onChange={e => onInlineScoreChange?.(e.target.value, inlineScoreRight ?? '')}
-              onKeyDown={e => {
-                if (e.key === 'Enter') { e.preventDefault(); onInlineSubmit?.(); }
-                if (e.key === 'Escape') { e.preventDefault(); onInlineCancel?.(); }
-              }}
-              style={inlineInputStyle}
-            />
-            <span style={{ fontSize: '0.6rem', color: '#6b7280' }}>:</span>
-            <input
-              type="number"
-              min={0}
-              value={inlineScoreRight ?? ''}
-              onChange={e => onInlineScoreChange?.(inlineScoreLeft ?? '', e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') { e.preventDefault(); onInlineSubmit?.(); }
-                if (e.key === 'Escape') { e.preventDefault(); onInlineCancel?.(); }
-                if (e.key === 'Tab') { e.preventDefault(); onInlineSubmit?.(); }
-              }}
-              style={inlineInputStyle}
-            />
-          </div>
+          <input
+            ref={inputRef}
+            type="number"
+            min={0}
+            value={inlineSingleScore ?? ''}
+            onChange={e => onInlineSingleScoreChange?.(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); onInlineSubmit?.(); }
+              if (e.key === 'Escape') { e.preventDefault(); onInlineCancel?.(); }
+            }}
+            style={{ ...inlineInputStyle, width: '36px', fontSize: '0.85rem' }}
+          />
         </div>
       );
     }
@@ -199,6 +187,8 @@ const ScoreCell = React.memo<ScoreCellProps>(
               </button>
             )}
           </>
+        ) : bufferedScore !== undefined ? (
+          <span style={{ color: '#3b82f6', fontStyle: 'italic', fontSize: '0.85rem' }}>{bufferedScore}</span>
         ) : (
           <span style={{ color: '#9CA3AF' }}>-</span>
         )}
@@ -224,9 +214,9 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
   onWheelScore,
   simplifiedInputMode = false,
   inlineEditKey,
-  inlineScoreLeft,
-  inlineScoreRight,
-  onInlineScoreChange,
+  inlineSingleScore,
+  cellScoreBuffer,
+  onInlineSingleScoreChange,
   onInlineSubmit,
   onInlineCancel,
 }) => {
@@ -563,9 +553,9 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                   onHoverOut={onHoverLeave}
                   onWheelScore={onWheelScore ? (shiftKey, delta) => onWheelScore(rowFencer, colFencer, shiftKey, delta) : undefined}
                   isInlineEditing={simplifiedInputMode && inlineEditKey === cellKey}
-                  inlineScoreLeft={inlineScoreLeft}
-                  inlineScoreRight={inlineScoreRight}
-                  onInlineScoreChange={onInlineScoreChange}
+                  inlineSingleScore={inlineSingleScore}
+                  bufferedScore={cellScoreBuffer?.[cellKey]}
+                  onInlineSingleScoreChange={onInlineSingleScoreChange}
                   onInlineSubmit={onInlineSubmit}
                   onInlineCancel={onInlineCancel}
                 />

--- a/src/renderer/components/training/TrainingLauncherModal.tsx
+++ b/src/renderer/components/training/TrainingLauncherModal.tsx
@@ -13,7 +13,7 @@ const WEAPON_LABELS: Record<string, string> = {
   [Weapon.EPEE]: 'Épée',
   [Weapon.FOIL]: 'Fleuret',
   [Weapon.SABRE]: 'Sabre',
-  [Weapon.LASER]: 'Laser Sabre',
+  [Weapon.LASER]: 'Sabre Laser',
 };
 
 const ALL_ZONES: TargetZone[] = [TargetZone.ZONE_A, TargetZone.ZONE_B, TargetZone.ZONE_C];


### PR DESCRIPTION
## Résumé

- **Saisie rapide cellule par cellule** : en mode saisie simplifiée, un seul champ numérique par cellule. Enter (ou Tab) valide et passe automatiquement à la cellule suivante. Quand les deux cellules miroir d'un match sont remplies, le match est soumis automatiquement. Les valeurs en attente (une seule cellule saisie) s'affichent en bleu italique pour feedback visuel.
- **Fix "Sabre Laser"** : dans le modal Mode Entraînement, l'arme était libellée "Laser Sabre" → corrigé en "Sabre Laser".

## Comportement

1. Clic sur une cellule → champ de saisie unique (score du tireur de la ligne)
2. Saisir la valeur → Enter → cellule suivante sélectionnée automatiquement
3. Quand la cellule miroir est aussi remplie → match soumis, les deux cellules effacées du buffer
4. Escape → annule la saisie en cours
5. Les cellules avec une valeur en attente (miroir pas encore saisi) affichent la valeur en bleu italique

## Fichiers modifiés

- `src/renderer/components/pool/PoolScoreMatrix.tsx` — interface props simplifiée (1 input au lieu de 2), affichage valeur bufferisée
- `src/renderer/components/PoolView.tsx` — logique buffer + navigation + soumission automatique
- `src/renderer/components/training/TrainingLauncherModal.tsx` — fix libellé "Sabre Laser"

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqtx11QrWRLcP3EVsFsZaA)_