### PR TITLE
Fix: noms des tireurs tronqués dans la modale de saisie rapide du score

### DIFF
--- a/src/renderer/components/poolView.styles.ts
+++ b/src/renderer/components/poolView.styles.ts
@@ -96,18 +96,28 @@ export const nameCol = (align: 'flex-start' | 'flex-end'): CSSProperties => ({
   alignItems: align,
   flex: 1,
   minWidth: '200px',
+  maxWidth: '100%',
+  overflow: 'hidden',
 });
 
 export const nameLast = (align: 'left' | 'right'): CSSProperties => ({
   fontSize: '1.5rem',
   fontWeight: 600,
   textAlign: align,
+  maxWidth: '100%',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 });
 
 export const nameFirst = (align: 'left' | 'right'): CSSProperties => ({
   fontSize: '1rem',
   color: '#6b7280',
   textAlign: align,
+  maxWidth: '100%',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 });
 
 export const victoryBtn = (active: boolean): CSSProperties => ({

--- a/src/renderer/hooks/useModalResize.ts
+++ b/src/renderer/hooks/useModalResize.ts
@@ -26,21 +26,28 @@ export const useModalResize = (options: UseModalResizeOptions = {}) => {
     const modal = modalRef.current;
     if (!modal) return;
 
-    // Restaurer les dimensions sauvegardées
+    // Restaurer les dimensions sauvegardées (la clé est partagée entre plusieurs
+    // vues dont les contenus n'ont pas les mêmes contraintes minimales : on
+    // reclamp toujours sur les min de CETTE instance pour éviter qu'une taille
+    // trop petite enregistrée ailleurs ne rende les cases illisibles ici).
     const savedWidth = localStorage.getItem('modal-score-width');
     const savedHeight = localStorage.getItem('modal-score-height');
 
-    const width = savedWidth ? parseInt(savedWidth, 10) : defaultWidth;
-    const height = savedHeight ? parseInt(savedHeight, 10) : defaultHeight;
+    const width = Math.max(minWidth, savedWidth ? parseInt(savedWidth, 10) : defaultWidth);
+    const height = Math.max(minHeight, savedHeight ? parseInt(savedHeight, 10) : defaultHeight);
 
     setDimensions({ width, height });
 
-    // Appliquer les dimensions initiales
+    // Appliquer les dimensions initiales (min-width/min-height inline pour que
+    // la poignée de redimensionnement respecte aussi le plancher par instance,
+    // le CSS partagé `.modal.resizable` n'ayant qu'un plancher générique bas).
     requestAnimationFrame(() => {
       modal.style.width = `${width}px`;
       modal.style.height = `${height}px`;
+      modal.style.minWidth = `${minWidth}px`;
+      modal.style.minHeight = `${minHeight}px`;
     });
-  }, [defaultWidth, defaultHeight]);
+  }, [defaultWidth, defaultHeight, minWidth, minHeight]);
 
   useEffect(() => {
     const modal = modalRef.current;


### PR DESCRIPTION
## Summary

- La modale « Saisie rapide du score » tronquait les noms des tireurs, en vue poule unique comme en vue globale.
- Cause : `useModalResize` acceptait des options `minWidth`/`minHeight` mais ne les appliquait jamais nulle part. Le CSS partagé `.modal.resizable` n'imposait qu'un plancher générique de 400px, très inférieur à ce que le layout (deux noms + boutons V + champs de score) nécessite réellement.
- Cette taille trop petite (obtenue en redimensionnant la modale dans une vue avec un besoin minimal plus faible, ex. `TableauView` avec `minWidth: 400`) était persistée dans une clé `localStorage` **partagée** par `PoolView` et `TableauView`, donc réappliquée à toutes les futures ouvertures de la modale, quelle que soit la vue.
- Fix : la taille restaurée est désormais reclampée sur le `minWidth`/`minHeight` propre à chaque instance, et ce plancher est appliqué en style inline pour que la poignée de redimensionnement le respecte aussi. Ajout d'un `text-overflow: ellipsis` en filet de sécurité sur les noms.

## Fichiers modifiés

- `src/renderer/hooks/useModalResize.ts`
- `src/renderer/components/poolView.styles.ts`

## Test plan

- [x] `npx tsc --noEmit` sans erreur
- [x] `npx eslint` sur les fichiers modifiés sans nouvelle erreur
- [x] `npx vitest run src/renderer/components/pool/PoolScoreMatrix.test.tsx` (5 tests passent)
- [ ] Vérification manuelle en app : ouvrir la modale de score en vue poule unique et en vue globale après avoir précédemment réduit la modale du tableau, confirmer que les noms complets s'affichent


---
_Generated by [Claude Code](https://claude.ai/code/session_01JCPik18rUHb5pYV4QjorxM)_