### PR TITLE
Fix: la fenêtre se redimensionne à chaque changement de poule en vue poule unique

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1411,7 +1411,8 @@ ipcMain.handle('dialog:saveFile', async (_, options) => {
 
 // Window resize handler
 ipcMain.handle('window:setSize', (_event, width: number, height: number) => {
-  if (mainWindow) {
+  // Ne pas écraser une fenêtre maximisée par l'utilisateur (ex: auto-fit poule unique)
+  if (mainWindow && !mainWindow.isMaximized()) {
     mainWindow.setSize(Math.max(width, 800), Math.max(height, 600), true);
   }
 });

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -227,11 +227,18 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     }
   }, [pools.length, singlePoolIndex]);
 
-  // Ajuste la taille de la fenêtre à la poule affichée (colonnes choisies + nb de tireurs)
-  // pour éviter les ascenseurs en vue "poule unique".
+  // Ajuste la taille de la fenêtre à l'entrée en vue "poule unique" (colonnes choisies
+  // + nb de tireurs de la poule affichée) pour éviter les ascenseurs. Ne se redéclenche
+  // pas à chaque changement de poule : naviguer d'une poule à l'autre ne doit pas
+  // réinitialiser la taille de fenêtre choisie par l'utilisateur (cf. bug dimension reset).
+  const poolsRef = useRef(pools);
+  poolsRef.current = pools;
+  const singlePoolIndexRef = useRef(singlePoolIndex);
+  singlePoolIndexRef.current = singlePoolIndex;
+
   useEffect(() => {
     if (poolsViewMode !== 'single' || currentPhase !== 'pools') return;
-    const pool = pools[singlePoolIndex];
+    const pool = poolsRef.current[singlePoolIndexRef.current];
     if (!pool) return;
 
     const POOL_CELL = 52; // px — doit rester synchro avec .pool-cell (main.css)
@@ -254,7 +261,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     );
 
     window.electronAPI?.setWindowSize(Math.round(width), Math.round(height));
-  }, [poolsViewMode, singlePoolIndex, pools, currentPhase, getVisibleColumns, isLaserSabre]);
+  }, [poolsViewMode, currentPhase, getVisibleColumns, isLaserSabre]);
 
   const {
     exportFencersList,


### PR DESCRIPTION
## Summary
- En vue "poule unique" (phase Poules), un effet auto-fit redimensionnait la fenêtre à chaque navigation entre poules (`◀`/`▶`/sélecteur), écrasant la taille voulue par l'utilisateur — d'où l'impression que "la dimension de l'application est reset" au changement de poule.
- L'auto-fit ne se déclenche désormais qu'à l'entrée en vue poule unique (changement de `poolsViewMode`/`currentPhase`), plus à chaque changement de `singlePoolIndex`.
- Ajout d'un garde-fou côté process principal : `window:setSize` n'agit plus si la fenêtre est maximisée, pour ne jamais annuler une maximisation volontaire de l'utilisateur.

## Changes
- `src/renderer/components/CompetitionView.tsx` : l'effet d'auto-fit de fenêtre lit désormais `pools`/`singlePoolIndex` via des refs et ne dépend plus que de `poolsViewMode`, `currentPhase`, `getVisibleColumns`, `isLaserSabre`.
- `src/main/main.ts` : le handler IPC `window:setSize` ignore la demande si `mainWindow.isMaximized()`.

## Test plan
- [x] `npm run type-check` (aucune erreur)
- [x] `npx eslint src/renderer/components/CompetitionView.tsx src/main/main.ts` (0 erreur, warnings prettier préexistants uniquement)
- [x] `npx vitest run` (976 tests passent)
- [ ] Vérification manuelle en application Electron : ouvrir vue poule unique, naviguer entre poules, vérifier que la fenêtre garde sa taille (non testable en environnement CI sans affichage Electron)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyXdHij5ymeHN9wESdmsbF)_