### PR TITLE
i18n: translate KioskDisplay and XiaomiRemotePanel (de/en/fr)

### DIFF
--- a/src/renderer/components/KioskDisplay.tsx
+++ b/src/renderer/components/KioskDisplay.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useTranslation } from '../hooks/useTranslation';
 import { Competition, Pool, Weapon, MatchStatus, Fencer } from '../../shared/types';
 import { OrgNote } from '../../shared/types/remote';
 import { TableauMatch } from './tableau/tableauTypes';
@@ -319,15 +320,22 @@ const KIOSK_STYLES = {
   orgNoteMessage: { fontSize: 'clamp(2rem, 7vw, 6rem)' as const, color: '#94a3b8', fontStyle: 'italic' as const },
 } satisfies Record<string, React.CSSProperties>;
 
-const roundNames: Record<number, string> = {
-  2: 'Finale',
-  3: 'Petite finale',
-  4: 'Demi-finales',
-  8: 'Quarts de finale',
-  16: '1/8 de finale',
-  32: '1/16 de finale',
-  64: '1/32 de finale',
-  128: '1/64 de finale',
+// Rounds sans contexte de rendu : t() est reçu en paramètre (cf. useColumnVisibility.ts / XiaomiRemotePanel.tsx)
+type TFunction = (key: string, params?: { [key: string]: string | number }) => string;
+
+const ROUND_LABEL_KEYS: Record<number, string> = {
+  2: 'tableau.round_final',
+  3: 'tableau.round_third_place',
+  4: 'tableau.round_semifinals',
+  8: 'tableau.round_quarterfinals',
+  16: 'tableau.round_of_16',
+  32: 'tableau.round_of_32',
+  64: 'tableau.round_of_64',
+};
+
+const getRoundLabel = (round: number, t: TFunction): string => {
+  const key = ROUND_LABEL_KEYS[round];
+  return key ? t(key) : t('tableau.round_of_n', { round });
 };
 
 interface KioskDisplayProps {
@@ -346,6 +354,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
   onClose,
 }) => {
   const isLaserSabre = weapon === 'L';
+  const { t } = useTranslation();
 
   // Déterminer la vue initiale selon les données disponibles
   const initialView = useMemo((): KioskView => {
@@ -415,21 +424,22 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
     const first = finalMatch.winner;
     const second = finalMatch.fencerA?.id === first.id ? finalMatch.fencerB : finalMatch.fencerA;
     results.push({ place: 1, fencer: first, eliminatedAt: '' });
-    if (second) results.push({ place: 2, fencer: second, eliminatedAt: 'Finale' });
+    if (second) results.push({ place: 2, fencer: second, eliminatedAt: t('tableau.round_final') });
 
     const thirdMatch = tableauMatches.find(m => m.round === 3);
     if (thirdMatch?.winner) {
       const third = thirdMatch.winner;
       const fourth = thirdMatch.fencerA?.id === third.id ? thirdMatch.fencerB : thirdMatch.fencerA;
       results.push({ place: 3, fencer: third, eliminatedAt: '' });
-      if (fourth) results.push({ place: 4, fencer: fourth, eliminatedAt: 'Petite finale' });
+      if (fourth)
+        results.push({ place: 4, fencer: fourth, eliminatedAt: t('tableau.round_third_place') });
     } else {
       // Sans petite finale : perdants des demi-finales ex-aequo 3e
       const semis = tableauMatches.filter(m => m.round === 4 && m.winner);
       let place = 3;
       for (const semi of semis) {
         const loser = semi.fencerA?.id === semi.winner!.id ? semi.fencerB : semi.fencerA;
-        if (loser) results.push({ place, fencer: loser, eliminatedAt: 'Demi-finales' });
+        if (loser) results.push({ place, fencer: loser, eliminatedAt: t('tableau.round_semifinals') });
         place++;
       }
     }
@@ -445,14 +455,14 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
           results.push({
             place: currentPlace,
             fencer: loser,
-            eliminatedAt: roundNames[round] || `Tour ${round}`,
+            eliminatedAt: getRoundLabel(round, t),
           });
       }
       currentPlace += roundMatches.length;
     }
 
     return results;
-  }, [tableauMatches, activeRound]);
+  }, [tableauMatches, activeRound, t]);
 
   // Menu auto-masquant
   const showMenu = useCallback(() => {
@@ -635,7 +645,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
         }}
       >
         <span style={KIOSK_STYLES.menuLabel}>
-          Mode Kiosk
+          {t('competitionHeader.kiosk_mode')}
         </span>
         <button
           style={btnStyle(currentView === 'pools', !hasPoolData)}
@@ -644,7 +654,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             if (hasPoolData) setCurrentView('pools');
           }}
         >
-          🏆 Poules
+          🏆 {t('kiosk.pools')}
         </button>
         <button
           style={btnStyle(currentView === 'ranking', !hasRankingData)}
@@ -653,7 +663,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             if (hasRankingData) setCurrentView('ranking');
           }}
         >
-          📊 Classement
+          📊 {t('kiosk.ranking')}
         </button>
         <button
           style={btnStyle(currentView === 'tableau', !hasTableauData)}
@@ -662,15 +672,15 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             if (hasTableauData) setCurrentView('tableau');
           }}
         >
-          🥇 Tableau
+          🥇 {t('kiosk.tableau')}
         </button>
         <div style={KIOSK_STYLES.menuFlex} />
-        <span style={KIOSK_STYLES.menuEscHint}>Echap pour quitter</span>
+        <span style={KIOSK_STYLES.menuEscHint}>{t('kiosk.esc_exit')}</span>
         <button
           onClick={onClose}
           style={KIOSK_STYLES.menuCloseBtn}
         >
-          ✕ Fermer
+          ✕ {t('kiosk.close')}
         </button>
       </div>
 
@@ -684,9 +694,9 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                 {competition.title}
               </h1>
               <p style={KIOSK_STYLES.poolsSubtitle}>
-                Poule {currentPool.number} / {pools.length}
+                {t('pools.pool_number')} {currentPool.number} / {pools.length}
                 <span style={KIOSK_STYLES.poolsNavHint}>
-                  {pools.length > 1 && '← → naviguer'}
+                  {pools.length > 1 && t('kiosk.navigate_hint')}
                 </span>
               </p>
             </div>
@@ -694,7 +704,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
               <div style={KIOSK_STYLES.poolsScoreNum}>
                 {poolCompleted}/{poolTotal}
               </div>
-              <div style={KIOSK_STYLES.poolsScoreLabel}>matchs terminés</div>
+              <div style={KIOSK_STYLES.poolsScoreLabel}>{t('kiosk.finished_matches')}</div>
             </div>
           </div>
 
@@ -713,7 +723,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             {/* Classement poule */}
             <div style={KIOSK_STYLES.poolsRankingCol}>
               <h2 style={KIOSK_STYLES.poolsRankingTitle}>
