### PR TITLE
Poule: suppression rapide d'un match terminé + Undo

### DIFF
--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -189,6 +189,52 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
   }, [pool.id, onRefereeAssigned]);
 
   const { addAction, undo, redo, canUndo, canRedo } = useHistory();
+
+  // Supprime (réinitialise) un match terminé et rend l'opération annulable via Ctrl+Z
+  const handleMatchDelete = useCallback(
+    (matchIndex: number) => {
+      if (!onMatchReset) return;
+      const match = pool.matches[matchIndex];
+
+      if (!match || match.status !== MatchStatus.FINISHED) {
+        onMatchReset(matchIndex);
+        return;
+      }
+
+      const prevScoreA = match.scoreA;
+      const prevScoreB = match.scoreB;
+      const winner: 'A' | 'B' | undefined = prevScoreA?.isVictory
+        ? 'A'
+        : prevScoreB?.isVictory
+          ? 'B'
+          : undefined;
+      const specialStatus: 'abandon' | 'forfait' | 'exclusion' | undefined =
+        prevScoreA?.isAbstention || prevScoreB?.isAbstention
+          ? 'abandon'
+          : prevScoreA?.isForfait || prevScoreB?.isForfait
+            ? 'forfait'
+            : prevScoreA?.isExclusion || prevScoreB?.isExclusion
+              ? 'exclusion'
+              : undefined;
+
+      addAction({
+        type: 'DELETE_MATCH',
+        description: `Suppression score poule ${pool.number} match ${matchIndex + 1}`,
+        undo: () => {
+          if (prevScoreA?.value != null && prevScoreB?.value != null) {
+            onScoreUpdate(matchIndex, prevScoreA.value, prevScoreB.value, winner, specialStatus);
+          }
+        },
+        redo: () => {
+          onMatchReset(matchIndex);
+        },
+      });
+
+      onMatchReset(matchIndex);
+    },
+    [pool, onMatchReset, onScoreUpdate, addAction]
+  );
+
   const [showPoolConfetti, setShowPoolConfetti] = useState(false);
   const [showAddFencerModal, setShowAddFencerModal] = useState(false);
   const [auditMatchId, setAuditMatchId] = useState<string | null>(null);
@@ -1190,7 +1236,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         isLocked={isLocked}
         onMatchReset={!isLocked && onMatchReset ? (rowFencer, colFencer) => {
           const matchIndex = getMatchIndex(rowFencer, colFencer);
-          if (matchIndex !== -1) onMatchReset(matchIndex);
+          if (matchIndex !== -1) handleMatchDelete(matchIndex);
         } : undefined}
         quickMouseScoring={quickMouseScoring}
         highlightedFencerIds={hoveredFencerIds}
@@ -1539,7 +1585,7 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
             isLaserSabre={isLaserSabre}
             isLocked={isLocked}
             openScoreModal={openScoreModal}
-            onMatchReset={onMatchReset}
+            onMatchReset={onMatchReset ? handleMatchDelete : undefined}
             onShowMatchAudit={setAuditMatchId}
             defaultArena={defaultArena}
             arenaCount={arenaCount}

--- a/src/renderer/components/pool/PoolMatchList.test.tsx
+++ b/src/renderer/components/pool/PoolMatchList.test.tsx
@@ -26,8 +26,19 @@ const pending = (a: Fencer, b: Fencer, index: number) => ({
   } as Match,
 });
 
