### PR TITLE
Ajout du raccourci Ctrl+P pour imprimer les feuilles de poule et de match

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -200,7 +200,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     syncFencersToPool,
   } = usePoolManagement({ isLaserSabre, poolMaxScore, showToast, competitionId: competition?.id });
 
-  const { exportFencersList, exportRanking, exportResults, exportPoolsPDF } = useExport({
+  const { exportFencersList, exportRanking, exportResults, exportPoolsPDF, printPoolsPDF } = useExport({
     competition,
     showToast,
   });
@@ -670,6 +670,24 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const handleExportAllPoolsPDF = () => {
     exportPoolsPDF(pools, currentPoolRound);
   };
+
+  const handlePrintAllPoolsPDF = () => {
+    printPoolsPDF(pools, currentPoolRound);
+  };
+
+  // Ctrl+P / Cmd+P → imprimer les feuilles de poule (le tableau gère son propre raccourci)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'p') {
+        if (currentPhase === 'pools' && pools.length > 0) {
+          e.preventDefault();
+          handlePrintAllPoolsPDF();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [currentPhase, pools, currentPoolRound]);
 
   const handleImportFencers = async (importedFencers: Partial<Fencer>[]) => {
     await bulkAddFencers(importedFencers as any);
@@ -1282,6 +1300,13 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
                 >
                   <GlobalPoolColumnsMenu isLaserSabre={isLaserSabre} />
                   <WindowSizePresets />
+                  <button
+                    className="btn btn-primary"
+                    onClick={handlePrintAllPoolsPDF}
+                    title="Imprimer les feuilles de poule (Ctrl+P)"
+                  >
+                    🖨️ Imprimer les feuilles de poule
+                  </button>
                   {pools.length > 1 && (
                     <button className="btn btn-success" onClick={handleExportAllPoolsPDF}>
                       📄 Exporter toutes les poules en PDF

--- a/src/renderer/components/KeyboardShortcutsHelp.tsx
+++ b/src/renderer/components/KeyboardShortcutsHelp.tsx
@@ -30,6 +30,7 @@ const SHORTCUTS: Shortcut[] = [
   { key: 'Ctrl + Z', descriptionKey: 'shortcuts.undo', category: 'actions' },
   { key: 'Ctrl + Y', descriptionKey: 'shortcuts.redo', category: 'actions' },
   { key: 'Ctrl + N', descriptionKey: 'shortcuts.new_competition', category: 'actions' },
+  { key: 'Ctrl + P', descriptionKey: 'shortcuts.print_sheets', category: 'actions' },
 
   // Competition
   { key: 'F5', descriptionKey: 'shortcuts.refresh_data', category: 'competition' },

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -748,33 +748,50 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   );
   const totalMatches = pool.matches.length;
 
+  // Options communes à l'export PDF et à l'impression de la feuille de poule
+  const buildPoolPrintOptions = async () => {
+    const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+    const sigsArray = await window.electronAPI.db.getPoolSignatures(pool.id);
+    const signatures = Object.fromEntries(sigsArray.map(s => [s.fencerId, s.signatureData]));
+    return {
+      title: `Poule ${pool.number} - ${pool.fencers.length} tireurs`,
+      includeFinishedMatches: true,
+      includePendingMatches: true,
+      includePoolStats: true,
+      logoBase64: logo,
+      competitionName,
+      competitionId,
+      visibleColumns: getVisibleColumns('pool', pool.id),
+      signatures,
+    };
+  };
+
   // Export PDF function
   const handleExportPDF = async () => {
     try {
-      const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
-      const sigsArray = await window.electronAPI.db.getPoolSignatures(pool.id);
-      const signatures = Object.fromEntries(sigsArray.map(s => [s.fencerId, s.signatureData]));
+      const options = await buildPoolPrintOptions();
       const { exportPoolToPDF } = await import('../../shared/utils/pdfExport');
-      await exportPoolToPDF(
-        pool,
-        {
-          title: `Poule ${pool.number} - ${pool.fencers.length} tireurs`,
-          includeFinishedMatches: true,
-          includePendingMatches: true,
-          includePoolStats: true,
-          logoBase64: logo,
-          competitionName,
-          competitionId,
-          visibleColumns: getVisibleColumns('pool', pool.id),
-          signatures,
-        },
-        poolTemplate
-      );
+      await exportPoolToPDF(pool, options, poolTemplate);
       showToast(`Export PDF de la poule ${pool.number} généré avec succès`, 'success');
     } catch (error) {
       logger.error(LogCategory.UI, "Erreur lors de l'export PDF", error as Error);
       showToast(
         `Erreur lors de la génération du PDF: ${error instanceof Error ? error.message : 'Erreur inconnue'}`,
+        'error'
+      );
+    }
+  };
+
+  // Impression directe de la feuille de poule (Ctrl+P / bouton 🖨️)
+  const handlePrintPool = async () => {
+    try {
+      const options = await buildPoolPrintOptions();
+      const { printPoolHTML } = await import('../../shared/utils/pdfExport');
+      await printPoolHTML(pool, options, poolTemplate);
+    } catch (error) {
+      logger.error(LogCategory.UI, "Erreur lors de l'impression de la poule", error as Error);
+      showToast(
+        `Erreur lors de l'impression: ${error instanceof Error ? error.message : 'Erreur inconnue'}`,
         'error'
       );
     }
@@ -1374,6 +1391,13 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
             title="Remplir automatiquement les scores (test)"
           >
             🎲 Auto
+          </button>
+          <button
+            onClick={handlePrintPool}
+            style={{ ...TOOLBAR_BTN, background: '#3b82f6', color: 'white' }}
+            title="Imprimer la feuille de poule (Ctrl+P)"
+          >
+            🖨️ Imprimer
           </button>
           <button
             onClick={handleExportPDF}

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -795,6 +795,25 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
     }
   };
 
+  const handlePrintClick = useCallback(() => {
+    setPdfMode('print');
+    const rounds = [...new Set(matches.filter(m => m.fencerA && m.fencerB && !m.isBye).map(m => m.round))].sort((a, b) => b - a);
+    setSelectedRounds(new Set(rounds));
+    setShowPdfModal(true);
+  }, [matches]);
+
+  // Ctrl+P / Cmd+P → imprimer les feuilles de match du tableau
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'p') {
+        e.preventDefault();
+        handlePrintClick();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [handlePrintClick]);
+
   const handleSpecialStatus = (
     status: 'abandon' | 'forfait' | 'exclusion',
     fencerId: string
@@ -1066,12 +1085,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         onViewModeToggle={() => setViewMode(viewMode === 'full' ? 'pending' : 'full')}
         pyramidViewMode={pyramidViewMode}
         onPyramidViewModeToggle={() => setPyramidViewMode(!pyramidViewMode)}
-        onPrintClick={() => {
-          setPdfMode('print');
-          const rounds = [...new Set(matches.filter(m => m.fencerA && m.fencerB && !m.isBye).map(m => m.round))].sort((a, b) => b - a);
-          setSelectedRounds(new Set(rounds));
-          setShowPdfModal(true);
-        }}
+        onPrintClick={handlePrintClick}
         onExportPdfClick={() => {
           setPdfMode('pdf');
           const rounds = [...new Set(matches.filter(m => m.fencerA && m.fencerB && !m.isBye).map(m => m.round))].sort((a, b) => b - a);

--- a/src/renderer/hooks/useExport.ts
+++ b/src/renderer/hooks/useExport.ts
@@ -234,6 +234,30 @@ export const useExport = ({ competition, showToast }: UseExportProps) => {
     [competition.title, showToast, poolTemplate]
   );
 
+  // Impression PDF de toutes les poules — dialogue d'impression natif
+  const printPoolsPDF = useCallback(
+    async (pools: Pool[], currentPoolRound: number) => {
+      try {
+        const { printMultiplePoolsHTML } = await import('../../shared/utils/pdfExport');
+        const logo = localStorage.getItem('bellepoule-logo') ?? undefined;
+        await printMultiplePoolsHTML(
+          pools,
+          `Toutes les Poules - ${competition.title} - Tour ${currentPoolRound}`,
+          logo,
+          poolTemplate,
+          competition.title
+        );
+      } catch (error) {
+        logger.error(LogCategory.UI, "Erreur lors de l'impression des poules", error as Error);
+        showToast(
+          `Erreur lors de l'impression: ${error instanceof Error ? error.message : 'Erreur inconnue'}`,
+          'error'
+        );
+      }
+    },
+    [competition.title, showToast, poolTemplate]
+  );
+
   // Export HTML des résultats
   const exportResultsHTMLFormat = useCallback(
     (poolRanking: PoolRanking[], finalResults: FinalResult[]) => {
@@ -303,6 +327,7 @@ export const useExport = ({ competition, showToast }: UseExportProps) => {
     exportRanking,
     exportResults,
     exportPoolsPDF,
+    printPoolsPDF,
     downloadFile,
     exportResultsHTML: exportResultsHTMLFormat,
     exportRankingExcelCSV,

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -354,7 +354,8 @@
     "refresh_data": "Hizivaat roadennoù",
     "timer": "Krogañ/Paouez kronometr",
     "nav_list": "Levenez en rol",
-    "validate": "Gwiriañ / Digeriñ"
+    "validate": "Gwiriañ / Digeriñ",
+    "print_sheets": "Moullañ follennoù ar poulennoù / mataboliezhioù"
   },
   "formula": {
     "builder_title": "Saver reoladur",

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -354,7 +354,8 @@
     "refresh_data": "Actualitzar dades",
     "timer": "Iniciar/Pausar cronòmetre",
     "nav_list": "Navegar a la llista",
-    "validate": "Validar / Obrir"
+    "validate": "Validar / Obrir",
+    "print_sheets": "Imprimir els fulls de poule / de combat"
   },
   "formula": {
     "builder_title": "Constructor de fórmules",

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -322,6 +322,7 @@
     "nav_fields": "Zwischen Feldern navigieren",
     "nav_list": "In der Liste navigieren",
     "new_competition": "Neuer Wettkampf",
+    "print_sheets": "Poolblätter / Gefechtsblätter drucken",
     "quick_search": "Schnellsuche",
     "redo": "Wiederholen",
     "refresh_data": "Daten aktualisieren",

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -354,7 +354,8 @@
     "refresh_data": "Refresh data",
     "timer": "Start/Pause timer",
     "nav_list": "Navigate in list",
-    "validate": "Validate / Open"
+    "validate": "Validate / Open",
+    "print_sheets": "Print pool / match sheets"
   },
   "formula": {
     "builder_title": "Formula builder",

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -354,7 +354,8 @@
     "refresh_data": "Actualizar datos",
     "timer": "Iniciar/Pausar cronómetro",
     "nav_list": "Navegar en la lista",
-    "validate": "Validar / Abrir"
+    "validate": "Validar / Abrir",
+    "print_sheets": "Imprimir las hojas de poule / de combate"
   },
   "formula": {
     "builder_title": "Constructor de fórmulas",

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -354,7 +354,8 @@
     "refresh_data": "Rafraîchir les données",
     "timer": "Démarrer/Pause le chronomètre",
     "nav_list": "Naviguer dans la liste",
-    "validate": "Valider / Ouvrir"
+    "validate": "Valider / Ouvrir",
+    "print_sheets": "Imprimer les feuilles de poule / de match"
   },
   "wiki": {
     "button_title": "Documentation"

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -354,7 +354,8 @@
     "refresh_data": "重新整理資料",
     "timer": "開始/暫停計時器",
     "nav_list": "在列表中導航",
-    "validate": "確認 / 開啟"
+    "validate": "確認 / 開啟",
+    "print_sheets": "列印小組賽 / 對戰表"
   },
   "formula": {
     "builder_title": "賽制編輯器",

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -9,7 +9,13 @@
 
 // ─── Poules ───────────────────────────────────────────────────────────────────
 export type { PoolExportOptions } from './pdfExport/poolPdf';
-export { generatePoolHTML, exportPoolToPDF, exportMultiplePoolsToPDF } from './pdfExport/poolPdf';
+export {
+  generatePoolHTML,
+  exportPoolToPDF,
+  exportMultiplePoolsToPDF,
+  printPoolHTML,
+  printMultiplePoolsHTML,
+} from './pdfExport/poolPdf';
 
 // ─── Tableau Élimination Directe ─────────────────────────────────────────────
 export type { TableauMatchForPDF } from './pdfExport/tableauPdf';

--- a/src/shared/utils/pdfExport/poolPdf.ts
+++ b/src/shared/utils/pdfExport/poolPdf.ts
@@ -351,7 +351,7 @@ ${body}
 
 // ─── Export Poule ─────────────────────────────────────────────────────────────
 
-export async function exportPoolToPDF(pool: Pool, options: PoolExportOptions = {}, template?: PdfTemplate): Promise<void> {
+async function buildPoolExportHTML(pool: Pool, options: PoolExportOptions, template?: PdfTemplate): Promise<string> {
   if (!pool.fencers || pool.fencers.length === 0) throw new Error('La poule ne contient aucun tireur');
   if (!pool.matches || pool.matches.length === 0) throw new Error('La poule ne contient aucun match');
 
@@ -366,7 +366,11 @@ export async function exportPoolToPDF(pool: Pool, options: PoolExportOptions = {
     // QR silencieusement omis si qrcode indisponible
   }
 
-  const html = generatePoolHTML(pool, { ...options, title, qrDataUrl }, template);
+  return generatePoolHTML(pool, { ...options, title, qrDataUrl }, template);
+}
+
+export async function exportPoolToPDF(pool: Pool, options: PoolExportOptions = {}, template?: PdfTemplate): Promise<void> {
+  const html = await buildPoolExportHTML(pool, options, template);
   await savePDF(html, `poule-${pool.number}.pdf`);
 }
 
@@ -380,5 +384,32 @@ export async function exportMultiplePoolsToPDF(
   if (pools.length === 0) throw new Error('Aucune poule à exporter');
   for (const pool of pools) {
     await exportPoolToPDF(pool, { title: `${title} - Poule ${pool.number}`, logoBase64, competitionName }, template);
+  }
+}
+
+// ─── Impression Poule (dialogue d'impression natif) ───────────────────────────
+
+export async function printPoolHTML(pool: Pool, options: PoolExportOptions = {}, template?: PdfTemplate): Promise<void> {
+  const html = await buildPoolExportHTML(pool, options, template);
+  const api = (window as any).electronAPI;
+  if (!api?.file?.printHtml) {
+    throw new Error('API Electron non disponible');
+  }
+  const res = await api.file.printHtml(html);
+  if (!res?.success) {
+    throw new Error(res?.error ?? "Échec de l'impression");
+  }
+}
+
+export async function printMultiplePoolsHTML(
+  pools: Pool[],
+  title: string = 'Impression des Poules',
+  logoBase64?: string,
+  template?: PdfTemplate,
+  competitionName?: string
+): Promise<void> {
+  if (pools.length === 0) throw new Error('Aucune poule à imprimer');
+  for (const pool of pools) {
+    await printPoolHTML(pool, { title: `${title} - Poule ${pool.number}`, logoBase64, competitionName }, template);
   }
 }


### PR DESCRIPTION
## Summary

- Ajoute le raccourci clavier **Ctrl+P** pour imprimer les feuilles de poule (phase poules) et les feuilles de match (phase tableau à élimination directe).
- Ajoute un bouton **🖨️ Imprimer** explicite (impression native, sans passer par un enregistrement de PDF) :
  - sur chaque carte de poule, à côté du bouton "📄 PDF" existant ;
  - dans un nouveau bouton "🖨️ Imprimer les feuilles de poule" au-dessus de la grille de poules (visible même avec une seule poule).
- En phase tableau, Ctrl+P déclenche la même action que le bouton "🖨️ Imprimer" déjà présent dans le menu "⋮ Options" (mais peu visible, d'où le raccourci).
- Ajoute `printPoolHTML` / `printMultiplePoolsHTML` dans `pdfExport/poolPdf.ts`, symétriques aux fonctions d'export PDF existantes mais utilisant l'impression native Electron (`window.electronAPI.file.printHtml`), comme le fait déjà `printTableauHTML` pour le tableau.
- Documente le raccourci dans l'aide clavier (`?`) et dans toutes les locales (fr, en, de, es, ca, br, zh-HK).

## Context

L'utilisateur signalait ne pas trouver de bouton pour imprimer les feuilles de poule/match : le bouton existant pour les poules ("📄 PDF") ne fait qu'exporter vers un fichier PDF (dialogue d'enregistrement), et celui du tableau ("🖨️ Imprimer") est caché dans un menu secondaire. Ce PR ajoute une vraie impression directe (dialogue d'impression système) et un raccourci clavier standard.

## Test plan

- [x] `npm run type-check` — OK
- [x] `npx vitest run` — 87 fichiers / 963 tests passent
- [ ] Test manuel dans l'application : Ctrl+P en phase poules ouvre le dialogue d'impression pour chaque poule ; Ctrl+P en phase tableau ouvre la modale de sélection des tours puis imprime


---
_Generated by [Claude Code](https://claude.ai/code/session_0131DBontZTV9ZNSMcpzhdL6)_