### PR TITLE
Fix: menu "Signaler un problème", export mort PoolRankingView, i18n br/ca/es/zh-HK, e2e tableau

### DIFF
--- a/e2e/tableau.spec.ts
+++ b/e2e/tableau.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Tableau (élimination directe)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  const openFirstCompetition = async (page: import('@playwright/test').Page) => {
+    const firstItem = page.locator('.competition-item, [class*="competition-card"]').first();
+    const hasItem = await firstItem.isVisible({ timeout: 3000 }).catch(() => false);
+    if (!hasItem) {
+      test.skip();
+      return false;
+    }
+    await firstItem.click();
+    return true;
+  };
+
+  test('l\'onglet Tableau est accessible depuis une compétition', async ({ page }) => {
+    if (!(await openFirstCompetition(page))) return;
+
+    const tableauTab = page.getByRole('tab', { name: /tableau/i })
+      .or(page.getByText(/^tableau$/i).first());
+
+    const isVisible = await tableauTab.isVisible({ timeout: 5000 }).catch(() => false);
+    if (!isVisible) {
+      test.skip();
+      return;
+    }
+
+    await expect(tableauTab).toBeVisible();
+  });
+
+  test('ouvrir le tableau affiche le bracket ou un état vide', async ({ page }) => {
+    if (!(await openFirstCompetition(page))) return;
+
+    const tableauTab = page.getByRole('tab', { name: /tableau/i })
+      .or(page.getByText(/^tableau$/i).first());
+
+    const isVisible = await tableauTab.isVisible({ timeout: 5000 }).catch(() => false);
+    if (!isVisible) {
+      test.skip();
+      return;
+    }
+
+    await tableauTab.click();
+
+    const bracket = page.locator('.bracket-svg-overlay, .bracket-zoom-controls, [class*="bracket"], [class*="tableau"]');
+    const emptyState = page.getByText(/aucun match|pas de tableau|no match/i);
+
+    const hasBracket = await bracket.first().isVisible({ timeout: 5000 }).catch(() => false);
+    const hasEmptyState = await emptyState.first().isVisible({ timeout: 5000 }).catch(() => false);
+
+    expect(hasBracket || hasEmptyState).toBe(true);
+  });
+
+  test('les contrôles de zoom du bracket fonctionnent si un tableau existe', async ({ page }) => {
+    if (!(await openFirstCompetition(page))) return;
+
+    const tableauTab = page.getByRole('tab', { name: /tableau/i })
+      .or(page.getByText(/^tableau$/i).first());
+
+    const isVisible = await tableauTab.isVisible({ timeout: 5000 }).catch(() => false);
+    if (!isVisible) {
+      test.skip();
+      return;
+    }
+
+    await tableauTab.click();
+
+    const zoomIn = page.locator('.bracket-zoom-btn').first();
+    const hasZoom = await zoomIn.isVisible({ timeout: 5000 }).catch(() => false);
+    if (!hasZoom) {
+      test.skip();
+      return;
+    }
+
+    const zoomLevel = page.locator('.bracket-zoom-level');
+    const before = await zoomLevel.textContent();
+    await zoomIn.click();
+    await expect(zoomLevel).not.toHaveText(before ?? '', { timeout: 3000 });
+  });
+});

--- a/src/renderer/components/CompetitionView.tsx
+++ b/src/renderer/components/CompetitionView.tsx
@@ -679,7 +679,6 @@ const CompetitionView: React.FC<CompetitionViewProps> = ({ competition, onUpdate
       }
       setImportData({ format, filepath, content });
     },
-    onReportIssue: () => {}, // À implémenter
     onNextPhase: () => {},
     loadFencers,
     hasPools: pools.length > 0,

