### PR TITLE
Aperçu avant impression (contournement de la limitation Windows 11)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1465,73 +1465,82 @@ ipcMain.handle('file:printHtml', async (_, html: string) => {
   });
 });
 
+// Rendu HTML → buffer PDF via une fenêtre Electron cachée (partagé par export et aperçu)
+function renderHtmlToPdfBuffer(html: string): Promise<Buffer> {
+  const tmpFile = path.join(os.tmpdir(), `bp-pdf-${Date.now()}.html`);
+  return fs.promises.writeFile(tmpFile, html, 'utf-8').then(
+    () =>
+      new Promise<Buffer>((resolve, reject) => {
+        const pdfWin = new BrowserWindow({
+          show: false,
+          width: 1200,
+          height: 1600,
+          webPreferences: { contextIsolation: true, nodeIntegration: false, javascript: false },
+        });
+        pdfWin.setMenu(null);
+        pdfWin.loadFile(tmpFile);
+
+        pdfWin.webContents.once('did-finish-load', () => {
+          setTimeout(() => {
+            pdfWin.webContents
+              .printToPDF({
+                printBackground: true,
+                landscape: false,
+                pageSize: 'A4',
+                preferCSSPageSize: true,
+                margins: { marginType: 'none' },
+              })
+              .then((data: Buffer) => {
+                pdfWin.destroy();
+                fs.promises.unlink(tmpFile).catch(() => {});
+                resolve(data);
+              })
+              .catch((err: Error) => {
+                pdfWin.destroy();
+                fs.promises.unlink(tmpFile).catch(() => {});
+                reject(err);
+              });
+          }, 800);
+        });
+
+        pdfWin.webContents.once('did-fail-load', () => {
+          pdfWin.destroy();
+          fs.promises.unlink(tmpFile).catch(() => {});
+          reject(new Error('Chargement HTML échoué'));
+        });
+      }),
+    e => Promise.reject(new Error(`Impossible de créer le fichier temporaire: ${e}`))
+  );
+}
+
 // PDF generation via hidden BrowserWindow (propre, sans menus d'application)
 ipcMain.handle('file:printHtmlToPDF', async (_, html: string, outputPath: string) => {
-  const tmpFile = path.join(os.tmpdir(), `bp-pdf-${Date.now()}.html`);
   try {
-    await fs.promises.writeFile(tmpFile, html, 'utf-8');
+    const data = await renderHtmlToPdfBuffer(html);
+    await fs.promises.writeFile(outputPath, data);
+    return { success: true, path: outputPath };
   } catch (e) {
-    return { success: false, error: `Impossible de créer le fichier temporaire: ${e}` };
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
   }
+});
 
