### PR TITLE
Double-clic pour modifier un tireur dans l'appel

### DIFF
--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -854,7 +854,12 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                 <tr style={{ height: virtual.state.offsetY }}><td colSpan={colSpanTotal} /></tr>
               )}
               {(useVirtual ? virtual.visibleItems : filteredFencers).map(fencer => (
-                <tr key={fencer.id}>
+                <tr
+                  key={fencer.id}
+                  onDoubleClick={() => setEditingFencer(fencer)}
+                  style={{ cursor: 'pointer' }}
+                  title="Double-cliquer pour modifier"
+                >
                   {visibleCols.map(col => {
                     switch (col.id) {
                       case 'ref':       return <td key="ref" className="text-muted">{fencer.ref}</td>;
@@ -867,7 +872,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
                       default:          return null;
                     }
                   })}
-                  <td>
+                  <td onDoubleClick={e => e.stopPropagation()}>
                     <div
                       style={{
                         display: 'flex',


### PR DESCRIPTION
## Résumé
- Double-cliquer sur une ligne du tableau d'appel (`FencerList.tsx`) ouvre désormais la modale d'édition du tireur, comme le fait déjà le bouton crayon (✏️)
- Le double-clic sur la cellule d'actions (boutons Pointer/Abandonner/Forfait/Réactiver/Supprimer) est isolé (`stopPropagation`) pour ne pas déclencher l'ouverture de la modale par-dessus une autre action

## Plan de test
- [x] `npm run type-check`
- [x] `npx vitest run src/renderer/components/FencerList.test.tsx`
- [ ] Vérification manuelle dans l'app (double-clic sur une ligne de l'appel ouvre la modale d'édition)


---
_Generated by [Claude Code](https://claude.ai/code/session_018mQw6TVfyaBz4abxtYJasF)_