### PR TITLE
UX: confirmations cohérentes, audit log par défaut, a11y remote, assistant de planning, centre d'export

### DIFF
--- a/src/remote/arena.html
+++ b/src/remote/arena.html
@@ -1304,9 +1304,9 @@
       <span class="arena-word-label">Arène</span> <span id="arena-strip-number">1</span>
     </div>
 
-    <div class="header">
+    <header class="header">
       <div class="arena-title">
-        <span>⚔️</span>
+        <span aria-hidden="true">⚔️</span>
         <span><span class="arena-word-label">Arène</span> <span id="arena-number">1</span></span>
       </div>
       <div class="status-section">
@@ -1314,15 +1314,15 @@
           <input type="checkbox" id="inversion-checkbox" />
           <label for="inversion-checkbox" data-i18n="arena.invert">⇄ Inverser</label>
         </div>
-        <div class="match-status-badge status-waiting" id="match-status" data-i18n="arena.waiting">En attente</div>
-        <div class="connection-indicator">
-          <div id="connection-dot" class="connection-dot"></div>
+        <div class="match-status-badge status-waiting" id="match-status" role="status" aria-live="polite" data-i18n="arena.waiting">En attente</div>
+        <div class="connection-indicator" role="status" aria-live="polite">
+          <div id="connection-dot" class="connection-dot" aria-hidden="true"></div>
           <span id="connection-text" data-i18n="remote.connecting">Connexion...</span>
         </div>
       </div>
-    </div>
+    </header>
 
-    <div class="main-content">
+    <main class="main-content">
       <!-- Écran d'attente -->
       <div class="waiting-screen" id="waiting-screen">
         <!-- Aperçu prochain combat (visible quand nextMatch disponible) -->
@@ -1419,31 +1419,31 @@
       <div class="match-display" id="match-display">
         <div class="fencers-row">
           <!-- Tireur A (Rouge) -->
-          <div id="fencer-a-display" class="fencer-display red-side">
-            <div id="color-badge-a" class="color-badge red"></div>
+          <div id="fencer-a-display" class="fencer-display red-side" role="region" aria-label="Tireur rouge">
+            <div id="color-badge-a" class="color-badge red" aria-hidden="true"></div>
             <div class="fencer-name" id="fencer-a-name">-</div>
             <div class="fencer-club" id="fencer-a-club">-</div>
             <div class="cards-container" id="fencer-a-cards"></div>
-            <div class="score-big red" id="score-a">0</div>
+            <div class="score-big red" id="score-a" role="status" aria-live="polite" aria-atomic="true">0</div>
           </div>
 
           <!-- VS -->
-          <div class="vs-divider">VS</div>
+          <div class="vs-divider" aria-hidden="true">VS</div>
 
           <!-- Tireur B (Vert) -->
-          <div id="fencer-b-display" class="fencer-display green-side">
-            <div id="color-badge-b" class="color-badge green"></div>
+          <div id="fencer-b-display" class="fencer-display green-side" role="region" aria-label="Tireur vert">
+            <div id="color-badge-b" class="color-badge green" aria-hidden="true"></div>
             <div class="fencer-name" id="fencer-b-name">-</div>
             <div class="fencer-club" id="fencer-b-club">-</div>
             <div class="cards-container" id="fencer-b-cards"></div>
-            <div class="score-big green" id="score-b">0</div>
+            <div class="score-big green" id="score-b" role="status" aria-live="polite" aria-atomic="true">0</div>
           </div>
         </div>
 
         <!-- Chronomètre -->
         <div class="timer-section">
           <div class="mort-subite-banner" id="mort-subite-banner">⚡ MORT SUBITE</div>
-          <div class="timer-display" id="timer-display">03:00</div>
+          <div class="timer-display" id="timer-display" role="timer" aria-label="Temps restant">03:00</div>
           <div class="waiting-overtime-banner" id="waiting-overtime-banner">⚖️ ÉGALITÉ – attente arbitre</div>
           <div class="sudden-death-banner" id="sudden-death-banner">⏱ 30s SUPPLEMENTAIRE</div>
           <div class="timer-label">Temps restant</div>
@@ -1480,7 +1480,7 @@
           <div class="next-referee-name hidden" id="next-referee-name">⚖️ <span id="next-referee-label"></span></div>
         </div>
       </div>
