### PR TITLE
Compacter la barre d'outils de la poule (icônes + tooltip)

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -22,8 +22,8 @@ import Confetti from './Confetti';
 import AddFencerToPoolModal from './AddFencerToPoolModal';
 import { MatchAuditLog } from './MatchAuditLog';
 import {
-  TOOLBAR_BTN,
   ICON_BTN,
+  ICON_ONLY_BTN,
   SPECIAL_BTN,
   ROW_BETWEEN,
   MATCH_LABEL,
@@ -1387,24 +1387,27 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           </button>
           <button
             onClick={handleAutoFillScores}
-            style={{ ...TOOLBAR_BTN, background: '#f59e0b', color: 'white' }}
+            style={{ ...ICON_ONLY_BTN, background: '#f59e0b', color: 'white' }}
             title="Remplir automatiquement les scores (test)"
+            aria-label="Remplir automatiquement les scores (test)"
           >
-            🎲 Auto
+            🎲
           </button>
           <button
             onClick={handlePrintPool}
-            style={{ ...TOOLBAR_BTN, background: '#3b82f6', color: 'white' }}
+            style={{ ...ICON_ONLY_BTN, background: '#3b82f6', color: 'white' }}
             title="Imprimer la feuille de poule (Ctrl+P)"
+            aria-label="Imprimer la feuille de poule"
           >
-            🖨️ Imprimer
+            🖨️
           </button>
           <button
             onClick={handleExportPDF}
-            style={{ ...TOOLBAR_BTN, background: '#10b981', color: 'white' }}
-            title="Exporter la pôle en PDF"
+            style={{ ...ICON_ONLY_BTN, background: '#10b981', color: 'white' }}
+            title="Exporter la poule en PDF"
+            aria-label="Exporter la poule en PDF"
           >
-            📄 PDF
+            📄
           </button>
           {pool.isComplete && isRemoteActive && remoteServerUrl && (
             <button
@@ -1416,30 +1419,33 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
                   window.open(url, '_blank');
                 }
               }}
-              style={{ ...TOOLBAR_BTN, background: '#6366f1', color: 'white' }}
+              style={{ ...ICON_ONLY_BTN, background: '#6366f1', color: 'white' }}
               title={`Page signatures — arène ${defaultArena}`}
+              aria-label="Page signatures"
             >
-              ✍️ Signature
+              ✍️
             </button>
           )}
           {competitionId && (
             <button
               onClick={() => setShowAddFencerModal(true)}
-              style={{ ...TOOLBAR_BTN, background: '#e5e7eb', color: '#374151' }}
+              style={{ ...ICON_ONLY_BTN, background: '#e5e7eb', color: '#374151' }}
               title="Ajouter un tireur à cette poule"
+              aria-label="Ajouter un tireur à cette poule"
             >
-              ➕ Tireur
+              ➕
             </button>
           )}
           <div style={RELATIVE} ref={columnMenuRef}>
             <button
               onClick={() => setShowColumnMenu(!showColumnMenu)}
               style={{
-                ...TOOLBAR_BTN,
+                ...ICON_ONLY_BTN,
                 background: showColumnMenu ? '#6b7280' : '#e5e7eb',
                 color: showColumnMenu ? 'white' : '#374151',
               }}
               title="Afficher/masquer les colonnes"
+              aria-label="Afficher/masquer les colonnes"
             >
               ⚙️
             </button>
@@ -1471,24 +1477,28 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
             <button
               onClick={() => setViewMode('grid')}
               style={{
-                ...TOOLBAR_BTN,
+                ...ICON_ONLY_BTN,
                 background: viewMode === 'grid' ? '#3b82f6' : '#e5e7eb',
                 color: viewMode === 'grid' ? 'white' : '#374151',
                 borderRadius: '4px 0 0 4px',
               }}
+              title="Vue tableau"
+              aria-label="Vue tableau"
             >
-              📊 Tableau
+              📊
             </button>
             <button
               onClick={() => setViewMode('matches')}
               style={{
-                ...TOOLBAR_BTN,
+                ...ICON_ONLY_BTN,
                 background: viewMode === 'matches' ? '#3b82f6' : '#e5e7eb',
                 color: viewMode === 'matches' ? 'white' : '#374151',
                 borderRadius: '0 4px 4px 0',
               }}
+              title="Vue matches"
+              aria-label="Vue matches"
             >
-              ⚔️ Matches
+              ⚔️
             </button>
           </div>
         </div>

--- a/src/renderer/components/poolView.styles.ts
+++ b/src/renderer/components/poolView.styles.ts
@@ -24,6 +24,20 @@ export const ICON_BTN: CSSProperties = {
   borderRadius: '4px',
 };
 
+// Boutons compacts icône seule (libellé affiché en info-bulle au survol via `title`)
+export const ICON_ONLY_BTN: CSSProperties = {
+  width: '2rem',
+  height: '2rem',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '0.95rem',
+  border: 'none',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  flexShrink: 0,
+};
+
 // Boutons de statut spécial (abandon/forfait/exclusion/annuler)
 export const SPECIAL_BTN: CSSProperties = { fontSize: '0.8rem', padding: '0.4rem 0.75rem' };
 
@@ -171,7 +185,7 @@ export const LOCKED_BANNER: CSSProperties = {
 };
 
 export const HEADER_LEFT: CSSProperties = { display: 'flex', alignItems: 'center', gap: '0.75rem' };
-export const TOOLBAR_GROUP: CSSProperties = { display: 'flex', gap: '0.5rem' };
+export const TOOLBAR_GROUP: CSSProperties = { display: 'flex', gap: '0.5rem', flexWrap: 'wrap', justifyContent: 'flex-end' };
 export const VIEW_GROUP: CSSProperties = { display: 'flex', gap: '0.25rem' };
 export const RELATIVE: CSSProperties = { position: 'relative' };
 export const VS: CSSProperties = { opacity: 0.7 };


### PR DESCRIPTION
## Summary
- La barre d'outils de `PoolView` (Auto, Imprimer, PDF, Signature, +Tireur, colonnes, Tableau/Matches) débordait horizontalement sans scrollbar visible sur les fenêtres étroites.
- Les boutons passent en icône seule ; le libellé (ex. « Imprimer ») s'affiche désormais en info-bulle native au survol via l'attribut `title` (+ `aria-label` pour l'accessibilité).
- Nouveau style partagé `ICON_ONLY_BTN` dans `poolView.styles.ts` (bouton carré 2rem).
- `TOOLBAR_GROUP` passe en `flex-wrap: wrap` en secours si la barre reste trop large.

## Test plan
- [x] `npx tsc --noEmit` sans erreur sur `PoolView.tsx`
- [x] `npx eslint` sans nouvelle erreur (warnings prettier préexistants uniquement)
- [x] `npx vitest run src/renderer/components/__tests__`
- [ ] Vérification visuelle manuelle dans l'app (fenêtre étroite) — à faire par un mainteneur


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEidf8TeiwkMcvZsMkSWAm)_