### PR TITLE
Ajoute le format arène Sabre Laser équipe (règlement ASL-FFE)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -2076,15 +2076,23 @@ export class DatabaseManager {
     this.run('DELETE FROM team_fencers WHERE team_id = ? AND fencer_id = ?', [teamId, fencerId]);
   }
 
-  public createTeamMatch(competitionId: string, poolNumber: number, teamAId: string, teamBId: string): { id: string } {
+  // `round` : calendrier de poule figé (format arène Sabre Laser, 8/12 équipes)
+  // — optionnel, reste `NULL` pour la génération round-robin générique existante.
+  public createTeamMatch(
+    competitionId: string,
+    poolNumber: number,
+    teamAId: string,
+    teamBId: string,
+    round?: number
+  ): { id: string } {
     if (!this.db) throw new Error('Database not open');
     const { v4: gen } = require('uuid');
     const matchId = gen();
     const now = new Date().toISOString();
     this.run(
-      `INSERT INTO team_matches (id, competition_id, pool_number, team_a_id, team_b_id, status, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, 'not_started', ?, ?)`,
-      [matchId, competitionId, poolNumber, teamAId, teamBId, now, now]
+      `INSERT INTO team_matches (id, competition_id, pool_number, round, team_a_id, team_b_id, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, 'not_started', ?, ?)`,
+      [matchId, competitionId, poolNumber, round ?? null, teamAId, teamBId, now, now]
     );
     return { id: matchId };
   }
@@ -2142,7 +2150,8 @@ export class DatabaseManager {
   }
 
   public getTeamMatchesByCompetition(competitionId: string): Array<{
-    id: string; poolNumber: number; teamAId: string; teamBId: string;
+    id: string; poolNumber: number; round: number | null;
+    teamAId: string; teamBId: string;
     scoreBoutsA: number; scoreBoutsB: number; status: string; winnerId: string | null;
     currentBoutIndex: number;
     bouts: Array<{ id: string; boutOrder: number; fencerAId: string; fencerBId: string; scoreA: number; scoreB: number; maxScore: number; status: string; winnerId: string | null }>;
@@ -2159,6 +2168,7 @@ export class DatabaseManager {
       );
       return {
         id: m.id as string, poolNumber: Number(m.pool_number),
+        round: m.round != null ? Number(m.round) : null,
         teamAId: m.team_a_id as string, teamBId: m.team_b_id as string,
         scoreBoutsA: Number(m.score_bouts_a), scoreBoutsB: Number(m.score_bouts_b),
         status: m.status as string, winnerId: (m.winner_id as string) ?? null,
@@ -2221,6 +2231,112 @@ export class DatabaseManager {
       `UPDATE team_matches SET score_bouts_a = ?, score_bouts_b = ?, status = ?, winner_id = ?, current_bout_index = ?, updated_at = ? WHERE id = ?`,
       [scoreA, scoreB, newStatus, winnerId, finishedCount, now, matchId]
     );
+  }
+
+  // ── Cartons d'équipe "E" (format arène Sabre Laser) ─────────────────────────
+  // Traçabilité uniquement : ces cartons n'affectent pas encore le score
+  // (impact en points pas encore tranché par le règlement).
+
+  public createTeamMatchCard(
+    matchId: string,
+    teamId: string,
+    type: 'white' | 'yellow' | 'red' | 'black',
+    reason: string
+  ): { id: string } {
+    if (!this.db) throw new Error('Database not open');
+    const { v4: gen } = require('uuid');
+    const id = gen();
+    const now = new Date().toISOString();
+    this.run(
+      `INSERT INTO team_match_cards (id, match_id, team_id, type, reason, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [id, matchId, teamId, type, reason, now]
+    );
+    return { id };
+  }
+
+  public getTeamMatchCards(matchId: string): Array<{
+    id: string; matchId: string; teamId: string; type: string; reason: string; createdAt: string;
+  }> {
+    if (!this.db) return [];
+    const rows = this.queryAll<any>(
+      'SELECT * FROM team_match_cards WHERE match_id = ? ORDER BY created_at',
+      [matchId]
+    );
+    return rows.map(r => ({
+      id: r.id as string,
+      matchId: r.match_id as string,
+      teamId: r.team_id as string,
+      type: r.type as string,
+      reason: r.reason as string,
+      createdAt: r.created_at as string,
+    }));
+  }
+
+  // ── Format arène Sabre Laser : saisie temps réel (tablette arbitre) ─────────
+  // Résout un match d'équipe avec noms d'équipes/tireurs pour la diffusion en
+  // direct, sans que le renderer ait à repousser ces données via IPC : le
+  // serveur de score distant lit directement la DB (il en a déjà l'accès).
+
+  public getTeamMatchDetail(matchId: string): {
+    id: string;
+    competitionId: string;
+    teamAId: string;
+    teamAName: string;
+    teamBId: string;
+    teamBName: string;
+    status: string;
+    currentBoutIndex: number;
+    bouts: Array<{
+      id: string;
+      boutOrder: number;
+      fencerAId: string;
+      fencerAName: string;
+      fencerBId: string;
+      fencerBName: string;
+      scoreA: number;
+      scoreB: number;
+      maxScore: number;
+      status: string;
+      winnerId: string | null;
+    }>;
+  } | null {
+    if (!this.db) return null;
+    const m = this.queryOne<any>('SELECT * FROM team_matches WHERE id = ?', [matchId]);
+    if (!m) return null;
+    const teamA = this.queryOne<any>('SELECT name FROM teams WHERE id = ?', [m.team_a_id]);
+    const teamB = this.queryOne<any>('SELECT name FROM teams WHERE id = ?', [m.team_b_id]);
+    const bouts = this.queryAll<any>(
+      `SELECT b.*, fa.last_name AS fa_last, fa.first_name AS fa_first, fb.last_name AS fb_last, fb.first_name AS fb_first
+       FROM team_bouts b
+       JOIN fencers fa ON b.fencer_a_id = fa.id
+       JOIN fencers fb ON b.fencer_b_id = fb.id
+       WHERE b.match_id = ? ORDER BY b.bout_order`,
+      [matchId]
+    );
+    return {
+      id: m.id as string,
+      competitionId: m.competition_id as string,
+      teamAId: m.team_a_id as string,
+      teamAName: (teamA?.name as string) ?? '—',
+      teamBId: m.team_b_id as string,
+      teamBName: (teamB?.name as string) ?? '—',
+      status: m.status as string,
+      currentBoutIndex: Number(m.current_bout_index),
+      bouts: bouts.map(b => ({
+        id: b.id as string,
+        boutOrder: Number(b.bout_order),
+        fencerAId: b.fencer_a_id as string,
+        fencerAName: `${b.fa_last} ${b.fa_first ?? ''}`.trim(),
+        fencerBId: b.fencer_b_id as string,
+        fencerBName: `${b.fb_last} ${b.fb_first ?? ''}`.trim(),
+        scoreA: Number(b.score_a),
+        scoreB: Number(b.score_b),
+        maxScore: Number(b.max_score),
+        status: b.status as string,
+        winnerId: (b.winner_id as string) ?? null,
+      })),
+    };
   }
 }
 

--- a/src/database/migrations/migrations.ts
+++ b/src/database/migrations/migrations.ts
@@ -451,4 +451,28 @@ export const ALL_MIGRATIONS: Migration[] = [
       db.run(`CREATE INDEX IF NOT EXISTS idx_team_matches_table ON team_matches(table_id)`);
     },
   },
+  {
+    version: 15,
+    description:
+      "Cartons d'équipe 'E' (format arène Sabre Laser) : table team_match_cards, traçabilité par rencontre",
+    up(db) {
+      // Un carton "E" (blanc/jaune/rouge/noir) sanctionne un retard de désignation
+      // de combattant, cumulable durant les 9 assauts d'une même rencontre
+      // (règlement épreuve par équipe Sabre Laser). N'affecte pas encore le score
+      // automatiquement (traçabilité uniquement).
+      db.run(`
+        CREATE TABLE IF NOT EXISTS team_match_cards (
+          id TEXT PRIMARY KEY,
+          match_id TEXT NOT NULL,
+          team_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          reason TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          FOREIGN KEY (match_id) REFERENCES team_matches(id) ON DELETE CASCADE,
+          FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE
+        )
+      `);
+      db.run(`CREATE INDEX IF NOT EXISTS idx_team_match_cards_match ON team_match_cards(match_id)`);
+    },
+  },
 ];

--- a/src/features/teams/types/team.types.ts
+++ b/src/features/teams/types/team.types.ts
@@ -139,7 +139,7 @@ export interface TeamBoutRow {
 export interface TeamMatchRow {
   id: string;
   poolNumber?: number;
-  round?: number;
+  round?: number | null;
   position?: number;
   teamAId: string;
   teamBId: string;
@@ -149,4 +149,13 @@ export interface TeamMatchRow {
   winnerId: string | null;
   currentBoutIndex: number;
   bouts: TeamBoutRow[];
+}
+
+export interface TeamMatchCardRow {
+  id: string;
+  matchId: string;
+  teamId: string;
+  type: 'white' | 'yellow' | 'red' | 'black';
+  reason: string;
+  createdAt: string;
 }

--- a/src/features/teams/utils/laserArenaBracketRules.test.ts
+++ b/src/features/teams/utils/laserArenaBracketRules.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests unitaires - laserArenaBracketRules
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import { applyRematchAvoidanceSwap, buildPoolPairHistory } from './laserArenaBracketRules';
+import { calculateTableSize, placeRankedTeamsInTable } from './teamCalculations';
+import { TeamRow, TeamMatchRow } from '../types/team.types';
+
+const makeTeams = (count: number): TeamRow[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `t${i + 1}`,
+    name: `Équipe ${i + 1}`,
+    club: 'C',
+    fencers: [],
+  }));
+
+describe('buildPoolPairHistory', () => {
+  it("n'enregistre que les rencontres de poule terminées", () => {
+    const matches: TeamMatchRow[] = [
+      {
+        id: 'm1',
+        teamAId: 'a',
+        teamBId: 'b',
+        scoreBoutsA: 5,
+        scoreBoutsB: 2,
+        status: 'finished',
+        winnerId: 'a',
+        currentBoutIndex: 3,
+        bouts: [],
+      },
+      {
+        id: 'm2',
+        teamAId: 'c',
+        teamBId: 'd',
+        scoreBoutsA: 0,
+        scoreBoutsB: 0,
+        status: 'not_started',
+        winnerId: null,
+        currentBoutIndex: 0,
+        bouts: [],
+      },
+    ];
+    const history = buildPoolPairHistory(matches);
+    expect(history.has(['a', 'b'].sort().join('|'))).toBe(true);
+    expect(history.has(['c', 'd'].sort().join('|'))).toBe(false);
+  });
+});
+
+describe('applyRematchAvoidanceSwap', () => {
+  it('ne modifie rien avec moins de 6 équipes classées', () => {
+    const teams = makeTeams(4);
+    const result = applyRematchAvoidanceSwap(teams, new Set());
+    expect(result.map(t => t.id)).toEqual(teams.map(t => t.id));
+  });
+
+  it("ne modifie rien si aucune revanche n'est détectée au 1er tour", () => {
+    const teams = makeTeams(8);
+    const result = applyRematchAvoidanceSwap(teams, new Set());
+    expect(result.map(t => t.id)).toEqual(teams.map(t => t.id));
+  });
+
+  it('échange les équipes classées 5 et 6 si leur confrontation au 1er tour est une revanche de poule', () => {
+    const teams = makeTeams(8);
+    const tableSize = calculateTableSize(teams.length);
+    const placements = placeRankedTeamsInTable(teams, tableSize);
+    const seed5 = teams[4];
+    const pos5 = placements.findIndex(t => t?.id === seed5.id);
+    const opponentPos = pos5 % 2 === 0 ? pos5 + 1 : pos5 - 1;
+    const opponent = placements[opponentPos];
+    expect(opponent).not.toBeNull();
+
+    const history = new Set([[seed5.id, opponent!.id].sort().join('|')]);
+    const result = applyRematchAvoidanceSwap(teams, history);
+
+    // Seed 5 et seed 6 ont été échangés (et eux seuls)
+    expect(result[4].id).toBe(teams[5].id);
+    expect(result[5].id).toBe(teams[4].id);
+    expect(result[0].id).toBe(teams[0].id);
+    expect(result[6].id).toBe(teams[6].id);
+  });
+});

--- a/src/features/teams/utils/laserArenaBracketRules.ts
+++ b/src/features/teams/utils/laserArenaBracketRules.ts
@@ -1,0 +1,63 @@
+/**
+ * BellePoule Modern - Laser Sabre "arena" team format
+ * Règle d'évitement de revanche au 1er tour du tableau : si deux équipes
+ * déjà rencontrées en poule tombent l'une contre l'autre au 1er tour du
+ * tableau à élimination directe, l'équipe la moins bien classée change de
+ * place — seed 5↔6 ou 7↔8 uniquement (règlement, section "Déroulement de la
+ * compétition"). Réutilise `placeRankedTeamsInTable`/`calculateTableSize`
+ * tels quels, sans les modifier.
+ * Licensed under GPL-3.0
+ */
+
+import { TeamRow, TeamMatchRow } from '../types/team.types';
+import { calculateTableSize, placeRankedTeamsInTable } from './teamCalculations';
+
+function pairKey(a: string, b: string): string {
+  return [a, b].sort().join('|');
+}
+
+/** Construit l'historique des rencontres de poule déjà jouées (paires d'équipes). */
+export function buildPoolPairHistory(matches: TeamMatchRow[]): Set<string> {
+  const history = new Set<string>();
+  for (const m of matches) {
+    if (m.status !== 'finished') continue;
+    history.add(pairKey(m.teamAId, m.teamBId));
+  }
+  return history;
+}
+
+/**
+ * Échange les équipes classées 5/6 (ou 7/8) si l'échange évite une revanche
+ * de poule au 1er tour du tableau. N'échange que ces deux paires précises,
+ * conformément au règlement. Ne modifie rien si moins de 6 équipes classées.
+ */
+export function applyRematchAvoidanceSwap(
+  rankedTeams: TeamRow[],
+  poolPairHistory: Set<string>
+): TeamRow[] {
+  if (rankedTeams.length < 6) return rankedTeams;
+
+  const tableSize = calculateTableSize(rankedTeams.length);
+  const result = [...rankedTeams];
+
+  const trySwap = (rankA: number, rankB: number) => {
+    if (result.length < rankB) return;
+    const placements = placeRankedTeamsInTable(result, tableSize);
+    const teamA = result[rankA - 1];
+    const posA = placements.findIndex(t => t?.id === teamA.id);
+    if (posA === -1) return;
+    const opponentPos = posA % 2 === 0 ? posA + 1 : posA - 1;
+    const opponent = placements[opponentPos];
+    if (!opponent) return; // exempt (bye) au 1er tour : pas de revanche possible
+    if (poolPairHistory.has(pairKey(teamA.id, opponent.id))) {
+      const tmp = result[rankA - 1];
+      result[rankA - 1] = result[rankB - 1];
+      result[rankB - 1] = tmp;
+    }
+  };
+
+  trySwap(5, 6);
+  trySwap(7, 8);
+
+  return result;
+}

--- a/src/features/teams/utils/laserArenaCalculations.test.ts
+++ b/src/features/teams/utils/laserArenaCalculations.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests unitaires - laserArenaCalculations
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getLaserArenaBoutCap,
+  isLaserArenaBoutComplete,
+  calculateLaserArenaMatchScore,
+  isLaserArenaMatchComplete,
+  getLaserArenaMatchWinner,
+  calculateLaserArenaPoolRanking,
+} from './laserArenaCalculations';
+import { TeamRow, TeamMatchRow, TeamBoutRow } from '../types/team.types';
+
+const team = (id: string): TeamRow => ({ id, name: id, club: 'C', fencers: [] });
+
+const bout = (overrides: Partial<TeamBoutRow> = {}): TeamBoutRow => ({
+  id: overrides.id ?? 'b',
+  boutOrder: overrides.boutOrder ?? 1,
+  fencerAId: overrides.fencerAId ?? 'fa',
+  fencerBId: overrides.fencerBId ?? 'fb',
+  scoreA: overrides.scoreA ?? 0,
+  scoreB: overrides.scoreB ?? 0,
+  maxScore: overrides.maxScore ?? 5,
+  status: overrides.status ?? 'not_started',
+  winnerId: overrides.winnerId ?? null,
+});
+
+const match = (bouts: TeamBoutRow[], overrides: Partial<TeamMatchRow> = {}): TeamMatchRow => ({
+  id: overrides.id ?? 'm',
+  teamAId: overrides.teamAId ?? 'A',
+  teamBId: overrides.teamBId ?? 'B',
+  scoreBoutsA: overrides.scoreBoutsA ?? 0,
+  scoreBoutsB: overrides.scoreBoutsB ?? 0,
+  status: overrides.status ?? 'not_started',
+  winnerId: overrides.winnerId ?? null,
+  currentBoutIndex: overrides.currentBoutIndex ?? 0,
+  bouts,
+});
+
+describe('getLaserArenaBoutCap', () => {
+  it('plafonne à 5 touches ou 3 minutes', () => {
+    expect(getLaserArenaBoutCap()).toEqual({ maxTouches: 5, maxDurationSec: 180 });
+  });
+});
+
+describe('isLaserArenaBoutComplete', () => {
+  const cap = getLaserArenaBoutCap();
+
+  it('se termine dès que le cumul des deux côtés atteint 5', () => {
+    expect(isLaserArenaBoutComplete(3, 1, 0, cap)).toBe(false);
+    expect(isLaserArenaBoutComplete(3, 2, 0, cap)).toBe(true);
+    expect(isLaserArenaBoutComplete(5, 0, 0, cap)).toBe(true);
+  });
+
+  it('se termine au bout de 3 minutes même sans 5 touches', () => {
+    expect(isLaserArenaBoutComplete(1, 1, 179, cap)).toBe(false);
+    expect(isLaserArenaBoutComplete(1, 1, 180, cap)).toBe(true);
+  });
+});
+
+describe('calculateLaserArenaMatchScore', () => {
+  it('additionne uniquement les assauts terminés', () => {
+    const m = match([
+      bout({ scoreA: 3, scoreB: 2, status: 'finished' }),
+      bout({ scoreA: 5, scoreB: 0, status: 'finished' }),
+      bout({ scoreA: 2, scoreB: 3, status: 'in_progress' }),
+    ]);
+    expect(calculateLaserArenaMatchScore(m)).toEqual({ scoreA: 8, scoreB: 2 });
+  });
+});
+
+describe('isLaserArenaMatchComplete / getLaserArenaMatchWinner', () => {
+  it("n'est pas terminée tant que tous les assauts ne le sont pas", () => {
+    const m = match([bout({ status: 'finished' }), bout({ status: 'not_started' })]);
+    expect(isLaserArenaMatchComplete(m)).toBe(false);
+    expect(getLaserArenaMatchWinner(m)).toBeNull();
+  });
+
+  it('désigne le vainqueur au total de points, pas au nombre d’assauts gagnés', () => {
+    const m = match([
+      bout({ scoreA: 1, scoreB: 5, status: 'finished' }),
+      bout({ scoreA: 1, scoreB: 5, status: 'finished' }),
+      bout({ scoreA: 5, scoreB: 0, status: 'finished' }),
+    ]);
+    // A gagne 1 assaut (5-0) mais B totalise plus de points (10 vs 7)
+    expect(isLaserArenaMatchComplete(m)).toBe(true);
+    expect(getLaserArenaMatchWinner(m)).toBe('B');
+  });
+
+  it('renvoie null en cas d’égalité totale (départage au niveau poule)', () => {
+    const m = match([
+      bout({ scoreA: 5, scoreB: 0, status: 'finished' }),
+      bout({ scoreA: 0, scoreB: 5, status: 'finished' }),
+    ]);
+    expect(getLaserArenaMatchWinner(m)).toBeNull();
+  });
+});
+
+describe('calculateLaserArenaPoolRanking', () => {
+  it('classe par total de points marqués, pas par nombre de victoires', () => {
+    const teamA = team('A');
+    const teamB = team('B');
+    const teamC = team('C');
+    const matches: TeamMatchRow[] = [
+      // A bat B et C de justesse (2 victoires) mais peu de points marqués
+      match([bout({ scoreA: 3, scoreB: 2, status: 'finished' })], {
+        id: 'm1',
+        teamAId: 'A',
+        teamBId: 'B',
+        status: 'finished',
+      }),
+      match([bout({ scoreA: 3, scoreB: 2, status: 'finished' })], {
+        id: 'm2',
+        teamAId: 'A',
+        teamBId: 'C',
+        status: 'finished',
+      }),
+      // B et C, un gros score (beaucoup de points marqués au total pour B)
+      match([bout({ scoreA: 15, scoreB: 3, status: 'finished' })], {
+        id: 'm3',
+        teamAId: 'B',
+        teamBId: 'C',
+        status: 'finished',
+      }),
+    ];
+    const ranking = calculateLaserArenaPoolRanking([teamA, teamB, teamC], matches);
+    // Points marqués : A = 3+3 = 6, B = 2+15 = 17, C = 2+3 = 5
+    expect(ranking[0].team.id).toBe('B');
+    expect(ranking[0].pointsFor).toBe(17);
+    expect(ranking[1].team.id).toBe('A');
+    expect(ranking[2].team.id).toBe('C');
+  });
+
+  it('signale une égalité totale (points et ratio) sans la départager', () => {
+    const teamA = team('A');
+    const teamB = team('B');
+    const matches: TeamMatchRow[] = [
+      match([bout({ scoreA: 5, scoreB: 5, status: 'finished' })], {
+        id: 'm1',
+        teamAId: 'A',
+        teamBId: 'B',
+        status: 'finished',
+      }),
+    ];
+    const ranking = calculateLaserArenaPoolRanking([teamA, teamB], matches);
+    expect(ranking[0].tied).toBe(true);
+    expect(ranking[1].tied).toBe(true);
+  });
+});

--- a/src/features/teams/utils/laserArenaCalculations.ts
+++ b/src/features/teams/utils/laserArenaCalculations.ts
@@ -1,0 +1,143 @@
+/**
+ * BellePoule Modern - Laser Sabre "arena" team format
+ * Règlement épreuve par équipe Sabre Laser (ASL-FFE, 2026) : assauts
+ * indépendants plafonnés à 5 touches valides ou 3 minutes, score d'une
+ * rencontre = total des points marqués sur les 9 (ou N²) assauts.
+ * Distinct du relais FIE classique (`teamCalculations.ts`, cible cumulée
+ * progressive) : ce module ne modifie ni ne réutilise sa logique de cible.
+ * Licensed under GPL-3.0
+ */
+
+import { TeamMatchRow, TeamRow } from '../types/team.types';
+
+export interface LaserArenaBoutCap {
+  maxTouches: number;
+  maxDurationSec: number;
+}
+
+/** Plafond d'un assaut arène Sabre Laser : 5 touches valides ou 3 minutes. */
+export function getLaserArenaBoutCap(): LaserArenaBoutCap {
+  return { maxTouches: 5, maxDurationSec: 180 };
+}
+
+/**
+ * Un assaut se termine dès que le cumul des touches valides des deux côtés
+ * atteint le plafond, ou que le temps imparti est écoulé.
+ */
+export function isLaserArenaBoutComplete(
+  touchesA: number,
+  touchesB: number,
+  elapsedSec: number,
+  cap: LaserArenaBoutCap = getLaserArenaBoutCap()
+): boolean {
+  return touchesA + touchesB >= cap.maxTouches || elapsedSec >= cap.maxDurationSec;
+}
+
+/**
+ * Score total d'une rencontre = somme des points de tous les assauts
+ * terminés (pas de cible de fin anticipée par palier, contrairement au
+ * relais FIE classique).
+ */
+export function calculateLaserArenaMatchScore(match: TeamMatchRow): {
+  scoreA: number;
+  scoreB: number;
+} {
+  let scoreA = 0;
+  let scoreB = 0;
+  for (const bout of match.bouts) {
+    if (bout.status !== 'finished') continue;
+    scoreA += bout.scoreA;
+    scoreB += bout.scoreB;
+  }
+  return { scoreA, scoreB };
+}
+
+/** Une rencontre est terminée quand tous les assauts prévus ont été joués. */
+export function isLaserArenaMatchComplete(match: TeamMatchRow): boolean {
+  return match.bouts.length > 0 && match.bouts.every(b => b.status === 'finished');
+}
+
+/**
+ * Vainqueur de la rencontre = équipe au total de points le plus haut.
+ * `null` en cas d'égalité (le règlement ne départage qu'au niveau poule,
+ * pas au niveau d'une rencontre individuelle).
+ */
+export function getLaserArenaMatchWinner(match: TeamMatchRow): 'A' | 'B' | null {
+  if (!isLaserArenaMatchComplete(match)) return null;
+  const { scoreA, scoreB } = calculateLaserArenaMatchScore(match);
+  if (scoreA > scoreB) return 'A';
+  if (scoreB > scoreA) return 'B';
+  return null;
+}
+
+export interface LaserArenaPoolRankingRow {
+  team: TeamRow;
+  pointsFor: number;
+  pointsAgainst: number;
+  victories: number;
+  defeats: number;
+  draws: number;
+  tied: boolean; // égalité avec le rang suivant/précédent après tous les critères — tirage au sort manuel
+}
+
+/**
+ * Classement de poule format arène : critère principal = total de points
+ * marqués cumulés (pas le nombre de victoires), puis ratio marqués/reçus,
+ * puis égalité laissée au tirage au sort (signalée via `tied`, pas résolue
+ * automatiquement côté logiciel).
+ */
+export function calculateLaserArenaPoolRanking(
+  teams: TeamRow[],
+  matches: TeamMatchRow[]
+): LaserArenaPoolRankingRow[] {
+  const stats: LaserArenaPoolRankingRow[] = teams.map(team => ({
+    team,
+    pointsFor: 0,
+    pointsAgainst: 0,
+    victories: 0,
+    defeats: 0,
+    draws: 0,
+    tied: false,
+  }));
+  const byId = new Map(stats.map(s => [s.team.id, s]));
+
+  for (const m of matches) {
+    if (m.status !== 'finished') continue;
+    const sa = byId.get(m.teamAId);
+    const sb = byId.get(m.teamBId);
+    if (!sa || !sb) continue;
+
+    const { scoreA, scoreB } = calculateLaserArenaMatchScore(m);
+    sa.pointsFor += scoreA;
+    sa.pointsAgainst += scoreB;
+    sb.pointsFor += scoreB;
+    sb.pointsAgainst += scoreA;
+
+    if (scoreA > scoreB) {
+      sa.victories++;
+      sb.defeats++;
+    } else if (scoreB > scoreA) {
+      sb.victories++;
+      sa.defeats++;
+    } else {
+      sa.draws++;
+      sb.draws++;
+    }
+  }
+
+  const ratio = (s: LaserArenaPoolRankingRow) =>
+    s.pointsAgainst === 0 ? s.pointsFor : s.pointsFor / s.pointsAgainst;
+
+  const sorted = [...stats].sort((a, b) => b.pointsFor - a.pointsFor || ratio(b) - ratio(a));
+
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const a = sorted[i];
+    const b = sorted[i + 1];
+    if (a.pointsFor === b.pointsFor && ratio(a) === ratio(b)) {
+      a.tied = true;
+      b.tied = true;
+    }
+  }
+
+  return sorted;
+}

--- a/src/features/teams/utils/laserArenaPoolSchedules.test.ts
+++ b/src/features/teams/utils/laserArenaPoolSchedules.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests unitaires - laserArenaPoolSchedules
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  LASER_ARENA_SCHEDULE_8,
+  LASER_ARENA_SCHEDULE_12,
+  getLaserArenaPoolSchedule,
+  assignTeamsToPoolSlots,
+  resolveLaserArenaSchedule,
+} from './laserArenaPoolSchedules';
+import { TeamRow } from '../types/team.types';
+
+const makeTeams = (count: number): TeamRow[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `t${i + 1}`,
+    name: `Équipe ${i + 1}`,
+    club: 'C',
+    fencers: [],
+  }));
+
+describe('getLaserArenaPoolSchedule', () => {
+  it('renvoie le calendrier figé pour 8 et 12 équipes uniquement', () => {
+    expect(getLaserArenaPoolSchedule(8)).toBe(LASER_ARENA_SCHEDULE_8);
+    expect(getLaserArenaPoolSchedule(12)).toBe(LASER_ARENA_SCHEDULE_12);
+    expect(getLaserArenaPoolSchedule(6)).toBeNull();
+    expect(getLaserArenaPoolSchedule(10)).toBeNull();
+    expect(getLaserArenaPoolSchedule(16)).toBeNull();
+  });
+});
+
+describe('assignTeamsToPoolSlots', () => {
+  it('affecte les équipes par blocs de 4 (A puis B puis C)', () => {
+    const slots = assignTeamsToPoolSlots(makeTeams(12));
+    expect(slots.get('A1')?.id).toBe('t1');
+    expect(slots.get('A4')?.id).toBe('t4');
+    expect(slots.get('B1')?.id).toBe('t5');
+    expect(slots.get('C4')?.id).toBe('t12');
+  });
+});
+
+describe('resolveLaserArenaSchedule — 12 équipes', () => {
+  it('génère exactement 6 rencontres par poule (round-robin complet à 4 équipes)', () => {
+    const resolved = resolveLaserArenaSchedule(makeTeams(12), LASER_ARENA_SCHEDULE_12);
+    const perPool: Record<string, number> = { A: 0, B: 0, C: 0 };
+    for (const m of resolved) perPool[m.pool]++;
+    expect(perPool).toEqual({ A: 6, B: 6, C: 6 });
+    expect(resolved).toHaveLength(18);
+  });
+
+  it('chaque équipe rencontre toutes les autres de sa poule exactement une fois', () => {
+    const resolved = resolveLaserArenaSchedule(makeTeams(12), LASER_ARENA_SCHEDULE_12);
+    const poolAMatches = resolved.filter(m => m.pool === 'A');
+    const pairs = new Set(poolAMatches.map(m => [m.teamA.id, m.teamB.id].sort().join('-')));
+    expect(pairs.size).toBe(6); // C(4,2) = 6 paires distinctes, aucune répétée
+  });
+});
+
+describe('resolveLaserArenaSchedule — 8 équipes', () => {
+  it('génère exactement 6 rencontres par poule pour 2 poules de 4', () => {
+    const resolved = resolveLaserArenaSchedule(makeTeams(8), LASER_ARENA_SCHEDULE_8);
+    const perPool: Record<string, number> = { A: 0, B: 0 };
+    for (const m of resolved) perPool[m.pool]++;
+    expect(perPool).toEqual({ A: 6, B: 6 });
+  });
+});

--- a/src/features/teams/utils/laserArenaPoolSchedules.ts
+++ b/src/features/teams/utils/laserArenaPoolSchedules.ts
@@ -1,0 +1,142 @@
+/**
+ * BellePoule Modern - Laser Sabre "arena" team format
+ * Calendriers de poule figés du règlement (section "Déroulement de la
+ * compétition") pour 8 et 12 équipes : 3 poules A/B/C de 4 (12 équipes,
+ * 4 arènes) ou 2 poules A/B de 4 (8 équipes, 3 arènes), avec désignation
+ * d'équipe(s) assesseur(s) (arbitrage) par round. Aucune génération
+ * automatique n'est proposée pour un autre nombre d'équipes.
+ * Licensed under GPL-3.0
+ */
+
+import { TeamRow } from '../types/team.types';
+
+export interface LaserArenaScheduleSlot {
+  pool: string; // 'A' | 'B' | 'C'
+  slot: number; // position 1..4 dans la poule
+}
+
+export interface LaserArenaScheduleMatch {
+  pool: string;
+  slotA: number;
+  slotB: number;
+}
+
+export interface LaserArenaScheduleRound {
+  round: number;
+  matches: LaserArenaScheduleMatch[];
+  assessors: LaserArenaScheduleSlot[];
+}
+
+const m = (pool: string, slotA: number, slotB: number): LaserArenaScheduleMatch => ({
+  pool,
+  slotA,
+  slotB,
+});
+const a = (pool: string, slot: number): LaserArenaScheduleSlot => ({ pool, slot });
+
+/** 3 poules A/B/C de 4 équipes, 4 arènes (règlement, "Pour 12 équipes"). */
+export const LASER_ARENA_SCHEDULE_12: LaserArenaScheduleRound[] = [
+  {
+    round: 1,
+    matches: [m('A', 1, 2), m('A', 3, 4), m('B', 1, 2), m('B', 3, 4)],
+    assessors: [a('C', 1), a('C', 2), a('C', 3), a('C', 4)],
+  },
+  {
+    round: 2,
+    matches: [m('C', 1, 2), m('C', 3, 4), m('A', 1, 3), m('A', 2, 4)],
+    assessors: [a('B', 1), a('B', 2), a('B', 3), a('B', 4)],
+  },
+  {
+    round: 3,
+    matches: [m('B', 1, 3), m('B', 2, 4), m('C', 1, 3), m('C', 2, 4)],
+    assessors: [a('A', 1), a('A', 2), a('A', 3), a('A', 4)],
+  },
+  {
+    round: 4,
+    matches: [m('A', 1, 4), m('A', 2, 3), m('B', 1, 4), m('B', 2, 3)],
+    assessors: [a('C', 1), a('C', 2), a('C', 3), a('C', 4)],
+  },
+  {
+    round: 5,
+    matches: [m('C', 1, 4), m('C', 2, 3)],
+    assessors: [a('B', 1), a('B', 2)],
+  },
+];
+
+/** 2 poules A/B de 4 équipes, 3 arènes (règlement, "Pour 8 équipes"). */
+export const LASER_ARENA_SCHEDULE_8: LaserArenaScheduleRound[] = [
+  {
+    round: 1,
+    matches: [m('A', 1, 2), m('A', 3, 4), m('B', 1, 2)],
+    assessors: [a('B', 3), a('B', 4)],
+  },
+  {
+    round: 2,
+    matches: [m('B', 3, 4), m('A', 2, 4), m('A', 1, 3)],
+    assessors: [a('B', 1), a('B', 2)],
+  },
+  {
+    round: 3,
+    matches: [m('A', 1, 4), m('B', 1, 3), m('B', 2, 4)],
+    assessors: [a('A', 2), a('A', 3)],
+  },
+  {
+    round: 4,
+    matches: [m('A', 2, 3), m('B', 1, 4), m('B', 2, 3)],
+    assessors: [a('A', 1), a('A', 4)],
+  },
+];
+
+/** Calendrier figé pour `teamCount` équipes, ou `null` si non couvert par le règlement. */
+export function getLaserArenaPoolSchedule(teamCount: number): LaserArenaScheduleRound[] | null {
+  if (teamCount === 12) return LASER_ARENA_SCHEDULE_12;
+  if (teamCount === 8) return LASER_ARENA_SCHEDULE_8;
+  return null;
+}
+
+/**
+ * Affecte les équipes aux poules dans l'ordre de la liste fournie, par blocs
+ * de 4 (A, puis B, puis C) : `teams[0..3]` = poule A, `teams[4..7]` = poule
+ * B, `teams[8..11]` = poule C. Il n'existe pas d'affectation de poule
+ * explicite ailleurs dans l'app ; l'ordre de création des équipes fait foi.
+ */
+export function assignTeamsToPoolSlots(teams: TeamRow[]): Map<string, TeamRow> {
+  const poolLetters = ['A', 'B', 'C'];
+  const slots = new Map<string, TeamRow>();
+  teams.forEach((team, i) => {
+    const letter = poolLetters[Math.floor(i / 4)];
+    if (!letter) return;
+    slots.set(`${letter}${(i % 4) + 1}`, team);
+  });
+  return slots;
+}
+
+export interface ResolvedLaserArenaMatch {
+  round: number;
+  pool: string;
+  teamA: TeamRow;
+  teamB: TeamRow;
+  assessorTeamIds: string[];
+}
+
+/** Résout le calendrier figé (poule/slot) en équipes réelles pour un effectif donné. */
+export function resolveLaserArenaSchedule(
+  teams: TeamRow[],
+  schedule: LaserArenaScheduleRound[]
+): ResolvedLaserArenaMatch[] {
+  const slots = assignTeamsToPoolSlots(teams);
+  const resolved: ResolvedLaserArenaMatch[] = [];
+  for (const round of schedule) {
+    const assessorTeamIds = round.assessors
+      .map(s => slots.get(`${s.pool}${s.slot}`)?.id)
+      .filter((id): id is string => !!id);
+    for (const match of round.matches) {
+      const teamA = slots.get(`${match.pool}${match.slotA}`);
+      const teamB = slots.get(`${match.pool}${match.slotB}`);
+      if (teamA && teamB) {
+        resolved.push({ round: round.round, pool: match.pool, teamA, teamB, assessorTeamIds });
+      }
+    }
+  }
+  return resolved;
+}

--- a/src/features/teams/utils/teamCardEscalation.test.ts
+++ b/src/features/teams/utils/teamCardEscalation.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests unitaires - teamCardEscalation
+ * BellePoule Modern
+ */
+
+import { describe, it, expect } from 'vitest';
+import { determineTeamCardEscalation, countTeamYellowCards } from './teamCardEscalation';
+import { TeamMatchCardRow } from '../types/team.types';
+
+const card = (overrides: Partial<TeamMatchCardRow> = {}): TeamMatchCardRow => ({
+  id: overrides.id ?? 'c',
+  matchId: overrides.matchId ?? 'm',
+  teamId: overrides.teamId ?? 'A',
+  type: overrides.type ?? 'white',
+  reason: overrides.reason ?? 'late_designation',
+  createdAt: overrides.createdAt ?? new Date().toISOString(),
+});
+
+describe('determineTeamCardEscalation', () => {
+  it('attribue un carton blanc à la première désignation tardive de la rencontre', () => {
+    expect(determineTeamCardEscalation([])).toBe('white');
+  });
+
+  it('attribue un carton jaune dès qu’un blanc a déjà été donné, même dans un autre assaut', () => {
+    expect(determineTeamCardEscalation([card({ type: 'white' })])).toBe('yellow');
+    expect(determineTeamCardEscalation([card({ type: 'white' }), card({ type: 'yellow' })])).toBe(
+      'yellow'
+    );
+  });
+});
+
+describe('countTeamYellowCards', () => {
+  it('compte uniquement les jaunes de l’équipe concernée', () => {
+    const cards = [
+      card({ teamId: 'A', type: 'white' }),
+      card({ teamId: 'A', type: 'yellow' }),
+      card({ teamId: 'A', type: 'yellow' }),
+      card({ teamId: 'B', type: 'yellow' }),
+    ];
+    expect(countTeamYellowCards(cards, 'A')).toBe(2);
+    expect(countTeamYellowCards(cards, 'B')).toBe(1);
+  });
+});

--- a/src/features/teams/utils/teamCardEscalation.ts
+++ b/src/features/teams/utils/teamCardEscalation.ts
@@ -1,0 +1,38 @@
+/**
+ * BellePoule Modern - Laser Sabre "arena" team format
+ * Cartons d'équipe "E" : sanctionnent le retard d'une équipe à désigner son
+ * combattant (règlement épreuve par équipe Sabre Laser, section "Cartons").
+ * Un carton blanc E est adressé à la première désignation tardive (pause de
+ * 2 minutes dépassée) de la rencontre ; toute désignation tardive suivante,
+ * dans ce match ou un match ultérieur de la même rencontre, reçoit
+ * directement un carton jaune E. Les jaunes E sont cumulables sur les 9
+ * assauts. Le règlement ne précise ni impact en points, ni escalade au-delà
+ * du jaune : rouge/noir E restent disponibles au choix manuel de l'arbitre
+ * (traçabilité uniquement, pas d'automatisation inventée au-delà du texte).
+ * Distinct du système de cartons individuels par tireur (`cardSystem.ts`),
+ * qui reste inchangé.
+ * Licensed under GPL-3.0
+ */
+
+import { TeamMatchCardRow } from '../types/team.types';
+
+export const TEAM_CARD_DESIGNATION_DELAY_SEC = 120; // 2 minutes
+
+export type TeamCardEscalationType = 'white' | 'yellow';
+
+/**
+ * Type de carton à attribuer pour une nouvelle désignation tardive dans
+ * cette rencontre : blanc pour la première, jaune pour toutes les
+ * suivantes (cumulable sur les 9 assauts).
+ */
+export function determineTeamCardEscalation(
+  previousCardsInMatch: TeamMatchCardRow[]
+): TeamCardEscalationType {
+  const hasWhite = previousCardsInMatch.some(c => c.type === 'white');
+  return hasWhite ? 'yellow' : 'white';
+}
+
+/** Nombre de cartons jaunes E cumulés par une équipe sur la rencontre en cours. */
+export function countTeamYellowCards(cardsInMatch: TeamMatchCardRow[], teamId: string): number {
+  return cardsInMatch.filter(c => c.teamId === teamId && c.type === 'yellow').length;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1793,6 +1793,30 @@ ipcMain.handle('remote:finishPoolMatch', async (_, competitionId: string, matchI
   }
 });
 
+// Format arène Sabre Laser équipe : assigne/retire une rencontre d'équipe sur
+// une arène pour saisie temps réel (tablette arbitre + affichage arène).
+ipcMain.handle('remote:setTeamArenaMatch', async (_, competitionId: string, arenaId: string, matchId: string, isLaserPoints: boolean) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: false, error: 'Serveur distant non démarré' };
+    const ok = entry.server.setTeamArenaMatch(arenaId, matchId, isLaserPoints);
+    return ok ? { success: true } : { success: false, error: 'Match introuvable' };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+  }
+});
+
+ipcMain.handle('remote:clearTeamArenaMatch', async (_, competitionId: string, arenaId: string) => {
+  try {
+    const entry = remoteServers.get(competitionId);
+    if (!entry) return { success: true };
+    entry.server.clearTeamArenaMatch(arenaId);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur' };
+  }
+});
+
 ipcMain.handle('remote:stopSession', async (_event, competitionId: string) => {
   try {
     const entry = remoteServers.get(competitionId);
@@ -2527,8 +2551,8 @@ ipcMain.handle('db:removeTeamFencer', async (_, teamId: string, fencerId: string
   return db.removeTeamFencer(teamId, fencerId);
 });
 
-ipcMain.handle('db:createTeamMatch', async (_, competitionId: string, poolNumber: number, teamAId: string, teamBId: string) => {
-  return db.createTeamMatch(competitionId, poolNumber, teamAId, teamBId);
+ipcMain.handle('db:createTeamMatch', async (_, competitionId: string, poolNumber: number, teamAId: string, teamBId: string, round?: number) => {
+  return db.createTeamMatch(competitionId, poolNumber, teamAId, teamBId, round);
 });
 
 ipcMain.handle('db:getTeamMatchesByCompetition', async (_, competitionId: string) => {
@@ -2549,6 +2573,14 @@ ipcMain.handle('db:createTeamTableauMatch', async (_, competitionId: string, tab
 
 ipcMain.handle('db:getTeamTableauMatches', async (_, competitionId: string, tableId: string) => {
   return db.getTeamTableauMatches(competitionId, tableId);
+});
+
+ipcMain.handle('db:createTeamMatchCard', async (_, matchId: string, teamId: string, type: 'white' | 'yellow' | 'red' | 'black', reason: string) => {
+  return db.createTeamMatchCard(matchId, teamId, type, reason);
+});
+
+ipcMain.handle('db:getTeamMatchCards', async (_, matchId: string) => {
+  return db.getTeamMatchCards(matchId);
 });
 
 // ============================================================================

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -332,8 +332,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('db:upsertTeamFencer', teamId, fencerId, teamOrder, isReserve),
     removeTeamFencer: (teamId: string, fencerId: string) =>
       ipcRenderer.invoke('db:removeTeamFencer', teamId, fencerId),
-    createTeamMatch: (competitionId: string, poolNumber: number, teamAId: string, teamBId: string) =>
-      ipcRenderer.invoke('db:createTeamMatch', competitionId, poolNumber, teamAId, teamBId),
+    createTeamMatch: (competitionId: string, poolNumber: number, teamAId: string, teamBId: string, round?: number) =>
+      ipcRenderer.invoke('db:createTeamMatch', competitionId, poolNumber, teamAId, teamBId, round),
     getTeamMatchesByCompetition: (competitionId: string) =>
       ipcRenderer.invoke('db:getTeamMatchesByCompetition', competitionId),
     createTeamBout: (matchId: string, boutOrder: number, fencerAId: string, fencerBId: string, maxScore: number) =>
@@ -344,6 +344,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('db:createTeamTableauMatch', competitionId, tableId, round, position, teamAId, teamBId),
     getTeamTableauMatches: (competitionId: string, tableId: string) =>
       ipcRenderer.invoke('db:getTeamTableauMatches', competitionId, tableId),
+    createTeamMatchCard: (matchId: string, teamId: string, type: 'white' | 'yellow' | 'red' | 'black', reason: string) =>
+      ipcRenderer.invoke('db:createTeamMatchCard', matchId, teamId, type, reason),
+    getTeamMatchCards: (matchId: string) =>
+      ipcRenderer.invoke('db:getTeamMatchCards', matchId),
   },
 
   // File operations with validation
@@ -580,6 +584,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('remote:resetPoolMatch', competitionId, matchId),
     finishPoolMatch: (competitionId: string, matchId: string, scoreA: number, scoreB: number) =>
       ipcRenderer.invoke('remote:finishPoolMatch', competitionId, matchId, scoreA, scoreB),
+    setTeamArenaMatch: (competitionId: string, arenaId: string, matchId: string, isLaserPoints: boolean) =>
+      ipcRenderer.invoke('remote:setTeamArenaMatch', competitionId, arenaId, matchId, isLaserPoints),
+    clearTeamArenaMatch: (competitionId: string, arenaId: string) =>
+      ipcRenderer.invoke('remote:clearTeamArenaMatch', competitionId, arenaId),
     setRegistrationEnabled: (competitionId: string, enabled: boolean) =>
       ipcRenderer.invoke('remote:setRegistrationEnabled', competitionId, enabled),
     getConnectedClients: (competitionId: string) =>

--- a/src/main/remoteScoreServer.ts
+++ b/src/main/remoteScoreServer.ts
@@ -26,6 +26,51 @@ import {
 } from '../shared/types/remote';
 import { Competition, Match, Fencer, MatchStatus, FencerStatus, Score } from '../shared/types';
 import { DatabaseManager } from '../database';
+import {
+  getLaserArenaBoutCap,
+  isLaserArenaBoutComplete,
+} from '../features/teams/utils/laserArenaCalculations';
+
+// Format arène Sabre Laser équipe : état de saisie temps réel pour une
+// rencontre assignée à une arène. Distinct de `Arena`/`ArenaMatch`
+// (scoring individuel) — aucun champ ni logique partagée.
+interface TeamArenaBout {
+  id: string;
+  boutOrder: number;
+  fencerAId: string;
+  fencerAName: string;
+  fencerBId: string;
+  fencerBName: string;
+  scoreA: number;
+  scoreB: number;
+  maxScore: number;
+  status: string;
+  winnerId: string | null;
+}
+
+interface TeamArenaCard {
+  id: string;
+  teamId: string;
+  type: 'white' | 'yellow' | 'red' | 'black';
+  createdAt: string;
+}
+
+interface TeamArenaState {
+  matchId: string;
+  competitionId: string;
+  teamAId: string;
+  teamAName: string;
+  teamBId: string;
+  teamBName: string;
+  isLaserPoints: boolean; // saisie par zones A/B/C (1/3/5) ou touche simple
+  bouts: TeamArenaBout[];
+  currentBoutIndex: number; // index dans `bouts`
+  liveScoreA: number; // score de l'assaut en cours, pas encore persisté
+  liveScoreB: number;
+  elapsedAccumulatedSec: number; // temps déjà écoulé (assaut en pause)
+  timerStartedAt: number | null; // epoch ms, null = chrono à l'arrêt
+  cards: TeamArenaCard[];
+}
 
 /**
  * Vérifie qu'une origine HTTP appartient au réseau local (localhost + plages LAN privées).
@@ -96,6 +141,10 @@ export class RemoteScoreServer {
   } | null = null;
   private sessionLogo: string | null = null; // Logo organisateur (base64) pour kiosk et affichages publics
   private sessionWallpaper: string | null = null; // Fond d'écran (base64) affiché sur les arènes en attente
+  // Format arène Sabre Laser équipe (assauts 5 touches/3min) : état de saisie
+  // temps réel par arène, entièrement séparé de `this.arenas` (arènes
+  // individuelles) — aucune interférence possible avec le scoring individuel.
+  private teamArenaState: Map<string, TeamArenaState> = new Map();
   // Config TTS (minuteur vocal) poussée aux tablettes d'arbitrage depuis les paramètres globaux
   private ttsConfig: {
     voiceName: string | null;
@@ -290,6 +339,8 @@ export class RemoteScoreServer {
       'overlay.html',
       'overlay-config.html',
       'register.html',
+      'teamArena.html',
+      'teamReferee.html',
     ];
 
     // Essayer plusieurs chemins pour trouver les fichiers
@@ -378,6 +429,74 @@ export class RemoteScoreServer {
       console.error(`[RemoteScoreServer] ERREUR: Fichier ${filename} non trouvé en mémoire`);
       res.status(500).send(`Erreur: fichier ${filename} non trouvé`);
     }
+  }
+
+  // ── Format arène Sabre Laser équipe : saisie temps réel ──────────────────────
+  // API publique appelée depuis les IPC handlers (renderer → main → ici), suivant
+  // le même modèle que les arènes individuelles mais sur un état séparé.
+
+  /** Assigne une rencontre d'équipe à une arène pour saisie temps réel. */
+  public setTeamArenaMatch(arenaId: string, matchId: string, isLaserPoints: boolean): boolean {
+    const detail = this.db.getTeamMatchDetail(matchId);
+    if (!detail) return false;
+    this.teamArenaState.set(arenaId, {
+      matchId: detail.id,
+      competitionId: detail.competitionId,
+      teamAId: detail.teamAId,
+      teamAName: detail.teamAName,
+      teamBId: detail.teamBId,
+      teamBName: detail.teamBName,
+      isLaserPoints,
+      bouts: detail.bouts,
+      currentBoutIndex: detail.bouts.findIndex(b => b.status !== 'finished'),
+      liveScoreA: 0,
+      liveScoreB: 0,
+      elapsedAccumulatedSec: 0,
+      timerStartedAt: null,
+      cards: this.db.getTeamMatchCards(matchId) as TeamArenaCard[],
+    });
+    this.io.to(`team-arena:${arenaId}`).emit('team_arena_state', this.getPublicTeamArenaState(arenaId));
+    return true;
+  }
+
+  /** Retire l'assignation d'une arène (fin de saisie temps réel pour cette arène). */
+  public clearTeamArenaMatch(arenaId: string): void {
+    this.teamArenaState.delete(arenaId);
+    this.io.to(`team-arena:${arenaId}`).emit('team_arena_state', null);
+  }
+
+  private teamArenaElapsedSec(state: TeamArenaState): number {
+    const running = state.timerStartedAt ? (Date.now() - state.timerStartedAt) / 1000 : 0;
+    return state.elapsedAccumulatedSec + running;
+  }
+
+  private getPublicTeamArenaState(arenaId: string): unknown {
+    const state = this.teamArenaState.get(arenaId);
+    if (!state) return null;
+    const cap = getLaserArenaBoutCap();
+    const currentBout = state.bouts[state.currentBoutIndex] ?? null;
+    const elapsedSec = this.teamArenaElapsedSec(state);
+    return {
+      matchId: state.matchId,
+      teamAId: state.teamAId,
+      teamAName: state.teamAName,
+      teamBId: state.teamBId,
+      teamBName: state.teamBName,
+      isLaserPoints: state.isLaserPoints,
+      bouts: state.bouts,
+      currentBoutIndex: state.currentBoutIndex,
+      currentBout,
+      liveScoreA: state.liveScoreA,
+      liveScoreB: state.liveScoreB,
+      elapsedSec,
+      timerRunning: state.timerStartedAt !== null,
+      cap,
+      boutComplete: currentBout
+        ? isLaserArenaBoutComplete(state.liveScoreA, state.liveScoreB, elapsedSec, cap)
+        : false,
+      matchComplete: !currentBout,
+      cards: state.cards,
+    };
   }
 
   private parseCookies(header: string | undefined): Record<string, string> {
@@ -944,6 +1063,26 @@ export class RemoteScoreServer {
         );
       }
       this.sendHtmlFromMemory('referee.html', res);
+    });
+
+    // ── Format arène Sabre Laser équipe : affichage + tablette arbitre ──────────
+    // Routes distinctes des arènes individuelles ci-dessus (aucun chemin partagé),
+    // même modèle d'authentification par arène (checkArenaAuth).
+    this.app.get('/equipe:arenaId', (req, res) => {
+      console.log(`[RemoteScoreServer] Accès affichage équipe /equipe${req.params.arenaId}`);
+      this.sendHtmlFromMemory('teamArena.html', res);
+    });
+
+    this.app.get('/equipe:arenaId/arbitre', (req, res) => {
+      const arenaId = req.params.arenaId;
+      console.log(`[RemoteScoreServer] Accès arbitre équipe /equipe${arenaId}/arbitre`);
+      if (!this.checkArenaAuth(arenaId, req.headers.cookie)) {
+        return res.redirect(
+          302,
+          `/login?arena=arena${arenaId}&return=${encodeURIComponent(req.path)}`
+        );
+      }
+      this.sendHtmlFromMemory('teamReferee.html', res);
     });
 
     // Configurateur d'overlay (interface graphique pour générer l'URL OBS)
@@ -2797,6 +2936,106 @@ export class RemoteScoreServer {
           client.lastSeen = new Date().toISOString();
         }
       });
+
+      // ── Format arène Sabre Laser équipe : saisie temps réel ────────────────────
+      // Room dédiée `team-arena:{arenaId}`, événements `team_*` — aucun recouvrement
+      // avec les événements `arena_control`/`join_arena` du scoring individuel.
+      socket.on('join_team_arena', (data: { arenaId: string; role?: string }) => {
+        if (data.role === 'referee' && !this.checkArenaAuth(data.arenaId, socket.handshake.headers.cookie as string)) {
+          socket.emit('auth_error', { message: 'Authentification requise' });
+          socket.disconnect(true);
+          return;
+        }
+        socket.join(`team-arena:${data.arenaId}`);
+        socket.emit('team_arena_state', this.getPublicTeamArenaState(data.arenaId));
+      });
+
+      const broadcastTeamArena = (arenaId: string) => {
+        this.io.to(`team-arena:${arenaId}`).emit('team_arena_state', this.getPublicTeamArenaState(arenaId));
+      };
+
+      // Touche (simple, ou zone A/B/C = 1/3/5 en mode points) — assaut plafonné
+      // à 5 touches valides cumulées, vérifié après chaque saisie.
+      socket.on('team_touch', (data: { arenaId: string; side: 'A' | 'B'; points: number }) => {
+        const state = this.teamArenaState.get(data.arenaId);
+        if (!state) return;
+        const bout = state.bouts[state.currentBoutIndex];
+        if (!bout || bout.status === 'finished') return;
+        if (data.side === 'A') state.liveScoreA += data.points;
+        else state.liveScoreB += data.points;
+        broadcastTeamArena(data.arenaId);
+      });
+
+      // Réinitialise l'assaut en cours (score et chrono), sans le terminer.
+      socket.on('team_reset_bout', (data: { arenaId: string }) => {
+        const state = this.teamArenaState.get(data.arenaId);
+        if (!state) return;
+        state.liveScoreA = 0;
+        state.liveScoreB = 0;
+        state.elapsedAccumulatedSec = 0;
+        state.timerStartedAt = null;
+        broadcastTeamArena(data.arenaId);
+      });
+
+      socket.on('team_timer_start', (data: { arenaId: string }) => {
+        const state = this.teamArenaState.get(data.arenaId);
+        if (!state || state.timerStartedAt !== null) return;
+        state.timerStartedAt = Date.now();
+        broadcastTeamArena(data.arenaId);
+      });
+
+      socket.on('team_timer_pause', (data: { arenaId: string }) => {
+        const state = this.teamArenaState.get(data.arenaId);
+        if (!state || state.timerStartedAt === null) return;
+        state.elapsedAccumulatedSec = this.teamArenaElapsedSec(state);
+        state.timerStartedAt = null;
+        broadcastTeamArena(data.arenaId);
+      });
+
+      // Termine l'assaut en cours (persiste le score), avance au suivant s'il en reste.
+      socket.on('team_advance_bout', (data: { arenaId: string }) => {
+        const state = this.teamArenaState.get(data.arenaId);
+        if (!state) return;
+        const bout = state.bouts[state.currentBoutIndex];
+        if (!bout || bout.status === 'finished') return;
+        const scoreA = state.liveScoreA;
+        const scoreB = state.liveScoreB;
+        const winnerId =
+          scoreA > scoreB ? bout.fencerAId : scoreB > scoreA ? bout.fencerBId : null;
+        this.db.updateTeamBout(bout.id, scoreA, scoreB, 'finished', winnerId);
+        bout.scoreA = scoreA;
+        bout.scoreB = scoreB;
+        bout.status = 'finished';
+        bout.winnerId = winnerId;
+        state.currentBoutIndex = state.bouts.findIndex(b => b.status !== 'finished');
+        state.liveScoreA = 0;
+        state.liveScoreB = 0;
+        state.elapsedAccumulatedSec = 0;
+        state.timerStartedAt = null;
+        broadcastTeamArena(data.arenaId);
+      });
+
+      // Carton d'équipe "E" (traçabilité, pas d'impact automatique sur le score).
+      socket.on(
+        'team_card',
+        (data: { arenaId: string; teamId: string; type: 'white' | 'yellow' | 'red' | 'black' }) => {
+          const state = this.teamArenaState.get(data.arenaId);
+          if (!state) return;
+          const { id } = this.db.createTeamMatchCard(
+            state.matchId,
+            data.teamId,
+            data.type,
+            'late_designation'
+          );
+          state.cards.push({
+            id,
+            teamId: data.teamId,
+            type: data.type,
+            createdAt: new Date().toISOString(),
+          });
+          broadcastTeamArena(data.arenaId);
+        }
+      );
 
       // Niveau de batterie remonté par les tablettes arbitre
       socket.on('client:battery', (data: { level: number; charging: boolean }) => {

--- a/src/remote/teamArena.html
+++ b/src/remote/teamArena.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Arène équipe — BellePoule</title>
+    <script src="/socket.io.min.js"></script>
+    <style>
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+        background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+        color: #fff;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        text-align: center;
+      }
+      #waiting { font-size: 1.5rem; opacity: 0.7; }
+      #match { display: none; width: 100%; max-width: 60rem; }
+      .bout-info { font-size: 1.1rem; opacity: 0.75; margin-bottom: 1rem; letter-spacing: 0.05em; text-transform: uppercase; }
+      .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: 1.5rem;
+        margin-bottom: 1.5rem;
+      }
+      .team-name { font-size: 2rem; font-weight: 800; }
+      .fencer-name { font-size: 1.3rem; opacity: 0.85; margin-top: 0.3rem; }
+      .vs { font-size: 1.5rem; opacity: 0.5; }
+      .score-row {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: 1.5rem;
+        margin-bottom: 1.5rem;
+      }
+      .score {
+        font-size: 7rem;
+        font-weight: 900;
+        font-variant-numeric: tabular-nums;
+        text-shadow: 0 0 30px rgba(255, 255, 255, 0.35);
+      }
+      .score-sep { font-size: 4rem; opacity: 0.4; }
+      .cap { font-size: 1rem; opacity: 0.6; margin-bottom: 1.5rem; }
+      .timer {
+        font-size: 4rem;
+        font-weight: 800;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: 0.05em;
+        color: #ffaa00;
+        text-shadow: 0 0 20px rgba(255, 170, 0, 0.6);
+      }
+      .timer.warning { color: #ff4444; text-shadow: 0 0 20px rgba(255, 68, 68, 0.7); }
+      .cards { margin-top: 1.5rem; font-size: 1.5rem; display: flex; justify-content: center; gap: 2rem; }
+      .match-complete { font-size: 2rem; font-weight: 800; color: #4ade80; margin-top: 1rem; }
+    </style>
+  </head>
+  <body>
+    <div id="waiting">En attente d'une rencontre équipe sur cette arène…</div>
+    <div id="match">
+      <div class="bout-info" id="bout-info">Assaut —/—</div>
+      <div class="teams">
+        <div>
+          <div class="team-name" id="team-a-name">—</div>
+          <div class="fencer-name" id="fencer-a-name">—</div>
+        </div>
+        <div class="vs">VS</div>
+        <div>
+          <div class="team-name" id="team-b-name">—</div>
+          <div class="fencer-name" id="fencer-b-name">—</div>
+        </div>
+      </div>
+      <div class="score-row">
+        <div class="score" id="score-a">0</div>
+        <div class="score-sep">–</div>
+        <div class="score" id="score-b">0</div>
+      </div>
+      <div class="cap" id="cap-label"></div>
+      <div class="timer" id="timer">3:00</div>
+      <div class="cards" id="cards"></div>
+      <div class="match-complete" id="match-complete" style="display: none">Rencontre terminée</div>
+    </div>
+
+    <script>
+      (function () {
+        const CARD_BADGE = { white: '⬜', yellow: '🟨', red: '🟥', black: '⬛' };
+
+        function getArenaId() {
+          const m = window.location.pathname.match(/equipe(\d+)/i);
+          return m ? m[1] : '1';
+        }
+
+        const arenaId = getArenaId();
+        const socket = io({ reconnection: true, reconnectionDelay: 300, reconnectionDelayMax: 5000 });
+        let lastState = null;
+
+        socket.on('connect', () => socket.emit('join_team_arena', { arenaId, role: 'display' }));
+
+        function formatTime(sec) {
+          const s = Math.max(0, Math.round(sec));
+          const m = Math.floor(s / 60);
+          const r = s % 60;
+          return `${m}:${r.toString().padStart(2, '0')}`;
+        }
+
+        function render() {
+          const waiting = document.getElementById('waiting');
+          const match = document.getElementById('match');
+          if (!lastState) {
+            waiting.style.display = 'block';
+            match.style.display = 'none';
+            return;
+          }
+          waiting.style.display = 'none';
+          match.style.display = 'block';
+
+          document.getElementById('team-a-name').textContent = lastState.teamAName;
+          document.getElementById('team-b-name').textContent = lastState.teamBName;
+
+          const complete = document.getElementById('match-complete');
+          if (lastState.matchComplete) {
+            complete.style.display = 'block';
+            document.getElementById('bout-info').textContent = '';
+            document.getElementById('fencer-a-name').textContent = '';
+            document.getElementById('fencer-b-name').textContent = '';
+          } else {
+            complete.style.display = 'none';
+            const bout = lastState.currentBout;
+            document.getElementById('bout-info').textContent = bout
+              ? `Assaut ${bout.boutOrder}/${lastState.bouts.length}`
+              : '';
+            document.getElementById('fencer-a-name').textContent = bout ? bout.fencerAName : '';
+            document.getElementById('fencer-b-name').textContent = bout ? bout.fencerBName : '';
+          }
+
+          document.getElementById('score-a').textContent = lastState.liveScoreA;
+          document.getElementById('score-b').textContent = lastState.liveScoreB;
+          document.getElementById('cap-label').textContent =
+            `Plafond : ${lastState.cap.maxTouches} touches valides ou ${formatTime(lastState.cap.maxDurationSec)}`;
+
+          const remaining = Math.max(0, lastState.cap.maxDurationSec - lastState.elapsedSec);
+          const timerEl = document.getElementById('timer');
+          timerEl.textContent = formatTime(remaining);
+          timerEl.classList.toggle('warning', remaining <= 20);
+
+          const cardsEl = document.getElementById('cards');
+          const cardsA = lastState.cards.filter(c => c.teamId === lastState.teamAId);
+          const cardsB = lastState.cards.filter(c => c.teamId === lastState.teamBId);
+          cardsEl.innerHTML = '';
+          if (cardsA.length || cardsB.length) {
+            const left = document.createElement('div');
+            left.textContent = cardsA.map(c => CARD_BADGE[c.type]).join(' ');
+            const right = document.createElement('div');
+            right.textContent = cardsB.map(c => CARD_BADGE[c.type]).join(' ');
+            cardsEl.appendChild(left);
+            cardsEl.appendChild(right);
+          }
+        }
+
+        socket.on('team_arena_state', state => {
+          lastState = state;
+          render();
+        });
+
+        setInterval(() => {
+          if (lastState && lastState.timerRunning) render();
+        }, 1000);
+      })();
+    </script>
+  </body>
+</html>

--- a/src/remote/teamReferee.html
+++ b/src/remote/teamReferee.html
@@ -1,0 +1,336 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>Arbitre équipe — BellePoule</title>
+    <script src="/socket.io.min.js"></script>
+    <style>
+      * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; user-select: none; }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+        background: #0f172a;
+        color: #f1f5f9;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        padding: 0.75rem 1rem;
+        background: #1e293b;
+        text-align: center;
+        font-size: 0.85rem;
+        color: #94a3b8;
+      }
+      #waiting {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.1rem;
+        color: #64748b;
+        padding: 2rem;
+        text-align: center;
+      }
+      #match {
+        display: none;
+        flex: 1;
+        flex-direction: column;
+        padding: 0.75rem;
+        gap: 0.75rem;
+      }
+      .bout-info {
+        text-align: center;
+        font-size: 0.8rem;
+        color: #94a3b8;
+      }
+      .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .team-col { text-align: center; }
+      .team-name { font-weight: 700; font-size: 1rem; }
+      .fencer-name { font-size: 0.85rem; color: #cbd5e1; margin-top: 0.15rem; }
+      .vs { color: #64748b; font-weight: 700; }
+      .timer {
+        text-align: center;
+        font-variant-numeric: tabular-nums;
+        font-size: 2.5rem;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+      }
+      .timer.running { color: #4ade80; }
+      .timer.warning { color: #f87171; }
+      .timer-controls { display: flex; justify-content: center; gap: 0.5rem; }
+      button {
+        font-family: inherit;
+        border: none;
+        border-radius: 0.6rem;
+        cursor: pointer;
+        color: #f1f5f9;
+        background: #334155;
+        padding: 0.5rem 1rem;
+        font-size: 0.9rem;
+      }
+      button:active { filter: brightness(1.3); }
+      button:disabled { opacity: 0.35; cursor: not-allowed; }
+      .score-row {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .score { font-size: 3rem; font-weight: 800; text-align: center; font-variant-numeric: tabular-nums; }
+      .score-sep { font-size: 2rem; color: #475569; text-align: center; }
+      .cap { text-align: center; font-size: 0.75rem; color: #64748b; }
+      .zone-row { display: flex; gap: 0.4rem; justify-content: center; flex-wrap: wrap; }
+      .zone-btn { flex: 1; min-width: 4.5rem; padding: 1.2rem 0.5rem; font-size: 1.3rem; font-weight: 700; }
+      .zone-A { background: #1d4ed8; }
+      .zone-B { background: #7c3aed; }
+      .zone-C { background: #be185d; }
+      .touch-btn { flex: 1; padding: 1.4rem; font-size: 1.6rem; font-weight: 700; background: #1d4ed8; }
+      .actions-row { display: flex; gap: 0.5rem; }
+      .advance-btn {
+        flex: 1;
+        padding: 1rem;
+        font-size: 1.1rem;
+        font-weight: 700;
+        background: #16a34a;
+      }
+      .advance-btn.ready { background: #22c55e; box-shadow: 0 0 0 3px rgba(34,197,94,0.4); }
+      .reset-btn { background: #7f1d1d; }
+      .cards-section {
+        border-top: 1px solid #334155;
+        padding-top: 0.6rem;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.6rem;
+      }
+      .cards-team { text-align: center; }
+      .cards-label { font-size: 0.7rem; color: #94a3b8; margin-bottom: 0.3rem; }
+      .card-buttons { display: flex; gap: 0.3rem; justify-content: center; }
+      .card-btn { padding: 0.35rem 0.5rem; font-size: 1rem; background: #1e293b; border: 1px solid #334155; }
+      .cards-log { margin-top: 0.3rem; font-size: 0.9rem; }
+      .match-complete {
+        text-align: center;
+        font-size: 1rem;
+        font-weight: 700;
+        color: #4ade80;
+        padding: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>Arène <span id="arena-number">—</span> · Format arène Sabre Laser équipe</header>
+    <div id="waiting">En attente d'assignation d'une rencontre depuis l'application…</div>
+    <div id="match">
+      <div class="bout-info" id="bout-info">Assaut —/—</div>
+      <div class="teams">
+        <div class="team-col">
+          <div class="team-name" id="team-a-name">—</div>
+          <div class="fencer-name" id="fencer-a-name">—</div>
+        </div>
+        <div class="vs">vs</div>
+        <div class="team-col">
+          <div class="team-name" id="team-b-name">—</div>
+          <div class="fencer-name" id="fencer-b-name">—</div>
+        </div>
+      </div>
+
+      <div class="score-row">
+        <div class="score" id="score-a">0</div>
+        <div class="score-sep">–</div>
+        <div class="score" id="score-b">0</div>
+      </div>
+      <div class="cap" id="cap-label">/ 5 touches · 3:00</div>
+
+      <div class="timer" id="timer">3:00</div>
+      <div class="timer-controls">
+        <button id="timer-start">▶ Démarrer</button>
+        <button id="timer-pause">⏸ Pause</button>
+      </div>
+
+      <div id="zones-a" class="zone-row"></div>
+      <div id="zones-b" class="zone-row"></div>
+
+      <div class="actions-row">
+        <button class="reset-btn" id="reset-bout">↩ Réinitialiser l'assaut</button>
+        <button class="advance-btn" id="advance-bout">Relais suivant →</button>
+      </div>
+
+      <div class="cards-section">
+        <div class="cards-team">
+          <div class="cards-label" id="cards-label-a">Cartons équipe « E » — A</div>
+          <div class="card-buttons" id="card-buttons-a"></div>
+          <div class="cards-log" id="cards-log-a"></div>
+        </div>
+        <div class="cards-team">
+          <div class="cards-label" id="cards-label-b">Cartons équipe « E » — B</div>
+          <div class="card-buttons" id="card-buttons-b"></div>
+          <div class="cards-log" id="cards-log-b"></div>
+        </div>
+      </div>
+
+      <div class="match-complete" id="match-complete" style="display: none">
+        Rencontre terminée — tous les assauts ont été joués.
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        const CARD_BADGE = { white: '⬜', yellow: '🟨', red: '🟥', black: '⬛' };
+        const CARD_TYPES = ['white', 'yellow', 'red', 'black'];
+
+        function getArenaId() {
+          const m = window.location.pathname.match(/equipe(\d+)/i);
+          return m ? m[1] : '1';
+        }
+
+        const arenaId = getArenaId();
+        document.getElementById('arena-number').textContent = arenaId;
+
+        const socket = io({ reconnection: true, reconnectionDelay: 300, reconnectionDelayMax: 5000 });
+        let localTimer = null;
+        let lastState = null;
+
+        socket.on('connect', () => {
+          socket.emit('join_team_arena', { arenaId, role: 'referee' });
+        });
+
+        socket.on('auth_error', () => {
+          window.location.href = `/login?arena=arena${arenaId}&return=${encodeURIComponent(window.location.pathname)}`;
+        });
+
+        function formatTime(sec) {
+          const s = Math.max(0, Math.round(sec));
+          const m = Math.floor(s / 60);
+          const r = s % 60;
+          return `${m}:${r.toString().padStart(2, '0')}`;
+        }
+
+        function renderZones(container, side) {
+          container.innerHTML = '';
+          if (lastState.isLaserPoints) {
+            [
+              ['A', 1, 'zone-A'],
+              ['B', 3, 'zone-B'],
+              ['C', 5, 'zone-C'],
+            ].forEach(([zone, points, cls]) => {
+              const btn = document.createElement('button');
+              btn.className = `zone-btn ${cls}`;
+              btn.textContent = `${zone} (${points})`;
+              btn.disabled = !lastState.currentBout || lastState.boutComplete;
+              btn.onclick = () => socket.emit('team_touch', { arenaId, side, points });
+              container.appendChild(btn);
+            });
+          } else {
+            const btn = document.createElement('button');
+            btn.className = 'touch-btn';
+            btn.textContent = side === 'A' ? '+ Touche (côté A)' : '+ Touche (côté B)';
+            btn.disabled = !lastState.currentBout || lastState.boutComplete;
+            btn.onclick = () => socket.emit('team_touch', { arenaId, side, points: 1 });
+            container.appendChild(btn);
+          }
+        }
+
+        function renderCardButtons(container, teamId) {
+          container.innerHTML = '';
+          CARD_TYPES.forEach(type => {
+            const btn = document.createElement('button');
+            btn.className = 'card-btn';
+            btn.textContent = CARD_BADGE[type];
+            btn.title = `Carton ${type} E`;
+            btn.onclick = () => socket.emit('team_card', { arenaId, teamId, type });
+            container.appendChild(btn);
+          });
+        }
+
+        function render() {
+          const waiting = document.getElementById('waiting');
+          const match = document.getElementById('match');
+          if (!lastState) {
+            waiting.style.display = 'flex';
+            match.style.display = 'none';
+            return;
+          }
+          waiting.style.display = 'none';
+          match.style.display = 'flex';
+
+          document.getElementById('team-a-name').textContent = lastState.teamAName;
+          document.getElementById('team-b-name').textContent = lastState.teamBName;
+          document.getElementById('cards-label-a').textContent = `Cartons équipe « E » — ${lastState.teamAName}`;
+          document.getElementById('cards-label-b').textContent = `Cartons équipe « E » — ${lastState.teamBName}`;
+
+          const complete = document.getElementById('match-complete');
+          if (lastState.matchComplete) {
+            complete.style.display = 'block';
+            document.getElementById('bout-info').textContent = 'Rencontre terminée';
+            document.getElementById('fencer-a-name').textContent = '—';
+            document.getElementById('fencer-b-name').textContent = '—';
+          } else {
+            complete.style.display = 'none';
+            const bout = lastState.currentBout;
+            document.getElementById('bout-info').textContent = bout
+              ? `Assaut ${bout.boutOrder}/${lastState.bouts.length}`
+              : '—';
+            document.getElementById('fencer-a-name').textContent = bout ? bout.fencerAName : '—';
+            document.getElementById('fencer-b-name').textContent = bout ? bout.fencerBName : '—';
+          }
+
+          document.getElementById('score-a').textContent = lastState.liveScoreA;
+          document.getElementById('score-b').textContent = lastState.liveScoreB;
+          document.getElementById('cap-label').textContent = `Plafond : ${lastState.cap.maxTouches} touches · ${formatTime(lastState.cap.maxDurationSec)}`;
+
+          const remaining = Math.max(0, lastState.cap.maxDurationSec - lastState.elapsedSec);
+          const timerEl = document.getElementById('timer');
+          timerEl.textContent = formatTime(remaining);
+          timerEl.classList.toggle('running', lastState.timerRunning);
+          timerEl.classList.toggle('warning', remaining <= 20);
+
+          renderZones(document.getElementById('zones-a'), 'A');
+          renderZones(document.getElementById('zones-b'), 'B');
+          renderCardButtons(document.getElementById('card-buttons-a'), lastState.teamAId);
+          renderCardButtons(document.getElementById('card-buttons-b'), lastState.teamBId);
+
+          const advanceBtn = document.getElementById('advance-bout');
+          advanceBtn.disabled = !lastState.currentBout;
+          advanceBtn.classList.toggle('ready', !!lastState.boutComplete);
+
+          document.getElementById('timer-start').disabled = lastState.timerRunning || !lastState.currentBout;
+          document.getElementById('timer-pause').disabled = !lastState.timerRunning;
+
+          const logA = document.getElementById('cards-log-a');
+          const logB = document.getElementById('cards-log-b');
+          logA.textContent = lastState.cards
+            .filter(c => c.teamId === lastState.teamAId)
+            .map(c => CARD_BADGE[c.type])
+            .join(' ');
+          logB.textContent = lastState.cards
+            .filter(c => c.teamId === lastState.teamBId)
+            .map(c => CARD_BADGE[c.type])
+            .join(' ');
+        }
+
+        socket.on('team_arena_state', state => {
+          lastState = state;
+          render();
+        });
+
+        // Rafraîchit l'affichage du chrono localement entre deux broadcasts serveur.
+        setInterval(() => {
+          if (lastState && lastState.timerRunning) render();
+        }, 1000);
+
+        document.getElementById('timer-start').onclick = () => socket.emit('team_timer_start', { arenaId });
+        document.getElementById('timer-pause').onclick = () => socket.emit('team_timer_pause', { arenaId });
+        document.getElementById('reset-bout').onclick = () => {
+          if (confirm("Réinitialiser le score de cet assaut ?")) socket.emit('team_reset_bout', { arenaId });
+        };
+        document.getElementById('advance-bout').onclick = () => socket.emit('team_advance_bout', { arenaId });
+      })();
+    </script>
+  </body>
+</html>

--- a/src/renderer/components/NewCompetitionModal.tsx
+++ b/src/renderer/components/NewCompetitionModal.tsx
@@ -33,6 +33,10 @@ const NewCompetitionModal: React.FC<NewCompetitionModalProps> = ({ onClose, onCr
   const [teamSize, setTeamSize] = useState(3);
   const [teamReserveCount, setTeamReserveCount] = useState(1);
   const [laserTeamMode, setLaserTeamMode] = useState<'touches' | 'points'>('touches');
+  // Sabre Laser équipe uniquement : relais FIE classique (cible cumulée
+  // progressive) ou format arène (assauts indépendants 5 touches/3min, score
+  // = total de points, règlement épreuve par équipe Sabre Laser).
+  const [teamFormat, setTeamFormat] = useState<'fie-relay' | 'laser-arena'>('fie-relay');
 
   const handleWeaponChange = (w: Weapon) => {
     setWeapon(w);
@@ -45,7 +49,7 @@ const NewCompetitionModal: React.FC<NewCompetitionModalProps> = ({ onClose, onCr
     const teamSettings = {
       minTeamSize: teamSize,
       teamReserveCount,
-      ...(weapon === Weapon.LASER ? { laserTeamMode } : {}),
+      ...(weapon === Weapon.LASER ? { laserTeamMode, teamFormat } : {}),
     };
 
     const settings =
@@ -215,7 +219,7 @@ const NewCompetitionModal: React.FC<NewCompetitionModalProps> = ({ onClose, onCr
                 className="form-group"
                 style={{
                   display: 'grid',
-                  gridTemplateColumns: weapon === Weapon.LASER ? '1fr 1fr 1fr' : '1fr 1fr',
+                  gridTemplateColumns: weapon === Weapon.LASER ? '1fr 1fr 1fr 1fr' : '1fr 1fr',
                   gap: '1rem',
                   background: '#f9fafb',
                   padding: '0.75rem',
@@ -254,6 +258,21 @@ const NewCompetitionModal: React.FC<NewCompetitionModalProps> = ({ onClose, onCr
                     >
                       <option value="touches">Touches (comme les autres armes)</option>
                       <option value="points">Points de zone cumulés (A/B/C)</option>
+                    </select>
+                  </div>
+                )}
+                {weapon === Weapon.LASER && (
+                  <div className="form-group">
+                    <label className="form-label">Format de rencontre</label>
+                    <select
+                      className="form-input form-select"
+                      value={teamFormat}
+                      onChange={e => setTeamFormat(e.target.value as 'fie-relay' | 'laser-arena')}
+                    >
+                      <option value="fie-relay">Relais FIE classique (cible cumulée)</option>
+                      <option value="laser-arena">
+                        Arène équipe (assauts 5 touches/3min, règlement ASL-FFE)
+                      </option>
                     </select>
                   </div>
                 )}

--- a/src/renderer/components/TeamManagerView.tsx
+++ b/src/renderer/components/TeamManagerView.tsx
@@ -6,7 +6,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { Card, CardReason, Competition, Fencer, Weapon } from '../../shared/types';
-import { TeamRow, TeamMatchRow, TeamBoutRow } from '../../features/teams/types/team.types';
+import { TeamRow, TeamMatchRow, TeamBoutRow, TeamMatchCardRow } from '../../features/teams/types/team.types';
 import {
   generateRelayOrder,
   getTeamTargetRule,
@@ -15,11 +15,26 @@ import {
   placeRankedTeamsInTable,
   resolveTeamTableauSlot,
 } from '../../features/teams/utils/teamCalculations';
+import {
+  getLaserArenaBoutCap,
+  isLaserArenaBoutComplete,
+  calculateLaserArenaPoolRanking,
+} from '../../features/teams/utils/laserArenaCalculations';
+import {
+  applyRematchAvoidanceSwap,
+  buildPoolPairHistory,
+} from '../../features/teams/utils/laserArenaBracketRules';
+import {
+  getLaserArenaPoolSchedule,
+  resolveLaserArenaSchedule,
+} from '../../features/teams/utils/laserArenaPoolSchedules';
 import { createCard } from '../../shared/utils/cardSystem';
 import TeamPoolView, { CardTarget } from './TeamPoolView';
 import TeamTableauView from './TeamTableauView';
 import { useConfirm } from './ConfirmDialog';
 import { useTranslation } from '../hooks/useTranslation';
+
+const LASER_ARENA_POOL_NUMBER_BY_LETTER: Record<string, number> = { A: 1, B: 2, C: 3 };
 
 // ── Composant ─────────────────────────────────────────────────────────────────
 
@@ -42,6 +57,11 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
   );
   const isEpee = competition.weapon === Weapon.EPEE;
   const isLaserPoints = competition.weapon === Weapon.LASER && targetRule.mode === 'points';
+  // Format arène Sabre Laser (assauts indépendants plafonnés à 5 touches/3min,
+  // score = total de points) — distinct du relais FIE classique ci-dessus,
+  // qui reste le comportement par défaut pour tous les autres cas.
+  const isLaserArena = competition.settings?.teamFormat === 'laser-arena';
+  const boutCap = getLaserArenaBoutCap();
   const tableId = competition.id; // Un seul tableau équipes par compétition
   const { confirm } = useConfirm();
   const { t } = useTranslation();
@@ -65,10 +85,14 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
   // Scoring
   const [scoringMatchId, setScoringMatchId] = useState<string | null>(null);
 
-  // Cartons par assaut (en mémoire pour la session — cf. limites connues en documentation)
+  // Cartons individuels par assaut (en mémoire pour la session — cf. limites connues en documentation)
   const [boutCards, setBoutCards] = useState<Record<string, Card[]>>({});
   const [cardTarget, setCardTarget] = useState<CardTarget | null>(null);
   const [selectedReason, setSelectedReason] = useState<CardReason | ''>('');
+
+  // Cartons d'équipe "E" (format arène Sabre Laser uniquement), persistés en DB
+  // par rencontre (matchId), contrairement aux cartons individuels ci-dessus.
+  const [matchCards, setMatchCards] = useState<Record<string, TeamMatchCardRow[]>>({});
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -81,10 +105,21 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
       setTeams(t as TeamRow[]);
       setMatches(m as TeamMatchRow[]);
       setTableauMatches(tm as TeamMatchRow[]);
+      if (isLaserArena) {
+        const allMatchIds = [...(m as TeamMatchRow[]), ...(tm as TeamMatchRow[])].map(x => x.id);
+        const cardsArrays = await Promise.all(
+          allMatchIds.map(id => window.electronAPI.db.getTeamMatchCards(id))
+        );
+        const map: Record<string, TeamMatchCardRow[]> = {};
+        allMatchIds.forEach((id, i) => {
+          map[id] = cardsArrays[i] as TeamMatchCardRow[];
+        });
+        setMatchCards(map);
+      }
     } finally {
       setLoading(false);
     }
-  }, [competition.id, tableId]);
+  }, [competition.id, tableId, isLaserArena]);
 
   useEffect(() => {
     reload();
@@ -96,7 +131,16 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
   useEffect(() => {
     if (loading || teams.length < 2) return;
 
-    const rankedTeams = calculateTeamPoolRanking(teams, matches).map(r => r.team);
+    const baseRankedTeams = isLaserArena
+      ? calculateLaserArenaPoolRanking(teams, matches).map(r => r.team)
+      : calculateTeamPoolRanking(teams, matches).map(r => r.team);
+    // Évitement de revanche (format arène uniquement) : si les équipes classées
+    // 5/6 ou 7/8 tombent contre une équipe déjà rencontrée en poule au 1er tour,
+    // échange leurs places — n'affecte que le placement dans le tableau, pas le
+    // classement de poule affiché dans l'onglet Classement.
+    const rankedTeams = isLaserArena
+      ? applyRematchAvoidanceSwap(baseRankedTeams, buildPoolPairHistory(matches))
+      : baseRankedTeams;
     const tableSize = calculateTableSize(rankedTeams.length);
     const placements = placeRankedTeamsInTable(rankedTeams, tableSize);
     const teamByIdLocal = new Map(teams.map(t => [t.id, t]));
@@ -139,7 +183,7 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
                   k + 1,
                   mainA[oi].fencerId,
                   mainB[oj].fencerId,
-                  targetRule.stepSize
+                  isLaserArena ? boutCap.maxTouches : targetRule.stepSize
                 );
               }
             }
@@ -175,6 +219,8 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
     tableId,
     teamSize,
     targetRule.stepSize,
+    isLaserArena,
+    boutCap.maxTouches,
   ]);
 
   // ── Créer équipe ──────────────────────────────────────────────────────────────
@@ -225,6 +271,51 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
     if (matches.length > 0 && !(await confirm('Des matchs existent déjà. Supprimer et régénérer ?')))
       return;
 
+    if (isLaserArena) {
+      // Calendrier de poule figé du règlement (uniquement 8 ou 12 équipes) —
+      // aucune génération automatique pour un autre effectif : l'organisateur
+      // reste sur la saisie manuelle des équipes.
+      const schedule = getLaserArenaPoolSchedule(teams.length);
+      if (!schedule) {
+        alert(
+          `Le calendrier de poule figé "Sabre Laser équipe" n'est défini que pour 8 ou 12 équipes (actuellement ${teams.length}).`
+        );
+        return;
+      }
+      const resolved = resolveLaserArenaSchedule(teams, schedule);
+      for (const rm of resolved) {
+        const { id: matchId } = await window.electronAPI.db.createTeamMatch(
+          competition.id,
+          LASER_ARENA_POOL_NUMBER_BY_LETTER[rm.pool] ?? 1,
+          rm.teamA.id,
+          rm.teamB.id,
+          rm.round
+        );
+        const mainA = rm.teamA.fencers
+          .filter(f => !f.isReserve)
+          .sort((x, y) => x.teamOrder - y.teamOrder);
+        const mainB = rm.teamB.fencers
+          .filter(f => !f.isReserve)
+          .sort((x, y) => x.teamOrder - y.teamOrder);
+        if (mainA.length >= teamSize && mainB.length >= teamSize) {
+          const relayOrder = generateRelayOrder(teamSize);
+          for (let k = 0; k < relayOrder.length; k++) {
+            const [oi, oj] = relayOrder[k];
+            await window.electronAPI.db.createTeamBout(
+              matchId,
+              k + 1,
+              mainA[oi].fencerId,
+              mainB[oj].fencerId,
+              boutCap.maxTouches
+            );
+          }
+        }
+      }
+      await reload();
+      setView('pool');
+      return;
+    }
+
     for (let i = 0; i < teams.length; i++) {
       for (let j = i + 1; j < teams.length; j++) {
         const a = teams[i];
@@ -272,23 +363,64 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
     const newScoreA = side === 'A' || side === 'double' ? bout.scoreA + points : bout.scoreA;
     const newScoreB = side === 'B' || side === 'double' ? bout.scoreB + points : bout.scoreB;
 
-    // Cible progressive FIE : le relais s'arrête quand le cumul d'équipe atteint
-    // le palier (5-10-15…) de ce relais, ou la cible finale de la rencontre.
-    const priorBouts = match.bouts.filter(b => b.boutOrder < bout.boutOrder);
-    const cumulA = priorBouts.reduce((s, b) => s + b.scoreA, 0) + newScoreA;
-    const cumulB = priorBouts.reduce((s, b) => s + b.scoreB, 0) + newScoreB;
-    const cap = Math.min(bout.boutOrder * targetRule.stepSize, targetRule.target);
-    const maxReached = cumulA >= cap || cumulB >= cap;
+    let maxReached: boolean;
+    let winnerId: string | null;
+
+    if (isLaserArena) {
+      // Format arène : chaque assaut est indépendant, plafonné à 5 touches
+      // valides cumulées (les deux côtés) — pas de cible d'équipe progressive.
+      // Le plafond de 3 minutes s'applique côté saisie temps réel (tablette).
+      maxReached = isLaserArenaBoutComplete(newScoreA, newScoreB, 0, boutCap);
+      winnerId = maxReached
+        ? newScoreA > newScoreB
+          ? bout.fencerAId
+          : newScoreB > newScoreA
+            ? bout.fencerBId
+            : null
+        : null;
+    } else {
+      // Cible progressive FIE : le relais s'arrête quand le cumul d'équipe atteint
+      // le palier (5-10-15…) de ce relais, ou la cible finale de la rencontre.
+      const priorBouts = match.bouts.filter(b => b.boutOrder < bout.boutOrder);
+      const cumulA = priorBouts.reduce((s, b) => s + b.scoreA, 0) + newScoreA;
+      const cumulB = priorBouts.reduce((s, b) => s + b.scoreB, 0) + newScoreB;
+      const cap = Math.min(bout.boutOrder * targetRule.stepSize, targetRule.target);
+      maxReached = cumulA >= cap || cumulB >= cap;
+      winnerId = maxReached
+        ? cumulA > cumulB
+          ? bout.fencerAId
+          : cumulB > cumulA
+            ? bout.fencerBId
+            : null
+        : null;
+    }
+
     const newStatus = maxReached ? 'finished' : 'in_progress';
-    const winnerId = maxReached
-      ? cumulA > cumulB
-        ? bout.fencerAId
-        : cumulB > cumulA
-          ? bout.fencerBId
-          : null
-      : null;
     await window.electronAPI.db.updateTeamBout(bout.id, newScoreA, newScoreB, newStatus, winnerId);
     await reload();
+  };
+
+  // ── Carton d'équipe "E" (format arène Sabre Laser, persisté, traçabilité seule) ──
+  const handleAddTeamCard = async (
+    matchId: string,
+    teamId: string,
+    type: 'white' | 'yellow' | 'red' | 'black'
+  ) => {
+    await window.electronAPI.db.createTeamMatchCard(matchId, teamId, type, 'late_designation');
+    await reload();
+  };
+
+  // ── Envoyer une rencontre sur une arène pour saisie tablette temps réel ──────
+  const handleAssignArena = async (matchId: string, arenaId: string) => {
+    const result = await window.electronAPI.remote.setTeamArenaMatch(
+      competition.id,
+      arenaId,
+      matchId,
+      isLaserPoints
+    );
+    if (!result.success) {
+      alert(result.error ?? "Impossible d'assigner cette rencontre à l'arène (serveur distant démarré ?).");
+    }
   };
 
   const handleResetBout = async (bout: TeamBoutRow) => {
@@ -328,7 +460,11 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
     return f ? `${f.lastName} ${f.firstName ?? ''}`.trim() : id.slice(0, 8);
   };
 
-  const rankings = calculateTeamPoolRanking(teams, matches);
+  const fieRankings = calculateTeamPoolRanking(teams, matches);
+  const laserRankings = isLaserArena ? calculateLaserArenaPoolRanking(teams, matches) : [];
+  const rankedTeamsForBracket = isLaserArena
+    ? laserRankings.map(r => r.team)
+    : fieRankings.map(r => r.team);
 
   if (loading)
     return (
@@ -610,6 +746,11 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
               onSelectReason={setSelectedReason}
               onAddCard={handleAddCard}
               emptyLabel='Aucun match — cliquez sur "Générer la poule" dans l&apos;onglet Équipes.'
+              isLaserArena={isLaserArena}
+              boutCap={boutCap}
+              matchCards={matchCards}
+              onAddTeamCard={handleAddTeamCard}
+              onAssignArena={handleAssignArena}
             />
           )}
 
@@ -617,7 +758,7 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
           {view === 'tableau' && (
             <TeamTableauView
               teams={teams}
-              rankedTeams={rankings.map(r => r.team)}
+              rankedTeams={rankedTeamsForBracket}
               tableauMatches={tableauMatches}
               weapon={competition.weapon}
               targetRule={targetRule}
@@ -635,13 +776,131 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
               onSelectReason={setSelectedReason}
               onAddCard={handleAddCard}
               onGenerate={reload}
+              isLaserArena={isLaserArena}
+              boutCap={boutCap}
+              matchCards={matchCards}
+              onAddTeamCard={handleAddTeamCard}
+              onAssignArena={handleAssignArena}
             />
           )}
 
           {/* ── Vue CLASSEMENT ── */}
-          {view === 'ranking' && (
+          {view === 'ranking' && isLaserArena && (
             <div>
-              {rankings.length > 0 && (
+              {laserRankings.length > 0 && (
+                <div
+                  style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '0.5rem' }}
+                >
+                  <button
+                    className="btn btn-secondary"
+                    style={{ fontSize: '0.8rem', padding: '0.3rem 0.7rem' }}
+                    onClick={() => {
+                      const header = 'Rang,Équipe,Club,V,D,Points+,Points-,Ratio,Égalité\n';
+                      const rows = laserRankings
+                        .map((r, i) =>
+                          [
+                            i + 1,
+                            `"${r.team.name}"`,
+                            `"${r.team.club ?? ''}"`,
+                            r.victories,
+                            r.defeats,
+                            r.pointsFor,
+                            r.pointsAgainst,
+                            r.pointsAgainst === 0
+                              ? r.pointsFor
+                              : (r.pointsFor / r.pointsAgainst).toFixed(2),
+                            r.tied ? 'oui' : '',
+                          ].join(',')
+                        )
+                        .join('\n');
+                      const blob = new Blob([header + rows], { type: 'text/csv;charset=utf-8;' });
+                      const url = URL.createObjectURL(blob);
+                      const a = document.createElement('a');
+                      a.href = url;
+                      a.download = 'classement-equipes.csv';
+                      a.click();
+                      URL.revokeObjectURL(url);
+                    }}
+                  >
+                    ↓ Exporter CSV
+                  </button>
+                </div>
+              )}
+              {laserRankings.length === 0 ? (
+                <div className="text-center text-gray-400 py-10">Aucun match joué.</div>
+              ) : (
+                <table className="min-w-full text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center w-8">
+                        #
+                      </th>
+                      <th className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-left">
+                        Équipe
+                      </th>
+                      <th className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center">
+                        V
+                      </th>
+                      <th className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center">
+                        D
+                      </th>
+                      <th
+                        className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center"
+                        title="Critère principal du règlement : total de points marqués sur toutes les rencontres de poule"
+                      >
+                        Points+
+                      </th>
+                      <th className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center">
+                        Points-
+                      </th>
+                      <th
+                        className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase text-center"
+                        title="1er critère de départage : ratio points marqués / points reçus"
+                      >
+                        Ratio
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {laserRankings.map((r, i) => (
+                      <tr
+                        key={r.team.id}
+                        className={i === 0 ? 'bg-yellow-50' : 'hover:bg-gray-50'}
+                        title={r.tied ? 'Égalité totale avec une équipe voisine — à départager par tirage au sort' : undefined}
+                      >
+                        <td className="px-3 py-2 text-center font-bold text-gray-400">
+                          {i + 1}
+                          {r.tied && <span className="text-yellow-500 ml-1">⚠</span>}
+                        </td>
+                        <td className="px-3 py-2 font-semibold text-gray-900">
+                          {r.team.name}
+                          <span className="text-xs text-gray-400 font-normal ml-2">
+                            {r.team.club}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-center text-green-700 font-bold">
+                          {r.victories}
+                        </td>
+                        <td className="px-3 py-2 text-center text-red-500">{r.defeats}</td>
+                        <td className="px-3 py-2 text-center font-mono font-bold">{r.pointsFor}</td>
+                        <td className="px-3 py-2 text-center font-mono text-gray-400">
+                          {r.pointsAgainst}
+                        </td>
+                        <td className="px-3 py-2 text-center font-mono">
+                          {r.pointsAgainst === 0
+                            ? r.pointsFor
+                            : (r.pointsFor / r.pointsAgainst).toFixed(2)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          )}
+          {view === 'ranking' && !isLaserArena && (
+            <div>
+              {fieRankings.length > 0 && (
                 <div
                   style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '0.5rem' }}
                 >
@@ -651,7 +910,7 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
                     onClick={() => {
                       const header =
                         'Rang,Équipe,Club,V,D,RelaisG,RelaisP,Ind.,Touches+,Touches-\n';
-                      const rows = rankings
+                      const rows = fieRankings
                         .map((r, i) =>
                           [
                             i + 1,
@@ -680,7 +939,7 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
                   </button>
                 </div>
               )}
-              {rankings.length === 0 ? (
+              {fieRankings.length === 0 ? (
                 <div className="text-center text-gray-400 py-10">Aucun match joué.</div>
               ) : (
                 <table className="min-w-full text-sm">
@@ -728,7 +987,7 @@ export const TeamManagerView: React.FC<Props> = ({ competition, fencers, onClose
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-100">
-                    {rankings.map((r, i) => (
+                    {fieRankings.map((r, i) => (
                       <tr key={r.team.id} className={i === 0 ? 'bg-yellow-50' : 'hover:bg-gray-50'}>
                         <td className="px-3 py-2 text-center font-bold text-gray-400">{i + 1}</td>
                         <td className="px-3 py-2 font-semibold text-gray-900">

--- a/src/renderer/components/TeamPoolView.tsx
+++ b/src/renderer/components/TeamPoolView.tsx
@@ -7,11 +7,15 @@
 
 import React from 'react';
 import { Card, CardReason, TargetZone, ZONE_POINTS } from '../../shared/types';
-import { TeamRow, TeamMatchRow, TeamBoutRow } from '../../features/teams/types/team.types';
+import { TeamRow, TeamMatchRow, TeamBoutRow, TeamMatchCardRow } from '../../features/teams/types/team.types';
 import { TeamTargetRule, getRelayCap } from '../../features/teams/utils/teamCalculations';
+import { LaserArenaBoutCap } from '../../features/teams/utils/laserArenaCalculations';
+import { determineTeamCardEscalation } from '../../features/teams/utils/teamCardEscalation';
 import { CARD_REASON_LABELS, getAvailableReasons } from '../../shared/utils/cardSystem';
 
 const CARD_BADGE: Record<string, string> = { WHITE: '⬜', YELLOW: '🟨', RED: '🟥', BLACK: '⬛' };
+const TEAM_CARD_BADGE: Record<string, string> = { white: '⬜', yellow: '🟨', red: '🟥', black: '⬛' };
+const TEAM_CARD_TYPES: Array<'white' | 'yellow' | 'red' | 'black'> = ['white', 'yellow', 'red', 'black'];
 
 export interface CardTarget {
   boutId: string;
@@ -37,6 +41,14 @@ interface Props {
   onSelectReason: (reason: CardReason | '') => void;
   onAddCard: (matchId: string) => void;
   emptyLabel: string;
+  // Format arène Sabre Laser uniquement (`isLaserArena`) : plafond d'assaut fixe
+  // (5 touches/3min au lieu de la cible progressive FIE) et cartons d'équipe "E"
+  // (retard de désignation), distincts des cartons individuels par tireur.
+  isLaserArena?: boolean;
+  boutCap?: LaserArenaBoutCap;
+  matchCards?: Record<string, TeamMatchCardRow[]>;
+  onAddTeamCard?: (matchId: string, teamId: string, type: 'white' | 'yellow' | 'red' | 'black') => void;
+  onAssignArena?: (matchId: string, arenaId: string) => void;
 }
 
 const TeamPoolView: React.FC<Props> = ({
@@ -58,6 +70,11 @@ const TeamPoolView: React.FC<Props> = ({
   onSelectReason,
   onAddCard,
   emptyLabel,
+  isLaserArena = false,
+  boutCap,
+  matchCards = {},
+  onAddTeamCard,
+  onAssignArena,
 }) => {
   const teamById = new Map(teams.map(t => [t.id, t]));
 
@@ -106,6 +123,20 @@ const TeamPoolView: React.FC<Props> = ({
                   <div className="text-xs text-gray-400">{tb?.club}</div>
                 </div>
               </div>
+              {isLaserArena && onAssignArena && (
+                <button
+                  onClick={() => {
+                    const arenaId = window.prompt(
+                      "Numéro d'arène pour la saisie tablette (ex : 1)"
+                    );
+                    if (arenaId?.trim()) onAssignArena(m.id, arenaId.trim());
+                  }}
+                  title="Envoyer cette rencontre sur une arène pour saisie tablette temps réel"
+                  className="ml-4 text-xs px-3 py-1.5 rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                >
+                  📡 Arène
+                </button>
+              )}
               <button
                 onClick={() => onToggleScoring(m.id)}
                 className={`ml-4 text-xs px-3 py-1.5 rounded border ${isScoring ? 'bg-gray-200 border-gray-300 text-gray-700' : 'bg-blue-600 border-blue-600 text-white hover:bg-blue-700'}`}
@@ -126,10 +157,9 @@ const TeamPoolView: React.FC<Props> = ({
                   const fa = fencerName(bout.fencerAId);
                   const fb = fencerName(bout.fencerBId);
                   const done = bout.status === 'finished';
-                  const cap = Math.min(
-                    getRelayCap(bout.boutOrder - 1, targetRule.stepSize),
-                    targetRule.target
-                  );
+                  const cap = isLaserArena
+                    ? (boutCap?.maxTouches ?? 5)
+                    : Math.min(getRelayCap(bout.boutOrder - 1, targetRule.stepSize), targetRule.target);
                   const cardsA = (boutCards[bout.id] ?? []).filter(
                     c => c.fencerId === bout.fencerAId
                   );
@@ -310,6 +340,42 @@ const TeamPoolView: React.FC<Props> = ({
                     </React.Fragment>
                   );
                 })}
+                {isLaserArena && onAddTeamCard && (
+                  <div className="mt-2 pt-2 border-t border-gray-200 grid grid-cols-2 gap-3 text-xs">
+                    {([['A', ta, m.teamAId] as const, ['B', tb, m.teamBId] as const]).map(
+                      ([side, team, teamId]) => {
+                        const cards = (matchCards[m.id] ?? []).filter(c => c.teamId === teamId);
+                        const suggested = determineTeamCardEscalation(cards);
+                        return (
+                          <div key={side} className={side === 'B' ? 'text-right' : ''}>
+                            <div className="text-gray-500 mb-1">
+                              Cartons équipe « E » — {team?.name ?? '—'}
+                            </div>
+                            <div
+                              className={`flex items-center gap-1 flex-wrap ${side === 'B' ? 'justify-end' : ''}`}
+                            >
+                              {TEAM_CARD_TYPES.map(type => (
+                                <button
+                                  key={type}
+                                  onClick={() => onAddTeamCard(m.id, teamId, type)}
+                                  title={`Carton ${type} E${type === suggested ? ' (suggéré)' : ''}`}
+                                  className={`px-1.5 py-0.5 rounded border hover:bg-gray-50 ${type === suggested ? 'border-blue-400 ring-1 ring-blue-300' : 'border-gray-200'}`}
+                                >
+                                  {TEAM_CARD_BADGE[type]}
+                                </button>
+                              ))}
+                              {cards.map(c => (
+                                <span key={c.id} title={c.reason}>
+                                  {TEAM_CARD_BADGE[c.type]}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      }
+                    )}
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/renderer/components/TeamTableauView.tsx
+++ b/src/renderer/components/TeamTableauView.tsx
@@ -9,13 +9,14 @@
 
 import React from 'react';
 import { Card, CardReason } from '../../shared/types';
-import { TeamRow, TeamMatchRow, TeamBoutRow } from '../../features/teams/types/team.types';
+import { TeamRow, TeamMatchRow, TeamBoutRow, TeamMatchCardRow } from '../../features/teams/types/team.types';
 import {
   TeamTargetRule,
   calculateTableSize,
   placeRankedTeamsInTable,
   resolveTeamTableauSlot,
 } from '../../features/teams/utils/teamCalculations';
+import { LaserArenaBoutCap } from '../../features/teams/utils/laserArenaCalculations';
 import TeamPoolView, { CardTarget } from './TeamPoolView';
 
 interface Props {
@@ -38,6 +39,11 @@ interface Props {
   onSelectReason: (reason: CardReason | '') => void;
   onAddCard: (matchId: string) => void;
   onGenerate: () => void;
+  isLaserArena?: boolean;
+  boutCap?: LaserArenaBoutCap;
+  matchCards?: Record<string, TeamMatchCardRow[]>;
+  onAddTeamCard?: (matchId: string, teamId: string, type: 'white' | 'yellow' | 'red' | 'black') => void;
+  onAssignArena?: (matchId: string, arenaId: string) => void;
 }
 
 const ROUND_LABELS: Record<number, string> = {
@@ -69,6 +75,11 @@ const TeamTableauView: React.FC<Props> = ({
   onSelectReason,
   onAddCard,
   onGenerate,
+  isLaserArena,
+  boutCap,
+  matchCards,
+  onAddTeamCard,
+  onAssignArena,
 }) => {
   if (rankedTeams.length < 2) {
     return (
@@ -169,6 +180,11 @@ const TeamTableauView: React.FC<Props> = ({
                   onSelectReason={onSelectReason}
                   onAddCard={onAddCard}
                   emptyLabel=""
+                  isLaserArena={isLaserArena}
+                  boutCap={boutCap}
+                  matchCards={matchCards}
+                  onAddTeamCard={onAddTeamCard}
+                  onAssignArena={onAssignArena}
                 />
               );
             })}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -583,6 +583,9 @@ export interface CompetitionSettings {
   teamReserveCount?: number; // Nombre de réservistes par équipe (défaut: 1)
   laserTeamMode?: 'touches' | 'points'; // Cible équipe Sabre Laser : touches (défaut) ou points de zone cumulés
   teamRelayStepSize?: number; // Palier de progression par relais (défaut: 5, cf. règle FIE)
+  // 'fie-relay' (défaut) = relais classique à cible cumulée progressive. 'laser-arena' = format
+  // arène Sabre Laser (assauts indépendants plafonnés à 5 touches/3min, score = total de points).
+  teamFormat?: 'fie-relay' | 'laser-arena';
   questConfig?: QuestPhaseConfig; // Configuration du Tour Quest (Sabre Laser uniquement)
   refereeFeatureEnabled?: boolean; // Activer la gestion des arbitres sur arènes et saisie distante
   customFormula?: CustomFormulaConfig; // Formule à la carte (arme CUSTOM uniquement)

--- a/src/shared/types/preload.ts
+++ b/src/shared/types/preload.ts
@@ -485,6 +485,16 @@ export interface RemoteServerAPI {
     scoreA: number,
     scoreB: number
   ) => Promise<{ success: boolean; error?: string }>;
+  setTeamArenaMatch: (
+    competitionId: string,
+    arenaId: string,
+    matchId: string,
+    isLaserPoints: boolean
+  ) => Promise<{ success: boolean; error?: string }>;
+  clearTeamArenaMatch: (
+    competitionId: string,
+    arenaId: string
+  ) => Promise<{ success: boolean; error?: string }>;
   setRegistrationEnabled: (
     competitionId: string,
     enabled: boolean
@@ -723,9 +733,9 @@ export interface DatabaseAPI {
   deleteTeam: (teamId: string) => Promise<void>;
   upsertTeamFencer: (teamId: string, fencerId: string, teamOrder: number, isReserve: boolean) => Promise<void>;
   removeTeamFencer: (teamId: string, fencerId: string) => Promise<void>;
-  createTeamMatch: (competitionId: string, poolNumber: number, teamAId: string, teamBId: string) => Promise<{ id: string }>;
+  createTeamMatch: (competitionId: string, poolNumber: number, teamAId: string, teamBId: string, round?: number) => Promise<{ id: string }>;
   getTeamMatchesByCompetition: (competitionId: string) => Promise<Array<{
-    id: string; poolNumber: number; teamAId: string; teamBId: string;
+    id: string; poolNumber: number; round: number | null; teamAId: string; teamBId: string;
     scoreBoutsA: number; scoreBoutsB: number; status: string; winnerId: string | null; currentBoutIndex: number;
     bouts: Array<{ id: string; boutOrder: number; fencerAId: string; fencerBId: string; scoreA: number; scoreB: number; maxScore: number; status: string; winnerId: string | null }>;
   }>>;
@@ -736,6 +746,10 @@ export interface DatabaseAPI {
     id: string; round: number; position: number; teamAId: string; teamBId: string;
     scoreBoutsA: number; scoreBoutsB: number; status: string; winnerId: string | null; currentBoutIndex: number;
     bouts: Array<{ id: string; boutOrder: number; fencerAId: string; fencerBId: string; scoreA: number; scoreB: number; maxScore: number; status: string; winnerId: string | null }>;
+  }>>;
+  createTeamMatchCard: (matchId: string, teamId: string, type: 'white' | 'yellow' | 'red' | 'black', reason: string) => Promise<{ id: string }>;
+  getTeamMatchCards: (matchId: string) => Promise<Array<{
+    id: string; matchId: string; teamId: string; type: string; reason: string; createdAt: string;
   }>>;
 }
 


### PR DESCRIPTION
## Résumé

Ajoute un mode **"Sabre Laser équipe — format arène"** pour les compétitions par équipes, en plus du relais FIE classique existant (`teamCalculations.ts`, **inchangé**). Basé sur le règlement transmis par Vincent Thivolle (ASL-FFE) pour l'épreuve par équipe.

Le règlement décrit un format différent du relais FIE : assauts indépendants plafonnés à 5 touches/3min (pas de cible cumulée progressive), score de rencontre = total de points marqués sur les 9 assauts, classement de poule par points marqués cumulés (pas par nombre de victoires).

Tout le nouveau code est additif : `CompetitionSettings.teamFormat` (`'fie-relay'` par défaut | `'laser-arena'`) sélectionne le mode ; quand il vaut `'fie-relay'` (toutes les compétitions existantes), aucun chemin de code existant n'est modifié.

## Contenu

- **Modèle de score arène** (`laserArenaCalculations.ts`) : assaut plafonné 5 touches/3min, score = total de points, classement de poule par points marqués cumulés (puis ratio, puis égalité signalée pour tirage au sort manuel).
- **Cartons d'équipe "E"** (blanc/jaune/rouge/noir) : nouvelle table `team_match_cards` (migration v15), persistés (corrige au passage la limite connue "cartons non persistés"), traçabilité uniquement — pas d'impact automatique sur le score (pas encore tranché par le règlement).
- **Calendriers de poule figés** 8/12 équipes avec équipes assesseurs (`laserArenaPoolSchedules.ts`), transcrits du règlement.
- **Évitement de revanche** au 1er tour du tableau (échange seed 5↔6 ou 7↔8), réutilise `placeRankedTeamsInTable`/`calculateTableSize` existants sans les modifier.
- **Saisie temps réel** : nouvelles pages `teamArena.html`/`teamReferee.html` + routes `/equipe:id` et `/equipe:id/arbitre` sur le serveur de score distant, avec compteur de touches déclenchant le changement de relais (demande explicite du club partenaire).
- Sélecteur de format dans `NewCompetitionModal` (visible uniquement pour Sabre Laser + compétition par équipes).

## Test plan

- [x] `npm run type-check` — 0 erreur
- [x] `npm run lint` — 0 erreur (warnings pré-existants uniquement, aucun dans les fichiers touchés)
- [x] `npx vitest run` — 1023/1023 tests passent (92 fichiers), y compris 41 nouveaux tests pour les modules `laserArena*`/`teamCardEscalation`
- [x] `npm run build:ci` — build main + renderer OK, nouvelles pages HTML bien copiées dans `dist/remote`
- [x] Smoke test bout en bout headless (DB + `RemoteScoreServer` + client socket.io réel) : création compétition/équipes/tireurs/match/9 assauts, requêtes HTTP `/equipe1` et `/equipe1/arbitre` (200, client socket.io injecté), séquence de touches avec vérification du plafond 5 touches, `team_advance_bout` → persistance DB correcte, `team_card` → carton persisté

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkeaz7F8G63e8HAVaPahXc)_