### PR TITLE
Fix navigation saisie rapide : focus sur cellule suivante correcte

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -494,16 +494,19 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   };
 
   const openNextCell = (currentKey: string, skipKeys: Set<string>, buffer: Record<string, number>) => {
-    const cells = getOrderedCells().filter(c => !skipKeys.has(c.key));
+    const cells = getOrderedCells();
     const currentIndex = cells.findIndex(c => c.key === currentKey);
-    const next = currentIndex === -1 ? cells[0] : cells[currentIndex + 1];
-    if (!next) {
-      setInlineEditCell(null);
-      setInlineSingleScore('');
-      return;
+    const startFrom = currentIndex === -1 ? 0 : currentIndex + 1;
+    for (let i = startFrom; i < cells.length; i++) {
+      if (!skipKeys.has(cells[i].key)) {
+        const next = cells[i];
+        setInlineEditCell({ key: next.key, rowId: next.rowFencer.id, colId: next.colFencer.id, matchIndex: next.matchIndex, inverted: next.inverted });
+        setInlineSingleScore(buffer[next.key] !== undefined ? String(buffer[next.key]) : '');
+        return;
+      }
     }
-    setInlineEditCell({ key: next.key, rowId: next.rowFencer.id, colId: next.colFencer.id, matchIndex: next.matchIndex, inverted: next.inverted });
-    setInlineSingleScore(buffer[next.key] !== undefined ? String(buffer[next.key]) : '');
+    setInlineEditCell(null);
+    setInlineSingleScore('');
   };
 
   const handleCellClick = (rowFencer: Fencer, colFencer: Fencer) => {


### PR DESCRIPTION
## Résumé

Fix du bug de navigation en mode saisie rapide cellule par cellule.

**Symptôme** : après soumission automatique d'un match (les deux cellules miroir remplies), le focus sautait à la première cellule en attente au lieu de la suivante dans l'ordre.

**Cause** : `currentKey` était inclus dans `skipKeys`, donc filtré de la liste avant `findIndex` → `currentIndex = -1` → fallback sur `cells[0]`.

**Fix** : chercher la position dans la liste complète (non filtrée), puis scanner en avant en ignorant les clés à sauter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqtx11QrWRLcP3EVsFsZaA)_