-  return new Promise<{ success: boolean; path?: string; error?: string }>(resolve => {
-    const pdfWin = new BrowserWindow({
-      show: false,
-      width: 1200,
-      height: 1600,
-      webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: false,
-        javascript: false,
-      },
-    });
-    pdfWin.setMenu(null);
-
-    pdfWin.loadFile(tmpFile);
-
-    pdfWin.webContents.once('did-finish-load', () => {
-      setTimeout(() => {
-      pdfWin.webContents
-        .printToPDF({
-          printBackground: true,
-          landscape: false,
-          pageSize: 'A4',
-          preferCSSPageSize: true,
-          margins: { marginType: 'none' },
-        })
-        .then(async (data: Buffer) => {
-          try {
-            await fs.promises.writeFile(outputPath, data);
-            resolve({ success: true, path: outputPath });
-          } catch (writeErr) {
-            resolve({ success: false, error: `Impossible d'écrire le PDF: ${writeErr}` });
-          } finally {
-            fs.promises.unlink(tmpFile).catch(() => {});
-            pdfWin.destroy();
-          }
-        })
-        .catch((err: Error) => {
-          try {
-            fs.unlinkSync(tmpFile);
-          } catch {
-            /* ignore */
-          }
-          pdfWin.destroy();
-          resolve({ success: false, error: err.message });
-        });
-      }, 800);
-    });
-
-    pdfWin.webContents.once('did-fail-load', () => {
-      try {
-        fs.unlinkSync(tmpFile);
-      } catch {
-        /* ignore */
-      }
-      pdfWin.destroy();
-      resolve({ success: false, error: 'Chargement HTML échoué' });
-    });
-  });
+// Aperçu avant impression : génère le PDF et l'ouvre dans le lecteur PDF par défaut de l'OS.
+// Contourne la limitation de Windows 11 où la boîte de dialogue d'impression native
+// n'affiche pas d'aperçu pour les applications Win32/Electron (Chromium n'expose pas
+// sa propre page d'aperçu via webContents.print()).
+ipcMain.handle('file:previewHtmlAsPDF', async (_, html: string) => {
+  const tmpPdfFile = path.join(os.tmpdir(), `bp-preview-${Date.now()}.pdf`);
+  try {
+    const data = await renderHtmlToPdfBuffer(html);
+    await fs.promises.writeFile(tmpPdfFile, data);
+    const openError = await shell.openPath(tmpPdfFile);
+    if (openError) {
+      return { success: false, error: openError };
+    }
+    return { success: true, path: tmpPdfFile };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
 });
 
 // Shell handlers

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -378,6 +378,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       }
       return ipcRenderer.invoke('file:printHtmlToPDF', html, outputPath);
     },
+    previewHtmlAsPDF: (html: string) => {
+      if (!html || typeof html !== 'string') {
+        throw new Error('HTML content is required');
+      }
+      return ipcRenderer.invoke('file:previewHtmlAsPDF', html);
+    },
     exportPhotos: (competitionId: string, filepath: string) => {
       if (!competitionId || typeof competitionId !== 'string') {
         throw new Error('Competition ID is required and must be a string');

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -797,6 +797,22 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     }
   };
 
