### PR TITLE
Fix: score max modifié involontairement au scroll trackpad (macOS)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -172,6 +172,19 @@ const AppContent: React.FC = () => {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
+  // Un scroll (trackpad macOS notamment) sur un input number focus ne doit pas
+  // en changer la valeur (comportement natif Chromium trompeur, ex: score max)
+  useEffect(() => {
+    const handler = (e: WheelEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target instanceof HTMLInputElement && target.type === 'number' && document.activeElement === target) {
+        target.blur();
+      }
+    };
+    document.addEventListener('wheel', handler, { passive: true, capture: true });
+    return () => document.removeEventListener('wheel', handler, { capture: true });
+  }, []);
+
   // Sync logo from disk to localStorage so PDF exports always find it
   useEffect(() => {
     if (!window.electronAPI) return;


### PR DESCRIPTION
## Summary
- Un `wheel` event sur un `<input type="number">` focus modifiait sa valeur (comportement natif de Chromium : chaque cran de molette/scroll incrémente/décrémente le champ ciblé).
- Sur macOS, le trackpad génère de nombreux événements `wheel` en continu même pour un simple défilement de page/modale, donc il suffit que le curseur survole un champ focus (ex: « Score max poules » dans les propriétés de la compétition) pour que sa valeur change silencieusement — d'où le `5` saisi qui devient `2`.
- Sur Windows, la molette de souris est discrète et le phénomène est beaucoup plus rare, ce qui explique la différence observée entre les deux plateformes.
- Ajout d'un listener global (`src/renderer/App.tsx`) qui retire le focus de tout `input[type=number]` dès qu'un `wheel` event le cible, empêchant ainsi tout changement de valeur accidentel — la correction s'applique à tous les champs numériques de l'application, pas seulement au score max des poules.

## Test plan
- [x] `npm run type-check`
- [x] `npm run test:run` (963 tests, tous verts)
- [ ] Vérification manuelle sur macOS : ouvrir les propriétés de la compétition, saisir 5 dans « Score max poules », scroller la modale avec le trackpad en passant sur le champ, confirmer que la valeur reste 5


---
_Generated by [Claude Code](https://claude.ai/code/session_011HfDDVipoZwVnZdDHn7Q8p)_