### PR TITLE
Alerte batterie arbitre, export direct FFE, stats arbitres

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1230,6 +1230,46 @@ export class DatabaseManager {
     });
   }
 
+  public getRefereeStats(competitionId: string): Array<{
+    refereeId: string;
+    refereeName: string;
+    matchesCount: number;
+    averageDuration: number;
+    cardsYellow: number;
+    cardsRed: number;
+    cardsBlack: number;
+  }> {
+    if (!this.db) return [];
+    const rows = this.queryAll<any>(
+      `SELECT r.id AS referee_id, r.name AS referee_name,
+              COUNT(*) AS matches_count,
+              AVG(CASE WHEN m.status = 'finished' AND m.duration IS NOT NULL THEN m.duration END) AS avg_duration,
+              (SELECT COUNT(*) FROM match_cards mc JOIN matches mm ON mc.match_id = mm.id
+                WHERE mm.referee_id = r.id AND mc.card_type = 'yellow') AS cards_yellow,
+              (SELECT COUNT(*) FROM match_cards mc JOIN matches mm ON mc.match_id = mm.id
+                WHERE mm.referee_id = r.id AND mc.card_type = 'red') AS cards_red,
+              (SELECT COUNT(*) FROM match_cards mc JOIN matches mm ON mc.match_id = mm.id
+                WHERE mm.referee_id = r.id AND mc.card_type = 'black') AS cards_black
+       FROM referees r
+       JOIN matches m ON m.referee_id = r.id
+       JOIN pools p ON m.pool_id = p.id
+       JOIN phases ph ON p.phase_id = ph.id
+       WHERE ph.competition_id = ? AND r.competition_id = ?
+       GROUP BY r.id, r.name
+       ORDER BY matches_count DESC`,
+      [competitionId, competitionId]
+    );
+    return rows.map(row => ({
+      refereeId: row.referee_id as string,
+      refereeName: row.referee_name as string,
+      matchesCount: row.matches_count as number,
+      averageDuration: (row.avg_duration as number) ?? 0,
+      cardsYellow: (row.cards_yellow as number) ?? 0,
+      cardsRed: (row.cards_red as number) ?? 0,
+      cardsBlack: (row.cards_black as number) ?? 0,
+    }));
+  }
+
   // ─── Touch / Card read methods ───────────────────────────────────────────────
 
   public getTouches(matchId: string): Array<{

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -621,7 +621,7 @@ function createWindow(initialLang?: string): void {
             "font-src 'self' https://fonts.gstatic.com; " +
             "img-src 'self' data: blob:; " +
             "media-src 'self' blob:; " +
-            "connect-src 'self' http://localhost:* https://api.github.com; " +
+            "connect-src 'self' http://localhost:* https://api.github.com https://api.ffe.fr; " +
             "frame-ancestors 'none';",
         ],
         'X-Content-Type-Options': ['nosniff'],
@@ -1209,6 +1209,9 @@ ipcMain.handle('db:deleteReferee', async (_, id) => {
 });
 ipcMain.handle('db:getMatchesWithReferees', async (_, competitionId) => {
   return db.getMatchesWithReferees(competitionId);
+});
+ipcMain.handle('db:getRefereeStats', async (_, competitionId) => {
+  return db.getRefereeStats(competitionId);
 });
 
 // Touch / Card read handlers

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -235,6 +235,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     deleteReferee: (id: string) => ipcRenderer.invoke('db:deleteReferee', id),
     getMatchesWithReferees: (competitionId: string) =>
       ipcRenderer.invoke('db:getMatchesWithReferees', competitionId),
+    getRefereeStats: (competitionId: string) =>
+      ipcRenderer.invoke('db:getRefereeStats', competitionId),
 
     // Touch / Card read
     getTouches: (matchId: string) => ipcRenderer.invoke('db:getTouches', matchId),

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -153,6 +153,7 @@ export class RemoteScoreServer {
     lastSeen: string;
     label?: string;
     screenId?: string;
+    battery?: { level: number; charging: boolean; updatedAt: string };
   }> = new Map();
 
   // Labels persistants par screenId (survivent aux reconnexions)
@@ -2658,6 +2659,18 @@ export class RemoteScoreServer {
         if (client) {
           client.lastSeen = new Date().toISOString();
         }
+      });
+
+      // Niveau de batterie remonté par les tablettes arbitre
+      socket.on('client:battery', (data: { level: number; charging: boolean }) => {
+        const client = this.connectedClients.get(socket.id);
+        if (!client) return;
+        client.battery = {
+          level: Math.max(0, Math.min(1, data.level)),
+          charging: !!data.charging,
+          updatedAt: new Date().toISOString(),
+        };
+        this.broadcastClientList();
       });
 
       socket.on('disconnect', () => {

--- a/src/remote/referee.html
+++ b/src/remote/referee.html
@@ -1261,6 +1261,20 @@
         >
           ⟳ Sync...
         </span>
+        <span
+          id="battery-badge"
+          style="
+            display: none;
+            background: #ef4444;
+            padding: 0.15rem 0.45rem;
+            border-radius: 1rem;
+            font-size: 0.7rem;
+            margin-left: 0.4rem;
+          "
+          title="Batterie faible"
+        >
+          🔋 <span id="battery-level">--</span>%
+        </span>
         <button
           id="btn-dt-icon"
           class="dt-icon-btn"
@@ -1798,6 +1812,7 @@
           this.setupSocketListeners();
           this.setupTimerInteractions();
           this.setupLongPressInteractions();
+          this.setupBatteryMonitor();
           this.showNextMatchesScreen();
           // Détecter l'arme de la compétition pour la mort subite Laser Sabre
           fetch('/api/session')
@@ -2228,6 +2243,38 @@
             dot.classList.add('disconnected');
             text.textContent = window.T('remote.offline');
           }
+        }
+
+        setupBatteryMonitor() {
+          if (!navigator.getBattery) return;
+          const badge = document.getElementById('battery-badge');
+          const levelSpan = document.getElementById('battery-level');
+          const LOW_THRESHOLD = 0.2;
+          let lastSent = 0;
+
+          const report = (battery, force) => {
+            const level = battery.level;
+            const pct = Math.round(level * 100);
+            const low = level <= LOW_THRESHOLD && !battery.charging;
+            badge.style.display = low ? 'inline-block' : 'none';
+            levelSpan.textContent = pct;
+            const now = Date.now();
+            if (force || now - lastSent > 60000) {
+              lastSent = now;
+              if (this.socket && this.socket.connected) {
+                this.socket.emit('client:battery', { level, charging: battery.charging });
+              }
+            }
+            if (low && force) {
+              this.showNotification(`🔋 Batterie faible (${pct}%)`, true);
+            }
+          };
+
+          navigator.getBattery().then(battery => {
+            report(battery, true);
+            battery.addEventListener('levelchange', () => report(battery, true));
+            battery.addEventListener('chargingchange', () => report(battery, true));
+          }).catch(() => {});
         }
 
         selectMatch(matchId) {

--- a/src/renderer/components/AnalyticsDashboard.tsx
+++ b/src/renderer/components/AnalyticsDashboard.tsx
@@ -275,8 +275,11 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
   onClose,
 }) => {
   const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
-  const [activeTab, setActiveTab] = useState<'performance' | 'stats' | 'charts' | 'journal'>('performance');
+  const [activeTab, setActiveTab] = useState<'performance' | 'stats' | 'charts' | 'journal' | 'referees'>('performance');
   const [fencerStats, setFencerStats] = useState<FencerCompetitionStats[]>([]);
+  const [refereeStats, setRefereeStats] = useState<
+    Array<{ refereeId: string; refereeName: string; matchesCount: number; averageDuration: number; cardsYellow: number; cardsRed: number; cardsBlack: number }>
+  >([]);
   const [selectedTimeframe, setSelectedTimeframe] = useState<'live' | 'last30min' | 'all'>('live');
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [lastUpdate, setLastUpdate] = useState(new Date());
@@ -285,6 +288,11 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
   const loadFencerStats = useCallback(async () => {
     const data = await window.electronAPI?.db?.getCompetitionFencerStats?.(competition.id);
     if (data) setFencerStats(data as FencerCompetitionStats[]);
+  }, [competition.id]);
+
+  const loadRefereeStats = useCallback(async () => {
+    const data = await window.electronAPI?.db?.getRefereeStats?.(competition.id);
+    if (data) setRefereeStats(data);
   }, [competition.id]);
 
   useEffect(() => { loadFencerStats(); }, [loadFencerStats]);
@@ -391,6 +399,12 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
         >
           Journal
         </button>
+        <button
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${activeTab === 'referees' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'}`}
+          onClick={() => { setActiveTab('referees'); loadRefereeStats(); }}
+        >
+          Arbitres
+        </button>
       </div>
 
       {activeTab === 'stats' && <FencerStatsTable competition={competition} />}
@@ -399,6 +413,38 @@ const AnalyticsDashboard_: React.FC<AnalyticsDashboardProps> = ({
         <Suspense fallback={null}>
           <MatchAuditLog competitionId={competition.id} competitionName={competition.title} />
         </Suspense>
+      )}
+      {activeTab === 'referees' && (
+        refereeStats.length === 0 ? (
+          <div className="text-center py-12 text-gray-500 text-sm">
+            Aucun match arbitré enregistré pour cette compétition.
+          </div>
+        ) : (
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="bg-gray-50 border-b-2 border-gray-200">
+                <th className="text-left px-3 py-2 font-semibold text-gray-500">Arbitre</th>
+                <th className="text-right px-3 py-2 font-semibold text-gray-500">Matchs</th>
+                <th className="text-right px-3 py-2 font-semibold text-gray-500">Durée moy.</th>
+                <th className="text-right px-3 py-2 font-semibold text-yellow-600">🟨</th>
+                <th className="text-right px-3 py-2 font-semibold text-red-600">🟥</th>
+                <th className="text-right px-3 py-2 font-semibold text-gray-800">⬛</th>
+              </tr>
+            </thead>
+            <tbody>
+              {refereeStats.map((r, i) => (
+                <tr key={r.refereeId} className={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                  <td className="px-3 py-2 font-medium text-gray-800">{r.refereeName}</td>
+                  <td className="px-3 py-2 text-right">{r.matchesCount}</td>
+                  <td className="px-3 py-2 text-right font-mono">{formatTime(r.averageDuration * 1000)}</td>
+                  <td className="px-3 py-2 text-right">{r.cardsYellow}</td>
+                  <td className="px-3 py-2 text-right">{r.cardsRed}</td>
+                  <td className="px-3 py-2 text-right">{r.cardsBlack}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )
       )}
 
       {activeTab === 'performance' && <>

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -54,6 +54,7 @@ const AnalyticsDashboard = React.lazy(() => import('./AnalyticsDashboard').then(
 const SeasonRankingView = React.lazy(() => import('./SeasonRankingView').then(m => ({ default: m.SeasonRankingView })));
 const TeamManagerView = React.lazy(() => import('./TeamManagerView').then(m => ({ default: m.TeamManagerView })));
 const FFEConnectModal = React.lazy(() => import('./FFEConnectModal'));
+const FFEExportModal = React.lazy(() => import('./FFEExportModal'));
 const PresentationMode = React.lazy(() => import('./PresentationMode').then(m => ({ default: m.PresentationMode })));
 const QuestPhaseView = React.lazy(() => import('./QuestPhaseView'));
 
@@ -143,6 +144,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
   const [showSeasonRanking, setShowSeasonRanking] = useState(false);
   const [showTeamManager, setShowTeamManager] = useState(false);
   const [showFFEConnect, setShowFFEConnect] = useState(false);
+  const [showFFEExport, setShowFFEExport] = useState(false);
   const [showQRCode, setShowQRCode] = useState(false);
   const [showKiosk, setShowKiosk] = useState(false);
   const [showPresentation, setShowPresentation] = useState(false);
@@ -1684,6 +1686,16 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
             exportDetailedStats={exportDetailedStats}
             onGoToTableau={() => { setCurrentPhase('tableau'); setShowExportCenter(false); }}
             onGoToResults={() => { setCurrentPhase('results'); setShowExportCenter(false); }}
+            onExportFFE={() => { setShowFFEExport(true); setShowExportCenter(false); }}
+          />
+        </Suspense>
+      )}
+
+      {showFFEExport && (
+        <Suspense fallback={null}>
+          <FFEExportModal
+            ranking={overallRanking}
+            onClose={() => setShowFFEExport(false)}
           />
         </Suspense>
       )}

--- a/src/renderer/components/FFEExportModal.tsx
+++ b/src/renderer/components/FFEExportModal.tsx
@@ -1,0 +1,138 @@
+/**
+ * BellePoule Modern - FFE Export Modal
+ * Export direct des résultats vers l'API FFE Connect
+ * Licensed under GPL-3.0
+ */
+
+import React, { useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import { PoolRanking } from '../../shared/types';
+import { FFEConnectService, FFEResultEntry } from '@shared/services/ffeConnectService';
+
+interface FFEExportModalProps {
+  ranking: PoolRanking[];
+  onClose: () => void;
+}
+
+function toResultEntries(ranking: PoolRanking[]): { entries: FFEResultEntry[]; missingLicense: number } {
+  const entries: FFEResultEntry[] = [];
+  let missingLicense = 0;
+  for (const r of ranking) {
+    if (!r.fencer.license) {
+      missingLicense++;
+      continue;
+    }
+    entries.push({
+      licence: r.fencer.license,
+      rank: r.rank,
+      victories: r.victories,
+      defeats: r.defeats,
+      touchesScored: r.touchesScored,
+      touchesReceived: r.touchesReceived,
+    });
+  }
+  return { entries, missingLicense };
+}
+
+const FFEExportModal: React.FC<FFEExportModalProps> = ({ ranking, onClose }) => {
+  const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
+  const [competitionCode, setCompetitionCode] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [sending, setSending] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [success, setSuccess] = useState(false);
+
+  const { entries, missingLicense } = toResultEntries(ranking);
+
+  const handleExport = async () => {
+    if (!competitionCode.trim()) {
+      setErrors(['Le code de compétition est requis']);
+      return;
+    }
+    setSending(true);
+    setErrors([]);
+    setSuccess(false);
+
+    const service = new FFEConnectService({ apiKey: apiKey.trim() || undefined });
+    const result = await service.exportResults(competitionCode.trim(), entries);
+
+    setSending(false);
+    if (!result.success) {
+      setErrors(result.errors.length > 0 ? result.errors : ["Échec de l'export"]);
+      return;
+    }
+    setSuccess(true);
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        ref={modalRef}
+        className="modal"
+        onClick={e => e.stopPropagation()}
+        style={{ maxWidth: '520px' }}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className="modal-header">
+          <h2 className="modal-title">Exporter vers FFE Connect</h2>
+          <button className="btn btn-icon btn-secondary" onClick={onClose}>&times;</button>
+        </div>
+
+        <div className="modal-body">
+          <div className="form-group" style={{ marginBottom: '1rem' }}>
+            <label className="form-label">Code de compétition *</label>
+            <input
+              className="form-input"
+              type="text"
+              placeholder="ex: 2024-IDF-001"
+              value={competitionCode}
+              onChange={e => setCompetitionCode(e.target.value)}
+              disabled={sending}
+            />
+          </div>
+          <div className="form-group" style={{ marginBottom: '1rem' }}>
+            <label className="form-label">Clé API (optionnelle)</label>
+            <input
+              className="form-input"
+              type="password"
+              placeholder="Votre clé API FFE"
+              value={apiKey}
+              onChange={e => setApiKey(e.target.value)}
+              disabled={sending}
+            />
+          </div>
+
+          <p style={{ fontSize: '0.85rem', color: 'var(--color-text-light)' }}>
+            {entries.length} tireur(s) prêt(s) à exporter
+            {missingLicense > 0 && ` — ${missingLicense} sans numéro de licence (ignoré(s))`}
+          </p>
+
+          {errors.length > 0 && (
+            <div style={{ marginTop: '0.75rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '6px', color: '#dc2626' }}>
+              {errors.map((e, i) => <div key={i}>{e}</div>)}
+            </div>
+          )}
+          {success && (
+            <div style={{ marginTop: '0.75rem', padding: '0.75rem', background: '#dcfce7', borderRadius: '6px', color: '#15803d' }}>
+              Résultats envoyés à la FFE avec succès.
+            </div>
+          )}
+        </div>
+
+        <div className="modal-footer" style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+          <button className="btn btn-secondary" onClick={onClose}>Fermer</button>
+          <button
+            className="btn btn-primary"
+            onClick={handleExport}
+            disabled={sending || entries.length === 0 || !competitionCode.trim()}
+          >
+            {sending ? 'Envoi…' : 'Exporter'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(FFEExportModal);

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -1501,6 +1501,21 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
                   {clientLabel}
                 </span>
                 <span style={{ fontSize: '0.75rem', color: '#64748b' }}>{client.ip}</span>
+                {client.battery && (
+                  <span
+                    title={client.battery.charging ? 'En charge' : 'Sur batterie'}
+                    style={{
+                      fontSize: '0.75rem',
+                      padding: '0.15rem 0.4rem',
+                      borderRadius: '0.3rem',
+                      background: client.battery.level <= 0.2 && !client.battery.charging ? '#7f1d1d' : '#1e293b',
+                      color: client.battery.level <= 0.2 && !client.battery.charging ? '#fca5a5' : '#94a3b8',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {client.battery.charging ? '🔌' : '🔋'} {Math.round(client.battery.level * 100)}%
+                  </span>
+                )}
                 <div style={{ display: 'flex', gap: '0.35rem', marginLeft: 'auto', flexWrap: 'wrap' }}>
                   <button
                     className="btn-secondary"

--- a/src/renderer/components/competition/ExportCenterModal.tsx
+++ b/src/renderer/components/competition/ExportCenterModal.tsx
@@ -29,6 +29,7 @@ interface ExportCenterModalProps {
   exportDetailedStats: (pools: Pool[], ranking: PoolRanking[]) => void;
   onGoToTableau: () => void;
   onGoToResults: () => void;
+  onExportFFE: () => void;
 }
 
 const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
@@ -60,6 +61,7 @@ const ExportCenterModal: React.FC<ExportCenterModalProps> = ({
   exportDetailedStats,
   onGoToTableau,
   onGoToResults,
+  onExportFFE,
 }) => {
   return (
     <div className="modal-overlay" onClick={onClose} style={{ zIndex: 11000 }}>
@@ -102,6 +104,7 @@ const ExportCenterModal: React.FC<ExportCenterModalProps> = ({
               <button className="btn btn-secondary" onClick={() => exportRanking(overallRanking, 'csv', isLaserSabre)}>CSV</button>
               <button className="btn btn-secondary" onClick={() => exportRankingExcelCSV(overallRanking)}>CSV Excel</button>
               <button className="btn btn-secondary" onClick={() => exportRanking(overallRanking, 'json', isLaserSabre)}>JSON</button>
+              <button className="btn btn-secondary" onClick={onExportFFE}>📡 Envoyer à la FFE</button>
             </Section>
           )}
 

--- a/src/shared/services/ffeConnectService.ts
+++ b/src/shared/services/ffeConnectService.ts
@@ -23,6 +23,15 @@ export interface FFEConnectConfig {
   baseUrl?: string;
 }
 
+export interface FFEResultEntry {
+  licence: string;
+  rank: number;
+  victories?: number;
+  defeats?: number;
+  touchesScored?: number;
+  touchesReceived?: number;
+}
+
 const DEFAULT_BASE_URL = 'https://api.ffe.fr';
 const TIMEOUT_MS = 5000;
 
@@ -89,6 +98,51 @@ export class FFEConnectService {
       }
       const message = err instanceof Error ? err.message : String(err);
       return { success: false, participants: [], errors: [`Erreur réseau: ${message}`] };
+    }
+  }
+
+  async exportResults(
+    competitionCode: string,
+    results: FFEResultEntry[]
+  ): Promise<{ success: boolean; errors: string[] }> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    const url = `${this.baseUrl}/competition/${encodeURIComponent(competitionCode)}/results`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    if (this.apiKey) {
+      headers['X-Api-Key'] = this.apiKey;
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        signal: controller.signal,
+        headers,
+        body: JSON.stringify({ results }),
+      });
+      clearTimeout(timeoutId);
+
+      if (response.status === 401) {
+        return { success: false, errors: ['Clé API invalide'] };
+      }
+      if (response.status === 404) {
+        return { success: false, errors: ['Compétition non trouvée'] };
+      }
+      if (!response.ok) {
+        return { success: false, errors: [`Erreur serveur: ${response.status} ${response.statusText}`] };
+      }
+      return { success: true, errors: [] };
+    } catch (err: unknown) {
+      clearTimeout(timeoutId);
+      if (err instanceof Error && err.name === 'AbortError') {
+        return { success: false, errors: ['Délai de connexion dépassé (5s)'] };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, errors: [`Erreur réseau: ${message}`] };
     }
   }
 

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -354,6 +354,7 @@ export interface ConnectedClient {
   lastSeen: string;
   label?: string;
   screenId?: string;
+  battery?: { level: number; charging: boolean; updatedAt: string };
 }
 
 export interface KioskScreenConfig {
@@ -600,6 +601,10 @@ export interface DatabaseAPI {
     fencerAName: string; fencerBName: string;
     scoreA: number | null; scoreB: number | null; status: string;
     refereeId: string | null; refereeName: string | null;
+  }>>;
+  getRefereeStats: (competitionId: string) => Promise<Array<{
+    refereeId: string; refereeName: string; matchesCount: number;
+    averageDuration: number; cardsYellow: number; cardsRed: number; cardsBlack: number;
   }>>;
 
   // Touch / Card read


### PR DESCRIPTION
## Résumé
- Alerte batterie tablette arbitre : Battery Status API dans `referee.html`, badge local sous 20%, remontée socket `client:battery` → dashboard (`RemoteScoreManager`) avec indicateur par écran connecté.
- Export direct vers FFE Connect : `FFEConnectService.exportResults` (POST classement), nouveau `FFEExportModal`, bouton "📡 Envoyer à la FFE" dans le centre d'export. CSP `connect-src` étendu à `api.ffe.fr`.
- Onglet "Arbitres" dans le dashboard analytics : nouvelle méthode DB `getRefereeStats` (nb matchs, durée moyenne, cartons jaune/rouge/noir par arbitre) + IPC.

## Test plan
- [x] `npm run type-check`
- [x] `npx vitest run` (974 tests, tous verts)
- [x] `npx eslint` sur les fichiers modifiés (0 erreur, warnings prettier préexistants uniquement)
- [ ] Vérification manuelle UI (dashboard analytics, export FFE, badge batterie) en environnement Electron réel


---
_Generated by [Claude Code](https://claude.ai/code/session_01CuMrB31is2dRPcR8n7k2iR)_