### PR TITLE
Route hardcoded French strings through i18n (fixes #897)

### DIFF
--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -645,7 +645,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     onExportFencers: format => exportFencersList(fencers, format),
     onExportFencersBpf: async () => {
       const result = await window.electronAPI.dialog.saveFile({
-        title: 'Exporter tireurs + photos (.bpf)',
+        title: t('dialogs.exportFencersArchive'),
         defaultPath: `tireurs-${competition.title}.bpf`,
         filters: [{ name: 'BellePoule Fencers', extensions: ['bpf'] }],
       });
@@ -656,7 +656,7 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
     },
     onExportPhotos: async () => {
       const result = await window.electronAPI.dialog.saveFile({
-        title: 'Exporter les photos (.zip)',
+        title: t('dialogs.exportPhotos'),
         defaultPath: `photos-${competition.title}.zip`,
         filters: [{ name: 'Archive ZIP', extensions: ['zip'] }],
       });

--- a/src/renderer/components/FencerList.tsx
+++ b/src/renderer/components/FencerList.tsx
@@ -224,7 +224,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
     const filterName = format === 'fff' ? 'Fichier FFE' : 'Fichier texte';
 
     const result = await window.electronAPI.dialog.saveFile({
-      title: `Exporter les tireurs (.${extension})`,
+      title: t('dialogs.exportFencers', { ext: extension }),
       defaultPath: `tireurs.${extension}`,
       filters: [
         { name: filterName, extensions: [extension] },
@@ -252,7 +252,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const handleExportPhotos = async () => {
     if (!competitionId) return;
     const result = await window.electronAPI.dialog.saveFile({
-      title: 'Exporter les photos (.zip)',
+      title: t('dialogs.exportPhotos'),
       defaultPath: 'photos-tireurs.zip',
       filters: [{ name: 'Archive ZIP', extensions: ['zip'] }],
     });
@@ -274,7 +274,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const handleImportPhotos = async () => {
     if (!competitionId) return;
     const result = await window.electronAPI.dialog.openFile({
-      title: 'Importer les photos (.zip)',
+      title: t('dialogs.importPhotos'),
       filters: [{ name: 'Archive ZIP', extensions: ['zip'] }],
     });
     if (result && result.filePath) {
@@ -295,7 +295,7 @@ const FencerListComponent: React.FC<FencerListProps> = ({
   const handleExportFencersArchive = async () => {
     if (!competitionId) return;
     const result = await window.electronAPI.dialog.saveFile({
-      title: 'Exporter tireurs + photos (.bpf)',
+      title: t('dialogs.exportFencersArchive'),
       defaultPath: 'tireurs.bpf',
       filters: [{ name: 'BellePoule Fencers', extensions: ['bpf'] }],
     });

--- a/src/renderer/components/RemoteScoreManager.tsx
+++ b/src/renderer/components/RemoteScoreManager.tsx
@@ -15,6 +15,7 @@ import ThemeEditor from './ThemeEditor';
 import { OBSOverlayConfig } from './OBSOverlayConfig';
 import { CustomTheme, DisplayTheme } from '../../shared/types/remote';
 import { ConnectedClient, KioskScreenConfig } from '../../shared/types/preload';
+import { useTranslation } from '../hooks/useTranslation';
 
 interface RemoteScoreManagerProps {
   competition: Competition;
@@ -106,6 +107,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
   isVisible = false,
 }) => {
   const { showToast } = useToast();
+  const { t } = useTranslation();
   const [session, setSession] = useState<RemoteSession | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [serverUrl, setServerUrl] = useState<string>('');
@@ -672,7 +674,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
           <div className="rsm-hero">
             <span className="rsm-status-dot rsm-status-dot--off" />
             <div>
-              <h3 className="rsm-hero-title">Saisie distante inactive</h3>
+              <h3 className="rsm-hero-title">{t('remote.inactive_title')}</h3>
               <p className="rsm-hero-desc">
                 Les arbitres saisissent les scores depuis une tablette via navigateur web sur le réseau local.
               </p>
@@ -788,7 +790,7 @@ const RemoteScoreManager: React.FC<RemoteScoreManagerProps> = ({
     <div className="remote-score-manager">
       <div className="remote-header">
         <div className="remote-status active">
-          <h3>🟢 Saisie distante active</h3>
+          <h3>🟢 {t('remote.active_title')}</h3>
           <p>
             Serveur: <strong>{serverUrl}</strong>
           </p>

--- a/src/renderer/components/ScoreAuditLog.tsx
+++ b/src/renderer/components/ScoreAuditLog.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect, useCallback , memo} from 'react';
 import { ScoreAuditEntry, ScoreIpConflict } from '../../shared/types/preload';
 import { useToast } from './Toast';
+import { useTranslation } from '../hooks/useTranslation';
 
 interface Props {
   competitionId: string;
@@ -22,6 +23,7 @@ function formatScore(score: any): string {
 
 const ScoreAuditLog_: React.FC<Props> = ({ competitionId }) => {
   const { showToast } = useToast();
+  const { t } = useTranslation();
   const [entries, setEntries] = useState<ScoreAuditEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [filterPool, setFilterPool] = useState('');
@@ -84,7 +86,7 @@ const ScoreAuditLog_: React.FC<Props> = ({ competitionId }) => {
     const csv = header + rows.join('\n');
     try {
       const result = await window.electronAPI.dialog.saveFile({
-        title: 'Exporter le journal des scores',
+        title: t('dialogs.exportScoreHistory'),
         defaultPath: `historique_scores_${new Date().toISOString().slice(0,10)}.csv`,
         filters: [{ name: 'CSV / TXT', extensions: ['csv', 'txt'] }],
       });

--- a/src/renderer/components/TeamManagerView.tsx
+++ b/src/renderer/components/TeamManagerView.tsx
@@ -19,6 +19,7 @@ import { createCard } from '../../shared/utils/cardSystem';
 import TeamPoolView, { CardTarget } from './TeamPoolView';
 import TeamTableauView from './TeamTableauView';
 import { useConfirm } from './ConfirmDialog';
+import { useTranslation } from '../hooks/useTranslation';
 
 // ── Composant ─────────────────────────────────────────────────────────────────
 
@@ -43,6 +44,7 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
   const isLaserPoints = competition.weapon === Weapon.LASER && targetRule.mode === 'points';
   const tableId = competition.id; // Un seul tableau équipes par compétition
   const { confirm } = useConfirm();
+  const { t } = useTranslation();
   const [view, setView] = useState<ViewMode>('teams');
   const [teams, setTeams] = useState<TeamRow[]>([]);
   const [matches, setMatches] = useState<TeamMatchRow[]>([]);
@@ -698,15 +700,15 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
                       </th>
                       <th
                         className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center"
-                        title="Relais individuels gagnés/perdus"
+                        title={t('teams.relaysTooltip')}
                       >
-                        Relais G
+                        {t('teams.relaysWon')}
                       </th>
                       <th
                         className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center"
-                        title="Relais individuels gagnés/perdus"
+                        title={t('teams.relaysTooltip')}
                       >
-                        Relais P
+                        {t('teams.relaysLost')}
                       </th>
                       <th className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center">
                         Ind.

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -170,7 +170,9 @@
     "reset_scores": "Adwekaat ar skorioù",
     "waiting_match": "C'hort an emgann war heñ d'ar",
     "in_progress": "E-brient",
-    "finished": "Echuet"
+    "finished": "Echuet",
+    "inactive_title": "Enrollañ a-bell dizoberiant",
+    "active_title": "Enrollañ a-bell oberiant"
   },
   "settings": {
     "title": "Arventennoù",
@@ -382,5 +384,17 @@
     "scoring_zones": "Takadoù personelaet",
     "zone_label": "Takad",
     "zone_points": "Poentoù"
+  },
+  "dialogs": {
+    "exportScoreHistory": "Ezporñ istor ar skorioù",
+    "exportFencers": "Ezporñ klezeourion (.{{ext}})",
+    "exportPhotos": "Ezporñ fotoioù (.zip)",
+    "importPhotos": "Importañ fotoioù (.zip)",
+    "exportFencersArchive": "Ezporñ klezeourion + fotoioù (.bpf)"
+  },
+  "teams": {
+    "relaysWon": "Relev G",
+    "relaysLost": "Relev P",
+    "relaysTooltip": "Relev unan hag unan gounezet/kollet"
   }
 }

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -170,7 +170,9 @@
     "reset_scores": "Restablir Puntuacions",
     "waiting_match": "Esperant el combat següent",
     "in_progress": "En Curs",
-    "finished": "Finalitzat"
+    "finished": "Finalitzat",
+    "inactive_title": "Entrada remota inactiva",
+    "active_title": "Entrada remota activa"
   },
   "settings": {
     "title": "Configuració",
@@ -382,5 +384,17 @@
     "scoring_zones": "Zones personalitzades",
     "zone_label": "Zona",
     "zone_points": "Punts"
+  },
+  "dialogs": {
+    "exportScoreHistory": "Exportar historial de puntuacions",
+    "exportFencers": "Exportar tiradors (.{{ext}})",
+    "exportPhotos": "Exportar fotos (.zip)",
+    "importPhotos": "Importar fotos (.zip)",
+    "exportFencersArchive": "Exportar tiradors + fotos (.bpf)"
+  },
+  "teams": {
+    "relaysWon": "Relleus G",
+    "relaysLost": "Relleus P",
+    "relaysTooltip": "Relleus individuals guanyats/perduts"
   }
 }

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -291,7 +291,9 @@
     "start_match": "Starten",
     "stop": "Ferne Eingabe Stoppen",
     "title": "Ferne Punkteingabe",
-    "waiting_match": "Warten auf nächstes Match"
+    "waiting_match": "Warten auf nächstes Match",
+    "inactive_title": "Ferneingabe inaktiv",
+    "active_title": "Ferneingabe aktiv"
   },
   "results": {
     "congratulations": "Herzlichen Glückwunsch an die Gewinner!",
@@ -382,5 +384,17 @@
     "foil": "Florett",
     "laser": "Laser-Säbel",
     "sabre": "Säbel"
+  },
+  "dialogs": {
+    "exportScoreHistory": "Punkteverlauf exportieren",
+    "exportFencers": "Fechter exportieren (.{{ext}})",
+    "exportPhotos": "Fotos exportieren (.zip)",
+    "importPhotos": "Fotos importieren (.zip)",
+    "exportFencersArchive": "Fechter + Fotos exportieren (.bpf)"
+  },
+  "teams": {
+    "relaysWon": "Staffeln G",
+    "relaysLost": "Staffeln V",
+    "relaysTooltip": "Einzelstaffeln gewonnen/verloren"
   }
 }

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -170,7 +170,9 @@
     "reset_scores": "Reset Scores",
     "waiting_match": "Waiting for next match",
     "in_progress": "In Progress",
-    "finished": "Finished"
+    "finished": "Finished",
+    "inactive_title": "Remote entry inactive",
+    "active_title": "Remote entry active"
   },
   "settings": {
     "title": "Settings",
@@ -385,5 +387,17 @@
   },
   "wiki": {
     "button_title": "Documentation"
+  },
+  "dialogs": {
+    "exportScoreHistory": "Export score history",
+    "exportFencers": "Export fencers (.{{ext}})",
+    "exportPhotos": "Export photos (.zip)",
+    "importPhotos": "Import photos (.zip)",
+    "exportFencersArchive": "Export fencers + photos (.bpf)"
+  },
+  "teams": {
+    "relaysWon": "Relays W",
+    "relaysLost": "Relays L",
+    "relaysTooltip": "Individual relays won/lost"
   }
 }

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -170,7 +170,9 @@
     "reset_scores": "Restablecer Puntuaciones",
     "waiting_match": "Esperando siguiente partido",
     "in_progress": "En Curso",
-    "finished": "Terminado"
+    "finished": "Terminado",
+    "inactive_title": "Entrada remota inactiva",
+    "active_title": "Entrada remota activa"
   },
   "settings": {
     "title": "Ajustes",
@@ -382,5 +384,17 @@
     "scoring_zones": "Zonas personalizadas",
     "zone_label": "Zona",
     "zone_points": "Puntos"
+  },
+  "dialogs": {
+    "exportScoreHistory": "Exportar historial de puntuaciones",
+    "exportFencers": "Exportar tiradores (.{{ext}})",
+    "exportPhotos": "Exportar fotos (.zip)",
+    "importPhotos": "Importar fotos (.zip)",
+    "exportFencersArchive": "Exportar tiradores + fotos (.bpf)"
+  },
+  "teams": {
+    "relaysWon": "Relevos G",
+    "relaysLost": "Relevos P",
+    "relaysTooltip": "Relevos individuales ganados/perdidos"
   }
 }

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -170,7 +170,9 @@
     "reset_scores": "Réinitialiser scores",
     "waiting_match": "En attente du prochain match",
     "in_progress": "En cours",
-    "finished": "Terminé"
+    "finished": "Terminé",
+    "inactive_title": "Saisie distante inactive",
+    "active_title": "Saisie distante active"
   },
   "settings": {
     "title": "Paramètres",
@@ -385,5 +387,17 @@
     "scoring_zones": "Zones personnalisées",
     "zone_label": "Zone",
     "zone_points": "Points"
+  },
+  "dialogs": {
+    "exportScoreHistory": "Exporter le journal des scores",
+    "exportFencers": "Exporter les tireurs (.{{ext}})",
+    "exportPhotos": "Exporter les photos (.zip)",
+    "importPhotos": "Importer les photos (.zip)",
+    "exportFencersArchive": "Exporter tireurs + photos (.bpf)"
+  },
+  "teams": {
+    "relaysWon": "Relais G",
+    "relaysLost": "Relais P",
+    "relaysTooltip": "Relais individuels gagnés/perdus"
   }
 }

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -170,7 +170,9 @@
     "reset_scores": "重設分數",
     "waiting_match": "等待下一場比賽",
     "in_progress": "進行中",
-    "finished": "已結束"
+    "finished": "已結束",
+    "inactive_title": "遠程輸入未啟動",
+    "active_title": "遠程輸入已啟動"
   },
   "settings": {
     "title": "設定",
@@ -382,5 +384,17 @@
     "scoring_zones": "自訂區域",
     "zone_label": "區域",
     "zone_points": "分數"
+  },
+  "dialogs": {
+    "exportScoreHistory": "匯出比分記錄",
+    "exportFencers": "匯出劍手 (.{{ext}})",
+    "exportPhotos": "匯出照片 (.zip)",
+    "importPhotos": "匯入照片 (.zip)",
+    "exportFencersArchive": "匯出劍手 + 照片 (.bpf)"
+  },
+  "teams": {
+    "relaysWon": "接力勝",
+    "relaysLost": "接力負",
+    "relaysTooltip": "個人接力勝/負"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #897 — several strings bypassed `t()`/`TranslationContext` and stayed French regardless of the selected UI language.

- **Native save/open-dialog titles**: `ScoreAuditLog.tsx`, `FencerList.tsx` (export fencers/photos/archive + import photos), `CompetitionView.tsx` (export archive/photos) now build their `dialog.saveFile`/`dialog.openFile` titles via `t('dialogs.*')` instead of literal French strings.
- **Raw French JSX text**: `RemoteScoreManager.tsx` ("Saisie distante inactive/active" headings) and `TeamManagerView.tsx` ("Relais G"/"Relais P" column headers + their tooltip) now use `t()`.
- Added the corresponding `dialogs.*` and `teams.*` namespaces, and `remote.inactive_title`/`remote.active_title` keys, to all 7 locale files (`fr`, `en`, `de`, `es`, `br`, `ca`, `zh-HK`).

Note on the issue's point 2 (`kiosk.*`/`xiaomi.*` namespaces missing from `fr.json`): those namespaces/keys don't actually exist anywhere in this repo (`KioskDisplay.tsx`, `XiaomiRemotePanel.tsx`, `Bracket.tsx` don't call `t('kiosk...')`/`t('xiaomi...')` here), so there's nothing to reconcile on this side — likely specific to the German fork mentioned in the issue. Left out of this PR; happy to revisit if it turns out to apply here too.

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none introduced)
- [x] `npm run test:run` — 979/979 tests pass
- [x] All 7 locale JSON files validated as well-formed JSON


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7Y5DuEmMgcjrZXWt9BHor)_