### PR TITLE
Documente le format arène Sabre Laser équipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,27 @@ Merci pour votre soutien ! / Thank you for your support!
 
 > ⚠️ **Version de test** : Contient les dernières fonctionnalités mais peut être instable
 
-## 🆕 Nouveautés Récentes (Février 2026)
+## 🆕 Nouveautés Récentes
+
+### ⚔️ **Sabre Laser équipe — format arène (Nouveau !)**
+
+Nouveau format de compétition par équipes pour le Sabre Laser, basé sur le
+règlement de l'ASL-FFE :
+
+- 🎯 **Assauts plafonnés** à 5 touches ou 3 minutes (au lieu du relais FIE à
+  cible cumulée progressive)
+- 🏆 **Score de rencontre** = total des points marqués, classement de poule
+  par points cumulés
+- 🟨 **Cartons d'équipe « E »** persistés (blanc/jaune/rouge/noir)
+- 📅 **Calendriers de poule figés** pour 8 ou 12 équipes, avec équipes
+  assesseurs
+- 🔀 **Évitement de revanche** au 1er tour du tableau à élimination directe
+- 📱 **Saisie temps réel sur tablette arbitre** avec compteur de touches
+  déclenchant automatiquement le changement de relayeur, et affichage arène
+  dédié
+
+Voir [docs/TEAM_COMPETITIONS.md](docs/TEAM_COMPETITIONS.md) pour le détail
+complet et les limites connues.
 
 ### 🚀 **Version 2.0 - Mise à jour majeure**
 
@@ -58,7 +78,7 @@ D'après l'analyse du code et les demandes utilisateurs, les prochaines mises à
 
 #### 🏆 **En Développement**
 
-- 👥 **Compétitions par Équipes** - Poules et tableau à élimination directe par équipes, relais arme-aware (voir [docs/TEAM_COMPETITIONS.md](docs/TEAM_COMPETITIONS.md) pour le détail et les limites connues)
+- 👥 **Compétitions par Équipes (relais FIE)** - Poules et tableau à élimination directe par équipes, relais arme-aware — le format arène Sabre Laser (ci-dessus) est disponible dès maintenant ; le relais FIE générique (Épée/Fleuret/Sabre) reste en développement (voir [docs/TEAM_COMPETITIONS.md](docs/TEAM_COMPETITIONS.md) pour le détail et les limites connues)
 - ⚖️ **Système de Pénalités** - Cartons jaunes/rouges/noirs avec impact sur scores
 - ⏰ **Gestion des Retardataires** - Auto-forfait après délai configurable
 - 🏅 **Double Élimination** - Brackets gagnants et perdants
@@ -465,5 +485,5 @@ Les contributions sont bienvenues ! Voir [CONTRIBUTING.md](./CONTRIBUTING.md) po
 
 📄 **Développé par** : Yann Deboeuf & communauté  
 📄 **Licence** : GPL-3.0  
-📄 **Dernière mise à jour** : 11 mars 2026  
+📄 **Dernière mise à jour** : 15 août 2026  
 📄 **Version actuelle** : v1.0.2 Build #546

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,19 +76,37 @@ Voir [docs/TEAM_COMPETITIONS.md](docs/TEAM_COMPETITIONS.md) pour le fonctionneme
    directe, têtes de série = classement de poule, tours suivants générés
    automatiquement (`resolveTeamTableauSlot`), migration DB v14
    (`team_matches.table_id/round/position`).
+6. ✅ **Format arène Sabre Laser équipe** (`teamFormat: 'laser-arena'`, règlement
+   ASL-FFE) — assaut plafonné 5 touches/3min, score = total de points, classement de
+   poule par points cumulés, cartons d'équipe « E » persistés (table
+   `team_match_cards`, migration v15), calendriers de poule figés 8/12 équipes avec
+   assesseurs, évitement de revanche au tableau (5↔6/7↔8). Fichiers :
+   `laserArenaCalculations.ts`, `laserArenaPoolSchedules.ts`,
+   `laserArenaBracketRules.ts`, `teamCardEscalation.ts`. Résout les points 7 et 8
+   ci-dessous, **pour ce format uniquement** — le relais FIE générique garde
+   l'ancien comportement (voir `docs/TEAM_COMPETITIONS.md`).
+7. ✅ **Saisie live arène/tablette** — `src/remote/teamArena.html` /
+   `teamReferee.html`, routes `/equipe:id` et `/equipe:id/arbitre` sur
+   `remoteScoreServer.ts` (compteur de touches déclenchant le relais suivant).
+   Format arène Sabre Laser uniquement.
+8. ✅ **Persistance des cartons** d'équipe en base — format arène Sabre Laser
+   uniquement (table `team_match_cards`) ; le relais FIE générique reste en mémoire
+   de session.
 
 ### Reste à faire
 