+const finished = (a: Fencer, b: Fencer, index: number) => ({
+  index,
+  match: {
+    id: `m${index}`, number: index + 1, fencerA: a, fencerB: b,
+    scoreA: { value: 5, isVictory: true, isAbstention: false, isExclusion: false, isForfait: false },
+    scoreB: { value: 3, isVictory: false, isAbstention: false, isExclusion: false, isForfait: false },
+    maxScore: 5, status: MatchStatus.FINISHED,
+    createdAt: new Date(), updatedAt: new Date(),
+  } as Match,
+});
+
 const renderList = (orderedMatches: any, over: Partial<Record<string, any>> = {}) => {
-  const props = {
+  const props: Record<string, any> = {
     orderedMatches,
     isLaserSabre: false,
     isLocked: false,
@@ -64,5 +75,26 @@ describe('PoolMatchList', () => {
   it('affiche « Poule terminée » sans match en attente', () => {
     renderList({ pending: [], finished: [], cancelled: [] });
     expect(screen.getByText('Poule terminée')).toBeInTheDocument();
+  });
+
+  it('le bouton supprimer d\'un match terminé n\'apparaît qu\'au survol de la ligne', () => {
+    renderList({ pending: [], finished: [finished(f1, f2, 0)], cancelled: [] }, { onMatchReset: vi.fn() });
+    const deleteBtn = screen.getByTitle(/Supprimer ce résultat/);
+    expect(deleteBtn).toHaveStyle({ opacity: '0' });
+
+    fireEvent.mouseEnter(deleteBtn.closest('div')!);
+    expect(deleteBtn).toHaveStyle({ opacity: '1' });
+
+    fireEvent.mouseLeave(deleteBtn.closest('div')!);
+    expect(deleteBtn).toHaveStyle({ opacity: '0' });
+  });
+
+  it('clique sur supprimer déclenche onMatchReset avec l\'index du match', () => {
+    const props = renderList(
+      { pending: [], finished: [finished(f1, f2, 0)], cancelled: [] },
+      { onMatchReset: vi.fn() }
+    );
+    fireEvent.click(screen.getByTitle(/Supprimer ce résultat/));
+    expect(props.onMatchReset).toHaveBeenCalledWith(0);
   });
 });

--- a/src/renderer/components/pool/PoolMatchList.tsx
+++ b/src/renderer/components/pool/PoolMatchList.tsx
@@ -127,6 +127,7 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
 }) => {
   const [showArenaModal, setShowArenaModal] = useState(false);
   const [selectedMatch, setSelectedMatch] = useState<Match | null>(null);
+  const [highlightedMatchId, setHighlightedMatchId] = useState<string | null>(null);
 
   const openArenaModal = (match: Match, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -351,22 +352,26 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
               match.fencerB?.status === FencerStatus.EXCLUDED;
             const isAbandonMatch = fencerAAbandoned || fencerBAbandoned;
             const winnerA = !!match.scoreA?.isVictory;
+            const isHighlighted = highlightedMatchId === match.id;
 
             return (
               <div
                 key={index}
                 onClick={() => !isAbandonMatch && !isLocked && openScoreModal(index)}
+                onMouseEnter={() => setHighlightedMatchId(match.id)}
+                onMouseLeave={() => setHighlightedMatchId(prev => (prev === match.id ? null : prev))}
                 style={{
                   display: 'flex',
                   alignItems: 'center',
                   padding: '0.5rem 0.75rem 0.5rem 0.875rem',
-                  background: 'white',
+                  background: isHighlighted ? '#f8fafc' : 'white',
                   borderRadius: '7px',
-                  border: '1px solid #e5e7eb',
+                  border: isHighlighted ? '1px solid #94a3b8' : '1px solid #e5e7eb',
                   borderLeft: isAbandonMatch ? '3px solid #9ca3af' : winnerA ? '3px solid #059669' : '3px solid #dc2626',
                   cursor: isAbandonMatch || isLocked ? 'default' : 'pointer',
                   opacity: isAbandonMatch ? 0.55 : 1,
                   gap: '0.5rem',
+                  transition: 'background 0.1s, border-color 0.1s',
                 }}
               >
                 <span
@@ -436,7 +441,7 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                       e.stopPropagation();
                       onMatchReset(index);
                     }}
-                    title="Annuler ce résultat"
+                    title="Supprimer ce résultat (Ctrl+Z pour annuler la suppression)"
                     style={{
                       padding: '0.2rem 0.4rem',
                       fontSize: '0.7rem',
@@ -446,9 +451,11 @@ const PoolMatchListComponent: React.FC<PoolMatchListProps> = ({
                       cursor: 'pointer',
                       color: '#dc2626',
                       flexShrink: 0,
+                      opacity: isHighlighted ? 1 : 0,
+                      transition: 'opacity 0.1s',
                     }}
                   >
-                    ↺
+                    🗑
                   </button>
                 )}
               </div>

--- a/src/renderer/hooks/useHistory.ts
+++ b/src/renderer/hooks/useHistory.ts
@@ -15,7 +15,8 @@ export type ActionType =
   | 'UPDATE_FENCER'
   | 'CREATE_POOL'
   | 'UPDATE_POOL'
-  | 'DELETE_POOL';
+  | 'DELETE_POOL'
+  | 'DELETE_MATCH';
 
 export interface HistoryAction<T = unknown> {
   id: string;


### PR DESCRIPTION
## Summary
- Dans la liste des matches d'une poule, un match terminé affiche désormais un bouton de suppression (🗑) qui n'apparaît qu'au survol de la ligne (surlignage).
- Ce bouton réinitialise le score du match (retour à l'état "non joué") — les matches de poule ne peuvent pas être physiquement supprimés puisqu'ils forment une grille round-robin fixe (une paire de tireurs = un match).
- L'action est désormais enregistrée dans la pile d'historique existante (`useHistory`, nouveau type `DELETE_MATCH`) : le bouton "Annuler" déjà présent dans l'en-tête de la poule (et le raccourci Ctrl+Z) permet de restaurer le score précédent.

## Détails d'implémentation
- `src/renderer/hooks/useHistory.ts` : ajout du type d'action `DELETE_MATCH`.
- `src/renderer/components/PoolView.tsx` : nouveau `handleMatchDelete` qui capture le score/vainqueur précédents avant réinitialisation et pousse une action d'historique (undo restaure le score via `onScoreUpdate`, redo réapplique la suppression). Câblé à la fois sur la vue grille (`PoolScoreMatrix`) et sur la vue liste (`PoolMatchList`).
- `src/renderer/components/pool/PoolMatchList.tsx` : surlignage de la ligne au survol (`highlightedMatchId`), le bouton de suppression n'est visible (opacity) que lorsque la ligne est surlignée.

## Test plan
- [x] `npm run type-check`
- [x] `npx vitest run` (976 tests, tous passants)
- [x] Nouveaux tests unitaires dans `PoolMatchList.test.tsx` : affichage du bouton au survol, déclenchement de `onMatchReset`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Efbh3bYrDpjEChRWVunSNU)_