-    </div>
+    </main>
 
     <script>
       class ArenaDisplay {

--- a/src/remote/dashboard.html
+++ b/src/remote/dashboard.html
@@ -487,28 +487,28 @@
           <div class="competition-name" id="competition-name">Coupe Régionale - Sabre Laser</div>
         </div>
         <div class="header-right">
-          <div class="last-update">
+          <div class="last-update" role="status" aria-live="polite">
             Mis à jour: <span class="time" id="last-update-time">--:--:--</span>
           </div>
-          <div class="connection-status">
-            <div id="status-dot" class="status-dot"></div>
+          <div class="connection-status" role="status" aria-live="polite">
+            <div id="status-dot" class="status-dot" aria-hidden="true"></div>
             <span id="connection-text">Connexion...</span>
           </div>
         </div>
       </header>
 
       <!-- Tab Navigation -->
-      <nav class="tab-nav">
-        <button class="tab-btn active" data-tab="poules" data-i18n="dashboard.pools">Poules</button>
-        <button class="tab-btn" data-tab="classement" data-i18n="dashboard.ranking">Classement Général</button>
-        <button class="tab-btn" data-tab="direct" data-i18n="dashboard.live">Matchs en Cours</button>
+      <nav class="tab-nav" role="tablist" aria-label="Vue du tableau de bord">
+        <button class="tab-btn active" role="tab" aria-selected="true" aria-controls="tab-poules" data-tab="poules" data-i18n="dashboard.pools">Poules</button>
+        <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-classement" data-tab="classement" data-i18n="dashboard.ranking">Classement Général</button>
+        <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-direct" data-tab="direct" data-i18n="dashboard.live">Matchs en Cours</button>
       </nav>
 
       <!-- Tab: Poules -->
-      <div id="tab-poules" class="tab-content active">
+      <div id="tab-poules" class="tab-content active" role="tabpanel">
         <div class="pools-grid" id="pools-container">
           <div class="no-data">
-            <div class="no-data-icon">🤺</div>
+            <div class="no-data-icon" aria-hidden="true">🤺</div>
             <h3 data-i18n="dashboard.no_pools">Aucune poule en cours</h3>
             <p data-i18n="dashboard.no_pools_hint">Les poules apparaîtront ici une fois la compétition démarrée</p>
           </div>
@@ -516,7 +516,7 @@
       </div>
 
       <!-- Tab: Classement Général -->
-      <div id="tab-classement" class="tab-content">
+      <div id="tab-classement" class="tab-content" role="tabpanel">
         <div class="overall-ranking">
           <div class="overall-header">
             <h2 data-i18n="dashboard.ranking_title">🏅 Classement Général Quest</h2>
@@ -544,7 +544,7 @@
       </div>
 
       <!-- Tab: Matchs en Cours -->
-      <div id="tab-direct" class="tab-content">
+      <div id="tab-direct" class="tab-content" role="tabpanel">
         <div class="live-matches" id="live-matches">
           <div class="no-data">
             <div class="no-data-icon">⏱️</div>

--- a/src/remote/pool.html
+++ b/src/remote/pool.html
@@ -678,45 +678,45 @@
     </style>
   </head>
   <body>
-    <div class="header">
+    <header class="header">
       <div class="header-left">
         <div class="header-title" id="pool-title" data-i18n="pool.loading">Chargement…</div>
         <div class="header-badge" id="match-count-badge" style="display:none"></div>
       </div>
       <button class="back-to-referee-btn" onclick="goBackToReferee()">← Arbitre</button>
-      <a href="/poule-ocr" class="back-to-referee-btn" style="text-decoration:none;margin-left:6px" title="Saisie par photo (OCR)">📷</a>
-      <div class="connection-badge" id="connection-badge">⚡ Connexion…</div>
-    </div>
+      <a href="/poule-ocr" class="back-to-referee-btn" style="text-decoration:none;margin-left:6px" title="Saisie par photo (OCR)" aria-label="Saisie par photo (OCR)">📷</a>
+      <div class="connection-badge" id="connection-badge" role="status" aria-live="polite">⚡ Connexion…</div>
+    </header>
 
-    <div class="tabs">
-      <button class="tab-btn active" id="tab-tableau" onclick="switchTab('tableau')">
+    <div class="tabs" role="tablist" aria-label="Vue de la poule">
+      <button class="tab-btn active" id="tab-tableau" role="tab" aria-selected="true" aria-controls="pool-container" onclick="switchTab('tableau')">
         <span data-i18n="pool.tab_grid">⊞ Tableau</span>
       </button>
-      <button class="tab-btn" id="tab-matches" onclick="switchTab('matches')">
+      <button class="tab-btn" id="tab-matches" role="tab" aria-selected="false" aria-controls="pool-container" onclick="switchTab('matches')">
         <span data-i18n="pool.tab_matches">⚔ Matchs</span>
       </button>
     </div>
 
-    <div class="pool-container" id="pool-container">
+    <main class="pool-container" id="pool-container" role="tabpanel">
       <div class="status-message" id="status-message" data-i18n="pool.loading_pool">Chargement de la poule…</div>
-    </div>
+    </main>
 
     <!-- Modal de saisie de score -->
-    <div class="modal-overlay" id="modal-overlay">
+    <div class="modal-overlay" id="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="modal-match-label">
       <div class="modal">
         <h2><span data-i18n="pool.score_entry">Saisie du score</span><strong id="modal-match-label"></strong></h2>
         <div class="score-inputs">
           <div class="score-fencer">
             <span class="score-fencer-name" id="modal-fencer-a"></span>
-            <input type="number" id="input-score-a" min="0" max="99" value="0" />
+            <input type="number" id="input-score-a" min="0" max="99" value="0" aria-labelledby="modal-fencer-a" />
           </div>
-          <div class="score-vs">–</div>
+          <div class="score-vs" aria-hidden="true">–</div>
           <div class="score-fencer">
             <span class="score-fencer-name" id="modal-fencer-b"></span>
-            <input type="number" id="input-score-b" min="0" max="99" value="0" />
+            <input type="number" id="input-score-b" min="0" max="99" value="0" aria-labelledby="modal-fencer-b" />
           </div>
         </div>
-        <div class="modal-error" id="modal-error"></div>
+        <div class="modal-error" id="modal-error" role="alert"></div>
         <div class="modal-actions">
           <button class="btn btn-secondary" id="btn-cancel" data-i18n="pool.cancel">Annuler</button>
           <button class="btn btn-primary" id="btn-submit" data-i18n="pool.validate">Valider</button>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,6 +23,7 @@ const WifiQRModal = React.lazy(() => import('./components/WifiQRModal').then(m =
 const XiaomiRemotePanel = React.lazy(() => import('./components/XiaomiRemotePanel').then(m => ({ default: m.XiaomiRemotePanel })));
 const TrainingLauncherModal = React.lazy(() => import('./components/training/TrainingLauncherModal'));
 const TrainingPanel = React.lazy(() => import('./components/training/TrainingPanel'));
+import { CompetitionViewSkeleton } from './components/Skeleton';
 import { ToastProvider, useToast } from './components/Toast';
 import { ConfirmProvider, useConfirm } from './components/ConfirmDialog';
 import { TranslationProvider, useTranslation, Theme } from './contexts/TranslationContext';
@@ -712,7 +713,7 @@ const AppContent: React.FC = () => {
 
           {view === 'competition' && currentCompetition && activeTabId && (
             <CompetitionErrorBoundary key={currentCompetition.id}>
-              <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>Chargement…</div>}>
+              <Suspense fallback={<CompetitionViewSkeleton />}>
                 <CompetitionView
                   competition={currentCompetition}
                   onUpdate={handleUpdateCompetition}

--- a/src/renderer/components/CompetitionList.tsx
+++ b/src/renderer/components/CompetitionList.tsx
@@ -116,6 +116,11 @@ const CompetitionListComponent: React.FC<CompetitionListProps> = ({
           <button className="btn btn-primary btn-lg" onClick={onNewCompetition} style={{ padding: '0.75rem 2rem' }}>
             + {t('menu.new_competition')}
           </button>
+
+          <p style={{ color: 'var(--color-text-light)', fontSize: '0.75rem' }}>
+            Astuce : appuyez sur <kbd>?</kbd> pour voir les raccourcis clavier, ou{' '}
+            <kbd>Ctrl</kbd>+<kbd>K</kbd> pour ouvrir la palette de commandes.
+          </p>
         </div>
       </div>
     );

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -18,6 +18,7 @@ import CompetitionPropertiesModal from './CompetitionPropertiesModal';
 import ImportModal from './ImportModal';
 import PoolPrepView from './PoolPrepView';
 import { useToast } from './Toast';
+import { useConfirm } from './ConfirmDialog';
 import { useTranslation } from '../hooks/useTranslation';
 import { useCompetitionSession, Phase } from '../hooks/useCompetitionSession';
 import { useFencerManagement } from '../hooks/useFencerManagement';
@@ -38,6 +39,8 @@ import { ScoreAuditLog } from './ScoreAuditLog';
 import { RefereeManagerComponent } from './RefereeManager';
 import CompetitionHeader from './competition/CompetitionHeader';
 import CompetitionNav from './competition/CompetitionNav';
+const PlanningAssistant = React.lazy(() => import('./competition/PlanningAssistant'));
+const ExportCenterModal = React.lazy(() => import('./competition/ExportCenterModal'));
 import GlobalPoolColumnsMenu from './pool/GlobalPoolColumnsMenu';
 import WindowSizePresets from './pool/WindowSizePresets';
 
@@ -77,6 +80,7 @@ const CV_STYLES = {
 
 const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate, requestPhase, onPhaseApplied, onRemoteServerChange }) => {
   const { showToast } = useToast();
+  const { confirm } = useConfirm();
   const { t, language } = useTranslation();
 
   // Settings avec valeurs par défaut
@@ -91,7 +95,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const poolWinnersOnly = competition.settings?.poolWinnersOnly ?? false;
   const postPoolSplitCriteria = competition.settings?.postPoolSplitCriteria;
 
-  const auditLogEnabled = localStorage.getItem('bellepoule-audit-log-enabled') === 'true';
+  const auditLogEnabled = localStorage.getItem('bellepoule-audit-log-enabled') !== 'false';
 
   // États locaux
   const [currentPhase, setCurrentPhase] = useState<Phase>('checkin');
@@ -104,6 +108,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   }, [requestPhase]);
 
   const [showAddFencerModal, setShowAddFencerModal] = useState(false);
+  const [showPlanningAssistant, setShowPlanningAssistant] = useState(false);
+  const [showExportCenter, setShowExportCenter] = useState(false);
   const [showPropertiesModal, setShowPropertiesModal] = useState(false);
   const [importData, setImportData] = useState<{
     format: string;
@@ -200,7 +206,17 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     syncFencersToPool,
   } = usePoolManagement({ isLaserSabre, poolMaxScore, showToast, competitionId: competition?.id });
 
-  const { exportFencersList, exportRanking, exportResults, exportPoolsPDF, printPoolsPDF } = useExport({
+  const {
+    exportFencersList,
+    exportRanking,
+    exportResults,
+    exportPoolsPDF,
+    printPoolsPDF,
+    exportResultsHTML,
+    exportRankingExcelCSV,
+    exportResultsXML,
+    exportDetailedStats,
+  } = useExport({
     competition,
     showToast,
   });
@@ -1188,6 +1204,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         setShowKiosk={setShowKiosk}
         setShowKioskDisplay={setShowKioskDisplay}
         setShowPropertiesModal={setShowPropertiesModal}
+        setShowExportCenter={setShowExportCenter}
       />
       <CompetitionNav
         competition={competition}
@@ -1205,6 +1222,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
         getCheckedInFencers={getCheckedInFencers}
         pools={pools}
         tableauMatches={tableauMatches}
+        onOpenPlanningAssistant={() => setShowPlanningAssistant(true)}
       />
 
       {/* Content — keyed pour animation de transition */}
@@ -1512,8 +1530,8 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             }}>
               <span>🔒 Tableau en lecture seule — résultats finaux générés.</span>
               <button
-                onClick={() => {
-                  if (window.confirm('Modifier le tableau effacera les résultats finaux. Continuer ?')) {
+                onClick={async () => {
+                  if (await confirm('Modifier le tableau effacera les résultats finaux. Continuer ?')) {
                     setFinalResults([]);
                   }
                 }}
@@ -1633,6 +1651,43 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       </div>
 
       {/* Modals */}
+      {showPlanningAssistant && (
+        <Suspense fallback={null}>
+          <PlanningAssistant
+            competition={competition}
+            pools={pools}
+            suggestedArenaCount={arenaStates.length || Math.min(pools.length, 4) || 1}
+            onClose={() => setShowPlanningAssistant(false)}
+          />
+        </Suspense>
+      )}
+
+      {showExportCenter && (
+        <Suspense fallback={null}>
+          <ExportCenterModal
+            fencers={fencers}
+            pools={pools}
+            currentPoolRound={currentPoolRound}
+            overallRanking={overallRanking}
+            finalResults={finalResults}
+            tableauMatchesCount={tableauMatches.length}
+            isLaserSabre={isLaserSabre}
+            onClose={() => setShowExportCenter(false)}
+            exportFencersList={exportFencersList}
+            exportPoolsPDF={exportPoolsPDF}
+            printPoolsPDF={printPoolsPDF}
+            exportRanking={exportRanking}
+            exportRankingExcelCSV={exportRankingExcelCSV}
+            exportResults={exportResults}
+            exportResultsHTML={exportResultsHTML}
+            exportResultsXML={exportResultsXML}
+            exportDetailedStats={exportDetailedStats}
+            onGoToTableau={() => { setCurrentPhase('tableau'); setShowExportCenter(false); }}
+            onGoToResults={() => { setCurrentPhase('results'); setShowExportCenter(false); }}
+          />
+        </Suspense>
+      )}
+
       {showAddFencerModal && (
         <AddFencerModal
           onClose={() => setShowAddFencerModal(false)}

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from '../hooks/useTranslation';
 import { exportFencersToTXT, exportFencersToFFF } from '../../shared/utils/fencerExport';
 // pdfExport (jsPDF) chargé à la demande pour alléger le bundle initial
 import { useConfirm } from './ConfirmDialog';
+import CoachMark from './CoachMark';
 import { useDebounce } from '../hooks/useDebounce';
 import { MENU_ITEM, SMALL_BTN, W250, DROPDOWN_WRAP } from './fencerList.styles';
 
@@ -752,9 +753,11 @@ const FencerListComponent: React.FC<FencerListProps> = ({
               <p className="empty-state-description">Importez une liste ou ajoutez des tireurs manuellement</p>
               <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap', marginTop: '1.25rem' }}>
                 {onImport && (
-                  <button className="btn btn-secondary" onClick={() => handleImportFencers('xml')}>
-                    📥 Importer XML
-                  </button>
+                  <CoachMark id="import-fencers" message="Formats acceptés : XML BellePoule, liste FFE (.fff/.csv/.txt)" position="bottom">
+                    <button className="btn btn-secondary" onClick={() => handleImportFencers('xml')}>
+                      📥 Importer XML
+                    </button>
+                  </CoachMark>
                 )}
                 <button className="btn btn-primary" onClick={onAddFencer}>
                   + {t('fencer.add')}

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -12,6 +12,7 @@ import LanguageSelector from './LanguageSelector';
 // Chargé à la demande : embarque jsPDF, lourd pour le bundle initial
 const PdfTemplateModal = React.lazy(() => import('./PdfTemplateModal'));
 import { logger, LogCategory } from '@shared/services/logger';
+import { isWebhookUrlSafe } from '@shared/services/notificationService';
 
 const LOGO_STORAGE_KEY = 'bellepoule-logo';
 const WEBHOOK_STORAGE_KEY = 'bellepoule-webhook-url';
@@ -59,23 +60,6 @@ function loadTtsConfig(): TtsConfig {
   return { ...DEFAULT_TTS_CONFIG, announce: { ...DEFAULT_TTS_CONFIG.announce } };
 }
 
-function isWebhookUrlSafe(rawUrl: string): boolean {
-  try {
-    const url = new URL(rawUrl);
-    if (url.protocol !== 'https:') return false;
-    const h = url.hostname;
-    if (
-      h === 'localhost' ||
-      h === '127.0.0.1' ||
-      /^10\./.test(h) ||
-      /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
-      /^192\.168\./.test(h)
-    ) return false;
-    return true;
-  } catch {
-    return false;
-  }
-}
 const LOGO_MAX_W = 600;
 const LOGO_MAX_H = 200;
 
@@ -124,8 +108,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave }) => {
   const [logoError, setLogoError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Activé par défaut (journal désactivable explicitement, pas activable par défaut négatif)
   const [auditLogEnabled, setAuditLogEnabled] = useState<boolean>(
-    () => localStorage.getItem(AUDIT_LOG_KEY) === 'true'
+    () => localStorage.getItem(AUDIT_LOG_KEY) !== 'false'
   );
 
   const [quickMouseScoring, setQuickMouseScoring] = useState<boolean>(

--- a/src/renderer/components/Skeleton.tsx
+++ b/src/renderer/components/Skeleton.tsx
@@ -155,6 +155,46 @@ const StatsCardSkeleton_: React.FC = () => {
   );
 };
 
+// Competition View Skeleton (header + nav + content, pendant le lazy-load de CompetitionView)
+const CompetitionViewSkeleton_: React.FC = () => {
+  return (
+    <div style={{ padding: '1.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+        <Skeleton width="280px" height="28px" />
+        <Skeleton width="120px" height="32px" borderRadius="6px" />
+      </div>
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem' }}>
+        {[1, 2, 3, 4].map(i => (
+          <Skeleton key={i} width="110px" height="36px" borderRadius="6px" />
+        ))}
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+          gap: '1rem',
+        }}
+      >
+        {[1, 2, 3, 4, 5, 6].map(i => (
+          <div
+            key={i}
+            style={{
+              padding: '1rem',
+              backgroundColor: 'white',
+              borderRadius: '8px',
+              border: '1px solid #e5e7eb',
+            }}
+          >
+            <Skeleton width="60%" height="18px" style={{ marginBottom: '0.75rem' }} />
+            <Skeleton width="100%" height="14px" style={{ marginBottom: '0.5rem' }} />
+            <Skeleton width="80%" height="14px" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
 // Add shimmer keyframes to global styles
 const SkeletonStyles_: React.FC = () => (
   <style>{`
@@ -174,6 +214,7 @@ export const CompetitionCardSkeleton = React.memo(CompetitionCardSkeleton_);
 export const PoolViewSkeleton = React.memo(PoolViewSkeleton_);
 export const TableRowSkeleton = React.memo(TableRowSkeleton_);
 export const StatsCardSkeleton = React.memo(StatsCardSkeleton_);
+export const CompetitionViewSkeleton = React.memo(CompetitionViewSkeleton_);
 export const SkeletonStyles = React.memo(SkeletonStyles_);
 
 export default {
@@ -182,5 +223,6 @@ export default {
   PoolViewSkeleton,
   TableRowSkeleton,
   StatsCardSkeleton,
+  CompetitionViewSkeleton,
   SkeletonStyles,
 };

--- a/src/renderer/components/TeamManagerView.tsx
+++ b/src/renderer/components/TeamManagerView.tsx
@@ -6,6 +6,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { Competition, Fencer } from '../../shared/types';
+import { useConfirm } from './ConfirmDialog';
 
 // ── Types locaux ───────────────────────────────────────────────────────────────
 
@@ -101,6 +102,7 @@ interface Props {
 type ViewMode = 'teams' | 'pool' | 'ranking';
 
 export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose }) => {
+  const { confirm } = useConfirm();
   const [view, setView] = useState<ViewMode>('teams');
   const [teams, setTeams] = useState<TeamRow[]>([]);
   const [matches, setMatches] = useState<MatchRow[]>([]);
@@ -169,7 +171,7 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
   // ── Générer poule (round-robin) ───────────────────────────────────────────────
   const handleGeneratePool = async () => {
     if (teams.length < 2) return;
-    if (matches.length > 0 && !confirm('Des matchs existent déjà. Supprimer et régénérer ?')) return;
+    if (matches.length > 0 && !(await confirm('Des matchs existent déjà. Supprimer et régénérer ?'))) return;
 
     for (const m of matches) {
       // No direct delete match API — we'll just regenerate on top via DB (match IDs change)

--- a/src/renderer/components/competition/CompetitionHeader.tsx
+++ b/src/renderer/components/competition/CompetitionHeader.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { MoreHorizontal, Swords, BarChart2, Share2, Monitor, Smartphone, Settings, ChevronDown, ChevronUp, Trophy, Users } from 'lucide-react';
+import { MoreHorizontal, Swords, BarChart2, Share2, Monitor, Smartphone, Settings, ChevronDown, ChevronUp, Trophy, Users, Download } from 'lucide-react';
 import { Competition, MatchStatus } from '../../../shared/types';
 import Confetti from '../Confetti';
 import CoachMark from '../CoachMark';
@@ -39,6 +39,7 @@ interface CompetitionHeaderProps {
   setShowKiosk: React.Dispatch<React.SetStateAction<boolean>>;
   setShowKioskDisplay: React.Dispatch<React.SetStateAction<boolean>>;
   setShowPropertiesModal: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowExportCenter: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const CompetitionHeaderComponent: React.FC<CompetitionHeaderProps> = ({
@@ -64,6 +65,7 @@ const CompetitionHeaderComponent: React.FC<CompetitionHeaderProps> = ({
   setShowKiosk,
   setShowKioskDisplay,
   setShowPropertiesModal,
+  setShowExportCenter,
 }) => {
   const storageKey = `bellepoule-header-expanded-${competition.id}`;
   const [expanded, setExpanded] = useState(() => {
@@ -184,6 +186,9 @@ const CompetitionHeaderComponent: React.FC<CompetitionHeaderProps> = ({
                     <Monitor size={14} /> Kiosk Public
                   </button>
                 )}
+                <button className="comp-header-dropdown-item" onClick={() => { setShowExportCenter(true); setShowActionsMenu(false); }}>
+                  <Download size={14} /> Exporter
+                </button>
                 <div className="comp-header-dropdown-sep" />
                 <button className="comp-header-dropdown-item" onClick={() => { setShowPropertiesModal(true); setShowActionsMenu(false); }}>
                   <Settings size={14} /> Propriétés

--- a/src/renderer/components/competition/CompetitionNav.tsx
+++ b/src/renderer/components/competition/CompetitionNav.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { ChevronLeft, ChevronRight, Swords, Target, Zap, Trophy, ScrollText } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Swords, Target, Zap, Trophy, ScrollText, CalendarClock } from 'lucide-react';
 import { Competition, MatchStatus, QuestPhaseConfig, Fencer } from '../../../shared/types';
 import { Phase } from '../../hooks/useCompetitionSession';
 import CoachMark from '../CoachMark';
@@ -49,6 +49,7 @@ interface CompetitionNavProps {
   getCheckedInFencers: () => Fencer[];
   pools: PoolItem[];
   tableauMatches: TableauMatchItem[];
+  onOpenPlanningAssistant?: () => void;
 }
 
 const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
@@ -66,6 +67,7 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
   getCheckedInFencers,
   pools,
   tableauMatches,
+  onOpenPlanningAssistant,
 }) => {
 
   return (
@@ -135,8 +137,20 @@ const CompetitionNavComponent: React.FC<CompetitionNavProps> = ({
           </CoachMark>
         )}
         {currentPhase === 'pools' && poolsNextAction && (
-          <button className="btn btn-primary" onClick={poolsNextAction.action}>
-            {poolsNextAction.label}
+          <CoachMark id="pools-next-action" message="Étape suivante une fois les poules terminées" position="bottom">
+            <button className="btn btn-primary" onClick={poolsNextAction.action}>
+              {poolsNextAction.label}
+            </button>
+          </CoachMark>
+        )}
+        {currentPhase === 'pools' && onOpenPlanningAssistant && pools.length > 0 && (
+          <button
+            className="btn btn-secondary btn-icon-label"
+            onClick={onOpenPlanningAssistant}
+            title="Estimation de fin de tournoi et recommandations de répartition des pistes"
+            style={{ fontSize: '0.8rem', padding: '0.3rem 0.6rem' }}
+          >
+            <CalendarClock size={14} /> Planning
           </button>
         )}
         <button

--- a/src/renderer/components/competition/ExportCenterModal.tsx
+++ b/src/renderer/components/competition/ExportCenterModal.tsx
@@ -1,0 +1,145 @@
+/**
+ * BellePoule Modern - Centre d'export
+ * Point d'entrée unique regroupant les exports jusque-là dispersés entre plusieurs vues
+ * (poules, classement, résultats, tableau, export complet).
+ * Licensed under GPL-3.0
+ */
+
+import React from 'react';
+import { Fencer, Pool, PoolRanking } from '../../../shared/types';
+import { FinalResult } from '../tableau/tableauTypes';
+
+interface ExportCenterModalProps {
+  fencers: Fencer[];
+  pools: Pool[];
+  currentPoolRound: number;
+  overallRanking: PoolRanking[];
+  finalResults: FinalResult[];
+  tableauMatchesCount: number;
+  isLaserSabre: boolean;
+  onClose: () => void;
+  exportFencersList: (fencers: Fencer[], format: 'txt' | 'fff') => void | Promise<void>;
+  exportPoolsPDF: (pools: Pool[], round: number) => void | Promise<void>;
+  printPoolsPDF: (pools: Pool[], round: number) => void | Promise<void>;
+  exportRanking: (ranking: PoolRanking[], format: 'csv' | 'json', isLaserSabre: boolean) => void;
+  exportRankingExcelCSV: (ranking: PoolRanking[]) => void;
+  exportResults: (results: FinalResult[], format: 'csv' | 'json') => void;
+  exportResultsHTML: (ranking: PoolRanking[], results: FinalResult[]) => void;
+  exportResultsXML: (ranking: PoolRanking[], results: FinalResult[], pools?: Pool[]) => void;
+  exportDetailedStats: (pools: Pool[], ranking: PoolRanking[]) => void;
+  onGoToTableau: () => void;
+  onGoToResults: () => void;
+}
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div style={{ marginBottom: '1.25rem' }}>
+    <h3 style={{ fontSize: '0.8125rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.03em', color: 'var(--color-text-light)', marginBottom: '0.5rem' }}>
+      {title}
+    </h3>
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>{children}</div>
+  </div>
+);
+
+const ExportCenterModal: React.FC<ExportCenterModalProps> = ({
+  fencers,
+  pools,
+  currentPoolRound,
+  overallRanking,
+  finalResults,
+  tableauMatchesCount,
+  isLaserSabre,
+  onClose,
+  exportFencersList,
+  exportPoolsPDF,
+  printPoolsPDF,
+  exportRanking,
+  exportRankingExcelCSV,
+  exportResults,
+  exportResultsHTML,
+  exportResultsXML,
+  exportDetailedStats,
+  onGoToTableau,
+  onGoToResults,
+}) => {
+  return (
+    <div className="modal-overlay" onClick={onClose} style={{ zIndex: 11000 }}>
+      <div
+        className="modal"
+        onClick={e => e.stopPropagation()}
+        style={{ maxWidth: '620px', maxHeight: '85vh', overflowY: 'auto' }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="export-center-title"
+      >
+        <div className="modal-header">
+          <h2 className="modal-title" id="export-center-title">📤 Centre d'export</h2>
+        </div>
+        <div className="modal-body">
+          {fencers.length > 0 && (
+            <Section title="Tireurs">
+              <button className="btn btn-secondary" onClick={() => exportFencersList(fencers, 'txt')}>Liste (.txt)</button>
+              <button className="btn btn-secondary" onClick={() => exportFencersList(fencers, 'fff')}>Liste FFE (.fff)</button>
+            </Section>
+          )}
+
+          {pools.length > 0 && (
+            <Section title="Poules">
+              <button className="btn btn-secondary" onClick={() => exportPoolsPDF(pools, currentPoolRound)}>Export PDF</button>
+              <button className="btn btn-secondary" onClick={() => printPoolsPDF(pools, currentPoolRound)}>Imprimer</button>
+            </Section>
+          )}
+
+          {tableauMatchesCount > 0 && (
+            <Section title="Tableau d'élimination">
+              <button className="btn btn-secondary" onClick={onGoToTableau}>
+                Aller à Tableau pour l'export PDF →
+              </button>
+            </Section>
+          )}
+
+          {overallRanking.length > 0 && (
+            <Section title="Classement">
+              <button className="btn btn-secondary" onClick={() => exportRanking(overallRanking, 'csv', isLaserSabre)}>CSV</button>
+              <button className="btn btn-secondary" onClick={() => exportRankingExcelCSV(overallRanking)}>CSV Excel</button>
+              <button className="btn btn-secondary" onClick={() => exportRanking(overallRanking, 'json', isLaserSabre)}>JSON</button>
+            </Section>
+          )}
+
+          {finalResults.length > 0 && (
+            <Section title="Résultats finaux">
+              <button className="btn btn-secondary" onClick={() => exportResults(finalResults, 'csv')}>CSV</button>
+              <button className="btn btn-secondary" onClick={() => exportResults(finalResults, 'json')}>JSON</button>
+              <button className="btn btn-secondary" onClick={() => exportResultsHTML(overallRanking, finalResults)}>HTML</button>
+              <button className="btn btn-secondary" onClick={() => exportResultsXML(overallRanking, finalResults, pools)}>XML FFE</button>
+            </Section>
+          )}
+
+          {pools.length > 0 && overallRanking.length > 0 && (
+            <Section title="Statistiques">
+              <button className="btn btn-secondary" onClick={() => exportDetailedStats(pools, overallRanking)}>Stats détaillées (CSV)</button>
+            </Section>
+          )}
+
+          {finalResults.length > 0 && (
+            <Section title="Export complet compétition">
+              <button className="btn btn-secondary" onClick={onGoToResults}>
+                Aller à Résultats pour l'export complet →
+              </button>
+            </Section>
+          )}
+
+          {fencers.length === 0 && pools.length === 0 && (
+            <p style={{ color: 'var(--color-text-light)', fontSize: '0.875rem' }}>
+              Aucune donnée à exporter pour le moment — ajoutez des tireurs pour commencer.
+            </p>
+          )}
+        </div>
+        <div className="modal-footer">
+          <button type="button" className="btn btn-primary" onClick={onClose}>Fermer</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(ExportCenterModal);

--- a/src/renderer/components/competition/PlanningAssistant.tsx
+++ b/src/renderer/components/competition/PlanningAssistant.tsx
@@ -1,0 +1,155 @@
+/**
+ * BellePoule Modern - Assistant de planning
+ * Expose le moteur d'optimisation TournamentFlowManager (jusque-là inutilisé côté UI)
+ * pour aider l'organisateur à répartir les matchs restants sur les pistes disponibles.
+ * Licensed under GPL-3.0
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Competition, MatchStatus, Pool } from '../../../shared/types';
+import {
+  TournamentFlowManager,
+  DEFAULT_TOURNAMENT_CONFIG,
+  Arena as FlowArena,
+  FlowOptimizationResult,
+} from '../../../shared/services/tournamentFlow';
+
+interface PlanningAssistantProps {
+  competition: Competition;
+  pools: Pool[];
+  suggestedArenaCount: number;
+  onClose: () => void;
+}
+
+const PlanningAssistant: React.FC<PlanningAssistantProps> = ({
+  competition,
+  pools,
+  suggestedArenaCount,
+  onClose,
+}) => {
+  const [arenaCount, setArenaCount] = useState(Math.max(1, suggestedArenaCount));
+  const [result, setResult] = useState<FlowOptimizationResult | null>(null);
+  const [recommendations, setRecommendations] = useState<string[]>([]);
+  const [insights, setInsights] = useState<{
+    estimatedFinishTime: Date;
+    bottlenecks: string[];
+    recommendations: string[];
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const manager = useMemo(() => new TournamentFlowManager(DEFAULT_TOURNAMENT_CONFIG), []);
+
+  const arenas: FlowArena[] = useMemo(
+    () =>
+      Array.from({ length: arenaCount }, (_, i) => ({
+        id: `piste-${i + 1}`,
+        name: `Piste ${i + 1}`,
+        available: true,
+      })),
+    [arenaCount]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    manager.optimizeTournamentFlow(competition, pools, arenas).then(res => {
+      if (cancelled) return;
+      setResult(res);
+      setRecommendations(manager.getFlowRecommendations(res.schedule, arenas));
+      setInsights(manager.generatePredictiveInsights(competition, pools, res.schedule));
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [manager, competition, pools, arenas]);
+
+  const remainingMatches = pools.reduce(
+    (sum, p) => sum + p.matches.filter(m => m.status !== MatchStatus.FINISHED).length,
+    0
+  );
+
+  return (
+    <div className="modal-overlay" onClick={onClose} style={{ zIndex: 11000 }}>
+      <div
+        className="modal"
+        onClick={e => e.stopPropagation()}
+        style={{ maxWidth: '560px' }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="planning-assistant-title"
+      >
+        <div className="modal-header">
+          <h2 className="modal-title" id="planning-assistant-title">🗓️ Assistant de planning</h2>
+        </div>
+        <div className="modal-body" style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <label htmlFor="planning-arena-count" style={{ fontSize: '0.875rem', fontWeight: 600 }}>
+              Nombre de pistes disponibles
+            </label>
+            <input
+              id="planning-arena-count"
+              type="number"
+              min={1}
+              max={20}
+              value={arenaCount}
+              onChange={e => setArenaCount(Math.max(1, Math.min(20, Number(e.target.value) || 1)))}
+              style={{ width: '4rem' }}
+            />
+          </div>
+
+          {loading && <p style={{ color: 'var(--color-text-light)' }}>Calcul en cours…</p>}
+
+          {!loading && insights && (
+            <>
+              <div
+                style={{
+                  padding: '0.75rem 1rem',
+                  background: 'var(--color-surface-alt, #f8fafc)',
+                  borderRadius: '8px',
+                  fontSize: '0.875rem',
+                }}
+              >
+                <strong>Fin estimée :</strong>{' '}
+                {insights.estimatedFinishTime.toLocaleTimeString('fr-FR', {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+                <br />
+                <strong>Matchs restants :</strong> {remainingMatches}
+              </div>
+
+              {recommendations.length === 0 && insights.bottlenecks.length === 0 ? (
+                <p style={{ fontSize: '0.875rem', color: 'var(--color-text-light)' }}>
+                  Aucun point de vigilance détecté avec cette configuration.
+                </p>
+              ) : (
+                <ul style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.875rem', display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                  {recommendations.map((r, i) => (
+                    <li key={`rec-${i}`}>{r}</li>
+                  ))}
+                  {insights.bottlenecks.map((b, i) => (
+                    <li key={`bn-${i}`}>⚠️ {b}</li>
+                  ))}
+                </ul>
+              )}
+
+              {result && result.metrics.arenaUtilization && (
+                <div style={{ fontSize: '0.8125rem', color: 'var(--color-text-light)' }}>
+                  Temps d'attente moyen estimé : {Math.max(0, Math.round(result.metrics.averageWaitTime))} min
+                </div>
+              )}
+            </>
+          )}
+        </div>
+        <div className="modal-footer">
+          <button type="button" className="btn btn-primary" onClick={onClose}>
+            Fermer
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(PlanningAssistant);

--- a/src/shared/services/notificationService.test.ts
+++ b/src/shared/services/notificationService.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import NotificationService from './notificationService';
+import NotificationService, { isWebhookUrlSafe } from './notificationService';
 import { Fencer, Match, Competition, Gender, FencerStatus, MatchStatus, Weapon, Category } from '../types';
 
 const fencer = (id: string, firstName: string, lastName: string): Fencer => ({
@@ -88,8 +88,7 @@ describe('NotificationService - payloads', () => {
 });
 
 describe('NotificationService - isWebhookUrlSafe', () => {
-  const svc = new NotificationService();
-  const safe = (u: string) => (svc as any).isWebhookUrlSafe(u) as boolean;
+  const safe = (u: string) => isWebhookUrlSafe(u);
 
   it('accepte une URL https publique', () => {
     expect(safe('https://hooks.example.com/abc')).toBe(true);

--- a/src/shared/services/notificationService.ts
+++ b/src/shared/services/notificationService.ts
@@ -26,6 +26,32 @@ export interface NotificationConfig {
   };
 }
 
+/**
+ * Valide qu'une URL webhook est sécurisée (https uniquement, pas d'IP privée/localhost).
+ * Partagée entre le service de notification et l'UI de réglages pour éviter toute divergence.
+ */
+export function isWebhookUrlSafe(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== 'https:') return false;
+    const h = url.hostname;
+    if (
+      h === 'localhost' ||
+      h === '127.0.0.1' ||
+      h === '::1' ||
+      /^10\./.test(h) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
+      /^192\.168\./.test(h) ||
+      /^169\.254\./.test(h)
+    ) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export interface NotificationPayload {
   title: string;
   body: string;
@@ -149,37 +175,12 @@ export class NotificationService {
   }
 
   /**
-   * Valide qu'une URL webhook est sécurisée (https uniquement, pas d'IP privée/localhost)
-   */
-  private isWebhookUrlSafe(rawUrl: string): boolean {
-    try {
-      const url = new URL(rawUrl);
-      if (url.protocol !== 'https:') return false;
-      const h = url.hostname;
-      if (
-        h === 'localhost' ||
-        h === '127.0.0.1' ||
-        h === '::1' ||
-        /^10\./.test(h) ||
-        /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
-        /^192\.168\./.test(h) ||
-        /^169\.254\./.test(h)
-      ) {
-        return false;
-      }
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
    * Send webhook notification
    */
   private async sendWebhook(payload: NotificationPayload): Promise<void> {
     if (!this.config.webhook) return;
 
-    if (!this.isWebhookUrlSafe(this.config.webhook.url)) {
+    if (!isWebhookUrlSafe(this.config.webhook.url)) {
       logger.error(LogCategory.NETWORK, 'Webhook refusé : URL non sécurisée (doit être https vers un hôte public)');
       return;
     }


### PR DESCRIPTION
## Contexte

Suite à un audit UX/parcours utilisateur du code (onboarding, navigation, confirmations, accessibilité, undo, aide contextuelle, export PDF, notifications), ce PR implémente les correctifs et améliorations validés — à l'exception de l'unification de la navigation entre les pages remote (`arena.html`, `pool.html`, `dashboard.html`, etc.), volontairement hors scope.

## Changements

**Corrections rapides**
- Remplace les derniers `window.confirm()` natifs par le `ConfirmDialog` custom (`CompetitionView.tsx:1516`, `TeamManagerView.tsx:172`) — cohérence visuelle et gestion du focus dans Electron.
- Active le journal d'audit des scores **par défaut** (`SettingsModal.tsx`, `CompetitionView.tsx`) — restait désactivé silencieusement auparavant.
- Ajoute des attributs ARIA (`role`, `aria-live`, `aria-label`, tabpanels) sur `arena.html`, `pool.html`, `dashboard.html`, qui n'en avaient aucun contrairement à `referee.html`.
- Ajoute un skeleton de chargement dédié (`CompetitionViewSkeleton`) pour la vue compétition, au lieu d'un simple texte "Chargement…".

**Parcours**
- Étend les `CoachMark` (jusque-là un seul point d'usage) à l'import de tireurs et à l'action suivante en phase poules.
- Expose `TournamentFlowManager` — moteur d'optimisation de planning complet mais totalement inutilisé côté UI (seulement référencé par son propre test) — via un nouvel **assistant de planning** (`PlanningAssistant.tsx`) : estimation de fin de tournoi, recommandations, temps d'attente moyen.
- Ajoute un **centre d'export unifié** (`ExportCenterModal.tsx`) regroupant les exports jusque-là dispersés entre plusieurs vues (tireurs, poules, classement, résultats, statistiques), avec redirection contextuelle vers Tableau/Résultats pour les exports qui restent propres à ces vues.

**Divers**
- Factorise `isWebhookUrlSafe` (dupliquée entre `notificationService.ts` et `SettingsModal.tsx`, avec une divergence réelle — la copie de `SettingsModal` ne bloquait pas `::1`/`169.254.x`) en une fonction exportée unique.
- Ajoute un indice discret de découvrabilité des raccourcis clavier (`?`, `Ctrl+K`) sur l'écran d'accueil.

## Test plan

- [x] `npm run type-check` — 0 erreur
- [x] `npm run lint` — 0 erreur (warnings prettier pré-existants uniquement, non liés à ce diff)
- [x] `npm run test:run` — 963/963 tests passent
- [x] `npm run build:renderer` — build webpack réussi
- [ ] Vérification manuelle en environnement Electron (non exécutable dans cet environnement — téléchargement du binaire Electron bloqué par le proxy réseau)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MfH8QmSM2iXMy3oGjnWvhr)_