-6. **Intégration dans le flux de phases `CompetitionView`** — par prudence (fichier de
+9. **Intégration dans le flux de phases `CompetitionView`** — par prudence (fichier de
    1800+ lignes, state machine `currentPhase` fortement couplée aux compétitions
    individuelles/Quest), les vues équipes restent pour l'instant dans la fenêtre
    modale « Gestion équipes » plutôt que dans les phases `pools`/`tableau` normales.
    À terme : soit brancher `phaseOrder` sur `competition.isTeamEvent`, soit accepter
    ce modal comme l'interface équipes définitive.
-7. **Saisie live arène/tablette** pour les rencontres d'équipe (actuellement saisie
-   uniquement dans la fenêtre Gestion équipes, pas d'écran arbitre dédié).
-8. **Persistance des cartons** d'équipe en base (actuellement en mémoire de session).
-9. **PDF export** équipes (extension de `pdfExport.ts`).
+10. **Persistance des cartons + saisie tablette pour le relais FIE générique**
+    (Épée/Fleuret/Sabre/Laser hors format arène) — actuellement résolu uniquement
+    pour `teamFormat: 'laser-arena'` (point 6-8 ci-dessus).
+11. **Impact en points des cartons d'équipe « E »** (format arène) — traçabilité
+    seule pour l'instant, en attendant que le club tranche la valeur.
+12. **PDF export** équipes (extension de `pdfExport.ts`).
 
 ---
 

--- a/docs/TEAM_COMPETITIONS.md
+++ b/docs/TEAM_COMPETITIONS.md
@@ -31,6 +31,45 @@ Le système ne traite pas toutes les armes de la même façon :
   - **Points** : chaque touche compte pour la valeur de sa zone (1/3/5), avec un
     sélecteur de zone dédié lors de la saisie.
 
+## Format arène Sabre Laser équipe (ASL-FFE)
+
+Un second format, spécifique au Sabre Laser, est disponible en plus du relais
+FIE ci-dessus : `competition.settings.teamFormat = 'laser-arena'` (défaut :
+`'fie-relay'`, aucun changement de comportement). Il suit le règlement
+épreuve par équipe transmis par l'ASL-FFE, structurellement différent du
+relais FIE :
+
+- **Assaut plafonné** : 5 touches valides cumulées (les deux côtés) ou 3
+  minutes, quel que soit le numéro de l'assaut — pas de cible progressive
+  5→10→…→45.
+- **Score de rencontre** = total des points marqués sur les 9 (ou N²)
+  assauts, pas le nombre d'assauts gagnés.
+- **Classement de poule** trié par points marqués cumulés en premier critère
+  (pas par nombre de victoires), puis ratio marqués/reçus, puis égalité
+  signalée pour tirage au sort manuel (`tied`, jamais résolu par le
+  logiciel).
+- **Cartons d'équipe « E »** (blanc/jaune/rouge/noir) pour retard de
+  désignation d'un combattant : persistés en base (table
+  `team_match_cards`), cumulables sur les 9 assauts d'une rencontre —
+  traçabilité uniquement, sans impact automatique sur le score (le club n'a
+  pas encore tranché la valeur en points).
+- **Calendriers de poule figés** pour 8 ou 12 équipes (3 poules A/B/C de 4
+  ou 2 poules de 4), avec désignation d'équipe(s) assesseur(s) par round,
+  transcrits du règlement.
+- **Évitement de revanche** au 1er tour du tableau : si les équipes classées
+  5/6 ou 7/8 tombent contre une équipe déjà rencontrée en poule, échange de
+  leurs places.
+- **Saisie temps réel** sur tablette : `http://IP:8066/equipe{N}` (affichage
+  arène) et `http://IP:8066/equipe{N}/arbitre` (tablette arbitre — compteur
+  de touches déclenchant automatiquement le passage au relais suivant,
+  boutons cartons E, minuteur 3 min).
+
+Fichiers clés : `src/features/teams/utils/laserArenaCalculations.ts`
+(score/plafond/classement), `laserArenaPoolSchedules.ts` (calendriers
+figés), `laserArenaBracketRules.ts` (évitement de revanche),
+`teamCardEscalation.ts` (échelle blanc→jaune), `src/remote/teamArena.html` /
+`teamReferee.html` (interfaces distantes).
+
 ## Activer une compétition par équipes
 
 Une compétition devient une compétition par équipes en positionnant
