### PR TITLE
Fix: la molette de saisie du score fait aussi défiler la poule

### DIFF
--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Pool, Fencer, Score, MatchStatus, FencerStatus } from '../../../shared/types';
 import { formatRatio, formatIndex } from '../../../shared/utils/poolCalculations';
 import { ColumnId } from '../../hooks/useColumnVisibility';
@@ -62,6 +62,24 @@ const ScoreCell = React.memo<ScoreCellProps>(
         inputRef.current?.select();
       }
     }, [isInlineEditing]);
+
+    // React attache onWheel en mode passif : preventDefault() y est ignoré silencieusement,
+    // donc la poule défile quand même sous la molette. On passe par un listener natif non-passif.
+    const wheelStateRef = useRef({ quickMouseScoring, onWheelScore, isLocked });
+    wheelStateRef.current = { quickMouseScoring, onWheelScore, isLocked };
+
+    const cellRef = useCallback((el: HTMLDivElement | null) => {
+      if (!el) return;
+      const listener = (e: WheelEvent) => {
+        const { quickMouseScoring, onWheelScore, isLocked } = wheelStateRef.current;
+        if (!quickMouseScoring || !onWheelScore || isLocked) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const delta = e.deltaY > 0 ? -1 : 1;
+        onWheelScore(e.shiftKey, delta);
+      };
+      el.addEventListener('wheel', listener, { passive: false });
+    }, []);
 
     if (abandoned) {
       return (
@@ -127,6 +145,7 @@ const ScoreCell = React.memo<ScoreCellProps>(
 
     return (
       <div
+        ref={cellRef}
         className={`pool-cell ${cellClass} ${isFlashing ? 'pool-cell-flash' : ''}`}
         onClick={() => !isLocked && onCellClick(rowFencer, colFencer)}
         onKeyDown={e => {
@@ -137,12 +156,6 @@ const ScoreCell = React.memo<ScoreCellProps>(
         }}
         onMouseEnter={quickMouseScoring ? onHoverIn : undefined}
         onMouseLeave={quickMouseScoring ? onHoverOut : undefined}
-        onWheel={quickMouseScoring && onWheelScore && !isLocked ? e => {
-          e.preventDefault();
-          e.stopPropagation();
-          const delta = e.deltaY > 0 ? -1 : 1;
-          onWheelScore(e.shiftKey, delta);
-        } : undefined}
         role="button"
         tabIndex={isLocked ? -1 : 0}
         aria-label={`${rowFencer.lastName} ${rowFencer.firstName} contre ${colFencer.lastName} ${colFencer.firstName}${


### PR DESCRIPTION
## Résumé

Correctif du bug rapporté : avec la saisie rapide à la souris activée, tourner la molette sur une cellule de la poule augmente/diminue bien le score, mais fait aussi défiler la fenêtre de la poule (verticalement à la molette, horizontalement avec shift+molette), ce qui rend la fonction peu utilisable en pratique.

## Cause

`ScoreCell` (`src/renderer/components/pool/PoolScoreMatrix.tsx`) gérait la molette via la prop synthétique React `onWheel`, avec un appel à `e.preventDefault()`/`e.stopPropagation()`. Or React attache les listeners `wheel`/`touchstart`/`touchmove` en mode **passif** par défaut (optimisation de perf de scroll) : dans un listener passif, `preventDefault()` est silencieusement ignoré par le navigateur. Le score se mettait donc bien à jour, mais rien n'empêchait le scroll par défaut du conteneur de se produire en parallèle.

## Changement

- Remplacement du handler `onWheel` (JSX) par un listener natif `wheel` attaché via une ref callback, avec l'option `{ passive: false }`, ce qui permet à `preventDefault()` de fonctionner réellement.
- La logique de calcul du score (delta, shift pour l'autre colonne, bornes 0..maxScore) est inchangée.

## Test plan

- [x] `npm run type-check`
- [x] `npx eslint src/renderer/components/pool/PoolScoreMatrix.tsx` (aucune erreur, warnings de formatage préexistants uniquement)
- [x] `npx vitest run` (974 tests, tous verts)
- [ ] Vérification manuelle : dans une poule, activer la saisie rapide à la souris, tourner la molette sur une cellule et vérifier que le score change sans que la poule défile (molette seule et shift+molette)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RttDBqzGwco7T6DjabdY2Y)_