-                Classement
+                {t('kiosk.ranking_label')}
               </h2>
               <div style={KIOSK_STYLES.poolsRankingList}>
                 {currentPool.ranking?.slice(0, 8).map((rank, i) => (
@@ -738,18 +748,21 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                         {rank.fencer.lastName} {rank.fencer.firstName}
                       </div>
                       <div style={KIOSK_STYLES.poolsRankClub}>
-                        {rank.fencer.club || 'Sans club'}
+                        {rank.fencer.club || t('presentation.no_club')}
                       </div>
                     </div>
                     <div style={KIOSK_STYLES.poolsRankStats}>
                       <div style={KIOSK_STYLES.poolsRankScore}>
-                        {rank.victories}V – {rank.defeats}D
+                        {rank.victories}
+                        {t('kiosk.victory_short')} – {rank.defeats}
+                        {t('kiosk.defeat_short')}
                       </div>
                       <div style={KIOSK_STYLES.poolsRankMatches}>
-                        {rank.matchesPlayed} match{rank.matchesPlayed !== 1 ? 's' : ''}
+                        {t('changePool.matches_played_count', { count: rank.matchesPlayed })}
                       </div>
                       <div style={KIOSK_STYLES.poolsRankTouches}>
-                        TD {rank.touchesScored} / TR {rank.touchesReceived}
+                        {t('ranking.touches_scored')} {rank.touchesScored} /{' '}
+                        {t('ranking.touches_received')} {rank.touchesReceived}
                       </div>
                     </div>
                   </div>
@@ -760,7 +773,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             {/* Matchs en cours */}
             <div style={KIOSK_STYLES.poolsMatchesCol}>
               <h2 style={KIOSK_STYLES.poolsMatchesTitle}>
-                Matchs en cours
+                {t('kiosk.matches_live')}
               </h2>
               <div style={KIOSK_STYLES.poolsMatchesList}>
                 {currentPool.matches
@@ -772,19 +785,19 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                       style={KIOSK_STYLES.poolsMatchCard}
                     >
                       <div style={KIOSK_STYLES.poolsMatchCardRow}>
-                        <span>{match.fencerA?.lastName || 'TBD'}</span>
+                        <span>{match.fencerA?.lastName || t('kiosk.tbd')}</span>
                         <span style={KIOSK_STYLES.poolsMatchVs}>VS</span>
-                        <span>{match.fencerB?.lastName || 'TBD'}</span>
+                        <span>{match.fencerB?.lastName || t('kiosk.tbd')}</span>
                       </div>
                       <div style={KIOSK_STYLES.poolsMatchStrip}>
-                        Piste {match.strip || idx + 1}
+                        {t('remote_score.lane_number', { number: match.strip || idx + 1 })}
                       </div>
                     </div>
                   ))}
                 {currentPool.matches.filter(m => m.status === MatchStatus.IN_PROGRESS).length ===
                   0 && (
                   <div style={KIOSK_STYLES.poolsMatchEmpty}>
-                    Aucun match en cours
+                    {t('kiosk.no_live')}
                   </div>
                 )}
               </div>
@@ -820,8 +833,8 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
           <div style={KIOSK_STYLES.rankingHeader}>
             <h1 style={KIOSK_STYLES.rankingTitle}>{competition.title}</h1>
             <p style={KIOSK_STYLES.rankingSubtitle}>
-              Classement Provisoire · {overallRanking.length} tireur
-              {overallRanking.length > 1 ? 's' : ''}
+              {t('kiosk.provisional_ranking')} ·{' '}
+              {t('poolView.fencers_count_suffix', { count: overallRanking.length })}
             </p>
           </div>
 
@@ -834,20 +847,20 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             <table style={KIOSK_STYLES.rankingTable}>
               <thead>
                 <tr style={KIOSK_STYLES.rankingThead}>
-                  <th style={KIOSK_STYLES.rankingThRg}>Rg</th>
-                  <th style={KIOSK_STYLES.rankingThName}>Nom</th>
-                  <th style={KIOSK_STYLES.rankingThName}>Prénom</th>
-                  <th style={KIOSK_STYLES.rankingThName}>Club</th>
-                  <th style={KIOSK_STYLES.rankingThVm}>V/M</th>
-                  <th style={KIOSK_STYLES.rankingThTd}>TD</th>
-                  <th style={KIOSK_STYLES.rankingThTr}>TR</th>
+                  <th style={KIOSK_STYLES.rankingThRg}>{t('ranking.rank')}</th>
+                  <th style={KIOSK_STYLES.rankingThName}>{t('fencer.last_name')}</th>
+                  <th style={KIOSK_STYLES.rankingThName}>{t('fencer.first_name')}</th>
+                  <th style={KIOSK_STYLES.rankingThName}>{t('fencer.club')}</th>
+                  <th style={KIOSK_STYLES.rankingThVm}>{t('ranking.ratio')}</th>
+                  <th style={KIOSK_STYLES.rankingThTd}>{t('ranking.touches_scored')}</th>
+                  <th style={KIOSK_STYLES.rankingThTr}>{t('ranking.touches_received')}</th>
                   {isLaserSabre && (
                     <th style={KIOSK_STYLES.rankingThQuest}>
-                      Quest
+                      {t('quest.label')}
                     </th>
                   )}
                   <th style={KIOSK_STYLES.rankingThIndice}>
-                    Indice
+                    {t('ranking.index')}
                   </th>
                 </tr>
               </thead>
@@ -907,8 +920,8 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             <h1 style={KIOSK_STYLES.tableauTitle}>{competition.title}</h1>
             <p style={KIOSK_STYLES.tableauRoundLabel}>
               {activeRound !== null
-                ? roundNames[activeRound] || `Tour ${activeRound}`
-                : 'Tableau terminé'}
+                ? getRoundLabel(activeRound, t)
+                : t('kiosk.tableau_done')}
             </p>
           </div>
 
@@ -928,7 +941,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                         style={KIOSK_STYLES.matchCardBye}
                       >
                         <div style={KIOSK_STYLES.matchCardByeLabel}>
-                          EXEMPT
+                          {t('kiosk.bye')}
                         </div>
                         <div style={KIOSK_STYLES.matchCardByeName}>
                           {match.fencerA?.lastName || match.fencerB?.lastName || '–'}