@@ -43,8 +82,9 @@ suivantes, dans `competition.settings`, ajustent le format :
 | `teamReserveCount`             | `1`         | Nombre de réservistes autorisés par équipe                        |
 | `laserTeamMode`                | `'touches'` | Sabre Laser uniquement : `'touches'` ou `'points'` (zones)         |
 | `teamRelayStepSize`             | `5`         | Palier de progression par relais (avancé — laisser à 5 sauf besoin spécifique) |
+| `teamFormat`                    | `'fie-relay'` | Sabre Laser + équipe uniquement : `'fie-relay'` (défaut, ci-dessus) ou `'laser-arena'` (règlement ASL-FFE, voir plus haut) |
 
-La cible totale de la rencontre se déduit automatiquement :
+La cible totale de la rencontre se déduit automatiquement (relais FIE uniquement) :
 `teamRelayStepSize × minTeamSize²` (45 pour le format FIE par défaut : 5×3²).
 
 ## Utilisation
@@ -67,15 +107,32 @@ l'en-tête, visible uniquement quand `isTeamEvent` est actif) :
 
 ## Limites connues
 
+**Relais FIE (`teamFormat: 'fie-relay'`, défaut) :**
+
 - **Pas de saisie live arène/tablette** pour les rencontres d'équipe : la saisie des
   scores se fait uniquement dans la fenêtre « Gestion équipes » (pas d'écran arbitre
-  dédié ni de retour temps réel comme pour les matchs individuels).
+  dédié ni de retour temps réel comme pour les matchs individuels). Résolu pour le
+  format arène Sabre Laser (`teamFormat: 'laser-arena'`) — voir plus haut.
 - **Cartons non persistés entre sessions** : les cartons enregistrés pendant un relais
   sont conservés en mémoire le temps de la session ; ils ne sont pas encore stockés en
-  base de données et sont donc perdus à la fermeture de la fenêtre.
+  base de données et sont donc perdus à la fermeture de la fenêtre. Résolu pour le
+  format arène (cartons « E » persistés en base).
+
+**Les deux formats :**
+
 - **Collision de têtes de série connue** : le calcul générique de placement en tableau
   (`generateSeedingChart`, partagé avec le tableau individuel) a un bug documenté qui
   peut faire disparaître la tête de série n°2 pour certaines tailles de tableau — ce
   n'est pas spécifique aux équipes, voir `tableCalculations.test.ts`.
 - Le nombre de réservistes n'est pas encore utilisé pour les remplacements en cours de
   match (affectation uniquement).
+
+**Format arène Sabre Laser (`teamFormat: 'laser-arena'`) uniquement :**
+
+- Les cartons d'équipe « E » n'ont **pas encore d'impact automatique sur le score** —
+  traçabilité seule, en attendant que le club tranche la valeur en points.
+- La génération automatique de la poule (calendrier figé + assesseurs) n'est
+  disponible que pour **8 ou 12 équipes** ; pour tout autre effectif, aucune
+  génération automatique n'est proposée (saisie manuelle des équipes).
+- L'affectation aux poules A/B/C se fait dans l'ordre de création des équipes (pas
+  de champ de poule explicite dans l'UI).


### PR DESCRIPTION
## Résumé

Suite au merge du format arène Sabre Laser équipe (PR #902), met à jour la documentation pour refléter l'état réel du code :

- **`docs/TEAM_COMPETITIONS.md`** : nouvelle section décrivant le format arène (assaut 5 touches/3min, score = total de points, cartons "E" persistés, calendriers figés 8/12, évitement de revanche, saisie tablette), ajout du réglage `teamFormat` dans la table des options, et section "Limites connues" scindée par format (le relais FIE générique garde ses anciennes limites — saisie non temps réel, cartons en mémoire — désormais résolues uniquement pour le format arène).
- **`ROADMAP.md`** : points 7 (saisie live) et 8 (persistance cartons) de "P1 — Interface équipes complète" cochés ✅ pour le format arène, avec précision que le relais FIE générique reste à faire.
- **`README.md`** : nouvelle entrée dans "Nouveautés Récentes" annonçant le format arène, avec renvoi vers la doc détaillée.

Documentation uniquement — aucun changement de code.

## Test plan

- [x] Relecture des diffs pour cohérence
- [x] Vérification que les fichiers/routes cités existent (`laserArenaCalculations.ts`, `laserArenaPoolSchedules.ts`, `laserArenaBracketRules.ts`, `teamCardEscalation.ts`, `teamArena.html`, `teamReferee.html`, routes `/equipe:id`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkeaz7F8G63e8HAVaPahXc)_