### PR TITLE
Poule : Suppr efface le score au survol (saisie simplifiée)

### DIFF
--- a/src/renderer/components/PoolView.test.tsx
+++ b/src/renderer/components/PoolView.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+/**
+ * Tests de composant - PoolView
+ * BellePoule Modern
+ */
+
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PoolView from './PoolView';
+import { Pool, Fencer, Match, MatchStatus, Gender, FencerStatus } from '../../shared/types';
+
+const fencer = (id: string, last: string): Fencer => ({
+  id, ref: Number(id), lastName: last, firstName: 'F',
+  gender: Gender.MALE, nationality: 'FRA', status: FencerStatus.CHECKED_IN,
+  createdAt: new Date(), updatedAt: new Date(),
+});
+
+const f1 = fencer('1', 'Dupont');
+const f2 = fencer('2', 'Martin');
+
+const finishedMatch: Match = {
+  id: 'm', number: 1, fencerA: f1, fencerB: f2,
+  scoreA: { value: 5, isVictory: true } as any,
+  scoreB: { value: 2, isVictory: false } as any,
+  status: MatchStatus.FINISHED, maxScore: 5, createdAt: new Date(), updatedAt: new Date(),
+};
+
+const testPool: Pool = {
+  id: 'p1', number: 1, phaseId: 'ph', fencers: [f1, f2], matches: [finishedMatch],
+  referees: [], isComplete: false, hasError: false, ranking: [],
+  createdAt: new Date(), updatedAt: new Date(),
+};
+
+describe('PoolView - saisie simplifiée : suppression au survol', () => {
+  beforeEach(() => {
+    (window as any).electronAPI = {
+      db: {
+        getPoolSignatures: vi.fn().mockResolvedValue([]),
+      },
+      onPoolSignatureUpdated: vi.fn().mockReturnValue(() => {}),
+    };
+    localStorage.setItem('bellepoule-simplified-input-mode', 'true');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('survoler une case scorée puis appuyer sur Suppr efface le score du match', () => {
+    const onMatchReset = vi.fn();
+    render(
+      <PoolView
+        pool={testPool}
+        onScoreUpdate={vi.fn()}
+        onMatchReset={onMatchReset}
+      />
+    );
+
+    const cell = screen.getByLabelText(/Dupont F contre Martin F/i);
+    fireEvent.mouseEnter(cell);
+    fireEvent.keyDown(document, { key: 'Delete' });
+
+    expect(onMatchReset).toHaveBeenCalledTimes(1);
+    expect(onMatchReset).toHaveBeenCalledWith(0);
+  });
+
+  it("n'efface rien si la souris ne survole aucune case", () => {
+    const onMatchReset = vi.fn();
+    render(
+      <PoolView
+        pool={testPool}
+        onScoreUpdate={vi.fn()}
+        onMatchReset={onMatchReset}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Delete' });
+
+    expect(onMatchReset).not.toHaveBeenCalled();
+  });
+
+  it('Suppr est sans effet hors saisie simplifiée', () => {
+    localStorage.setItem('bellepoule-simplified-input-mode', 'false');
+    const onMatchReset = vi.fn();
+    render(
+      <PoolView
+        pool={testPool}
+        onScoreUpdate={vi.fn()}
+        onMatchReset={onMatchReset}
+      />
+    );
+
+    const cell = screen.getByLabelText(/Dupont F contre Martin F/i);
+    fireEvent.mouseEnter(cell);
+    fireEvent.keyDown(document, { key: 'Delete' });
+
+    expect(onMatchReset).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/PoolView.tsx
+++ b/src/renderer/components/PoolView.tsx
@@ -440,12 +440,47 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
           if (!isLocked) redo();
           return;
         }
+        // Saisie simplifiée : survoler une case puis Suppr efface le score de ce match.
+        if (
+          e.key === 'Delete' &&
+          simplifiedInputMode &&
+          !isLocked &&
+          !inModalInput &&
+          target.tagName !== 'INPUT' &&
+          target.tagName !== 'TEXTAREA' &&
+          hoveredFencerIds.size === 2
+        ) {
+          e.preventDefault();
+          const [idA, idB] = Array.from(hoveredFencerIds);
+          const fencerA = fencers.find(f => f.id === idA);
+          const fencerB = fencers.find(f => f.id === idB);
+          if (fencerA && fencerB) {
+            const matchIndex = getMatchIndex(fencerA, fencerB);
+            if (matchIndex !== -1 && pool.matches[matchIndex]?.status === MatchStatus.FINISHED) {
+              handleMatchDelete(matchIndex);
+            }
+          }
+          return;
+        }
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [editingMatch, keyboardFocusField, isLaserSabre, orderedMatches.pending, undo, redo]);
+  }, [
+    editingMatch,
+    keyboardFocusField,
+    isLaserSabre,
+    orderedMatches.pending,
+    undo,
+    redo,
+    simplifiedInputMode,
+    isLocked,
+    hoveredFencerIds,
+    fencers,
+    pool.matches,
+    handleMatchDelete,
+  ]);
 
   // Calculer l'ordre optimal des matches restants
 
@@ -1239,8 +1274,8 @@ const PoolViewComponent: React.FC<PoolViewProps> = ({
         } : undefined}
         quickMouseScoring={quickMouseScoring}
         highlightedFencerIds={hoveredFencerIds}
-        onHoverCell={quickMouseScoring ? handleHoverCell : undefined}
-        onHoverLeave={quickMouseScoring ? handleHoverLeave : undefined}
+        onHoverCell={quickMouseScoring || simplifiedInputMode ? handleHoverCell : undefined}
+        onHoverLeave={quickMouseScoring || simplifiedInputMode ? handleHoverLeave : undefined}
         onWheelScore={quickMouseScoring ? handleWheelScore : undefined}
         simplifiedInputMode={simplifiedInputMode}
         inlineEditKey={inlineEditCell?.key ?? null}

--- a/src/renderer/components/pool/PoolScoreMatrix.tsx
+++ b/src/renderer/components/pool/PoolScoreMatrix.tsx
@@ -37,6 +37,7 @@ interface ScoreCellProps {
   onMatchReset?: (rowFencer: Fencer, colFencer: Fencer) => void;
   isHighlighted?: boolean;
   quickMouseScoring?: boolean;
+  simplifiedInputMode?: boolean;
   onHoverIn?: () => void;
   onHoverOut?: () => void;
   onWheelScore?: (shiftKey: boolean, delta: number) => void;
@@ -52,7 +53,7 @@ interface ScoreCellProps {
 // (la grille est O(n²), un re-rendu global coûte cher sur les grandes poules).
 const ScoreCell = React.memo<ScoreCellProps>(
   ({ rowFencer, colFencer, abandoned, score, isFlashing, isLocked, onCellClick, onMatchReset,
-     isHighlighted, quickMouseScoring, onHoverIn, onHoverOut, onWheelScore,
+     isHighlighted, quickMouseScoring, simplifiedInputMode, onHoverIn, onHoverOut, onWheelScore,
      isInlineEditing, inlineSingleScore, bufferedScore, onInlineSingleScoreChange, onInlineSubmit, onInlineCancel }) => {
     const inputRef = useRef<HTMLInputElement>(null);
 
@@ -154,8 +155,8 @@ const ScoreCell = React.memo<ScoreCellProps>(
             onCellClick(rowFencer, colFencer);
           }
         }}
-        onMouseEnter={quickMouseScoring ? onHoverIn : undefined}
-        onMouseLeave={quickMouseScoring ? onHoverOut : undefined}
+        onMouseEnter={quickMouseScoring || simplifiedInputMode ? onHoverIn : undefined}
+        onMouseLeave={quickMouseScoring || simplifiedInputMode ? onHoverOut : undefined}
         role="button"
         tabIndex={isLocked ? -1 : 0}
         aria-label={`${rowFencer.lastName} ${rowFencer.firstName} contre ${colFencer.lastName} ${colFencer.firstName}${
@@ -562,6 +563,7 @@ const PoolScoreMatrix: React.FC<PoolScoreMatrixProps> = ({
                   onMatchReset={onMatchReset}
                   isHighlighted={isHighlighted}
                   quickMouseScoring={quickMouseScoring}
+                  simplifiedInputMode={simplifiedInputMode}
                   onHoverIn={onHoverCell ? () => onHoverCell(rowFencer, colFencer) : undefined}
                   onHoverOut={onHoverLeave}
                   onWheelScore={onWheelScore ? (shiftKey, delta) => onWheelScore(rowFencer, colFencer, shiftKey, delta) : undefined}


### PR DESCRIPTION
## Summary
- En mode saisie simplifiée, survoler une case de la grille de poule (`PoolScoreMatrix`) active désormais le suivi de survol même quand le mode « scoring rapide à la souris » est désactivé.
- Appuyer sur la touche **Suppr** pendant ce survol réinitialise le score du match correspondant, en réutilisant le chemin existant `handleMatchDelete` (undo via Ctrl+Z, comme le bouton ↺ déjà présent).
- Aucune action si : mode saisie simplifiée désactivé, poule verrouillée, focus dans un champ de saisie, ou aucune case survolée.

## Détails d'implémentation
- `src/renderer/components/pool/PoolScoreMatrix.tsx` : `ScoreCell` accepte désormais `simplifiedInputMode` et déclenche `onHoverIn`/`onHoverOut` aussi bien en mode « scoring rapide » qu'en mode « saisie simplifiée ».
- `src/renderer/components/PoolView.tsx` : `onHoverCell`/`onHoverLeave` sont câblés dès que l'un des deux modes est actif ; le gestionnaire clavier global gère désormais la touche `Delete` en saisie simplifiée pour supprimer le score de la case survolée.
- `src/renderer/components/PoolView.test.tsx` (nouveau) : couvre le cas nominal (survol + Suppr efface le score) et les cas limites (pas de survol, mode désactivé).

## Test plan
- [x] `npm run type-check`
- [x] `npx vitest run` (193 tests, tous passants)
- [x] Nouveaux tests dans `PoolView.test.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TApPNPsqgHF1WpEnVD7nSy)_