@@ -979,7 +992,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                         >
                           {match.fencerA
                             ? `${match.fencerA.lastName} ${match.fencerA.firstName.charAt(0)}.`
-                            : 'À déterminer'}
+                            : t('kiosk.tbd')}
                           {match.fencerA?.club && (
                             <span
                               style={{ fontSize: '0.8rem', color: '#64748b', marginLeft: '8px' }}
@@ -1039,7 +1052,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                         >
                           {match.fencerB
                             ? `${match.fencerB.lastName} ${match.fencerB.firstName.charAt(0)}.`
-                            : 'À déterminer'}
+                            : t('kiosk.tbd')}
                           {match.fencerB?.club && (
                             <span
                               style={{ fontSize: '0.8rem', color: '#64748b', marginLeft: '8px' }}
@@ -1070,7 +1083,7 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
             <div style={KIOSK_STYLES.finishedWrapper}>
               {/* Titre */}
               <div style={KIOSK_STYLES.finishedTitle}>
-                🏆 RÉSULTATS FINAUX
+                🏆 {t('kiosk.final_results')}
               </div>
 
               {/* Podium visuel */}
@@ -1111,21 +1124,21 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
                   </div>
                 </div>
               ) : (
-                <div style={KIOSK_STYLES.podiumEmpty}>Tableau terminé</div>
+                <div style={KIOSK_STYLES.podiumEmpty}>{t('kiosk.tableau_done')}</div>
               )}
 
               {/* Classement général */}
               {elimRanking.length > 0 && (
                 <div ref={tableauScrollRef} style={KIOSK_STYLES.elimRankingWrapper}>
-                  <div style={KIOSK_STYLES.elimRankingLabel}>Classement général</div>
+                  <div style={KIOSK_STYLES.elimRankingLabel}>{t('kiosk.general_ranking')}</div>
                   <table style={KIOSK_STYLES.elimTable}>
                     <thead>
                       <tr style={KIOSK_STYLES.elimThead}>
-                        <th style={KIOSK_STYLES.elimThRg}>Rg</th>
-                        <th style={KIOSK_STYLES.elimThName}>Nom</th>
-                        <th style={KIOSK_STYLES.elimThName}>Prénom</th>
-                        <th style={KIOSK_STYLES.elimThName}>Club</th>
-                        <th style={KIOSK_STYLES.elimThElimAt}>Éliminé en</th>
+                        <th style={KIOSK_STYLES.elimThRg}>{t('ranking.rank')}</th>
+                        <th style={KIOSK_STYLES.elimThName}>{t('fencer.last_name')}</th>
+                        <th style={KIOSK_STYLES.elimThName}>{t('fencer.first_name')}</th>
+                        <th style={KIOSK_STYLES.elimThName}>{t('fencer.club')}</th>
+                        <th style={KIOSK_STYLES.elimThElimAt}>{t('tableau.elimination_in')}</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -1163,13 +1176,15 @@ const KioskDisplay: React.FC<KioskDisplayProps> = ({
       {/* ===== OVERLAY NOTE D'ORGANISATION ===== */}
       {orgNote && (
         <div style={KIOSK_STYLES.orgNoteOverlay}>
-          <div style={KIOSK_STYLES.orgNotePauseLabel}>⏸ Pause</div>
+          <div style={KIOSK_STYLES.orgNotePauseLabel}>⏸ {t('remote_score.prefix_break')}</div>
           {orgNote.type === 'target_time' && orgNote.targetTime && (
             <>
               <div style={KIOSK_STYLES.orgNoteResumeTime}>
-                Reprise à {orgNote.targetTime.replace(':', 'h')}
+                {t('kiosk.resume_at', { time: orgNote.targetTime.replace(':', 'h') })}
               </div>
-              <div style={KIOSK_STYLES.orgNoteCountdown}>dans {orgNoteCountdown}</div>
+              <div style={KIOSK_STYLES.orgNoteCountdown}>
+                {t('kiosk.countdown_in', { duration: orgNoteCountdown })}
+              </div>
             </>
           )}
           {orgNote.message && (

--- a/src/renderer/components/XiaomiRemotePanel.tsx
+++ b/src/renderer/components/XiaomiRemotePanel.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { useTranslation } from '../hooks/useTranslation';
 import type { ConnectedClient, TVCommand, KioskScreenConfig } from '@shared/types/preload';
 
 interface XiaomiRemotePanelProps {
@@ -14,16 +15,6 @@ interface XiaomiRemotePanelProps {
   onClose: () => void;
 }
 
-const CLIENT_TYPE_LABELS: Record<string, string> = {
-  arena: 'Arène',
-  lobby: 'Lobby',
-  kiosk: 'Kiosk',
-  public: 'Public',
-  pool: 'Poules',
-  dashboard: 'Dashboard',
-  referee: 'Arbitre',
-};
-
 function getOnlineStatus(lastSeen: string): 'online' | 'warn' | 'offline' {
   const diff = Date.now() - new Date(lastSeen).getTime();
   if (diff < 35000) return 'online';
@@ -31,11 +22,11 @@ function getOnlineStatus(lastSeen: string): 'online' | 'warn' | 'offline' {
   return 'offline';
 }
 
-function formatLastSeen(lastSeen: string): string {
+function formatLastSeen(lastSeen: string, t: (key: string, params?: { [key: string]: string | number }) => string): string {
   const diff = Math.floor((Date.now() - new Date(lastSeen).getTime()) / 1000);
-  if (diff < 10) return 'à l\'instant';
-  if (diff < 60) return `il y a ${diff}s`;
-  return `il y a ${Math.floor(diff / 60)}m`;
+  if (diff < 10) return t('xiaomi.just_now');
+  if (diff < 60) return t('xiaomi.seconds_ago', { s: diff });
+  return t('xiaomi.minutes_ago', { m: Math.floor(diff / 60) });
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -46,11 +37,13 @@ const STATUS_COLORS: Record<string, string> = {
 
 type AssignRole = 'affichage' | 'arbitre' | 'kiosk';
 
-const ASSIGN_ROLES: { value: AssignRole; label: string }[] = [
-  { value: 'affichage', label: '📺 Affichage' },
-  { value: 'arbitre', label: '🤺 Arbitre' },
-  { value: 'kiosk', label: '🖥️ Kiosk' },
-];
+function buildAssignRoles(t: (key: string, params?: { [key: string]: string | number }) => string): { value: AssignRole; label: string }[] {
+  return [
+    { value: 'affichage', label: `📺 ${t('remote_score.screen_type_display')}` },
+    { value: 'arbitre', label: `🤺 ${t('referee.arbitre')}` },
+    { value: 'kiosk', label: `🖥️ ${t('xiaomi.client_type_kiosk')}` },
+  ];
+}
 
 function arenaNum(client: ConnectedClient): number {
   if (!client.arenaId) return 1;
@@ -80,9 +73,17 @@ function clientDisplayUrl(base: string, client: ConnectedClient): string {
   return `${base}/arene${num}`;
 }
 
-function clientLabel(client: ConnectedClient): string {
+function clientLabel(client: ConnectedClient, t: (key: string, params?: { [key: string]: string | number }) => string): string {
   if (client.label) return client.label;
-  const type = CLIENT_TYPE_LABELS[client.clientType] ?? client.clientType;
+  const typeLabels: Record<string, string> = {
+    lobby: t('xiaomi.client_type_lobby'),
+    kiosk: t('xiaomi.client_type_kiosk'),
+    public: t('xiaomi.client_type_public'),
+    pool: t('ui.poule'),
+    dashboard: t('xiaomi.client_type_dashboard'),
+    referee: t('referee.arbitre'),
+  };
+  const type = client.clientType === 'arena' ? t('xiaomi.arena_label') : (typeLabels[client.clientType] ?? client.clientType);
   if ((client.clientType === 'arena' || client.clientType === 'referee') && client.arenaId) {
     const num = client.arenaId.replace('arena', '');
     return `${type} ${num}`;
@@ -104,14 +105,16 @@ function loadKioskConfig(): KioskScreenConfig {
   return DEFAULT_KIOSK_CONFIG;
 }
 
-const KIOSK_VIEWS: { key: keyof KioskScreenConfig; label: string }[] = [
-  { key: 'poules', label: 'Poules' },
-  { key: 'classement', label: 'Classement' },
-  { key: 'final', label: 'Classement final' },
-  { key: 'direct', label: 'Matchs en direct' },
-  { key: 'suivants', label: 'Matchs suivants' },
-  { key: 'tableau', label: 'Tableau DE' },
-];
+function buildKioskViews(t: (key: string, params?: { [key: string]: string | number }) => string): { key: keyof KioskScreenConfig; label: string }[] {
+  return [
+    { key: 'poules', label: t('remote_score.view_pools') },
+    { key: 'classement', label: t('remote_score.view_ranking') },
+    { key: 'final', label: t('remote_score.view_final_ranking') },
+    { key: 'direct', label: t('remote_score.view_live_matches') },
+    { key: 'suivants', label: t('remote_score.view_next_matches') },
+    { key: 'tableau', label: t('remote_score.view_bracket') },
+  ];
+}
 
 const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
   competitionId,
@@ -120,6 +123,7 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
   onClose,
 }) => {
   const modalRef = useFocusTrap<HTMLDivElement>(true, onClose);
+  const { t } = useTranslation();
   const [clients, setClients] = useState<ConnectedClient[]>([]);
   const [message, setMessage] = useState('');
   const [msgDuration, setMsgDuration] = useState(5);
@@ -142,7 +146,9 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
   };
 
   const base = serverUrl.replace(/\/$/, '');
-  const allNavTargets = buildNavTargets(base, arenaCount);
+  const allNavTargets = buildNavTargets(base, arenaCount, t);
+  const assignRoles = buildAssignRoles(t);
+  const kioskViews = buildKioskViews(t);
 
   const fetchClients = useCallback(async () => {
     const res = await window.electronAPI.remote.getConnectedClients(competitionId);
@@ -243,31 +249,31 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
         {/* Header */}
         <div style={{ padding: '1rem 1.25rem', borderBottom: '1px solid var(--color-border)', display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
           <span style={{ fontSize: '1.2rem' }}>📺</span>
-          <span style={{ fontWeight: 600, fontSize: '1rem', flex: 1 }}>Télécommande TV</span>
+          <span style={{ fontWeight: 600, fontSize: '1rem', flex: 1 }}>{t('xiaomi.title')}</span>
           <button
             className={`btn ${locked ? 'btn-primary' : 'btn-secondary'}`}
             onClick={toggleLock}
             style={{ padding: '0.25rem 0.6rem', fontSize: '0.78rem' }}
-            title={locked ? 'Déverrouiller la télécommande' : 'Verrouiller la télécommande pour éviter les changements'}
+            title={locked ? t('xiaomi.unlock_tooltip') : t('xiaomi.lock_tooltip')}
           >
-            {locked ? '🔒 Verrouillé' : '🔓 Verrouiller'}
+            {locked ? t('xiaomi.locked_label') : t('xiaomi.lock_label')}
           </button>
-          <button className="btn btn-secondary" onClick={fetchClients} style={{ padding: '0.25rem 0.6rem', fontSize: '0.78rem' }} title="Actualiser">↻</button>
-          <button className="btn btn-primary" onClick={() => broadcastCmd({ type: 'refresh' })} disabled={locked} style={{ padding: '0.25rem 0.6rem', fontSize: '0.78rem', opacity: locked ? 0.4 : 1 }}>Tout rafraîchir</button>
+          <button className="btn btn-secondary" onClick={fetchClients} style={{ padding: '0.25rem 0.6rem', fontSize: '0.78rem' }} title={t('xiaomi.refresh')}>↻</button>
+          <button className="btn btn-primary" onClick={() => broadcastCmd({ type: 'refresh' })} disabled={locked} style={{ padding: '0.25rem 0.6rem', fontSize: '0.78rem', opacity: locked ? 0.4 : 1 }}>{t('xiaomi.refresh_all')}</button>
           <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-light)', fontSize: '1.2rem', padding: '0 0.2rem' }}>×</button>
         </div>
 
         {/* Lobby URL hint */}
         <div style={{ padding: '0.55rem 1.25rem', background: 'rgba(56,189,248,0.1)', borderBottom: '1px solid var(--color-border)', fontSize: '0.78rem', color: 'var(--color-primary)', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <span>💡</span>
-          <span>URL sans arène : <strong>{base}/lobby</strong> — les écrans y attendent leur affectation</span>
+          <span>{t('xiaomi.url_no_arena')} <strong>{base}/lobby</strong> {t('xiaomi.screens_waiting')}</span>
         </div>
 
         {/* Bandeau verrou */}
         {locked && (
           <div style={{ padding: '0.55rem 1.25rem', background: 'rgba(34,197,94,0.1)', borderBottom: '1px solid rgba(34,197,94,0.3)', fontSize: '0.78rem', color: '#86efac', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <span>🔒</span>
-            <span>Télécommande verrouillée — actions désactivées. Cliquez sur « Verrouillé » pour déverrouiller.</span>
+            <span>{t('xiaomi.locked')}</span>
           </div>
         )}
 
@@ -275,8 +281,8 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
         <div style={{ flex: 1, overflowY: 'auto', padding: '0.75rem 1.25rem', pointerEvents: locked ? 'none' : 'auto', opacity: locked ? 0.55 : 1 }}>
           {clients.length === 0 ? (
             <div style={{ color: 'var(--color-text-light)', textAlign: 'center', padding: '2rem', fontSize: '0.9rem' }}>
-              Aucun écran connecté.<br />
-              <span style={{ fontSize: '0.8rem' }}>Ouvrez <strong>{base}/lobby</strong> sur une TV pour qu'elle apparaisse ici.</span>
+              {t('xiaomi.no_screen')}<br />
+              <span style={{ fontSize: '0.8rem' }}>{t('xiaomi.connect_tv')}</span>
             </div>
           ) : (
             clients.map((client) => {
@@ -300,21 +306,21 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
                         onChange={e => setRenameValue(e.target.value)}
                         onBlur={commitRename}
                         onKeyDown={e => { if (e.key === 'Enter') commitRename(); if (e.key === 'Escape') { setRenameTarget(null); setRenameValue(''); } }}
-                        placeholder="Nom de l'écran…"
+                        placeholder={t('xiaomi.screen_name')}
                         style={{ width: '100%', padding: '0.2rem 0.4rem', fontSize: '0.85rem', background: 'var(--color-bg)', border: '1px solid var(--color-border)', borderRadius: '5px', color: 'inherit' }}
                       />
                     ) : (
                       <div
                         style={{ fontWeight: 500, fontSize: '0.88rem', cursor: 'text', display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}
-                        title="Cliquer pour renommer"
-                        onClick={() => { setRenameTarget(client.socketId); setRenameValue(clientLabel(client)); }}
+                        title={t('xiaomi.click_rename')}
+                        onClick={() => { setRenameTarget(client.socketId); setRenameValue(clientLabel(client, t)); }}
                       >
-                        {clientLabel(client)}
+                        {clientLabel(client, t)}
                         <span style={{ fontSize: '0.7rem', opacity: 0.5 }}>✎</span>
                       </div>
                     )}
                     <div style={{ fontSize: '0.73rem', color: 'var(--color-text-light)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {client.ip} · {formatLastSeen(client.lastSeen)}
+                      {client.ip} · {formatLastSeen(client.lastSeen, t)}
                     </div>
                   </div>
 
@@ -327,19 +333,19 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
                           value={a.role}
                           onChange={e => applyAssign(client, e.target.value as AssignRole, a.arena)}
                           style={{ padding: '0.2rem 0.3rem', fontSize: '0.75rem', background: 'var(--color-bg)', border: '1px solid var(--color-border)', borderRadius: '5px', color: 'inherit' }}
-                          title="Rôle de la tablette"
+                          title={t('xiaomi.tablet_role')}
                         >
-                          {ASSIGN_ROLES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
+                          {assignRoles.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
                         </select>
                         {a.role !== 'kiosk' && (
                           <select
                             value={a.arena}
                             onChange={e => applyAssign(client, a.role, Number(e.target.value))}
                             style={{ padding: '0.2rem 0.3rem', fontSize: '0.75rem', background: 'var(--color-bg)', border: '1px solid var(--color-border)', borderRadius: '5px', color: 'inherit' }}
-                            title="Arène"
+                            title={t('xiaomi.arena')}
                           >
                             {Array.from({ length: arenaCount }, (_, i) => (
-                              <option key={i + 1} value={i + 1}>Arène {i + 1}</option>
+                              <option key={i + 1} value={i + 1}>{t('xiaomi.arena')} {i + 1}</option>
                             ))}
                           </select>
                         )}
@@ -348,16 +354,16 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
                   })()}
 
                   {/* Identifier */}
-                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.5rem', fontSize: '0.75rem', whiteSpace: 'nowrap' }} onClick={() => window.electronAPI.remote.identifyClient(competitionId, client.socketId)} title="Faire clignoter cet écran pour le repérer">🔦 Identifier</button>
+                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.5rem', fontSize: '0.75rem', whiteSpace: 'nowrap' }} onClick={() => window.electronAPI.remote.identifyClient(competitionId, client.socketId)} title={t('xiaomi.blink')}>{t('remote_score.identify_button')}</button>
 
                   {/* Renommer */}
-                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => { setRenameTarget(client.socketId); setRenameValue(client.label ?? ''); }} title="Renommer cet écran">✏️</button>
+                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => { setRenameTarget(client.socketId); setRenameValue(client.label ?? ''); }} title={t('xiaomi.rename')}>✏️</button>
 
                   {/* Mode kiosk */}
-                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => { setKioskTarget(client.socketId); setKioskConfig(loadKioskConfig()); }} title="Configurer et envoyer en mode kiosk">🖥️</button>
+                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => { setKioskTarget(client.socketId); setKioskConfig(loadKioskConfig()); }} title={t('ui.configure_send_kiosk')}>🖥️</button>
 
                   {/* Rafraîchir */}
-                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => sendCmd(client.socketId, { type: 'refresh' })} title="Rafraîchir">↻</button>
+                  <button className="btn btn-secondary" style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem' }} onClick={() => sendCmd(client.socketId, { type: 'refresh' })} title={t('xiaomi.refresh')}>↻</button>
 
                   {/* Naviguer (tous types) */}
                   <div ref={openNav === client.socketId ? navRef : null} style={{ position: 'relative' }}>
@@ -379,7 +385,7 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
                       className={`btn ${inSwap ? 'btn-primary' : 'btn-secondary'}`}
                       style={{ padding: '0.2rem 0.45rem', fontSize: '0.75rem', opacity: swapFull ? 0.4 : 1 }}
                       onClick={() => !swapFull && toggleSwap(client.socketId)}
-                      title={inSwap ? 'Retirer de la sélection' : 'Sélectionner pour intervertir'}
+                      title={inSwap ? t('xiaomi.deselect_swap') : t('xiaomi.select_swap')}
                       disabled={swapFull}
                     >
                       ⇄
@@ -395,31 +401,31 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
         {swapSet.size > 0 && (
           <div style={{ padding: '0.65rem 1.25rem', background: 'rgba(249,115,22,0.12)', borderTop: '1px solid rgba(249,115,22,0.3)', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
             <span style={{ fontSize: '0.88rem', flex: 1, color: '#ea580c' }}>
-              ⇄ Intervertir{' '}
-              {swapCandidates.map(c => <strong key={c.socketId}>{clientLabel(c)}</strong>).reduce((a, b) => <>{a} <span style={{ color: '#94a3b8' }}>↔</span> {b}</> as any)}
-              {swapSet.size === 1 && <span style={{ color: '#94a3b8' }}> — sélectionner un 2ᵉ écran</span>}
+              {t('xiaomi.swap_label')}{' '}
+              {swapCandidates.map(c => <strong key={c.socketId}>{clientLabel(c, t)}</strong>).reduce((a, b) => <>{a} <span style={{ color: '#94a3b8' }}>↔</span> {b}</> as any)}
+              {swapSet.size === 1 && <span style={{ color: '#94a3b8' }}> {t('xiaomi.select_2nd')}</span>}
             </span>
             {canSwap && (
               <button className="btn btn-primary" style={{ padding: '0.3rem 0.75rem', fontSize: '0.82rem' }} onClick={confirmSwap}>
-                Confirmer
+                {t('actions.confirm')}
               </button>
             )}
             <button className="btn btn-secondary" style={{ padding: '0.3rem 0.6rem', fontSize: '0.82rem' }} onClick={() => setSwapSet(new Set())}>
-              Annuler
+              {t('actions.cancel')}
             </button>
           </div>
         )}
 
         {/* Message global */}
         <div style={{ padding: '0.75rem 1.25rem', borderTop: '1px solid var(--color-border)', pointerEvents: locked ? 'none' : 'auto', opacity: locked ? 0.55 : 1 }}>
-          <div style={{ fontSize: '0.75rem', color: 'var(--color-text-light)', marginBottom: '0.4rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Message global</div>
+          <div style={{ fontSize: '0.75rem', color: 'var(--color-text-light)', marginBottom: '0.4rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{t('xiaomi.global_message_label')}</div>
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
             <input
               type="text"
               value={message}
               onChange={e => setMessage(e.target.value)}
               onKeyDown={e => { if (e.key === 'Enter') sendMessage(); }}
-              placeholder="Texte affiché en bas de tous les écrans…"
+              placeholder={t('xiaomi.bottom_text')}
               style={{ flex: 1, padding: '0.4rem 0.6rem', fontSize: '0.85rem', background: 'var(--color-bg)', border: '1px solid var(--color-border)', borderRadius: '6px', color: 'inherit' }}
             />
             <select
@@ -433,7 +439,7 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
               <option value={30}>30s</option>
               <option value={60}>60s</option>
             </select>
-            <button className="btn btn-primary" style={{ padding: '0.4rem 0.75rem', fontSize: '0.85rem' }} onClick={sendMessage}>Envoyer</button>
+            <button className="btn btn-primary" style={{ padding: '0.4rem 0.75rem', fontSize: '0.85rem' }} onClick={sendMessage}>{t('xiaomi.send')}</button>
           </div>
         </div>
       </div>
@@ -445,9 +451,9 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
           onClick={e => { if (e.target === e.currentTarget) setKioskTarget(null); }}
         >
           <div style={{ background: 'var(--color-surface, #1e293b)', color: 'var(--color-text, #f1f5f9)', border: '1px solid var(--color-border, rgba(255,255,255,0.1))', borderRadius: '12px', width: '360px', maxWidth: '94vw', padding: '1.25rem' }}>
-            <div style={{ fontWeight: 600, fontSize: '1rem', marginBottom: '0.85rem' }}>🖥️ Configurer le mode kiosk</div>
-            <div style={{ fontSize: '0.82rem', color: 'var(--color-text-light, #94a3b8)', marginBottom: '0.5rem' }}>Vues à afficher :</div>
-            {KIOSK_VIEWS.map(({ key, label }) => (
+            <div style={{ fontWeight: 600, fontSize: '1rem', marginBottom: '0.85rem' }}>{t('ui.configure_kiosk')}</div>
+            <div style={{ fontSize: '0.82rem', color: 'var(--color-text-light, #94a3b8)', marginBottom: '0.5rem' }}>{t('ui.views_label')}</div>
+            {kioskViews.map(({ key, label }) => (
               <label key={key} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: '0.3rem 0', cursor: 'pointer' }}>
                 <input
                   type="checkbox"
@@ -458,7 +464,7 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
               </label>
             ))}
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.75rem' }}>
-              <label style={{ fontSize: '0.82rem', color: 'var(--color-text-light, #94a3b8)', whiteSpace: 'nowrap' }}>Rotation (s) :</label>
+              <label style={{ fontSize: '0.82rem', color: 'var(--color-text-light, #94a3b8)', whiteSpace: 'nowrap' }}>{t('ui.rotation_label')}</label>
               <input
                 type="number"
                 min={3}
@@ -469,8 +475,8 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
               />
             </div>
             <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
-              <button className="btn btn-primary" style={{ flex: 1 }} onClick={sendKiosk}>Envoyer en kiosk</button>
-              <button className="btn btn-secondary" onClick={() => setKioskTarget(null)}>Annuler</button>
+              <button className="btn btn-primary" style={{ flex: 1 }} onClick={sendKiosk}>{t('ui.send_kiosk')}</button>
+              <button className="btn btn-secondary" onClick={() => setKioskTarget(null)}>{t('actions.cancel')}</button>
             </div>
           </div>
         </div>
@@ -479,11 +485,11 @@ const XiaomiRemotePanelComponent: React.FC<XiaomiRemotePanelProps> = ({
   );
 };
 
-function buildNavTargets(base: string, arenaCount: number) {
-  const targets: { label: string; url: string }[] = [{ label: 'Salle d\'attente (Lobby)', url: `${base}/lobby` }];
-  for (let i = 1; i <= arenaCount; i++) targets.push({ label: `Arène ${i}`, url: `${base}/arene${i}` });
-  targets.push({ label: 'Kiosk public', url: `${base}/kiosk` });
-  targets.push({ label: 'Classement', url: `${base}/` });
+function buildNavTargets(base: string, arenaCount: number, t: (key: string, params?: { [key: string]: string | number }) => string) {
+  const targets: { label: string; url: string }[] = [{ label: t('xiaomi.nav_lobby'), url: `${base}/lobby` }];
+  for (let i = 1; i <= arenaCount; i++) targets.push({ label: t('xiaomi.nav_arena', { n: i }), url: `${base}/arene${i}` });
+  targets.push({ label: t('xiaomi.nav_kiosk_public'), url: `${base}/kiosk` });
+  targets.push({ label: t('xiaomi.nav_ranking'), url: `${base}/` });
   return targets;
 }
 

--- a/src/renderer/locales/de.json
+++ b/src/renderer/locales/de.json
@@ -370,7 +370,11 @@
   "tableau": {
     "elimination_in": "Ausgeschieden in",
     "finalist": "Finalist",
-    "winner": "Gewinner"
+    "winner": "Gewinner",
+    "round_final": "Finale",
+    "round_of_n": "{{round}}er-Runde",
+    "round_semifinals": "Halbfinale",
+    "round_third_place": "Kleines Finale"
   },
   "time": {
     "days": "Tage",
@@ -396,5 +400,110 @@
     "relaysWon": "Staffeln G",
     "relaysLost": "Staffeln V",
     "relaysTooltip": "Einzelstaffeln gewonnen/verloren"
+  },
+  "kiosk": {
+    "ranking": "📊 Rangliste",
+    "tableau": "🥇 Tableau",
+    "esc_exit": "Esc zum Beenden",
+    "close": "✕ Schließen",
+    "finished_matches": "beendete Matches",
+    "ranking_label": "Rangliste",
+    "matches_live": "Laufende Matches",
+    "no_live": "Kein Match läuft",
+    "final_results": "🏆 ENDERGEBNISSE",
+    "tableau_done": "Tableau beendet",
+    "general_ranking": "Gesamtrangliste",
+    "tbd": "TBD",
+    "resume_at": "Fortsetzung um {{time}}",
+    "round_semi": "Halbfinale",
+    "round_quarter": "Viertelfinale",
+    "round_8": "Achtelfinale",
+    "round_16": "Achtelfinale (Achtel)",
+    "round_32": "32er-Runde",
+    "round_64": "64er-Runde",
+    "bye": "Freilos",
+    "pools": "Pools",
+    "navigate_hint": "← → navigieren",
+    "provisional_ranking": "Vorläufige Rangliste",
+    "countdown_in": "in {{duration}}",
+    "victory_short": "S",
+    "defeat_short": "N"
+  },
+  "xiaomi": {
+    "arena_label": "Arena",
+    "just_now": "gerade eben",
+    "unlock_tooltip": "Fernbedienung entsperren",
+    "lock_tooltip": "Fernbedienung sperren, um Änderungen zu verhindern",
+    "locked_label": "🔒 Gesperrt",
+    "lock_label": "🔓 Sperren",
+    "deselect_swap": "Aus der Auswahl entfernen",
+    "select_swap": "Zum Tauschen auswählen",
+    "nav_lobby": "Warteraum (Lobby)",
+    "nav_arena": "Arena {{n}}",
+    "screen_name": "Bildschirmname…",
+    "click_rename": "Zum Umbenennen klicken",
+    "tablet_role": "Rolle des Tablets",
+    "arena": "Arena",
+    "blink": "Diesen Bildschirm blinken lassen zur Identifikation",
+    "rename": "Diesen Bildschirm umbenennen",
+    "refresh": "Aktualisieren",
+    "bottom_text": "Unten auf allen Bildschirmen angezeigter Text…",
+    "title": "TV-Fernbedienung",
+    "refresh_all": "Alles aktualisieren",
+    "url_no_arena": "URL ohne Arena:",
+    "screens_waiting": "— die Bildschirme warten dort auf ihre Zuweisung",
+    "locked": "Fernbedienung gesperrt — Aktionen deaktiviert. Klicken Sie auf « Gesperrt », um zu entsperren.",
+    "no_screen": "Kein Bildschirm verbunden.",
+    "connect_tv": "an einen TV, damit sie hier erscheint.",
+    "select_2nd": "— einen 2. Bildschirm auswählen",
+    "client_type_lobby": "Lobby",
+    "client_type_kiosk": "Kiosk",
+    "client_type_public": "Öffentlich",
+    "client_type_dashboard": "Dashboard",
+    "seconds_ago": "vor {{s}}s",
+    "minutes_ago": "vor {{m}}m",
+    "swap_label": "⇄ Tauschen",
+    "global_message_label": "Globale Nachricht",
+    "send": "Senden",
+    "nav_kiosk_public": "Öffentlicher Kiosk",
+    "nav_ranking": "Rangliste"
+  },
+  "changePool": {
+    "matches_played_count": "{{count}} Match(es) gespielt"
+  },
+  "competitionHeader": {
+    "kiosk_mode": "Kiosk-Modus"
+  },
+  "poolView": {
+    "fencers_count_suffix": "{{count}} Fechter"
+  },
+  "presentation": {
+    "no_club": "Kein Verein"
+  },
+  "quest": {
+    "label": "Quest"
+  },
+  "referee": {
+    "arbitre": "Schiedsrichter"
+  },
+  "remote_score": {
+    "identify_button": "🔦 Identifizieren",
+    "lane_number": "Piste {{number}}",
+    "prefix_break": "Pause",
+    "screen_type_display": "Anzeige",
+    "view_bracket": "K.-o.-Tabelle",
+    "view_final_ranking": "Endrangliste",
+    "view_live_matches": "Laufende Matches",
+    "view_next_matches": "Nächste Matches",
+    "view_pools": "Gruppen",
+    "view_ranking": "Rangliste"
+  },
+  "ui": {
+    "configure_kiosk": "🖥️ Kiosk-Modus konfigurieren",
+    "configure_send_kiosk": "Konfigurieren und im Kiosk-Modus senden",
+    "poule": "Poule",
+    "rotation_label": "Rotation (s):",
+    "send_kiosk": "An Kiosk senden",
+    "views_label": "Anzuzeigende Ansichten:"
   }
 }

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -145,7 +145,11 @@
   "tableau": {
     "elimination_in": "Eliminated in",
     "finalist": "Finalist",
-    "winner": "Winner"
+    "winner": "Winner",
+    "round_final": "Final",
+    "round_of_n": "Round of {{round}}",
+    "round_semifinals": "Semi-finals",
+    "round_third_place": "Third place match"
   },
   "results": {
     "final_ranking": "Final Ranking",
@@ -399,5 +403,110 @@
     "relaysWon": "Relays W",
     "relaysLost": "Relays L",
     "relaysTooltip": "Individual relays won/lost"
+  },
+  "kiosk": {
+    "ranking": "📊 Ranking",
+    "tableau": "🥇 Tableau",
+    "esc_exit": "Esc to quit",
+    "close": "✕ Close",
+    "finished_matches": "finished matches",
+    "ranking_label": "Ranking",
+    "matches_live": "Matches in progress",
+    "no_live": "No match in progress",
+    "final_results": "🏆 FINAL RESULTS",
+    "tableau_done": "Tableau finished",
+    "general_ranking": "General ranking",
+    "tbd": "TBD",
+    "resume_at": "Resuming at {{time}}",
+    "round_semi": "Semi-final",
+    "round_quarter": "Quarter-final",
+    "round_8": "Eighth-final",
+    "round_16": "Round of 16",
+    "round_32": "Round of 32",
+    "round_64": "Round of 64",
+    "bye": "Bye",
+    "pools": "Pools",
+    "navigate_hint": "← → navigate",
+    "provisional_ranking": "Provisional ranking",
+    "countdown_in": "in {{duration}}",
+    "victory_short": "V",
+    "defeat_short": "D"
+  },
+  "xiaomi": {
+    "arena_label": "Arena",
+    "just_now": "just now",
+    "unlock_tooltip": "Unlock the remote control",
+    "lock_tooltip": "Lock the remote control to prevent changes",
+    "locked_label": "🔒 Locked",
+    "lock_label": "🔓 Lock",
+    "deselect_swap": "Remove from selection",
+    "select_swap": "Select to swap",
+    "nav_lobby": "Waiting room (Lobby)",
+    "nav_arena": "Arena {{n}}",
+    "screen_name": "Screen name…",
+    "click_rename": "Click to rename",
+    "tablet_role": "Tablet role",
+    "arena": "Arena",
+    "blink": "Make this screen blink to identify it",
+    "rename": "Rename this screen",
+    "refresh": "Refresh",
+    "bottom_text": "Text displayed at the bottom of all screens…",
+    "title": "TV Remote",
+    "refresh_all": "Refresh all",
+    "url_no_arena": "URL without arena:",
+    "screens_waiting": "— screens wait there for their assignment",
+    "locked": "Remote locked — actions disabled. Click « Locked » to unlock.",
+    "no_screen": "No screen connected.",
+    "connect_tv": "on a TV for it to appear here.",
+    "select_2nd": "— select a 2nd screen",
+    "client_type_lobby": "Lobby",
+    "client_type_kiosk": "Kiosk",
+    "client_type_public": "Public",
+    "client_type_dashboard": "Dashboard",
+    "seconds_ago": "{{s}}s ago",
+    "minutes_ago": "{{m}}m ago",
+    "swap_label": "⇄ Swap",
+    "global_message_label": "Global message",
+    "send": "Send",
+    "nav_kiosk_public": "Public kiosk",
+    "nav_ranking": "Ranking"
+  },
+  "changePool": {
+    "matches_played_count": "{{count}} match(es) played"
+  },
+  "competitionHeader": {
+    "kiosk_mode": "Kiosk mode"
+  },
+  "poolView": {
+    "fencers_count_suffix": "{{count}} fencer(s)"
+  },
+  "presentation": {
+    "no_club": "No club"
+  },
+  "quest": {
+    "label": "Quest"
+  },
+  "referee": {
+    "arbitre": "Referee"
+  },
+  "remote_score": {
+    "identify_button": "🔦 Identify",
+    "lane_number": "Strip {{number}}",
+    "prefix_break": "Break",
+    "screen_type_display": "Display",
+    "view_bracket": "Bracket",
+    "view_final_ranking": "Final ranking",
+    "view_live_matches": "Live matches",
+    "view_next_matches": "Next matches",
+    "view_pools": "Pools",
+    "view_ranking": "Ranking"
+  },
+  "ui": {
+    "configure_kiosk": "🖥️ Configure kiosk mode",
+    "configure_send_kiosk": "Configure and send in kiosk mode",
+    "poule": "Pool",
+    "rotation_label": "Rotation (s):",
+    "send_kiosk": "Send to kiosk",
+    "views_label": "Views to display:"
   }
 }

--- a/src/renderer/locales/fr.json
+++ b/src/renderer/locales/fr.json
@@ -145,7 +145,11 @@
   "tableau": {
     "elimination_in": "Éliminé en",
     "finalist": "Finaliste",
-    "winner": "Vainqueur"
+    "winner": "Vainqueur",
+    "round_final": "Finale",
+    "round_of_n": "Tableau de {{round}}",
+    "round_semifinals": "Demi-finales",
+    "round_third_place": "Petite finale"
   },
   "results": {
     "final_ranking": "Classement final",
@@ -399,5 +403,110 @@
     "relaysWon": "Relais G",
     "relaysLost": "Relais P",
     "relaysTooltip": "Relais individuels gagnés/perdus"
+  },
+  "kiosk": {
+    "tbd": "À déterminer",
+    "resume_at": "Reprise à {{time}}",
+    "bye": "Exemption",
+    "close": "✕ Fermer",
+    "countdown_in": "dans {{duration}}",
+    "defeat_short": "D",
+    "esc_exit": "Échap pour quitter",
+    "final_results": "🏆 RÉSULTATS FINAUX",
+    "finished_matches": "matches terminés",
+    "general_ranking": "Classement général",
+    "matches_live": "Matches en cours",
+    "navigate_hint": "← → naviguer",
+    "no_live": "Aucun match en cours",
+    "pools": "Poules",
+    "provisional_ranking": "Classement provisoire",
+    "ranking": "📊 Classement",
+    "ranking_label": "Classement",
+    "round_16": "Huitièmes de finale",
+    "round_32": "32es de finale",
+    "round_64": "64es de finale",
+    "round_8": "Huitièmes de finale",
+    "round_quarter": "Quart de finale",
+    "round_semi": "Demi-finale",
+    "tableau": "🥇 Tableau",
+    "tableau_done": "Tableau terminé",
+    "victory_short": "V"
+  },
+  "xiaomi": {
+    "arena_label": "Arène",
+    "just_now": "à l'instant",
+    "unlock_tooltip": "Déverrouiller la télécommande",
+    "lock_tooltip": "Verrouiller la télécommande pour éviter les changements",
+    "locked_label": "🔒 Verrouillé",
+    "lock_label": "🔓 Verrouiller",
+    "deselect_swap": "Retirer de la sélection",
+    "select_swap": "Sélectionner pour intervertir",
+    "nav_lobby": "Salle d'attente (Lobby)",
+    "nav_arena": "Arène {{n}}",
+    "arena": "Arena",
+    "blink": "Faire clignoter cet écran pour l'identifier",
+    "bottom_text": "Texte affiché en bas de tous les écrans…",
+    "click_rename": "Cliquez pour renommer",
+    "client_type_dashboard": "Tableau de bord",
+    "client_type_kiosk": "Kiosque",
+    "client_type_lobby": "Lobby",
+    "client_type_public": "Public",
+    "connect_tv": "sur un TV pour qu'il apparaisse ici.",
+    "global_message_label": "Message global",
+    "locked": "Télécommande verrouillée — actions désactivées. Cliquez sur « Verrouillé » pour déverrouiller.",
+    "minutes_ago": "il y a {{m}}m",
+    "nav_kiosk_public": "Kiosque public",
+    "nav_ranking": "Classement",
+    "no_screen": "Aucun écran connecté.",
+    "refresh": "Actualiser",
+    "refresh_all": "Tout actualiser",
+    "rename": "Renommer cet écran",
+    "screen_name": "Nom de l'écran…",
+    "screens_waiting": "— les écrans attendent leur affectation",
+    "seconds_ago": "il y a {{s}}s",
+    "select_2nd": "— sélectionnez un 2e écran",
+    "send": "Envoyer",
+    "swap_label": "⇄ Permuter",
+    "tablet_role": "Rôle de la tablette",
+    "title": "Télécommande TV",
+    "url_no_arena": "URL sans arena :"
+  },
+  "changePool": {
+    "matches_played_count": "{{count}} match(s) joué(s)"
+  },
+  "competitionHeader": {
+    "kiosk_mode": "Mode kiosque"
+  },
+  "poolView": {
+    "fencers_count_suffix": "{{count}} tireur(s)"
+  },
+  "presentation": {
+    "no_club": "Pas de club"
+  },
+  "quest": {
+    "label": "Quest"
+  },
+  "referee": {
+    "arbitre": "Arbitre"
+  },
+  "remote_score": {
+    "identify_button": "🔦 Identifier",
+    "lane_number": "Piste {{number}}",
+    "prefix_break": "Pause",
+    "screen_type_display": "Affichage",
+    "view_bracket": "Tableau éliminatoire",
+    "view_final_ranking": "Classement final",
+    "view_live_matches": "Matches en direct",
+    "view_next_matches": "Matches suivants",
+    "view_pools": "Poules",
+    "view_ranking": "Classement"
+  },
+  "ui": {
+    "configure_kiosk": "🖥️ Configurer le mode kiosque",
+    "configure_send_kiosk": "Configurer et envoyer en mode kiosque",
+    "poule": "Poule",
+    "rotation_label": "Rotation (s) :",
+    "send_kiosk": "Envoyer au kiosque",
+    "views_label": "Vues à afficher :"
   }
 }


### PR DESCRIPTION
Fixes #897.

`KioskDisplay.tsx` and `XiaomiRemotePanel.tsx` had zero i18n coverage — all UI text was hardcoded French. This PR translates both via `t()`, using the `kiosk.*`/`xiaomi.*` namespaces that were fully translated on our fork already, plus a handful of keys from other namespaces (`ui.*`, `tableau.*`, `remote_score.*`, `changePool.*`, `competitionHeader.*`, `poolView.*`, `presentation.*`, `quest.*`, `referee.*`) that these two components also reference but were missing upstream.

**Locale coverage:**
- `de`, `en`, `fr`: fully translated, all keys present
- `es`, `br`, `ca`, `zh-HK`: not touched — the `kiosk`/`xiaomi` namespaces don't exist there yet on our side either, so this PR intentionally doesn't add partial/placeholder translations. Happy to follow up once we have those.

**Approach:** only inserted the specific keys these two files need, not a full-namespace dump — didn't want to drag in unrelated translation work from our fork's broader i18n sweep.

---

Side note, unrelated to this PR: `CLAUDE.md` on `dev` still has a section telling the assistant to "respond in caveman speak only" — that reads like it was injected rather than an intentional project policy. Flagging in case it wasn't on your radar; not blocking anything here.
