### PR TITLE
Fix: le modal de saisie de score de poule perdait sa taille au redimensionnement

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -411,7 +411,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
     );
   };
 
-  const { modalRef, dimensions } = useModalResize({
+  const { modalRef } = useModalResize({
     defaultWidth: 1440, // Doublé de 720 à 1440 (+100%)
     defaultHeight: 400,
     minWidth: 960, // Doublé de 480 à 960 (+100%)
@@ -887,7 +887,6 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           ref={modalRef}
           className="modal resizable"
           onClick={e => e.stopPropagation()}
-          style={{ maxWidth: '900px', width: '95%', minHeight: '400px' }}
         >
           <div className="modal-header" style={{ cursor: 'move' }}>
             <h3 className="modal-title">Saisie rapide du score</h3>


### PR DESCRIPTION
## Résumé

Correctif du bug rapporté : la fenêtre de saisie du score d'un match de poule ne conservait jamais la taille voulue par l'utilisateur, et semblait se redimensionner de façon incohérente quand la fenêtre principale changeait de taille.

## Cause

Le modal `Saisie rapide du score` (`src/renderer/components/PoolView.tsx`) est redimensionnable via `resize: both` (CSS) et le hook `useModalResize`, qui restaure la taille sauvegardée en `localStorage` et persiste chaque redimensionnement manuel.

Mais le JSX appliquait en plus un style inline fixe sur le même élément :
```tsx
style={{ maxWidth: '900px', width: '95%', minHeight: '400px' }}
```
Cet inline style est réappliqué par React à **chaque re-rendu** du composant (changement de score, sélection d'un autre match, etc.), et écrase systématiquement la taille imposée par le hook/CSS. Comme `width: 95%` est relatif à la largeur de la fenêtre principale au moment du rendu, la taille effective du modal dépendait de façon non déterministe de l'état de la fenêtre principale plutôt que de rester celle choisie par l'utilisateur — d'où l'impression que la poule « rapetissait » à l'agrandissement de la fenêtre, et qu'il fallait repasser par un préréglage (« Compact ») pour la remettre correctement.

## Changement

- Suppression du style inline conflictuel : la taille du modal est désormais entièrement gérée par la classe CSS `.modal.resizable` (défaut, min/max, `resize: both`) et par `useModalResize` (persistance en `localStorage`).
- Suppression de la variable `dimensions` du hook, qui n'était jamais utilisée dans le rendu.

## Test plan

- [x] `npm run type-check`
- [x] `npx eslint src/renderer/components/PoolView.tsx src/renderer/hooks/useModalResize.ts` (aucune erreur, warnings préexistants uniquement)
- [x] `npx vitest run` sur les tests de composants renderer existants
- [ ] Vérification manuelle en conditions réelles (Windows) : redimensionner le modal de saisie de score, agrandir/rétrécir la fenêtre principale, rouvrir le modal et vérifier que la taille est conservée


---
_Generated by [Claude Code](https://claude.ai/code/session_01YLkdaxcuRqSh2RXsgKWZdj)_