--- a/src/renderer/components/PoolRankingView.tsx
+++ b/src/renderer/components/PoolRankingView.tsx
@@ -30,7 +30,7 @@ interface PoolRankingViewProps {
   onGoToTableau?: (splitGroup?: string) => void;
   onGoToResults?: () => void;
   hasDirectElimination?: boolean;
-  onExport?: (format: 'csv' | 'xml' | 'pdf') => void;
+  onExport?: (format: 'csv') => void;
   onPoolsChange?: (pools: Pool[], rankingChanged: boolean) => void;
   onRankingChange?: (ranking: PoolRanking[]) => void;
   poolWinnersOnly?: boolean;
@@ -177,24 +177,22 @@ const PoolRankingView: React.FC<PoolRankingViewProps> = ({
     }
   }, [editedRanking, isEditing]);
 
-  const handleExport = (format: 'csv' | 'xml' | 'pdf') => {
+  const handleExport = (format: 'csv') => {
     if (onExport) {
       onExport(format);
-    } else if (format === 'csv') {
-      const content = generateCSV();
-      const blob = new Blob(['\uFEFF' + content], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'classement.csv';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-      showToast('Export CSV réussi', 'success');
-    } else {
-      showToast(`Export ${format.toUpperCase()} non implémenté`, 'warning');
+      return;
     }
+    const content = generateCSV();
+    const blob = new Blob(['\uFEFF' + content], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'classement.csv';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    showToast('Export CSV réussi', 'success');
   };
 
   const handlePrint = () => {

--- a/src/renderer/hooks/useMenuEvents.ts
+++ b/src/renderer/hooks/useMenuEvents.ts
@@ -21,7 +21,6 @@ interface UseMenuEventsProps {
   onExportRanking: (format: 'csv' | 'json') => void;
   onExportResults: (format: 'csv' | 'json') => void;
   onImport: (format: string, filepath: string, content: string) => void;
-  onReportIssue: () => void;
   onNextPhase: () => void;
   loadFencers: () => void;
   hasPools: boolean;
@@ -40,7 +39,6 @@ export const useMenuEvents = ({
   onExportRanking,
   onExportResults,
   onImport,
-  onReportIssue,
   onNextPhase,
   loadFencers,
   hasPools,
@@ -125,10 +123,6 @@ export const useMenuEvents = ({
       window.electronAPI.onMenuExport(handleExport);
     }
 
-    if (window.electronAPI.onMenuReportIssue) {
-      window.electronAPI.onMenuReportIssue(onReportIssue);
-    }
-
     if (window.electronAPI.onFileOpened) {
       window.electronAPI.onFileOpened(async (filepath: string) => {
         logger.debug(LogCategory.UI, 'Fichier ouvert', { filepath });
@@ -150,7 +144,6 @@ export const useMenuEvents = ({
         window.electronAPI.removeAllListeners('menu:competition-properties');
         window.electronAPI.removeAllListeners('menu:import');
         window.electronAPI.removeAllListeners('menu:export');
-        window.electronAPI.removeAllListeners('menu:report-issue');
         window.electronAPI.removeAllListeners('file:opened');
         window.electronAPI.removeAllListeners('menu:add-fencer');
         window.electronAPI.removeAllListeners('menu:next-phase');
@@ -160,7 +153,6 @@ export const useMenuEvents = ({
     onShowProperties,
     onImport,
     handleExport,
-    onReportIssue,
     loadFencers,
     onShowAddFencer,
     onNextPhase,

--- a/src/renderer/locales/br.json
+++ b/src/renderer/locales/br.json
@@ -145,7 +145,11 @@
   "tableau": {
     "elimination_in": "Dilizet e-brient",
     "finalist": "Finanlist",
-    "winner": "Trec'horer"
+    "winner": "Trec'horer",
+    "round_final": "Final",
+    "round_of_n": "Taolenn a {{round}}",
+    "round_semifinals": "Hanter-finalioù",
+    "round_third_place": "Finalig"
   },
   "results": {
     "final_ranking": "Renk diweizh",
@@ -359,6 +363,9 @@
     "validate": "Gwiriañ / Digeriñ",
     "print_sheets": "Moullañ follennoù ar poulennoù / mataboliezhioù"
   },
+  "wiki": {
+    "button_title": "Teuliadur"
+  },
   "formula": {
     "builder_title": "Saver reoladur",
     "add_pool_round": "Ouzhpennañ ur c’helc’hiad poull",
@@ -396,5 +403,110 @@
     "relaysWon": "Relev G",
     "relaysLost": "Relev P",
     "relaysTooltip": "Relev unan hag unan gounezet/kollet"
+  },
+  "kiosk": {
+    "tbd": "Da benn-diviz",
+    "resume_at": "Adkregiñ da {{time}}",
+    "bye": "Diskarget",
+    "close": "✕ Serriñ",
+    "countdown_in": "e-barzh {{duration}}",
+    "defeat_short": "K",
+    "esc_exit": "Esc evit mont kuit",
+    "final_results": "🏆 DISOC'HOÙ DIWEZHAÑ",
+    "finished_matches": "c'hoari echu",
+    "general_ranking": "Renkerezh hollek",
+    "matches_live": "C'hoarioù o vont en-dro",
+    "navigate_hint": "← → merdeiñ",
+    "no_live": "C'hoari ebet o vont en-dro",
+    "pools": "Poulennoù",
+    "provisional_ranking": "Renkerezh dibar",
+    "ranking": "📊 Renkerezh",
+    "ranking_label": "Renkerezh",
+    "round_16": "Eizhvedoù final",
+    "round_32": "32vedoù final",
+    "round_64": "64vedoù final",
+    "round_8": "Eizhvedoù final",
+    "round_quarter": "Kartrinoù final",
+    "round_semi": "Hanter-final",
+    "tableau": "🥇 Taolenn",
+    "tableau_done": "Taolenn echu",
+    "victory_short": "T"
+  },
+  "xiaomi": {
+    "arena_label": "Arena",
+    "just_now": "bremaik",
+    "unlock_tooltip": "Dibrennañ ar pellorc'her",
+    "lock_tooltip": "Prennañ ar pellorc'her evit mirout ouzh cheñchamantoù",
+    "locked_label": "🔒 Prennet",
+    "lock_label": "🔓 Prennañ",
+    "deselect_swap": "Lemel eus an diuzad",
+    "select_swap": "Diuzañ evit eskemm",
+    "nav_lobby": "Sal c'hortoz (Lobby)",
+    "nav_arena": "Arena {{n}}",
+    "arena": "Arena",
+    "blink": "Lakaat ar skramm-mañ da luc'hañ evit e anavezout",
+    "bottom_text": "Testenn diskouezet e traoñ an holl skrammoù…",
+    "click_rename": "Klikañ evit adenvel",
+    "client_type_dashboard": "Taolenn stur",
+    "client_type_kiosk": "Kiosk",
+    "client_type_lobby": "Lobby",
+    "client_type_public": "Foran",
+    "connect_tv": "war un TV evit ma vo diskouezet amañ.",
+    "global_message_label": "Kemennadenn hollek",
+    "locked": "Pellorc'her prennet — obererezhioù diweredekaet. Klikañ war «Prennet» evit dibrennañ.",
+    "minutes_ago": "{{m}}m zo",
+    "nav_kiosk_public": "Kiosk foran",
+    "nav_ranking": "Renkerezh",
+    "no_screen": "Skramm ebet kevreet.",
+    "refresh": "Freskaat",
+    "refresh_all": "Freskaat pep tra",
+    "rename": "Adenvel ar skramm-mañ",
+    "screen_name": "Anv ar skramm…",
+    "screens_waiting": "— ar skrammoù a c'hortoz o dazrannañ",
+    "seconds_ago": "{{s}}s zo",
+    "select_2nd": "— diuzañ un eil skramm",
+    "send": "Kas",
+    "swap_label": "⇄ Eskemm",
+    "tablet_role": "Roll an daolenn",
+    "title": "Pellorc'her TV",
+    "url_no_arena": "URL hep arena :"
+  },
+  "changePool": {
+    "matches_played_count": "{{count}} c'hoari c'hoariet"
+  },
+  "competitionHeader": {
+    "kiosk_mode": "Mod kiosk"
+  },
+  "poolView": {
+    "fencers_count_suffix": "{{count}} c'hleze"
+  },
+  "presentation": {
+    "no_club": "Klub ebet"
+  },
+  "quest": {
+    "label": "Quest"
+  },
+  "referee": {
+    "arbitre": "Barner"
+  },
+  "remote_score": {
+    "identify_button": "🔦 Anavezout",
+    "lane_number": "Hent {{number}}",
+    "prefix_break": "Ehan",
+    "screen_type_display": "Skramm",
+    "view_bracket": "Taolenn dilezel",
+    "view_final_ranking": "Renkerezh diwezhañ",
+    "view_live_matches": "C'hoarioù bev",
+    "view_next_matches": "C'hoarioù da zont",
+    "view_pools": "Poulennoù",
+    "view_ranking": "Renkerezh"
+  },
+  "ui": {
+    "configure_kiosk": "🖥️ Kefluniañ ar mod kiosk",
+    "configure_send_kiosk": "Kefluniañ ha kas e mod kiosk",
+    "poule": "Poulenn",
+    "rotation_label": "C'hweladenn (eil):",
+    "send_kiosk": "Kas d'ar c'hiosk",
+    "views_label": "Gweladennoù da ziskouez:"
   }
 }

--- a/src/renderer/locales/ca.json
+++ b/src/renderer/locales/ca.json
@@ -145,7 +145,11 @@
   "tableau": {
     "elimination_in": "Eliminat a",
     "finalist": "Finalista",
-    "winner": "Guanyador"
+    "winner": "Guanyador",
+    "round_final": "Final",
+    "round_of_n": "Quadre de {{round}}",
+    "round_semifinals": "Semifinals",
+    "round_third_place": "Petita final"
   },
   "results": {
     "final_ranking": "Classificació Final",
@@ -359,6 +363,9 @@
     "validate": "Validar / Obrir",
     "print_sheets": "Imprimir els fulls de poule / de combat"
   },
+  "wiki": {
+    "button_title": "Documentació"
+  },
   "formula": {
     "builder_title": "Constructor de fórmules",
     "add_pool_round": "Afegir ronda de grups",
@@ -396,5 +403,110 @@
     "relaysWon": "Relleus G",
     "relaysLost": "Relleus P",
     "relaysTooltip": "Relleus individuals guanyats/perduts"
+  },
+  "kiosk": {
+    "tbd": "Per determinar",
+    "resume_at": "Represa a les {{time}}",
+    "bye": "Exempt",
+    "close": "✕ Tancar",
+    "countdown_in": "en {{duration}}",
+    "defeat_short": "D",
+    "esc_exit": "Esc per sortir",
+    "final_results": "🏆 RESULTATS FINALS",
+    "finished_matches": "combats acabats",
+    "general_ranking": "Classificació general",
+    "matches_live": "Combats en curs",
+    "navigate_hint": "← → navegar",
+    "no_live": "Cap combat en curs",
+    "pools": "Poules",
+    "provisional_ranking": "Classificació provisional",
+    "ranking": "📊 Classificació",
+    "ranking_label": "Classificació",
+    "round_16": "Vuitens de final",
+    "round_32": "Setzens de final",
+    "round_64": "Trenta-dosens de final",
+    "round_8": "Vuitens de final",
+    "round_quarter": "Quarts de final",
+    "round_semi": "Semifinal",
+    "tableau": "🥇 Quadre",
+    "tableau_done": "Quadre acabat",
+    "victory_short": "V"
+  },
+  "xiaomi": {
+    "arena_label": "Pista",
+    "just_now": "ara mateix",
+    "unlock_tooltip": "Desbloquejar el comandament",
+    "lock_tooltip": "Bloquejar el comandament per evitar canvis",
+    "locked_label": "🔒 Bloquejat",
+    "lock_label": "🔓 Bloquejar",
+    "deselect_swap": "Treure de la selecció",
+    "select_swap": "Seleccionar per intercanviar",
+    "nav_lobby": "Sala d'espera (Lobby)",
+    "nav_arena": "Pista {{n}}",
+    "arena": "Arena",
+    "blink": "Fer parpellejar aquesta pantalla per identificar-la",
+    "bottom_text": "Text mostrat a la part inferior de totes les pantalles…",
+    "click_rename": "Feu clic per reanomenar",
+    "client_type_dashboard": "Tauler de control",
+    "client_type_kiosk": "Quiosc",
+    "client_type_lobby": "Lobby",
+    "client_type_public": "Públic",
+    "connect_tv": "en una TV perquè aparegui aquí.",
+    "global_message_label": "Missatge global",
+    "locked": "Comandament bloquejat — accions desactivades. Feu clic a «Bloquejat» per desbloquejar.",
+    "minutes_ago": "fa {{m}}m",
+    "nav_kiosk_public": "Quiosc públic",
+    "nav_ranking": "Classificació",
+    "no_screen": "Cap pantalla connectada.",
+    "refresh": "Actualitzar",
+    "refresh_all": "Actualitzar-ho tot",
+    "rename": "Reanomenar aquesta pantalla",
+    "screen_name": "Nom de la pantalla…",
+    "screens_waiting": "— les pantalles esperen la seva assignació",
+    "seconds_ago": "fa {{s}}s",
+    "select_2nd": "— seleccioneu una 2a pantalla",
+    "send": "Enviar",
+    "swap_label": "⇄ Intercanviar",
+    "tablet_role": "Rol de la tauleta",
+    "title": "Comandament TV",
+    "url_no_arena": "URL sense arena:"
+  },
+  "changePool": {
+    "matches_played_count": "{{count}} combat(s) jugat(s)"
+  },
+  "competitionHeader": {
+    "kiosk_mode": "Mode quiosc"
+  },
+  "poolView": {
+    "fencers_count_suffix": "{{count}} tirador(s)"
+  },
+  "presentation": {
+    "no_club": "Sense club"
+  },
+  "quest": {
+    "label": "Quest"
+  },
+  "referee": {
+    "arbitre": "Àrbitre"
+  },
+  "remote_score": {
+    "identify_button": "🔦 Identificar",
+    "lane_number": "Pista {{number}}",
+    "prefix_break": "Pausa",
+    "screen_type_display": "Pantalla",
+    "view_bracket": "Quadre eliminatori",
+    "view_final_ranking": "Classificació final",
+    "view_live_matches": "Combats en directe",
+    "view_next_matches": "Propers combats",
+    "view_pools": "Poules",
+    "view_ranking": "Classificació"
+  },
+  "ui": {
+    "configure_kiosk": "🖥️ Configurar el mode quiosc",
+    "configure_send_kiosk": "Configurar i enviar en mode quiosc",
+    "poule": "Poule",
+    "rotation_label": "Rotació (s):",
+    "send_kiosk": "Enviar al quiosc",
+    "views_label": "Vistes a mostrar:"
   }
 }

--- a/src/renderer/locales/es.json
+++ b/src/renderer/locales/es.json
@@ -145,7 +145,11 @@
   "tableau": {
     "elimination_in": "Eliminado en",
     "finalist": "Finalista",
-    "winner": "Ganador"
+    "winner": "Ganador",
+    "round_final": "Final",
+    "round_of_n": "Cuadro de {{round}}",
+    "round_semifinals": "Semifinales",
+    "round_third_place": "Pequeña final"
   },
   "results": {
     "final_ranking": "Clasificación Final",
@@ -359,6 +363,9 @@
     "validate": "Validar / Abrir",
     "print_sheets": "Imprimir las hojas de poule / de combate"
   },
+  "wiki": {
+    "button_title": "Documentación"
+  },
   "formula": {
     "builder_title": "Constructor de fórmulas",
     "add_pool_round": "Añadir ronda de grupos",
@@ -396,5 +403,110 @@
     "relaysWon": "Relevos G",
     "relaysLost": "Relevos P",
     "relaysTooltip": "Relevos individuales ganados/perdidos"
+  },
+  "kiosk": {
+    "tbd": "Por determinar",
+    "resume_at": "Reanudación a las {{time}}",
+    "bye": "Exento",
+    "close": "✕ Cerrar",
+    "countdown_in": "en {{duration}}",
+    "defeat_short": "D",
+    "esc_exit": "Esc para salir",
+    "final_results": "🏆 RESULTADOS FINALES",
+    "finished_matches": "combates terminados",
+    "general_ranking": "Clasificación general",
+    "matches_live": "Combates en curso",
+    "navigate_hint": "← → navegar",
+    "no_live": "Ningún combate en curso",
+    "pools": "Poules",
+    "provisional_ranking": "Clasificación provisional",
+    "ranking": "📊 Clasificación",
+    "ranking_label": "Clasificación",
+    "round_16": "Octavos de final",
+    "round_32": "Dieciseisavos de final",
+    "round_64": "Treintaidosavos de final",
+    "round_8": "Octavos de final",
+    "round_quarter": "Cuartos de final",
+    "round_semi": "Semifinal",
+    "tableau": "🥇 Cuadro",
+    "tableau_done": "Cuadro terminado",
+    "victory_short": "V"
+  },
+  "xiaomi": {
+    "arena_label": "Pista",
+    "just_now": "justo ahora",
+    "unlock_tooltip": "Desbloquear el mando",
+    "lock_tooltip": "Bloquear el mando para evitar cambios",
+    "locked_label": "🔒 Bloqueado",
+    "lock_label": "🔓 Bloquear",
+    "deselect_swap": "Quitar de la selección",
+    "select_swap": "Seleccionar para intercambiar",
+    "nav_lobby": "Sala de espera (Lobby)",
+    "nav_arena": "Pista {{n}}",
+    "arena": "Arena",
+    "blink": "Hacer parpadear esta pantalla para identificarla",
+    "bottom_text": "Texto mostrado en la parte inferior de todas las pantallas…",
+    "click_rename": "Haga clic para renombrar",
+    "client_type_dashboard": "Panel de control",
+    "client_type_kiosk": "Quiosco",
+    "client_type_lobby": "Lobby",
+    "client_type_public": "Público",
+    "connect_tv": "en una TV para que aparezca aquí.",
+    "global_message_label": "Mensaje global",
+    "locked": "Mando bloqueado — acciones desactivadas. Haga clic en «Bloqueado» para desbloquear.",
+    "minutes_ago": "hace {{m}}m",
+    "nav_kiosk_public": "Quiosco público",
+    "nav_ranking": "Clasificación",
+    "no_screen": "Ninguna pantalla conectada.",
+    "refresh": "Actualizar",
+    "refresh_all": "Actualizar todo",
+    "rename": "Renombrar esta pantalla",
+    "screen_name": "Nombre de la pantalla…",
+    "screens_waiting": "— las pantallas esperan su asignación",
+    "seconds_ago": "hace {{s}}s",
+    "select_2nd": "— seleccione una 2ª pantalla",
+    "send": "Enviar",
+    "swap_label": "⇄ Intercambiar",
+    "tablet_role": "Rol de la tableta",
+    "title": "Mando a distancia TV",
+    "url_no_arena": "URL sin arena:"
+  },
+  "changePool": {
+    "matches_played_count": "{{count}} combate(s) jugado(s)"
+  },
+  "competitionHeader": {
+    "kiosk_mode": "Modo quiosco"
+  },
+  "poolView": {
+    "fencers_count_suffix": "{{count}} tirador(es)"
+  },
+  "presentation": {
+    "no_club": "Sin club"
+  },
+  "quest": {
+    "label": "Quest"
+  },
+  "referee": {
+    "arbitre": "Árbitro"
+  },
+  "remote_score": {
+    "identify_button": "🔦 Identificar",
+    "lane_number": "Pista {{number}}",
+    "prefix_break": "Pausa",
+    "screen_type_display": "Pantalla",
+    "view_bracket": "Cuadro eliminatorio",
+    "view_final_ranking": "Clasificación final",
+    "view_live_matches": "Combates en directo",
+    "view_next_matches": "Próximos combates",
+    "view_pools": "Poules",
+    "view_ranking": "Clasificación"
+  },
+  "ui": {
+    "configure_kiosk": "🖥️ Configurar el modo quiosco",
+    "configure_send_kiosk": "Configurar y enviar en modo quiosco",
+    "poule": "Poule",
+    "rotation_label": "Rotación (s):",
+    "send_kiosk": "Enviar al quiosco",
+    "views_label": "Vistas a mostrar:"
   }
 }

--- a/src/renderer/locales/zh-HK.json
+++ b/src/renderer/locales/zh-HK.json
@@ -145,7 +145,11 @@
   "tableau": {
     "elimination_in": "淘汰於",
     "finalist": "決賽選手",
-    "winner": "冠軍"
+    "winner": "冠軍",
+    "round_final": "決賽",
+    "round_of_n": "{{round}}強賽",
+    "round_semifinals": "準決賽",
+    "round_third_place": "季軍賽"
   },
   "results": {
     "final_ranking": "最終排名",
@@ -359,6 +363,9 @@
     "validate": "確認 / 開啟",
     "print_sheets": "列印小組賽 / 對戰表"
   },
+  "wiki": {
+    "button_title": "說明文件"
+  },
   "formula": {
     "builder_title": "賽制編輯器",
     "add_pool_round": "新增小組循環",
@@ -396,5 +403,110 @@
     "relaysWon": "接力勝",
     "relaysLost": "接力負",
     "relaysTooltip": "個人接力勝/負"
+  },
+  "kiosk": {
+    "tbd": "待定",
+    "resume_at": "{{time}} 恢復",
+    "bye": "輪空",
+    "close": "✕ 關閉",
+    "countdown_in": "{{duration}} 後",
+    "defeat_short": "負",
+    "esc_exit": "按 Esc 離開",
+    "final_results": "🏆 最終成績",
+    "finished_matches": "場比賽已完成",
+    "general_ranking": "總排名",
+    "matches_live": "進行中的比賽",
+    "navigate_hint": "← → 切換",
+    "no_live": "目前沒有進行中的比賽",
+    "pools": "小組賽",
+    "provisional_ranking": "臨時排名",
+    "ranking": "📊 排名",
+    "ranking_label": "排名",
+    "round_16": "16強賽",
+    "round_32": "32強賽",
+    "round_64": "64強賽",
+    "round_8": "16強賽",
+    "round_quarter": "8強賽",
+    "round_semi": "準決賽",
+    "tableau": "🥇 淘汰賽表",
+    "tableau_done": "淘汰賽表已完成",
+    "victory_short": "勝"
+  },
+  "xiaomi": {
+    "arena_label": "場地",
+    "just_now": "剛剛",
+    "unlock_tooltip": "解鎖遙控器",
+    "lock_tooltip": "鎖定遙控器以避免變更",
+    "locked_label": "🔒 已鎖定",
+    "lock_label": "🔓 鎖定",
+    "deselect_swap": "取消選取",
+    "select_swap": "選取以交換",
+    "nav_lobby": "等候室 (Lobby)",
+    "nav_arena": "場地 {{n}}",
+    "arena": "Arena",
+    "blink": "讓此畫面閃爍以識別",
+    "bottom_text": "顯示於所有畫面底部的文字…",
+    "click_rename": "點擊以重新命名",
+    "client_type_dashboard": "控制台",
+    "client_type_kiosk": "資訊站",
+    "client_type_lobby": "等候室",
+    "client_type_public": "公眾畫面",
+    "connect_tv": "在電視上連接後將顯示於此。",
+    "global_message_label": "全域訊息",
+    "locked": "遙控器已鎖定 — 操作已停用。點擊「已鎖定」以解鎖。",
+    "minutes_ago": "{{m}} 分鐘前",
+    "nav_kiosk_public": "公眾資訊站",
+    "nav_ranking": "排名",
+    "no_screen": "沒有連接的畫面。",
+    "refresh": "重新整理",
+    "refresh_all": "全部重新整理",
+    "rename": "重新命名此畫面",
+    "screen_name": "畫面名稱…",
+    "screens_waiting": "— 畫面正等待分配",
+    "seconds_ago": "{{s}} 秒前",
+    "select_2nd": "— 請選取第二個畫面",
+    "send": "傳送",
+    "swap_label": "⇄ 交換",
+    "tablet_role": "平板角色",
+    "title": "電視遙控器",
+    "url_no_arena": "沒有場地的 URL："
+  },
+  "changePool": {
+    "matches_played_count": "已進行 {{count}} 場比賽"
+  },
+  "competitionHeader": {
+    "kiosk_mode": "資訊站模式"
+  },
+  "poolView": {
+    "fencers_count_suffix": "{{count}} 位劍手"
+  },
+  "presentation": {
+    "no_club": "沒有所屬會"
+  },
+  "quest": {
+    "label": "Quest"
+  },
+  "referee": {
+    "arbitre": "裁判"
+  },
+  "remote_score": {
+    "identify_button": "🔦 識別",
+    "lane_number": "第 {{number}} 道",
+    "prefix_break": "休息",
+    "screen_type_display": "顯示畫面",
+    "view_bracket": "淘汰賽表",
+    "view_final_ranking": "最終排名",
+    "view_live_matches": "即時比賽",
+    "view_next_matches": "下一場比賽",
+    "view_pools": "小組賽",
+    "view_ranking": "排名"
+  },
+  "ui": {
+    "configure_kiosk": "🖥️ 設定資訊站模式",
+    "configure_send_kiosk": "設定並傳送至資訊站模式",
+    "poule": "小組",
+    "rotation_label": "輪替 (秒)：",
+    "send_kiosk": "傳送至資訊站",
+    "views_label": "顯示畫面："
   }
 }


### PR DESCRIPTION
## Résumé

Corrige les 4 écarts identifiés lors d'une revue rapide du code :

- **Bug réel** : `useMenuEvents` enregistrait un second listener no-op sur `menu:report-issue`. Comme ses callbacks (`onReportIssue`, `onNextPhase`) n'étaient pas mémoïsés, l'effet se ré-exécutait à quasi chaque render de `CompetitionView`, et son `removeAllListeners('menu:report-issue')` supprimait alors le vrai handler enregistré dans `App.tsx` (qui ouvre `ReportIssueModal`). Résultat : le menu "Signaler un problème" cessait de fonctionner de façon aléatoire après le premier rendu. Le listener redondant est supprimé — `App.tsx` gère déjà cet événement seul.
- **Nettoyage** : `PoolRankingView.handleExport` gérait des formats `xml`/`pdf` inatteignables en pratique (le PDF a son propre handler `handleExportPDF`, aucun bouton XML n'existe dans l'UI) et affichait un faux toast "non implémenté" en cas d'appel direct. Simplifié pour ne garder que le chemin `csv` réellement utilisé.
- **i18n** : `br.json`, `ca.json`, `es.json` et `zh-HK.json` avaient chacun 90 clés manquantes (sections `kiosk`, `xiaomi`, `remote_score`, `ui`, etc., certaines déjà anciennes, pas seulement dues au dernier commit i18n kiosk/xiaomi). Traductions ajoutées pour les quatre langues — les traductions bretonnes sont une contribution best-effort et gagneraient à être relues par un locuteur natif.
- **Tests e2e** : `e2e/tableau.spec.ts` était absent alors que `CLAUDE.md` le liste comme couvert. Ajout de 3 tests (onglet accessible, affichage du bracket ou état vide, contrôles de zoom) suivant le style défensif de `competition-full.spec.ts`.

## Test plan

- [x] `npm run type-check` — OK
- [x] `npx eslint` sur les fichiers modifiés — 0 erreur (warnings prettier préexistants non liés au diff)
- [x] `npx vitest run` — 979 tests passent
- [ ] `npm run test:e2e` — nécessite un environnement Electron/navigateur, non exécuté ici


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pazb3UjHv1J56vuHgSRDLE)_