+  // Aperçu avant impression : ouvre le PDF dans le lecteur par défaut de l'OS
+  // (utile sur Windows 11, où la boîte de dialogue d'impression native n'affiche pas d'aperçu)
+  const handlePreviewPool = async () => {
+    try {
+      const options = await buildPoolPrintOptions();
+      const { previewPoolHTML } = await import('../../shared/utils/pdfExport');
+      await previewPoolHTML(pool, options, poolTemplate);
+    } catch (error) {
+      logger.error(LogCategory.UI, "Erreur lors de l'aperçu de la poule", error as Error);
+      showToast(
+        `Erreur lors de la génération de l'aperçu: ${error instanceof Error ? error.message : 'Erreur inconnue'}`,
+        'error'
+      );
+    }
+  };
+
   // Fonction pour remplir automatiquement tous les scores de la poule (pour les tests)
   const handleAutoFillScores = async () => {
     const confirmed = await confirm({
@@ -1400,6 +1416,14 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
             aria-label="Imprimer la feuille de poule"
           >
             🖨️
+          </button>
+          <button
+            onClick={handlePreviewPool}
+            style={{ ...ICON_ONLY_BTN, background: '#8b5cf6', color: 'white' }}
+            title="Aperçu avant impression (ouvre un PDF dans le lecteur par défaut)"
+            aria-label="Aperçu avant impression"
+          >
+            👁️
           </button>
           <button
             onClick={handleExportPDF}

--- a/src/renderer/components/TableauView.tsx
+++ b/src/renderer/components/TableauView.tsx
@@ -137,7 +137,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
   const bracketWrapRef = useRef<HTMLDivElement | null>(null);
   const [colMeasures, setColMeasures] = useState<Map<number, { left: number; width: number }>>(new Map());
   const [showPdfModal, setShowPdfModal] = useState(false);
-  const [pdfMode, setPdfMode] = useState<'print' | 'pdf'>('pdf');
+  const [pdfMode, setPdfMode] = useState<'print' | 'pdf' | 'preview'>('pdf');
   const [pdfMatchesPerPage, setPdfMatchesPerPage] = useState<number>(MAX_MATCHES_PER_PAGE_TABLEAU);
   const [selectedRounds, setSelectedRounds] = useState<Set<number>>(new Set());
   const [autoAssignArenas, setAutoAssignArenas] = useState(false);
@@ -772,9 +772,11 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         }
       } catch { /* signatures optionnelles */ }
 
-      const { printTableauHTML, exportTableauToPDF } = await import('../../shared/utils/pdfExport');
+      const { printTableauHTML, exportTableauToPDF, previewTableauHTML } = await import('../../shared/utils/pdfExport');
       if (pdfMode === 'print') {
         await printTableauHTML(filteredMatches, perPage, title, logo, tableauTemplate, signatures);
+      } else if (pdfMode === 'preview') {
+        await previewTableauHTML(filteredMatches, perPage, title, logo, tableauTemplate, signatures);
       } else {
         await exportTableauToPDF(filteredMatches, perPage, title, logo, tableauTemplate, signatures);
       }
@@ -797,6 +799,13 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
 
   const handlePrintClick = useCallback(() => {
     setPdfMode('print');
+    const rounds = [...new Set(matches.filter(m => m.fencerA && m.fencerB && !m.isBye).map(m => m.round))].sort((a, b) => b - a);
+    setSelectedRounds(new Set(rounds));
+    setShowPdfModal(true);
+  }, [matches]);
+
+  const handlePreviewClick = useCallback(() => {
+    setPdfMode('preview');
     const rounds = [...new Set(matches.filter(m => m.fencerA && m.fencerB && !m.isBye).map(m => m.round))].sort((a, b) => b - a);
     setSelectedRounds(new Set(rounds));
     setShowPdfModal(true);
@@ -1086,6 +1095,7 @@ const TableauViewComponent: React.FC<TableauViewProps> = ({
         pyramidViewMode={pyramidViewMode}
         onPyramidViewModeToggle={() => setPyramidViewMode(!pyramidViewMode)}
         onPrintClick={handlePrintClick}
+        onPreviewClick={handlePreviewClick}
         onExportPdfClick={() => {
           setPdfMode('pdf');
           const rounds = [...new Set(matches.filter(m => m.fencerA && m.fencerB && !m.isBye).map(m => m.round))].sort((a, b) => b - a);

--- a/src/renderer/components/tableau/TableauPdfModal.tsx
+++ b/src/renderer/components/tableau/TableauPdfModal.tsx
@@ -10,7 +10,7 @@ import { TableauMatch } from './tableauTypes';
 import { getRoundName } from './tableauCalculations';
 
 interface TableauPdfModalProps {
-  pdfMode: 'print' | 'pdf';
+  pdfMode: 'print' | 'pdf' | 'preview';
   matches: TableauMatch[];
   pdfMatchesPerPage: number;
   setPdfMatchesPerPage: (n: number) => void;
@@ -46,7 +46,9 @@ const TableauPdfModal: React.FC<TableauPdfModalProps> = ({
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()} style={{ maxWidth: '400px' }}>
         <div className="modal-header">
-          <h3 className="modal-title">{pdfMode === 'print' ? 'Imprimer' : 'Export PDF'} – Feuilles de match</h3>
+          <h3 className="modal-title">
+            {pdfMode === 'print' ? 'Imprimer' : pdfMode === 'preview' ? 'Aperçu avant impression' : 'Export PDF'} – Feuilles de match
+          </h3>
           <button className="btn-close" onClick={onClose}>
             &times;
           </button>
@@ -122,7 +124,7 @@ const TableauPdfModal: React.FC<TableauPdfModalProps> = ({
             Annuler
           </button>
           <button className="btn btn-primary" onClick={onExport} disabled={selectedRounds.size === 0}>
-            {pdfMode === 'print' ? '🖨️ Imprimer' : '📄 Générer PDF'}
+            {pdfMode === 'print' ? '🖨️ Imprimer' : pdfMode === 'preview' ? '👁️ Aperçu' : '📄 Générer PDF'}
           </button>
         </div>
       </div>

--- a/src/renderer/components/tableau/TableauToolbar.tsx
+++ b/src/renderer/components/tableau/TableauToolbar.tsx
@@ -20,6 +20,7 @@ interface TableauToolbarProps {
   pyramidViewMode: boolean;
   onPyramidViewModeToggle: () => void;
   onPrintClick: () => void;
+  onPreviewClick: () => void;
   onExportPdfClick: () => void;
   onExportTreeClick: () => void;
   champion: Fencer | null | undefined;
@@ -38,6 +39,7 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
   pyramidViewMode,
   onPyramidViewModeToggle,
   onPrintClick,
+  onPreviewClick,
   onExportPdfClick,
   onExportTreeClick,
   champion,
@@ -156,6 +158,9 @@ const TableauToolbarComponent: React.FC<TableauToolbarProps> = ({
               <span className="tableau-fab-section-label">Export</span>
               <button className="tableau-fab-item" onClick={() => closeAndRun(onPrintClick)}>
                 🖨️ Imprimer
+              </button>
+              <button className="tableau-fab-item" onClick={() => closeAndRun(onPreviewClick)} title="Ouvre un PDF dans le lecteur par défaut pour voir un aperçu avant d'imprimer">
+                👁️ Aperçu avant impression
               </button>
               <button className="tableau-fab-item" onClick={() => closeAndRun(onExportPdfClick)}>
                 📄 Export PDF

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -737,6 +737,7 @@ export interface FileAPI {
     html: string,
     outputPath: string
   ) => Promise<{ success: boolean; path?: string; error?: string }>;
+  previewHtmlAsPDF: (html: string) => Promise<{ success: boolean; path?: string; error?: string }>;
   exportPhotos: (competitionId: string, filepath: string) => Promise<{ count: number }>;
   importPhotos: (
     competitionId: string,

--- a/src/shared/utils/pdfExport.ts
+++ b/src/shared/utils/pdfExport.ts
@@ -15,12 +15,18 @@ export {
   exportMultiplePoolsToPDF,
   printPoolHTML,
   printMultiplePoolsHTML,
+  previewPoolHTML,
 } from './pdfExport/poolPdf';
 
 // ─── Tableau Élimination Directe ─────────────────────────────────────────────
 export type { TableauMatchForPDF } from './pdfExport/tableauPdf';
 export { MAX_MATCHES_PER_PAGE_TABLEAU } from './pdfConstants';
-export { generateTableauHTML, exportTableauToPDF, printTableauHTML } from './pdfExport/tableauPdf';
+export {
+  generateTableauHTML,
+  exportTableauToPDF,
+  printTableauHTML,
+  previewTableauHTML,
+} from './pdfExport/tableauPdf';
 
 // ─── Arbre (Bracket Tree) ─────────────────────────────────────────────────────
 export {

--- a/src/shared/utils/pdfExport/poolPdf.ts
+++ b/src/shared/utils/pdfExport/poolPdf.ts
@@ -413,3 +413,17 @@ export async function printMultiplePoolsHTML(
     await printPoolHTML(pool, { title: `${title} - Poule ${pool.number}`, logoBase64, competitionName }, template);
   }
 }
+
+// ─── Aperçu avant impression (ouvre le PDF dans le lecteur par défaut de l'OS) ─
+
+export async function previewPoolHTML(pool: Pool, options: PoolExportOptions = {}, template?: PdfTemplate): Promise<void> {
+  const html = await buildPoolExportHTML(pool, options, template);
+  const api = (window as any).electronAPI;
+  if (!api?.file?.previewHtmlAsPDF) {
+    throw new Error('API Electron non disponible');
+  }
+  const res = await api.file.previewHtmlAsPDF(html);
+  if (!res?.success) {
+    throw new Error(res?.error ?? "Échec de la génération de l'aperçu");
+  }
+}

--- a/src/shared/utils/pdfExport/tableauPdf.ts
+++ b/src/shared/utils/pdfExport/tableauPdf.ts
@@ -392,3 +392,28 @@ export async function printTableauHTML(
     throw new Error(res?.error ?? "Échec de l'impression");
   }
 }
+
+// Aperçu avant impression : génère un PDF et l'ouvre dans le lecteur par défaut de l'OS
+// (contourne l'absence d'aperçu dans la boîte de dialogue d'impression native de Windows 11)
+export async function previewTableauHTML(
+  matches: TableauMatchForPDF[],
+  matchesPerPage: number,
+  title: string = 'Tableau Élimination Directe',
+  logoBase64?: string,
+  template?: PdfTemplate,
+  signatures?: Record<string, { A?: string; B?: string }>
+): Promise<void> {
+  const real = realMatches(matches);
+  if (real.length === 0) {
+    throw new Error('Aucun match à imprimer (tous sont des exempts ou sans tireurs assignés)');
+  }
+  const html = generateTableauHTML(matches, matchesPerPage, title, logoBase64, template, false, signatures);
+  const api = (window as any).electronAPI;
+  if (!api?.file?.previewHtmlAsPDF) {
+    throw new Error('API Electron non disponible');
+  }
+  const res = await api.file.previewHtmlAsPDF(html);
+  if (!res?.success) {
+    throw new Error(res?.error ?? "Échec de la génération de l'aperçu");
+  }
+}


### PR DESCRIPTION
## Summary

Suite à un retour utilisateur sur le PR #881 (déjà mergé) : sur Windows 11, la boîte de dialogue d'impression native affiche "This app doesn't support print preview". Après vérification, ce n'est pas un bug de BellePoule mais une limitation connue de Windows 11 (22H2+) pour les applications Win32/Chromium (Electron inclus) — même Notepad affiche le même message sur les mêmes builds Windows. L'impression fonctionne malgré le message, mais sans aperçu visuel.

Electron n'expose pas la page d'aperçu HTML de Chromium via `webContents.print()` (choix de conception documenté, cf. issue electron/electron#4890) : impossible d'obtenir un vrai aperçu par ce biais sur aucune plateforme.

Ce PR ajoute un contournement pratique : un bouton **👁️ Aperçu** qui génère le PDF (même rendu que l'impression/export) et l'ouvre directement dans le lecteur PDF par défaut de l'OS — ces applications (Edge, Acrobat, etc.) affichent un vrai aperçu et impriment normalement.

- `renderHtmlToPdfBuffer()` dans `main.ts` : factorisation du rendu HTML → PDF, partagée entre l'export PDF existant et le nouvel aperçu
- Nouvel IPC `file:previewHtmlAsPDF` : génère le PDF dans un fichier temporaire et l'ouvre via `shell.openPath`
- `previewPoolHTML` / `previewTableauHTML` dans `pdfExport` (symétriques à `printPoolHTML` / `printTableauHTML`)
- Bouton "👁️ Aperçu" sur chaque feuille de poule (`PoolView.tsx`)
- Option "👁️ Aperçu avant impression" dans le menu Options du tableau (`TableauToolbar.tsx`), réutilisant la modale existante de sélection des tours (`TableauPdfModal.tsx`, nouveau mode `preview`)

## Test plan

- [x] `npm run type-check` — OK
- [x] `npx vitest run` — 87 fichiers / 963 tests passent
- [x] `npm run build:main` — compile sans erreur
- [ ] Test manuel sur Windows : cliquer sur "👁️ Aperçu" ouvre bien le PDF dans le lecteur par défaut avec un aperçu fonctionnel


---
_Generated by [Claude Code](https://claude.ai/code/session_0131DBontZTV9ZNSMcpzhdL6)_